### PR TITLE
make parts of the driver more reusable

### DIFF
--- a/grammars/silver/driver/Command.sv
+++ b/grammars/silver/driver/Command.sv
@@ -131,6 +131,7 @@ Either<String  Decorated CmdArgs> ::= args::[String]
          else right(a);
 }
 
+-- This uses Either backwards. TODO: flip order? "right is correct" also TODO: use RunError?
 function determineBuildEnv
 IOVal<Either<BuildEnv [String]>> ::= a::Decorated CmdArgs  ioin::IO
 {


### PR DESCRIPTION
Hi @TravisCarlson 

I need to get back to doing other things. I got into a fight with the driver, and I think I've managed to come away with an improvement that should allow the IDE driver bits to more easily re-use what we have in the normal driver here.

I haven't actually re-written the IDE bits though. I'm pretty sure I didn't break them though, so I've got that going for me.

With this change we should be able to call `cmdLineRunInitial` (uhhh... so that was sort of a temporary name I never fixed. Maybe rename that to something better. I dunno what though! OH! And when we're calling it from Java code, there should be a comment on the function saying that. So we later don't think we can freely rename it and assume everything's fine.) and then implement the rest on the Java side of things (to implement the Java equivalent of `ideAnalyze` re: #81)

(Also, not sure if it's clear, but I think we should be able to do a better job of implementing the equivalent of `ideGenerate` using state. That is, save the `Decorated Compilation` from the previous analyze and then use it to call the postOps somehow. This might be obfuscated by the present design of these hooks in the silver-eclipse runtime. So maybe I'll have to look at that again. But right now "analyze" does a whole build to look for errors, and then "generate" does a full build again assuming no errors to actually do generation. This is pointlessly inefficient, it's just that we never did anything with state passing to fix it.)

If you think this looks sane, go ahead and merge it (and delete branch.) Thanks! (N.B. I'm requesting this into develop, not your branch so you'd want to merge it there too ofc.)