### PR TITLE
Feature/modanalysis

### DIFF
--- a/grammars/silver/definition/flow/driver/DumpGraph.sv
+++ b/grammars/silver/definition/flow/driver/DumpGraph.sv
@@ -52,7 +52,7 @@ function unList
 
 
 abstract production dumpFlowGraphAction
-top::DriverAction ::= prodGraph::[ProductionGraph]  finalGraph::[ProductionGraph]  flowTypes::[Pair<String [g:Graph<String>]>]
+top::DriverAction ::= prodGraph::[ProductionGraph]  finalGraph::[ProductionGraph]  flowTypes::[Pair<String [FlowType]>]
 {
   top.io = 
     writeFile("flow-types.dot", "digraph flow {\n" ++ generateFlowDotGraph(flowTypes) ++ "}", 
@@ -66,7 +66,7 @@ top::DriverAction ::= prodGraph::[ProductionGraph]  finalGraph::[ProductionGraph
 
 
 function generateFlowDotGraph
-String ::= flowTypes::[Pair<String [g:Graph<String>]>]
+String ::= flowTypes::[Pair<String [FlowType]>]
 {
   local nt::String = head(flowTypes).fst;
   local edges::[Pair<String String>] = g:toList(head(head(flowTypes).snd));

--- a/grammars/silver/definition/flow/driver/DumpGraph.sv
+++ b/grammars/silver/definition/flow/driver/DumpGraph.sv
@@ -36,6 +36,8 @@ top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
     else [];
 }
 
+-- Coalesce sequences of pairs with the same key
+-- e.g. "ab,ac,ad,bc,bd -> a[bcd],b[cd]"
 function unList
 [Pair<String [b]>] ::= l::[Pair<String b>]
 {
@@ -101,18 +103,20 @@ String ::= specs::[ProductionGraph]
 {
   return case specs of
   | [] -> ""
-  | productionGraph(prod, _, _, graph, _, _)::t ->
+  | productionGraph(prod, _, _, graph, suspect, _) :: t ->
       "subgraph \"cluster:" ++ prod ++ "\" {\n" ++ 
-      implode("", map(makeDotArrow(prod, _), g:toList(graph))) ++
+      implode("", map(makeDotArrow(prod, _, ""), g:toList(graph))) ++
+      implode("", map(makeDotArrow(prod, _, " [style=dotted]"), suspect)) ++
       "}\n" ++
       generateDotGraph(t)
   end;
 }
 
+-- "production/flowvertex" -> "production/flowvertex"
 function makeDotArrow
-String ::= p::String e::Pair<FlowVertex FlowVertex>
+String ::= p::String e::Pair<FlowVertex FlowVertex> style::String
 {
-  return "\"" ++ p ++ "/" ++ e.fst.dotName ++ "\" -> \"" ++ p ++ "/" ++ e.snd.dotName ++ "\";\n";
+  return "\"" ++ p ++ "/" ++ e.fst.dotName ++ "\" -> \"" ++ p ++ "/" ++ e.snd.dotName ++ "\"" ++ style ++ ";\n";
 }
 
 

--- a/grammars/silver/definition/flow/driver/FlowGraph.sv
+++ b/grammars/silver/definition/flow/driver/FlowGraph.sv
@@ -18,6 +18,7 @@ ProductionGraph ::= n::String  l::EnvTree<ProductionGraph>
   return head(lookup);
 }
 
+-- These two functions are used by Inh.sv:
 function expandGraph
 [FlowVertex] ::= v::[FlowVertex]  e::ProductionGraph
 {
@@ -27,7 +28,7 @@ function expandGraph
 function onlyLhsInh
 set:Set<String> ::= s::[FlowVertex]
 {
-  return set:add(foldr(collectInhs, [], s), set:empty(compareString));
+  return set:add(filterLhsInh(s), set:empty(compareString));
 }
 
 {--

--- a/grammars/silver/definition/flow/driver/FlowGraph.sv
+++ b/grammars/silver/definition/flow/driver/FlowGraph.sv
@@ -3,9 +3,9 @@ grammar silver:definition:flow:driver;
 type FlowType = g:Graph<String>;
 
 function findFlowType
-g:Graph<String> ::= prod::String  e::EnvTree<FlowType>
+FlowType ::= prod::String  e::EnvTree<FlowType>
 {
-  local lookup :: [g:Graph<String>] = searchEnvTree(prod, e);
+  local lookup :: [FlowType] = searchEnvTree(prod, e);
   
   return if null(lookup) then g:empty(compareString) else head(lookup);
 }
@@ -57,9 +57,7 @@ Boolean ::= v::FlowVertex  inhSet::set:Set<String>
 function compareFlowVertex
 Integer ::= a::FlowVertex  b::FlowVertex
 {
-  local astr :: String = a.unparse;
-  local bstr :: String = b.unparse;
-  return if astr < bstr then -1 else if astr == bstr then 0 else 1;
+  return if a.unparse < b.unparse then -1 else if a.unparse == b.unparse then 0 else 1;
 }
 
 function createFlowGraph

--- a/grammars/silver/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/definition/flow/driver/FlowTypes.sv
@@ -110,9 +110,17 @@ function findBrandNewEdges
 function expandVertexFilterTo
 Pair<String [String]> ::= ver::FlowVertex  graph::ProductionGraph
 {
-  return pair(ver.flowTypeName, foldr(collectInhs, [], set:toList(graph.edgeMap(ver)))); -- TODO: faster? using sets
+  return pair(ver.flowTypeName, filterLhsInh(set:toList(graph.edgeMap(ver)))); -- TODO: faster? using sets
 }
 
+{--
+ - Filters vertexes down to just the names of inherited attributes on the LHS
+ -}
+function filterLhsInh
+[String] ::= f::[FlowVertex]
+{
+  return foldr(collectInhs, [], f);
+}
 
 {--
  - Used to filter down to just the inherited attributes

--- a/grammars/silver/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/definition/flow/driver/FlowTypes.sv
@@ -34,16 +34,16 @@ function computeAllProductionGraphs
  - Iterates until convergence.
  -}
 function fullySolveFlowTypes
-Pair<[ProductionGraph] EnvTree<g:Graph<String>>> ::= 
+Pair<[ProductionGraph] EnvTree<FlowType>> ::= 
   graphs::[ProductionGraph]
-  ntEnv::EnvTree<g:Graph<String>>
+  ntEnv::EnvTree<FlowType>
 {
   -- Each iteration, we rebuild this... :/
   -- TODO: consider a 'mapValuesWithMapState' function :: 'k1, v1, map<k1 v1>, map<k2 v2> -> v1, k2, v2'
   local prodEnv :: EnvTree<ProductionGraph> =
     directBuildTree(map(prodGraphToEnv, graphs));
   
-  local iter :: Pair<Boolean Pair<[ProductionGraph] EnvTree<g:Graph<String>>>> =
+  local iter :: Pair<Boolean Pair<[ProductionGraph] EnvTree<FlowType>>> =
     solveFlowTypes(graphs, prodEnv, ntEnv);
   
   -- Just iterate until no new edges are added
@@ -57,10 +57,10 @@ Pair<[ProductionGraph] EnvTree<g:Graph<String>>> ::=
 function solveFlowTypes
 Pair<Boolean
      Pair<[ProductionGraph]
-          EnvTree<g:Graph<String>>>> ::=
+          EnvTree<FlowType>>> ::=
   graphs::[ProductionGraph]
   prodEnv::EnvTree<ProductionGraph>
-  ntEnv::EnvTree<g:Graph<String>>
+  ntEnv::EnvTree<FlowType>
 {
   local graph :: ProductionGraph = head(graphs);
   graph.flowTypes = ntEnv;
@@ -69,7 +69,7 @@ Pair<Boolean
   stitchedGraph.flowTypes = ntEnv;
   local updatedGraph :: ProductionGraph = stitchedGraph.cullSuspect;
 
-  local currentFlowType :: g:Graph<String> = findFlowType(graph.lhsNt, ntEnv);
+  local currentFlowType :: FlowType = findFlowType(graph.lhsNt, ntEnv);
   
   -- The New Improved Flow Type
   local synExpansion :: [Pair<String [String]>] =
@@ -79,10 +79,10 @@ Pair<Boolean
   local brandNewEdges :: [Pair<String String>] =
     findBrandNewEdges(synExpansion, currentFlowType);
     
-  local newFlowType :: g:Graph<String> =
+  local newFlowType :: FlowType =
     g:add(brandNewEdges, currentFlowType); -- TODO: faster?
   
-  local recurse :: Pair<Boolean Pair<[ProductionGraph] EnvTree<g:Graph<String>>>> =
+  local recurse :: Pair<Boolean Pair<[ProductionGraph] EnvTree<FlowType>>> =
     solveFlowTypes(tail(graphs), prodEnv, rtm:update(graph.lhsNt, [newFlowType], ntEnv));
     
   return if null(graphs) then pair(false, pair([], ntEnv))
@@ -91,7 +91,7 @@ Pair<Boolean
 
 
 function findBrandNewEdges
-[Pair<String String>] ::= candidates::[Pair<String [String]>]  currentFlowType::g:Graph<String>
+[Pair<String String>] ::= candidates::[Pair<String [String]>]  currentFlowType::FlowType
 {
   local syn :: String = head(candidates).fst;
   local inhs :: [String] = head(candidates).snd;

--- a/grammars/silver/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/definition/flow/driver/ProductionGraph.sv
@@ -5,7 +5,7 @@ import silver:definition:type only isDecorable;
 
 nonterminal ProductionGraph with flowTypes, stitchedGraph, prod, lhsNt, transitiveClosure, edgeMap, cullSuspect, flowTypeVertexes, prodGraphs;
 
-inherited attribute flowTypes :: EnvTree<g:Graph<String>>;
+inherited attribute flowTypes :: EnvTree<FlowType>;
 inherited attribute prodGraphs :: EnvTree<ProductionGraph>;
 
 -- TODO: future me note: these are good candidates to be "static attributes" maybe?
@@ -342,7 +342,7 @@ Pair<String ProductionGraph> ::= p::ProductionGraph
  -          always an lhsInhVertex.
  -}
 function findAdmissibleEdges
-[Pair<FlowVertex FlowVertex>] ::= edge::Pair<FlowVertex FlowVertex>  graph::g:Graph<FlowVertex>  ft::g:Graph<String>
+[Pair<FlowVertex FlowVertex>] ::= edge::Pair<FlowVertex FlowVertex>  graph::g:Graph<FlowVertex>  ft::FlowType
 {
   -- The current flow type of the edge's source vertex (which is always a thing in the flow type)
   local currentDeps :: set:Set<String> =

--- a/grammars/silver/definition/flow/driver/StitchPoint.sv
+++ b/grammars/silver/definition/flow/driver/StitchPoint.sv
@@ -83,7 +83,7 @@ function projectAttribute
 
 -- Useful for mapping
 function stitchEdgesFor
-[Pair<FlowVertex FlowVertex>] ::= sp::StitchPoint  ntEnv::EnvTree<g:Graph<String>>  prodEnv::EnvTree<ProductionGraph>
+[Pair<FlowVertex FlowVertex>] ::= sp::StitchPoint  ntEnv::EnvTree<FlowType>  prodEnv::EnvTree<ProductionGraph>
 {
   sp.prodGraphs = prodEnv;
   sp.flowTypes = ntEnv;

--- a/grammars/silver/definition/flow/driver/StitchPoint.sv
+++ b/grammars/silver/definition/flow/driver/StitchPoint.sv
@@ -75,7 +75,7 @@ function projectAttribute
     -- Turn into inh vertexes (in this production) on targetType
     map(targetType.inhVertex,
       -- Filter down to just LHS Inh in that production, (string names)
-      foldr(collectInhs, [], 
+      filterLhsInh(
         -- Deps of this vertex in that other production
         set:toList(prod.edgeMap(prodType.inhVertex(attr))))));
 }

--- a/grammars/silver/driver/util/FlowTypes.sv
+++ b/grammars/silver/driver/util/FlowTypes.sv
@@ -33,10 +33,10 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::Build
       map(constructPhantomProductionGraph(_, allFlowEnv, allRealEnv), allNts);
   
   -- Now, solve for flow types!!
-  local flowTypes1 :: Pair<[ProductionGraph] EnvTree<g:Graph<String>>> =
+  local flowTypes1 :: Pair<[ProductionGraph] EnvTree<FlowType>> =
     fullySolveFlowTypes(prodGraph, rtm:empty(compareString));
   
-  production flowTypes :: EnvTree<g:Graph<String>> = flowTypes1.snd;
+  production flowTypes :: EnvTree<FlowType> = flowTypes1.snd;
   production finalGraphs :: [ProductionGraph] = flowTypes1.fst;
   production finalGraphEnv :: EnvTree<ProductionGraph> = directBuildTree(map(prodGraphToEnv, finalGraphs));
   

--- a/runtime/java/src/common/rawlib/RawGraph.java
+++ b/runtime/java/src/common/rawlib/RawGraph.java
@@ -105,6 +105,7 @@ public final class RawGraph {
 			return g;
 		// Note that this clone only the tree map... it's up to us to clone the sets in the values.
 		TreeMap<Object,TreeSet<Object>> ret = (TreeMap<Object,TreeSet<Object>>)g.clone();
+		// This set tracks what elements are safe to mutate in 'ret' (i.e. have been cloned)
 		TreeSet<Object> mutated = new TreeSet<Object>(g.comparator());
 		
 		for(core.NPair elem : new ConsCellCollection<core.NPair>(l)) {
@@ -115,7 +116,9 @@ public final class RawGraph {
 			// So we have a transitively closed graph, currently, and we
 			// suddenly want to add the edge (src, dst), and repair the closure.
 			
+			// Obtain the transitive dependencies of src (which we can change)
 			TreeSet<Object> srcSet = getMutatable(src, ret, mutated);
+			// Transitive dependenceis of dst (need, but won't change)
 			TreeSet<Object> dstSet = ret.get(dst);
 			
 			// Short circuit if edge exists already
@@ -166,7 +169,7 @@ public final class RawGraph {
 		if(setToModify == null) {
 			setToModify = new TreeSet<Object>(ret.comparator());
 		} else {
-			setToModify = (TreeSet<Object>)ret.get(key).clone();
+			setToModify = (TreeSet<Object>)setToModify.clone();
 		}
 		ret.put(key, setToModify);
 		mutated.add(key);

--- a/test/stdlib/rawgraph/TestGraph.sv
+++ b/test/stdlib/rawgraph/TestGraph.sv
@@ -80,9 +80,16 @@ global g5 :: g:Graph<Integer> =
 global g6 :: g:Graph<Integer> =
   g:repairClosure([pair(6,1)], g4);
 
+global g7 :: g:Graph<Integer> =
+  g:repairClosure([pair(3,1)], g4);
+
+global g8 :: g:Graph<Integer> =
+  g:repairClosure([pair(3,1), pair(6, 4)], g4);
+
 equalityTest ( length(g:toList(g3)), 5, Integer, core_tests ) ;
 equalityTest ( length(g:toList(g4)), (0 + 1 + 2 + 3 + 4 + 5), Integer, core_tests ) ;
 equalityTest ( length(g:toList(g5)), (6 * 6), Integer, core_tests ) ;
 equalityTest ( length(g:toList(g6)), (6 * 6), Integer, core_tests ) ;
-
+equalityTest ( length(g:toList(g7)), 21, Integer, core_tests ) ;
+equalityTest ( length(g:toList(g8)), 27, Integer, core_tests ) ;
 


### PR DESCRIPTION
The primary change in these patches is to alter `repairClosure` to significantly reduce the number of comparisons it performs. Comparisons are actually quite expensive, and it's much better for performance to trade-off excessive duplication of graphs than to try to use comparisons to avoid them.

Hey @krame505 can you help me test this out. Specifically, I'd be interested to know (a) how long this takes on that problem AbleC branch now, and (b) whether you see any new errors show up that weren't there before. (Or errors disappearing, for that matter.)

Unfortunately, there isn't a good test suite for the modularity analysis so changes are difficult to judge, exactly. Silver itself shows the same errors being reported, so that's some confidence.

This change is related to issue #79 but I do not consider it resolved, yet.