### PR TITLE
Bringing flow analysis in line with thesis: part 1: phantom graphs

### DIFF
--- a/grammars/silver/analysis/warnings/defs/EqDef.sv
+++ b/grammars/silver/analysis/warnings/defs/EqDef.sv
@@ -145,26 +145,31 @@ synthesized attribute lookupEqDefLHS :: [FlowDef] occurs on DefLHS;
 aspect production childDefLHS
 top::DefLHS ::= q::Decorated QName
 {
+  -- prod, child, attr
   top.lookupEqDefLHS = lookupInh(top.signature.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production lhsDefLHS
 top::DefLHS ::= q::Decorated QName
 {
+  -- prod, attr
   top.lookupEqDefLHS = lookupSyn(top.signature.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production localDefLHS
 top::DefLHS ::= q::Decorated QName
 {
+  -- prod, local, attr
   top.lookupEqDefLHS = lookupLocalInh(top.signature.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production forwardDefLHS
 top::DefLHS ::= q::Decorated QName
 {
+  -- prod, attr
   top.lookupEqDefLHS = lookupFwdInh(top.signature.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production defaultLhsDefLHS
 top::DefLHS ::= q::Decorated QName
 {
+  -- nt, attr
   top.lookupEqDefLHS = lookupDef(top.signature.outputElement.typerep.typeName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production errorDefLHS

--- a/grammars/silver/definition/env/env_parser/Parser.sv
+++ b/grammars/silver/definition/env/env_parser/Parser.sv
@@ -137,7 +137,7 @@ top::ILocation ::= filename::IName ',' line::Num_t ',' column::Num_t
 concrete production aString
 top::IString ::= s::EscapedStringTerm
 {
-  top.str = unescapeString(substring(1,length(s.lexeme)-1,s.lexeme)); -- TODO fix unescape and escape!!
+  top.str = unescapeString(substring(1,length(s.lexeme)-1,s.lexeme));
 }
 
 concrete production aName

--- a/grammars/silver/definition/flow/ast/Flow.sv
+++ b/grammars/silver/definition/flow/ast/Flow.sv
@@ -2,8 +2,8 @@ grammar silver:definition:flow:ast;
 
 imports silver:definition:env only quoteString,unparseStrings, unparse;
 
-nonterminal FlowDefs with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, unparses, prodTreeContribs, prodGraphContribs, refTreeContribs, localInhTreeContribs, nonHostSynAttrs, nonSuspectContribs, localTreeContribs;
-nonterminal FlowDef with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, unparses, prodTreeContribs, prodGraphContribs, flowEdges, refTreeContribs, localInhTreeContribs, suspectFlowEdges, nonHostSynAttrs, nonSuspectContribs, localTreeContribs;
+nonterminal FlowDefs with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, unparses, prodTreeContribs, prodGraphContribs, refTreeContribs, localInhTreeContribs, extSynTreeContribs, nonSuspectContribs, localTreeContribs;
+nonterminal FlowDef with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, unparses, prodTreeContribs, prodGraphContribs, flowEdges, refTreeContribs, localInhTreeContribs, suspectFlowEdges, extSynTreeContribs, nonSuspectContribs, localTreeContribs;
 
 {-- lookup (production, attribute) to find synthesized equations
  - Used to ensure a necessary lhs.syn equation exists.
@@ -56,8 +56,8 @@ synthesized attribute flowEdges :: [Pair<FlowVertex FlowVertex>];
  - (e.g.  extsyn = hostsyn; hostsyn = hostinh; need to reflect extsyn's dep on hostinh) -}
 synthesized attribute suspectFlowEdges :: [Pair<FlowVertex FlowVertex>];
 
-{-- A list of non-host synthesized occurrences, to patch up flow types -}
-synthesized attribute nonHostSynAttrs :: [FlowDef];
+{-- A list of extension syn attr occurrences, subject to ft lower bounds. -}
+synthesized attribute extSynTreeContribs :: [Pair<String FlowDef>];
 
 {-- A list of attributes for a production that are non-suspect -}
 synthesized attribute nonSuspectContribs :: [Pair<String [String]>];
@@ -77,7 +77,7 @@ top::FlowDefs ::= h::FlowDef  t::FlowDefs
   top.refTreeContribs = h.refTreeContribs ++ t.refTreeContribs;
   top.localInhTreeContribs = h.localInhTreeContribs ++ t.localInhTreeContribs;
   top.localTreeContribs = h.localTreeContribs ++ t.localTreeContribs;
-  top.nonHostSynAttrs = h.nonHostSynAttrs ++ t.nonHostSynAttrs;
+  top.extSynTreeContribs = h.extSynTreeContribs ++ t.extSynTreeContribs;
   top.nonSuspectContribs = h.nonSuspectContribs ++ t.nonSuspectContribs;
   top.unparses = h.unparses ++ t.unparses;
 }
@@ -95,7 +95,7 @@ top::FlowDefs ::=
   top.refTreeContribs = [];
   top.localInhTreeContribs = [];
   top.localTreeContribs = [];
-  top.nonHostSynAttrs = [];
+  top.extSynTreeContribs = [];
   top.nonSuspectContribs = [];
   top.unparses = [];
 }
@@ -118,7 +118,7 @@ top::FlowDef ::=
   top.refTreeContribs = [];
   top.localInhTreeContribs = [];
   top.localTreeContribs = [];
-  top.nonHostSynAttrs = [];
+  top.extSynTreeContribs = [];
   top.nonSuspectContribs = [];
   top.suspectFlowEdges = []; -- flowEdges is required, but suspect is typically not!
   -- require unparses, prodGraphContibs, flowEdges
@@ -165,7 +165,7 @@ top::FlowDef ::= nt::String  inhs::[String]
 abstract production extSynFlowDef
 top::FlowDef ::= nt::String  attr::String
 {
-  top.nonHostSynAttrs = [top];
+  top.extSynTreeContribs = [pair(nt, top)];
   top.prodGraphContribs = [];
   top.flowEdges = error("Internal compiler error: this sort of def should not be in a context where edges are requested.");
   top.unparses = ["nonHostSyn(" ++ quoteString(attr) ++ ", " ++ quoteString(nt) ++ ")"];
@@ -247,9 +247,10 @@ top::FlowDef ::= prod::String  deps::[FlowVertex]  mayAffectFlowType::Boolean
 
 {--
  - Attributes that are non-suspect.
- - TODO: presently, these are all knowns syns where the prod is declared.
- -       should probably be all syns that are not subject to fwd superset rule, right?
- -       that's different. (i.e. syns exported by nonterminal grammar)
+ - 
+ - These are *allowed* to have their *implicit forward copy equations* affect the flow type.
+ -
+ - This is basically a hack to make flow type inference work a little better.
  -}
 abstract production implicitFwdAffects
 top::FlowDef ::= prod::String  attrs::[String]

--- a/grammars/silver/definition/flow/ast/Flow.sv
+++ b/grammars/silver/definition/flow/ast/Flow.sv
@@ -156,13 +156,14 @@ top::FlowDef ::= nt::String  inhs::[String]
 }
 
 {--
- - Declaration that a synthesized attribute occurrence is not in the host
- - and therefore subject to the forward flow type's whims.
- - @param attr  the full name of the synthesized attribute
+ - Declaration that a synthesized attribute *occurrence* is not in the host
+ - and therefore subject to the forward flow type's whims. (i.e. must be ft(syn) >= ft(fwd))
+ -
  - @param nt  the full name of the nonterminal
+ - @param attr  the full name of the synthesized attribute
  -}
-abstract production nonHostSynDef
-top::FlowDef ::= attr::String  nt::String
+abstract production extSynFlowDef
+top::FlowDef ::= nt::String  attr::String
 {
   top.nonHostSynAttrs = [top];
   top.prodGraphContribs = [];

--- a/grammars/silver/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/definition/flow/driver/FlowTypes.sv
@@ -21,10 +21,10 @@ type NtName = String;
 
 -- construct a production graph for each production
 function computeAllProductionGraphs
-[ProductionGraph] ::= prods::[String]  prodTree::EnvTree<FlowDef>  flowEnv::Decorated FlowEnv  realEnv::Decorated Env
+[ProductionGraph] ::= prods::[DclInfo]  prodTree::EnvTree<FlowDef>  flowEnv::Decorated FlowEnv  realEnv::Decorated Env
 {
   return if null(prods) then []
-  else constructProductionGraph(head(prods), searchEnvTree(head(prods), prodTree), flowEnv, realEnv) ::
+  else constructProductionGraph(head(prods), searchEnvTree(head(prods).fullName, prodTree), flowEnv, realEnv) ::
     computeAllProductionGraphs(tail(prods), prodTree, flowEnv, realEnv);
 }
 

--- a/grammars/silver/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/definition/flow/driver/FlowTypes.sv
@@ -147,7 +147,7 @@ function patchEditPair
 EnvTree<g:Graph<String>> ::= edit::FlowDef  current::EnvTree<g:Graph<String>>
 {
   return case edit of
-  | nonHostSynDef(attr, nt) -> 
+  | extSynFlowDef(nt, attr) -> 
       let ft :: g:Graph<String> = findFlowType(nt, current)
        in
       let fwdInhs :: set:Set<String> = g:edgesFrom("forward", ft),

--- a/grammars/silver/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/definition/flow/driver/FlowTypes.sv
@@ -130,43 +130,6 @@ function collectInhs
   end;
 }
 
-{--
- - Used to add the 'minimum' flow type for non-host synthesized attributes.
- - These attributes need to be able to evaluate the forwards of productions
- - to be able to be evaluated.
- - @param initial  the results from fullySolveFlowTypes
- - @param edits  the list of non-host synthesized attribute occurrences
- - @return the modified flow types
- -}
-function patchFlowTypes
-EnvTree<g:Graph<String>> ::= initial::EnvTree<g:Graph<String>>  edits::[FlowDef]
-{
-  return foldr(patchEditPair, initial, edits);
-}
-function patchEditPair
-EnvTree<g:Graph<String>> ::= edit::FlowDef  current::EnvTree<g:Graph<String>>
-{
-  return case edit of
-  | extSynFlowDef(nt, attr) -> 
-      let ft :: g:Graph<String> = findFlowType(nt, current)
-       in
-      let fwdInhs :: set:Set<String> = g:edgesFrom("forward", ft),
-          alreadyInhs :: set:Set<String> = g:edgesFrom(attr, ft)
-       in
-          rtm:update(nt, [
-            g:add(map(pair(attr, _), set:toList(set:difference(fwdInhs, alreadyInhs))), ft)
-            ], current)
-      end
-      end
-  end; -- for everything found under nt->forward, add something under nt->attr, if it doesn't exist already
-}
-
-
-
-
-
-
-
 function flowVertexEq
 Boolean ::= a::FlowVertex  b::FlowVertex
 {

--- a/grammars/silver/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/definition/flow/driver/ProductionGraph.sv
@@ -291,13 +291,13 @@ function localStitchPoints
   return case d of
   | [] -> []
   -- We add the forward stitch point here, too!
-  | fwdEq(_, _, _) :: rest -> nonterminalStitchPoint(nt, forwardVertex) :: localStitchPoints(nt, rest)
+  | fwdEq(_, _, _) :: rest -> nonterminalStitchPoint(nt, forwardVertexType) :: localStitchPoints(nt, rest)
   -- Ignore locals that aren't nonterminal types!
   | localEq(_, fN, "", _) :: rest -> localStitchPoints(nt, rest)
   -- Add locals that are nonterminal types.
-  | localEq(_, fN, tN, _) :: rest -> nonterminalStitchPoint(tN, localVertex(fN, _)) :: localStitchPoints(nt, rest)
+  | localEq(_, fN, tN, _) :: rest -> nonterminalStitchPoint(tN, localVertexType(fN)) :: localStitchPoints(nt, rest)
   -- Add all anon decoration sites
-  | anonEq(_, fN, tN, _, _) :: rest -> nonterminalStitchPoint(tN, anonVertex(fN, _)) :: localStitchPoints(nt, rest)
+  | anonEq(_, fN, tN, _, _) :: rest -> nonterminalStitchPoint(tN, anonVertexType(fN)) :: localStitchPoints(nt, rest)
   -- Ignore all other flow def info
   | _ :: rest -> localStitchPoints(nt, rest)
   end;
@@ -310,7 +310,7 @@ function rhsStitchPoints
   else if head(rhs).typerep.isDecorable
        then nonterminalStitchPoint(
               head(rhs).typerep.typeName,
-              rhsVertex(head(rhs).elementName, _)) :: rhsStitchPoints(tail(rhs))
+              rhsVertexType(head(rhs).elementName)) :: rhsStitchPoints(tail(rhs))
        else rhsStitchPoints(tail(rhs));
 }
 

--- a/grammars/silver/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/definition/flow/driver/ProductionGraph.sv
@@ -107,10 +107,10 @@ top::ProductionGraph ::=
  - @return A fixed up graph.
  -}
 function constructProductionGraph
-ProductionGraph ::= prod::String  defs::[FlowDef]  flowEnv::Decorated FlowEnv  realEnv::Decorated Env
+ProductionGraph ::= dcl::DclInfo  defs::[FlowDef]  flowEnv::Decorated FlowEnv  realEnv::Decorated Env
 {
-  -- The dcl for this production
-  local dcl :: DclInfo = head(getValueDclAll(prod, realEnv));
+  -- The name of this production
+  local prod :: String = dcl.fullName;
   -- The LHS nonterminal full name
   local nt :: NtName = dcl.namedSignature.outputElement.typerep.typeName;
   -- All attributes occurrences

--- a/grammars/silver/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/definition/flow/env/FlowEnv.sv
@@ -9,7 +9,7 @@ exports silver:definition:flow:env_parser with silver:definition:env:env_parser;
 autocopy attribute flowEnv :: Decorated FlowEnv;
 synthesized attribute flowDefs :: [FlowDef];
 
-nonterminal FlowEnv with synTree, inhTree, defTree, fwdTree, prodTree, fwdInhTree, refTree, localInhTree, localTree, nonSuspectTree;
+nonterminal FlowEnv with synTree, inhTree, defTree, fwdTree, prodTree, fwdInhTree, refTree, localInhTree, localTree, nonSuspectTree, extSynTree;
 
 inherited attribute synTree :: EnvTree<FlowDef>;
 inherited attribute inhTree :: EnvTree<FlowDef>;
@@ -21,6 +21,7 @@ inherited attribute refTree :: EnvTree<FlowDef>;
 inherited attribute localInhTree ::EnvTree<FlowDef>;
 inherited attribute localTree :: EnvTree<FlowDef>;
 inherited attribute nonSuspectTree :: EnvTree<[String]>;
+inherited attribute extSynTree :: EnvTree<FlowDef>;
 
 abstract production dummyFlowEnv
 top::FlowEnv ::=
@@ -42,6 +43,7 @@ Decorated FlowEnv ::= d::FlowDefs
   e.localInhTree = directBuildTree(d.localInhTreeContribs);
   e.localTree = directBuildTree(d.localTreeContribs);
   e.nonSuspectTree = directBuildTree(d.nonSuspectContribs);
+  e.extSynTree = directBuildTree(d.extSynTreeContribs);
   
   return e;
 }
@@ -109,9 +111,17 @@ function getInhsForNtRef
   return searchEnvTree(nt, e.refTree);
 }
 
+-- implicit forward syn copy equations that are allowed to affect the flow type
 function getNonSuspectAttrsForProd
 [String] ::= prod::String  e::Decorated FlowEnv
 {
   return foldr(append, [], searchEnvTree(prod, e.nonSuspectTree));
+}
+
+-- Ext Syns subject to ft lower bound
+function getExtSynsFor
+[FlowDef] ::= nt::String  e::Decorated FlowEnv
+{
+  return searchEnvTree(nt, e.extSynTree);
 }
 

--- a/grammars/silver/definition/flow/env/Occurs.sv
+++ b/grammars/silver/definition/flow/env/Occurs.sv
@@ -15,6 +15,6 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeList 'occurs' 'on' nt
     if !null(at.lookupAttribute.errors ++ nt.lookupType.errors) || isHost || !isSyn then 
       []
     else
-      [nonHostSynDef(at.lookupAttribute.fullName, nt.lookupType.fullName)];
+      [extSynFlowDef(nt.lookupType.fullName, at.lookupAttribute.fullName)];
 }
 

--- a/grammars/silver/definition/flow/env_parser/Parser.sv
+++ b/grammars/silver/definition/flow/env_parser/Parser.sv
@@ -187,7 +187,7 @@ top::IFlow ::= 'implicitFwdAffects' '(' prd::IName ',' attrs::INames ')'
 concrete production aFlowNonHostSyn
 top::IFlow ::= 'nonHostSyn' '(' attr::IName ',' nt::IName ')'
 {
-  top.flowDefs = [nonHostSynDef(attr.aname, nt.aname)];
+  top.flowDefs = [extSynFlowDef(nt.aname, attr.aname)];
 }
 concrete production aFlowInh
 top::IFlow ::= 'inh' '(' prod::IName ',' sigName::IName ',' attr::IName ',' fv::IFlowVertexes ')'

--- a/grammars/silver/driver/util/FlowTypes.sv
+++ b/grammars/silver/driver/util/FlowTypes.sv
@@ -22,8 +22,8 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::Build
   local allRealDefs :: [Def] = foldr(append, [], map((.defs), g.grammarList));
   local allRealEnv :: Decorated Env = toEnv(allRealDefs);
   
-  -- List of all productions (is this nub needed? TODO)
-  local allProds :: [String] = nubBy(stringEq, map((.fullName), foldr(consDefs, nilDefs(), allRealDefs).prodDclList));
+  -- List of all productions
+  local allProds :: [DclInfo] = foldr(consDefs, nilDefs(), allRealDefs).prodDclList;
   
   -- Fix the production graph information from the flow defs TODO: some of this maybe should be fixed somehow
   production prodGraph :: [ProductionGraph] = 

--- a/grammars/silver/driver/util/FlowTypes.sv
+++ b/grammars/silver/driver/util/FlowTypes.sv
@@ -24,10 +24,13 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::Build
   
   -- List of all productions
   local allProds :: [DclInfo] = foldr(consDefs, nilDefs(), allRealDefs).prodDclList;
+  local allNts :: [String] = nubBy(stringEq, map(getProdNt, allProds));
   
   -- Fix the production graph information from the flow defs TODO: some of this maybe should be fixed somehow
   production prodGraph :: [ProductionGraph] = 
-    computeAllProductionGraphs(allProds, prodTree, allFlowEnv, allRealEnv);
+    computeAllProductionGraphs(allProds, prodTree, allFlowEnv, allRealEnv) ++
+      -- Add in phantom graphs
+      map(constructPhantomProductionGraph(_, allFlowEnv, allRealEnv), allNts);
   
   -- Now, solve for flow types!!
   local flowTypes1 :: Pair<[ProductionGraph] EnvTree<g:Graph<String>>> =
@@ -44,3 +47,8 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::Build
   r.grammarFlowTypes = flowTypes;
 }
 
+function getProdNt
+String ::= d::DclInfo
+{
+  return d.namedSignature.outputElement.typerep.typeName;
+}

--- a/grammars/silver/driver/util/FlowTypes.sv
+++ b/grammars/silver/driver/util/FlowTypes.sv
@@ -33,18 +33,8 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::Build
   local flowTypes1 :: Pair<[ProductionGraph] EnvTree<g:Graph<String>>> =
     fullySolveFlowTypes(prodGraph, rtm:empty(compareString));
   
-  -- Non-host syn patch the flow types! (Composition generates new equations
-  -- that requires non-host syn to potentially need to evaluate forwards
-  -- to be able to evaluate on new productions.) TODO: could this need to be iterated?? probably yes, so BUG!
-  local flowTypes2 :: EnvTree<g:Graph<String>> =
-    patchFlowTypes(flowTypes1.snd, allFlowDefs.nonHostSynAttrs);
-    
-  -- Iterate once more, to propagate the patch above across flow types!
-  local flowTypes3 :: Pair<[ProductionGraph] EnvTree<g:Graph<String>>> =
-    fullySolveFlowTypes(flowTypes1.fst, flowTypes2);
-  
-  production flowTypes :: EnvTree<g:Graph<String>> = flowTypes3.snd;
-  production finalGraphs :: [ProductionGraph] = flowTypes3.fst;
+  production flowTypes :: EnvTree<g:Graph<String>> = flowTypes1.snd;
+  production finalGraphs :: [ProductionGraph] = flowTypes1.fst;
   production finalGraphEnv :: EnvTree<ProductionGraph> = directBuildTree(map(prodGraphToEnv, finalGraphs));
   
   g.productionFlowGraphs = finalGraphEnv;

--- a/grammars/silver/translation/java/core/DclInfo.sv
+++ b/grammars/silver/translation/java/core/DclInfo.sv
@@ -39,6 +39,9 @@ top::DclInfo ::= sg::String sl::Location fnnt::String fnat::String ntty::TypeExp
 aspect production localDcl
 top::DclInfo ::= sg::String sl::Location fn::String ty::TypeExp
 {
+  -- TODO: BUG: See https://github.com/melt-umn/silver/issues/52
+  -- This is the kind of nasty hack that we might fix with a FullName type, instead of hacking on 'fn'
+  -- Also, this choice of name is actually buggy! Can cause java compiler errors with name collisions.
   local attribute li :: Integer;
   li = lastIndexOf(":local:", fn);
   top.attrOccursIndexName = makeIdName(substring(li+7, length(fn), fn) ++ "__ON__" ++ substring(0,li,fn));

--- a/grammars/silver/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/translation/java/core/ProductionBody.sv
@@ -103,7 +103,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::Type ';'
   local attribute prod_orig_name :: String;
   prod_orig_name = substring(lastIndexOf(":", top.signature.fullName)+1, length(top.signature.fullName), top.signature.fullName);
   local attribute ugh_dcl_hack :: DclInfo;
-  ugh_dcl_hack = head(getValueDclAll(fName, top.env)); -- TODO
+  ugh_dcl_hack = head(getValueDclAll(fName, top.env)); -- TODO really, we should have a DclInfo for ourselves no problem. but out current approach of constructing it via localDef makes this annoyingly difficult. this suggests a probably environment refactoring...
   
   top.valueWeaving := "public static final int " ++ ugh_dcl_hack.attrOccursIndexName ++ " = " ++ makeName(prod_orig_grammar) ++ ".Init.count_local__ON__" ++ makeIdName(top.signature.fullName) ++ "++;\n";
 


### PR DESCRIPTION
We need to enforce `ft(syn) >= ft(fwd)` for *extension* synthesized attribute occurrences.

Previously, we used a hack that didn't work perfectly. This is now removed.

This change means we now construct phantom production graphs for each nonterminal, which is exactly what is described in my thesis.