### PR TITLE
Correct handling of lazy value parameters

### DIFF
--- a/grammars/silver/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/modification/lambda_fn/java/Lambda.sv
@@ -48,6 +48,9 @@ top::ProductionRHS ::=
 aspect production productionRHSElem
 top::ProductionRHSElem ::= id::Name '::' t::Type
 {
+  -- Args are unpacked as objects, they can either be an actual value or a Thunk.
+  -- We don't know which staticly, so they are just stored as Objects until use.
+  -- They are then demanded and converted to the correct type where they are needed.
   top.lambdaTranslation = s"final Object ${makeLambdaParamValueName(fName)} = args[${toString(top.accessIndex)}];\n";
 }
 

--- a/grammars/silver/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/modification/lambda_fn/java/Lambda.sv
@@ -48,7 +48,7 @@ top::ProductionRHS ::=
 aspect production productionRHSElem
 top::ProductionRHSElem ::= id::Name '::' t::Type
 {
-  top.lambdaTranslation = makeLambdaParamBinding(fName, t.typerep, top.accessIndex);
+  top.lambdaTranslation = s"final Object ${makeLambdaParamValueName(fName)} = args[${toString(top.accessIndex)}];\n";
 }
 
 function makeLambdaParamValueName
@@ -57,16 +57,10 @@ String ::= s::String
   return "__SV_LAMBDA_PARAM_" ++ makeIdName(s);
 }
 
-function makeLambdaParamBinding
-String ::= fn::String ty::TypeExp index::Integer
-{
-  return s"final ${ty.transType} ${makeLambdaParamValueName(fn)} = (${ty.transType})args[${toString(index)}];\n";
-}
-
 aspect production lambdaParamReference
 top::Expr ::= q::Decorated QName
 {
-  top.translation = makeLambdaParamValueName(q.lookupValue.fullName);
+  top.translation = s"((${top.typerep.transType})common.Util.demand(${makeLambdaParamValueName(q.lookupValue.fullName)}))";
   top.lazyTranslation = top.translation;
 }
 

--- a/test/silver_features/Lambda.sv
+++ b/test/silver_features/Lambda.sv
@@ -20,3 +20,6 @@ equalityTest(curriedSum(1)(2), 3, Integer, silver_tests);
 global differentTypes::((String ::= String) ::= Integer) = \ x::Integer -> \ x::String -> x;
 
 equalityTest(differentTypes(1)("abcd"), "abcd", String, silver_tests);
+
+global param::Integer = 4;
+equalityTest(addThree(param), 4, Integer, silver_tests);

--- a/test/silver_features/Lambda.sv
+++ b/test/silver_features/Lambda.sv
@@ -22,4 +22,4 @@ global differentTypes::((String ::= String) ::= Integer) = \ x::Integer -> \ x::
 equalityTest(differentTypes(1)("abcd"), "abcd", String, silver_tests);
 
 global param::Integer = 4;
-equalityTest(addThree(param), 4, Integer, silver_tests);
+equalityTest(addThree(param), 7, Integer, silver_tests);


### PR DESCRIPTION
This fixes a bug with Thunks passes in as objects being casted to their final types directly, instead of being unpacked if needed.  