### PR TITLE
Adds charsToString and stringToChars.

### DIFF
--- a/grammars/core/String.sv
+++ b/grammars/core/String.sv
@@ -289,3 +289,28 @@ Boolean ::= s1::String s2::String
   return s1 <= s2;
 }
 
+{--
+ - Converts a list of code points to a string. Note that due to Java's use of
+ - UCS-2, code points greater than 0xFFFF (i.e. and characters outside the Basic
+ - Multilingual Plane) aren't supported.
+ -}
+function charsToString
+String ::= chars::[Integer]
+{
+  return error("Foreign Function");
+} foreign {
+  "java" : return "common.StringCatter.fromChars(%chars%)";
+}
+
+{--
+ - Converts a string to a list of its UCS-2 characters. Note that this means
+ - that surrogate pairs are (probably?) not supported, and characters outside
+ - the Basic Multilingual Plane aren't as a consequence.
+ -}
+function stringToChars
+[Integer] ::= str::String
+{
+  return error("Foreign Function");
+} foreign {
+  "java" : return "%str%.toChars()";
+}

--- a/runtime/java/src/common/StringCatter.java
+++ b/runtime/java/src/common/StringCatter.java
@@ -1,5 +1,6 @@
 package common;
 
+import java.io.CharArrayWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.io.IOException;
@@ -103,4 +104,35 @@ public final class StringCatter {
 		snd.write(fout);
 	}
 	
+	/**
+	 * Creates a StringCatter from a cons-list of code points.
+	 */
+    public static StringCatter fromChars(ConsCell list) {
+		StringBuilder str = new StringBuilder();
+		while(!list.nil()) {
+			str.append((char) ((Integer) list.head()).intValue());
+			list = list.tail();
+		}
+		return new StringCatter(str.toString());
+	}
+	
+	/**
+	 * Creates a list of code points from the string.
+	 */
+    public ConsCell toChars() {
+		CharArrayWriter w = new CharArrayWriter(length());
+		try {
+			write(w);
+		} catch(IOException e) {
+			// This should be impossible.
+			throw new RuntimeException(e);
+		}
+
+		ConsCell out = ConsCell.nil;
+		char[] chars = w.toCharArray();
+		for(int i = chars.length - 1; i >= 0; i--) {
+			out = new ConsCell(Integer.valueOf(chars[i]), out);
+		}
+		return out;
+	}
 }


### PR DESCRIPTION
Does the simple thing and converts the string to/from a `char[]`, which is converted to/from a `[Integer]`. This allows manipulating nonprintable characters, as well as Unicode characters that we might not want to include in our source code.