### PR TITLE
Work on list patterns

### DIFF
--- a/grammars/silver/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/extension/patternmatching/PatternTypes.sv
@@ -165,15 +165,24 @@ concrete production listPattern
 top::Pattern ::= '[' ps::PatternList ']'
 {
   top.pp = s"[${ps.pp}]";
-  forwards to makeListPattern(ps.patternList, top.location);
+  forwards to ps.asListPattern;
 }
 
-function makeListPattern
-Pattern ::= ps::[Decorated Pattern] loc::Location
+synthesized attribute asListPattern::Pattern occurs on PatternList;
+
+aspect production patternList_one
+top::PatternList ::= p::Pattern
 {
-  return
-    case ps of
-      [] -> nilListPattern('[', ']', location=loc)
-    | p :: rest -> consListPattern(p, '::', makeListPattern(rest, loc), location=loc)
-    end;
+  top.asListPattern = 
+    consListPattern(p, '::', nilListPattern('[', ']', location=top.location), location=top.location);
+}
+aspect production patternList_more
+top::PatternList ::= p::Pattern ',' ps1::PatternList
+{
+  top.asListPattern = consListPattern(p, '::', ps1.asListPattern, location=top.location);
+}
+aspect production patternList_nil
+top::PatternList ::=
+{
+  top.asListPattern = nilListPattern('[', ']', location=top.location);
 }

--- a/grammars/silver/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/extension/patternmatching/PatternTypes.sv
@@ -140,7 +140,7 @@ top::Pattern ::= 'false'
   top.patternSortKey = "false";
 }
 
-concrete production nilListPattern
+abstract production nilListPattern
 top::Pattern ::= '[' ']'
 {
   top.pp = "[]";
@@ -160,3 +160,20 @@ top::Pattern ::= hp::Pattern '::' tp::Pattern
   top.patternSortKey = "core:cons";
 }
 
+-- List literal patterns
+concrete production listPattern
+top::Pattern ::= '[' ps::PatternList ']'
+{
+  top.pp = s"[${ps.pp}]";
+  forwards to makeListPattern(ps.patternList, top.location);
+}
+
+function makeListPattern
+Pattern ::= ps::[Decorated Pattern] loc::Location
+{
+  return
+    case ps of
+      [] -> nilListPattern('[', ']', location=loc)
+    | p :: rest -> consListPattern(p, '::', makeListPattern(rest, loc), location=loc)
+    end;
+}


### PR DESCRIPTION
I have added patterns of the form
case foo of
  [bar, bar1] -> baz
end
as an alternative to the current syntax
case foo of
  bar :: bar1 :: [] -> baz
end

This was done within the pattern matching extension, with the addition of a new production.  In addition, the current production for [] patterns was made abstract to avoid a conflict.  