### PR TITLE
More work on functor attributes

### DIFF
--- a/grammars/silver/composed/idetest/Main.sv
+++ b/grammars/silver/composed/idetest/Main.sv
@@ -28,6 +28,8 @@ parser svParse::Root {
 
   silver:extension:templating;
   silver:extension:patternmatching;
+  
+  silver:extension:functorattrib;
 
   silver:modification:let_fix;
   silver:modification:collection;

--- a/grammars/silver/extension/functorattrib/ProductionBody.sv
+++ b/grammars/silver/extension/functorattrib/ProductionBody.sv
@@ -47,11 +47,7 @@ function makeArgs
         map(getOccursDcl(_, head(inputs).typerep.typeName, env),
           -- the full names of each candidate
           map((.fullName), attrName.lookupAttribute.dcls))));
-  local validTypeHead :: Boolean =
-    case head(inputs).typerep of
-      nonterminalTypeExp(_, _) -> true
-    | _ -> false
-    end;
+  local validTypeHead :: Boolean = head(inputs).typerep.isDecorable;
   
   return
     case inputs of

--- a/grammars/silver/extension/functorattrib/ProductionBody.sv
+++ b/grammars/silver/extension/functorattrib/ProductionBody.sv
@@ -5,9 +5,9 @@ import silver:langutil:pp;
  - Actual implementation in propagateOne
  -}
 concrete production propagateAttrDcl
-top::ProductionStmt ::= 'propagate' 'functor' ns::NameList ';'
+top::ProductionStmt ::= 'propagate' ns::NameList ';'
 {
-  top.pp = s"propagate functor ${ns.pp};";
+  top.pp = s"propagate ${ns.pp};";
   
   -- Forwards to productionStmtAppend of propagating the first element in ns
   -- and propagateAttrDcl containing the remaining names
@@ -18,7 +18,7 @@ top::ProductionStmt ::= 'propagate' 'functor' ns::NameList ';'
     | nameListCons(n, _, rest) ->
         productionStmtAppend(
           propagateOne(n, location=top.location),
-          propagateAttrDcl($1, $2, rest, $4, location=top.location),
+          propagateAttrDcl($1, rest, $3, location=top.location),
           location=top.location)
     end;
 }

--- a/grammars/silver/extension/functorattrib/ProductionBody.sv
+++ b/grammars/silver/extension/functorattrib/ProductionBody.sv
@@ -41,24 +41,31 @@ function makeArgs
   
   -- Check if the attribute occurs on the first child
   local attrOccursOnHead :: Boolean = 
-    null(
+    !null(
       foldr(append, [], 
         -- The occurs dcls on this nonterminal for
         map(getOccursDcl(_, head(inputs).typerep.typeName, env),
           -- the full names of each candidate
           map((.fullName), attrName.lookupAttribute.dcls))));
+  local validTypeHead :: Boolean =
+    case head(inputs).typerep of
+      nonterminalTypeExp(_, _) -> true
+    | _ -> false
+    end;
   
   return
     case inputs of
       [] -> []
     | h :: rest -> 
-        (if attrOccursOnHead
-         then presentAppExpr(baseExpr(at, location=loc), location=loc)
-         else presentAppExpr(
+        (if validTypeHead && attrOccursOnHead
+         then presentAppExpr(
                 access(
                   baseExpr(at, location=loc), '.',
                   qNameAttrOccur(attrName, location=loc),
                   location=loc),
+                location=loc)
+         else presentAppExpr(
+                baseExpr(at, location=loc),
                 location=loc)) :: makeArgs(loc, env, attrName, rest)
     end;
 }

--- a/test/silver_features/Functor.sv
+++ b/test/silver_features/Functor.sv
@@ -1,8 +1,9 @@
 
 synthesized attribute functorSyn<a> :: a;
+annotation functorTestAnno::Integer;
 
-nonterminal FunctorTestNT with functorSyn<FunctorTestNT>;
-nonterminal FunctorTestNT2 with functorSyn<FunctorTestNT2>;
+nonterminal FunctorTestNT with functorSyn<FunctorTestNT>, functorTestAnno;
+nonterminal FunctorTestNT2 with functorSyn<FunctorTestNT2>, functorTestAnno;
 
 abstract production consFTNT
 top::FunctorTestNT ::= h::FunctorTestNT  t::FunctorTestNT
@@ -31,11 +32,14 @@ top::FunctorTestNT2 ::= s::String
 global functorValue :: FunctorTestNT =
   consFTNT(
     consFTNT2(
-      nilFTNT2("a"),
-      nilFTNT(1)),
+      nilFTNT2("a", functorTestAnno=1),
+      nilFTNT(1, functorTestAnno=2),
+      functorTestAnno=3),
     consFTNT2(
-      nilFTNT2("b"),
-      nilFTNT(2)));
+      nilFTNT2("b", functorTestAnno=4),
+      nilFTNT(2, functorTestAnno=5),
+      functorTestAnno=6),
+    functorTestAnno=7);
 
 -- Test to ensure it reaches all nils:
 equalityTest(hackUnparse(functorValue), hackUnparse(functorValue.functorSyn), String, silver_tests);

--- a/test/silver_features/Functor.sv
+++ b/test/silver_features/Functor.sv
@@ -20,7 +20,7 @@ top::FunctorTestNT ::= h::FunctorTestNT2  t::FunctorTestNT
 abstract production nilFTNT
 top::FunctorTestNT ::= i::Integer
 {
-  propagate functorSyn;
+  top.functorSyn = nilFTNT(10, functorTestAnno=123); -- test non-propagate
 }
 
 abstract production nilFTNT2
@@ -40,6 +40,18 @@ global functorValue :: FunctorTestNT =
       nilFTNT(2, functorTestAnno=5),
       functorTestAnno=6),
     functorTestAnno=7);
+    
+global functorValueRes :: FunctorTestNT =
+  consFTNT(
+    consFTNT2(
+      nilFTNT2("a", functorTestAnno=1),
+      nilFTNT(10, functorTestAnno=123),
+      functorTestAnno=3),
+    consFTNT2(
+      nilFTNT2("b", functorTestAnno=4),
+      nilFTNT(10, functorTestAnno=123),
+      functorTestAnno=6),
+    functorTestAnno=7);
 
 -- Test to ensure it reaches all nils:
-equalityTest(hackUnparse(functorValue), hackUnparse(functorValue.functorSyn), String, silver_tests);
+equalityTest(hackUnparse(functorValueRes), hackUnparse(functorValue.functorSyn), String, silver_tests);

--- a/test/silver_features/Functor.sv
+++ b/test/silver_features/Functor.sv
@@ -7,25 +7,25 @@ nonterminal FunctorTestNT2 with functorSyn<FunctorTestNT2>;
 abstract production consFTNT
 top::FunctorTestNT ::= h::FunctorTestNT  t::FunctorTestNT
 {
-  propagate functor functorSyn;
+  propagate functorSyn;
 }
 
 abstract production consFTNT2
 top::FunctorTestNT ::= h::FunctorTestNT2  t::FunctorTestNT
 {
-  propagate functor functorSyn;
+  propagate functorSyn;
 }
 
 abstract production nilFTNT
 top::FunctorTestNT ::= i::Integer
 {
-  propagate functor functorSyn;
+  propagate functorSyn;
 }
 
 abstract production nilFTNT2
 top::FunctorTestNT2 ::= s::String
 {
-  propagate functor functorSyn;
+  propagate functorSyn;
 }
 
 global functorValue :: FunctorTestNT =

--- a/test/silver_features/Functor.sv
+++ b/test/silver_features/Functor.sv
@@ -1,32 +1,37 @@
 
 synthesized attribute functorSyn<a> :: a;
+synthesized attribute functorTestAnnoSum :: Integer;
 annotation functorTestAnno::Integer;
 
-nonterminal FunctorTestNT with functorSyn<FunctorTestNT>, functorTestAnno;
-nonterminal FunctorTestNT2 with functorSyn<FunctorTestNT2>, functorTestAnno;
+nonterminal FunctorTestNT with functorSyn<FunctorTestNT>, functorTestAnnoSum, functorTestAnno;
+nonterminal FunctorTestNT2 with functorSyn<FunctorTestNT2>, functorTestAnnoSum, functorTestAnno;
 
 abstract production consFTNT
 top::FunctorTestNT ::= h::FunctorTestNT  t::FunctorTestNT
 {
   propagate functorSyn;
+  top.functorTestAnnoSum = h.functorTestAnnoSum + t.functorTestAnnoSum + top.functorTestAnno;
 }
 
 abstract production consFTNT2
 top::FunctorTestNT ::= h::FunctorTestNT2  t::FunctorTestNT
 {
   propagate functorSyn;
+  top.functorTestAnnoSum = h.functorTestAnnoSum + t.functorTestAnnoSum + top.functorTestAnno;
 }
 
 abstract production nilFTNT
 top::FunctorTestNT ::= i::Integer
 {
   top.functorSyn = nilFTNT(10, functorTestAnno=123); -- test non-propagate
+  top.functorTestAnnoSum = top.functorTestAnno;
 }
 
 abstract production nilFTNT2
 top::FunctorTestNT2 ::= s::String
 {
   propagate functorSyn;
+  top.functorTestAnnoSum = top.functorTestAnno;
 }
 
 global functorValue :: FunctorTestNT =
@@ -55,3 +60,5 @@ global functorValueRes :: FunctorTestNT =
 
 -- Test to ensure it reaches all nils:
 equalityTest(hackUnparse(functorValueRes), hackUnparse(functorValue.functorSyn), String, silver_tests);
+-- Test to ensure annotations are copied correctly
+equalityTest(functorValueRes.functorTestAnnoSum, functorValue.functorSyn.functorTestAnnoSum, Integer, silver_tests);


### PR DESCRIPTION
Misc updates / fixes:
* Changed syntax as discussed
* Including the extension in the IDE spec
* Annotations are now copied from the current tree - before they were just missing
* Decorated nonterminals on the production RHS are now used directly, instead of copying by attribute.  