### PR TITLE
Change Location and Message to add proper support for built-in locations

### DIFF
--- a/grammars/core/Location.sv
+++ b/grammars/core/Location.sv
@@ -1,13 +1,11 @@
 grammar core;
 
-import silver:langutil only unparse;
-
 annotation location :: Location;
 
 {--
  - Data structure storing location information on tree nodes from a parse.
  -}
-nonterminal Location with unparse, filename, line, column, endLine, endColumn, index, endIndex;
+nonterminal Location with filename, line, column, endLine, endColumn, index, endIndex;
 
 synthesized attribute filename :: String;
 synthesized attribute line :: Integer;
@@ -39,7 +37,6 @@ top::Location ::= filename::String  line::Integer  column::Integer
                   endLine::Integer  endColumn::Integer
                   index::Integer  endIndex::Integer
 {
-  top.unparse = filename ++ ":" ++ toString(line) ++ ":" ++ toString(column);
   top.filename = filename;
   top.line = line;
   top.column = column;
@@ -57,7 +54,6 @@ top::Location ::= filename::String  line::Integer  column::Integer
 abstract production builtinLoc
 top::Location ::= module::String
 {
-  top.unparse = "Built in from " ++ module;
   top.filename = "builtin";
   top.line = -1;
   top.column = -1;

--- a/grammars/core/Location.sv
+++ b/grammars/core/Location.sv
@@ -1,11 +1,13 @@
 grammar core;
 
+import silver:langutil only unparse;
+
 annotation location :: Location;
 
 {--
  - Data structure storing location information on tree nodes from a parse.
  -}
-nonterminal Location with filename, line, column, endLine, endColumn, index, endIndex;
+nonterminal Location with unparse, filename, line, column, endLine, endColumn, index, endIndex;
 
 synthesized attribute filename :: String;
 synthesized attribute line :: Integer;
@@ -16,7 +18,7 @@ synthesized attribute index :: Integer;
 synthesized attribute endIndex :: Integer;
 
 {--
- - The sole constructor for location information.
+ - The main constructor for location information.
  -
  - filename, line and column can be mutated by action blocks during parsing,
  - but character index cannot.
@@ -37,7 +39,7 @@ top::Location ::= filename::String  line::Integer  column::Integer
                   endLine::Integer  endColumn::Integer
                   index::Integer  endIndex::Integer
 {
-  --top.unparse = filename ++ ":" ++ toString(line) ++ ":" ++ toString(column);
+  top.unparse = filename ++ ":" ++ toString(line) ++ ":" ++ toString(column);
   top.filename = filename;
   top.line = line;
   top.column = column;
@@ -45,6 +47,24 @@ top::Location ::= filename::String  line::Integer  column::Integer
   top.endColumn = endColumn;
   top.index = index;
   top.endIndex = endIndex;
+}
+
+{--
+ - A secondary constructor for location information, for use by extensions.
+ -
+ - @param module The name of the module or extension where this location is defined
+ -}
+abstract production builtinLoc
+top::Location ::= module::String
+{
+  top.unparse = "Built in from " ++ module;
+  top.filename = "builtin";
+  top.line = -1;
+  top.column = -1;
+  top.endLine = -1;
+  top.endColumn = -1;
+  top.index = -1;
+  top.endIndex = -1;
 }
 
 {--

--- a/grammars/core/Location.sv
+++ b/grammars/core/Location.sv
@@ -47,20 +47,40 @@ top::Location ::= filename::String  line::Integer  column::Integer
 }
 
 {--
- - A secondary constructor for location information, for use by extensions.
+ - A secondary constructor for location information, for locations not from source code
  -
- - @param module The name of the module or extension where this location is defined
+ - @param text The text to return as unparse as defined in langutil
  -}
-abstract production builtinLoc
-top::Location ::= module::String
+abstract production txtLoc
+top::Location ::= text::String
 {
-  top.filename = "builtin";
+  top.filename = "N/A";
   top.line = -1;
   top.column = -1;
   top.endLine = -1;
   top.endColumn = -1;
   top.index = -1;
   top.endIndex = -1;
+}
+
+{--
+ - A helper constructor for location information, for built-in locations
+ -
+ - @param module The name of the extension/modifcation/module defining the location
+ -}
+function builtinLoc
+Location ::= module::String
+{
+  return txtLoc("Built in from " ++ module);
+}
+
+{--
+ - A helper constructor for location information, for invalid or undefined bogus locations
+ -}
+function bogusLoc
+Location ::=
+{
+  return txtLoc("Invalid or undefined bogus location");
 }
 
 {--

--- a/grammars/silver/langutil/Location.sv
+++ b/grammars/silver/langutil/Location.sv
@@ -1,0 +1,17 @@
+grammar silver:langutil;
+
+attribute unparse occurs on Location;
+
+aspect production loc
+top::Location ::= filename::String  line::Integer  column::Integer
+                  endLine::Integer  endColumn::Integer
+                  index::Integer  endIndex::Integer
+{
+  top.unparse = filename ++ ":" ++ toString(line) ++ ":" ++ toString(column);
+}
+
+aspect production builtinLoc
+top::Location ::= module::String
+{
+  top.unparse = "Built in from " ++ module;
+}

--- a/grammars/silver/langutil/Location.sv
+++ b/grammars/silver/langutil/Location.sv
@@ -10,8 +10,8 @@ top::Location ::= filename::String  line::Integer  column::Integer
   top.unparse = filename ++ ":" ++ toString(line) ++ ":" ++ toString(column);
 }
 
-aspect production builtinLoc
-top::Location ::= module::String
+aspect production txtLoc
+top::Location ::= text::String
 {
-  top.unparse = "Built in from " ++ module;
+  top.unparse = text;
 }

--- a/grammars/silver/langutil/Message.sv
+++ b/grammars/silver/langutil/Message.sv
@@ -33,7 +33,7 @@ top::Message ::= l::Location m::String
 {
   top.where = l;
   top.message = m;
-  top.output = l.filename ++ ":" ++ toString(l.line) ++ ":" ++ toString(l.column) ++ ": error: " ++ m;
+  top.output = l.unparse ++ ": error: " ++ m;
   top.severity = 0;
 }
 
@@ -46,7 +46,7 @@ top::Message ::= l::Location m::String
 {
   top.where = l;
   top.message = m;
-  top.output = l.filename ++ ":" ++ toString(l.line) ++ ":" ++ toString(l.column) ++ ": warning: " ++ m;
+  top.output = l.unparse ++ ": warning: " ++ m;
   top.severity = 0;
 }
 


### PR DESCRIPTION
Ted's (relevant) comments from before:
3. If we're introducing a builtinLoc should we have a bogusLoc as well? What about a generatedLoc construct? I've resisted trying to stuff this stuff into core previously just because I think there's a good design question to solve here. But maybe it's not such a big deal, we can deal with it later? We can always refactor code, I guess. :)
4. MAAAAJJJOR possible issue: there may be Java code in the runtime that assumes an NLocation is always a Ploc. I don't know. But this should be investigated. Perhaps this would be a good reason to make builtinLoc a function that just yields a loc? Is there a reason to prefer it as a separate production?