### PR TITLE
Do not strip carriage returns. Warn about forgetting them in terminals.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ JARS-BAK
 .\#*
 
 # Runtime and testing junk
-test/**/test.output
+test/**/*.test.output
 test/**/test.jar
 test/**/build.xml
 test/silver.testing.bin.jar

--- a/grammars/silver/definition/concrete_syntax/TerminalDcl.sv
+++ b/grammars/silver/definition/concrete_syntax/TerminalDcl.sv
@@ -30,6 +30,12 @@ top::AGDcl ::= t::TerminalKeywordModifier id::Name r::RegExpr tm::TerminalModifi
     if isLower(substring(0,1,id.name))
     then [err(id.location, "Types must be capitalized. Invalid terminal name " ++ id.name)]
     else [];
+  
+  -- This is a crude check, but effective.
+  top.errors <-
+    if indexOf("\\n", r.terminalRegExprSpec.regString) != -1 && indexOf("\\r", r.terminalRegExprSpec.regString) == -1
+    then [wrn(r.location, "Regex contains '\\n' but not '\\r'. This is your reminder about '\\r\\n' newlines.")]
+    else [];
 
   top.errors := tm.errors;
 

--- a/grammars/silver/definition/core/Terminals.sv
+++ b/grammars/silver/definition/core/Terminals.sv
@@ -107,5 +107,5 @@ terminal True_kwd  'true'   lexer classes {LITERAL,RESERVED};
 terminal False_kwd 'false'  lexer classes {LITERAL,RESERVED};
 terminal Int_t     /[\-]?[0-9]+/ lexer classes {LITERAL};
 terminal Float_t   /[\-]?[0-9]+[\.][0-9]+/ lexer classes {LITERAL};
-terminal String_t  /[\"]([^\n\"\\]|[\\][\"]|[\\][\\]|[\\]n|[\\]r|[\\]t)*[\"]/ lexer classes {LITERAL};
+terminal String_t  /[\"]([^\r\n\"\\]|[\\][\"]|[\\][\\]|[\\]n|[\\]r|[\\]t)*[\"]/ lexer classes {LITERAL};
 

--- a/grammars/silver/extension/easyterminal/TerminalDcl.sv
+++ b/grammars/silver/extension/easyterminal/TerminalDcl.sv
@@ -7,7 +7,7 @@ import silver:definition:type:syntax;
 import silver:definition:concrete_syntax;
 import silver:definition:regex only Regex_R, regString, literalRegex;
 
-terminal Terminal_t /\'[^\'\n]*\'/ lexer classes {LITERAL};
+terminal Terminal_t /\'[^\'\r\n]*\'/ lexer classes {LITERAL};
 
 -- TODO: refactor this to actually create two separate terminal declarations, one regular regex, one single quote.
     -- TODO: alternatively, we keep this as a 'RegExpr', but we introduce "added terminal modifiers" synthesized

--- a/grammars/silver/extension/templating/syntax/Templating.sv
+++ b/grammars/silver/extension/templating/syntax/Templating.sv
@@ -4,9 +4,9 @@ import silver:definition:core only Expr, RCurly_t, LITERAL;
 
 terminal TripleQuote /\"\"\"/ lexer classes {LITERAL};
 terminal DoubleDollar '$$' lexer classes {LITERAL};
-terminal QuoteWater /[^$\n\t\"\\]+/ lexer classes {LITERAL};
-terminal SingleLineQuoteWater /([^$\n\t\"\\]|[\\][\"]|[\\][\\]|[\\]n|[\\]r|[\\]t)+/ lexer classes {LITERAL};
-terminal LiteralNewline /\n/ lexer classes {LITERAL};
+terminal QuoteWater /[^$\r\n\t\"\\]+/ lexer classes {LITERAL};
+terminal SingleLineQuoteWater /([^$\r\n\t\"\\]|[\\][\"]|[\\][\\]|[\\]n|[\\]r|[\\]t)+/ lexer classes {LITERAL};
+terminal LiteralNewline /(\n|\r\n)/ lexer classes {LITERAL};
 terminal LiteralTab /\t/ lexer classes {LITERAL};
 terminal LiteralQuote /\"/ lexer classes {LITERAL};
 terminal LiteralBackslash /\\/ lexer classes {LITERAL};
@@ -171,6 +171,7 @@ concrete production waterNewline
 top::WaterItem ::= LiteralNewline
 layout {}
 {
+  -- We always interpret newlines as just \n, even if the source file was \r\n.
   top.waterString = "\\n";
 }
 

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -236,9 +236,7 @@ public final class Util {
 			in.readFully(b); // The only reason we use DataInputStream is this method.
 			in.close();
 			fis.close();
-			// TODO: is there a better way of handling \r\n? (Maybe implicitly in copper specs?)
-			// (We should also probably be more discriminating about charsets)
-			return new StringCatter(new String(b).replace("\r\n","\n"));
+			return new StringCatter(new String(b));
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
Fixes #24 and also fixes #49 

We discussed making this change long ago, as removing carriage returns now causes more problems than it solves (see #49.)

In order to help the transition along, I added a nice little hack of a warning to discover potentially broken terminal regexes. Then I fixed a few it discovered in Silver. Hah!