### PR TITLE
fix/vimhl: Issue #109, vim block comments

### DIFF
--- a/support/vim/sv.vim
+++ b/support/vim/sv.vim
@@ -36,7 +36,7 @@ syn keyword svlangTermAttr lexeme filename line column
 
 syn region svlangBlock start=/\v\{/ end=/\v\}/		transparent fold
 syn region svlangDocComment start=/\v\{--/ end=/\v-\}/	contains=svlangTodo,svlangBlockComment,svlangDocComment,svlangDocTags,svlangDocSeeTag fold
-syn region svlangBlockComment start=/\v\{-[^-]?/ end=/\v-\}/	contains=svlangTodo,svlangBlockComment,svlangDocComment fold
+syn region svlangBlockComment start=/\v\{-([^-]|$)/ end=/\v-\}/	contains=svlangTodo,svlangBlockComment,svlangDocComment fold
 syn match svlangComment /\v--.*/ 			contains=svlangTodo
 syn match svlangRegex /\v\/((\\\/)|[^/])*\//
 syn match svlangType /\v[^:]::[\\ ]*\zs(([A-Za-z_][A-Z0-9a-z_]+:\\)*[A-Z][A-Z0-9a-z_]*)/


### PR DESCRIPTION
Fixes Issue #109 regarding syntax highlighting of block comments in the vim editor.