### PR TITLE
Generate files in a single pass

### DIFF
--- a/grammars/core/IO.sv
+++ b/grammars/core/IO.sv
@@ -264,6 +264,34 @@ IOVal<Boolean> ::= s::String i::IO
 } foreign {
   "java" : return "new core.Pioval(%i%, common.Util.deleteFile(%s%.toString()))";
 }
+{--
+ - Delete a set of files.
+ -
+ - @param s  The list of paths to files to delete.
+ - @param i  The "before" world-state token.
+ - @return  true if all files are deleted successfully.  false otherwise.
+ -}
+function deleteFiles
+IOVal<Boolean> ::= s::[String] i::IO
+{
+  return error("Not Yet Implemented: deleteFiles");
+} foreign {
+  "java" : return "new core.Pioval(%i%, common.Util.deleteFiles(%s%))";
+}
+{--
+ - Empty a directory of all normal files (i.e. leaving subdirectories alone)
+ -
+ - @param s  The path to the directory to empty
+ - @param i  The "before" world-state token.
+ - @return  true if contents are deleted successfully.  false otherwise.
+ -}
+function deleteDirFiles
+IOVal<Boolean> ::= s::String i::IO
+{
+  return error("Not Yet Implemented: deleteDirFiles");
+} foreign {
+  "java" : return "new core.Pioval(%i%, common.Util.deleteDirFiles(%s%.toString()))";
+}
 
 {--
  - Delete a non-empty directory and all subdirectories and files.
@@ -308,6 +336,20 @@ IO ::= file::String i::IO
   return error("Not Yet Implemented: touchFile");
 } foreign {
   "java" : return "common.Util.io(%i%, common.Util.touchFile(%file%.toString()))";
+}
+{--
+ - Update a set of files' modification time to the current time.
+ - 
+ - @param files  The list of files to update the modification time of.
+ - @param i  The IO token.
+ - @return The IO token. Errors are suppressed.
+ -}
+function touchFiles
+IO ::= files::[String] i::IO
+{
+  return error("Not Yet Implemented: touchFiles");
+} foreign {
+  "java" : return "common.Util.io(%i%, common.Util.touchFiles(%files%))";
 }
 
 ------ IO Misc.

--- a/grammars/silver/analysis/warnings/defs/Inh.sv
+++ b/grammars/silver/analysis/warnings/defs/Inh.sv
@@ -410,7 +410,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
        -- We can ignore functions. We're checking LHS inhs here... functions don't have any!
        top.blockContext.hasFullSignature
     then if null(lhsInhExceedsFlowType) then []
-         else [wrn(top.location, "Local contribution (<-) equation exceeds flow dependencies with: " ++ implode(", ", lhsInhExceedsFlowType))]
+         else [wrn(top.location, "Local contribution (" ++ val.pp ++ " <-) equation exceeds flow dependencies with: " ++ implode(", ", lhsInhExceedsFlowType))]
     else [];
 }
 

--- a/grammars/silver/definition/concrete_syntax/ast/env_parser/Parser.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/env_parser/Parser.sv
@@ -78,9 +78,9 @@ top::IRootPart ::= 'parsers' s::IParsers
   top.parserSpecs = s.parserSpecs;
 }
 
-nonterminal IParsers with parserSpecs;
-nonterminal IParsersInner with parserSpecs;
-nonterminal IParser with parserSpecs;
+nonterminal IParsers with parserSpecs, grammarName;
+nonterminal IParsersInner with parserSpecs, grammarName;
+nonterminal IParser with parserSpecs, grammarName;
 
 concrete production aParsersNone
 top::IParsers ::= '[' ']'

--- a/grammars/silver/definition/core/AGDcl.sv
+++ b/grammars/silver/definition/core/AGDcl.sv
@@ -6,6 +6,8 @@ grammar silver:definition:core;
 nonterminal AGDcls with config, grammarName, env, location, pp, errors, defs, moduleNames, compiledGrammars, grammarDependencies;
 nonterminal AGDcl  with config, grammarName, env, location, pp, errors, defs, moduleNames, compiledGrammars, grammarDependencies;
 
+flowtype forward {grammarName, env} on AGDcl;
+
 concrete production nilAGDcls
 top::AGDcls ::=
 {

--- a/grammars/silver/definition/core/AspectDcl.sv
+++ b/grammars/silver/definition/core/AspectDcl.sv
@@ -9,6 +9,9 @@ nonterminal AspectFunctionLHS with config, grammarName, env, location, pp, error
 nonterminal AspectRHS with config, grammarName, env, location, pp, errors, defs, inputElements, realSignature;
 nonterminal AspectRHSElem with config, grammarName, env, location, pp, errors, defs, realSignature, inputElements, deterministicCount;
 
+flowtype forward {realSignature, env} on AspectProductionSignature, AspectProductionLHS, AspectFunctionSignature, AspectFunctionLHS, AspectRHS;
+flowtype forward {deterministicCount, realSignature, env} on AspectRHSElem;
+
 {--
  - The signature elements from the fun/produciton being aspected.
  -}

--- a/grammars/silver/definition/core/ProductionDcl.sv
+++ b/grammars/silver/definition/core/ProductionDcl.sv
@@ -5,6 +5,9 @@ nonterminal ProductionLHS with config, grammarName, env, location, pp, errors, d
 nonterminal ProductionRHS with config, grammarName, env, location, pp, errors, defs, inputElements;
 nonterminal ProductionRHSElem with config, grammarName, env, location, pp, errors, defs, inputElements, deterministicCount;
 
+flowtype forward {env} on ProductionSignature, ProductionLHS, ProductionRHS;
+flowtype forward {deterministicCount, env} on ProductionRHSElem;
+
 {--
  - Used to help give names to children, when names are omitted.
  -}

--- a/grammars/silver/definition/core/Project.sv
+++ b/grammars/silver/definition/core/Project.sv
@@ -15,6 +15,7 @@ imports silver:definition:env;
 imports silver:util;
 
 option silver:definition:concrete_syntax;
+option silver:definition:flow:syntax;
 option silver:modification:lambda_fn;
 option silver:modification:let_fix;
 option silver:modification:primitivepattern;

--- a/grammars/silver/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/definition/flow/env/ProductionBody.sv
@@ -278,6 +278,11 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
   top.flowDefs = e.flowDefs;
 }
+aspect production pushTokenIfStmt
+top::ProductionStmt ::= 'pushToken' '(' val::QName ',' lexeme::Expr ')' 'if' condition::Expr ';'
+{
+  top.flowDefs = lexeme.flowDefs ++ condition.flowDefs;
+}
 
 
 -- We're in the unfortunate position of HAVING to compute values for 'flowDefs'

--- a/grammars/silver/definition/type/syntax/AspectDcl.sv
+++ b/grammars/silver/definition/type/syntax/AspectDcl.sv
@@ -2,6 +2,9 @@ grammar silver:definition:type:syntax;
 
 attribute lexicalTypeVariables occurs on AspectProductionSignature, AspectProductionLHS, AspectRHS, AspectRHSElem, AspectFunctionSignature, AspectFunctionLHS;
 
+flowtype lexicalTypeVariables {realSignature, env} on AspectProductionSignature, AspectProductionLHS, AspectRHS, AspectFunctionSignature, AspectFunctionLHS;
+flowtype lexicalTypeVariables {deterministicCount, realSignature, env} on AspectRHSElem;
+
 function addNewLexicalTyVars_ActuallyVariables
 [Def] ::= gn::String sl::Location l::[String]
 {

--- a/grammars/silver/definition/type/syntax/ProductionDcl.sv
+++ b/grammars/silver/definition/type/syntax/ProductionDcl.sv
@@ -2,6 +2,9 @@ grammar silver:definition:type:syntax;
 
 attribute lexicalTypeVariables occurs on ProductionSignature, ProductionLHS, ProductionRHS, ProductionRHSElem;
 
+flowtype lexicalTypeVariables {env} on ProductionSignature, ProductionLHS, ProductionRHS;
+flowtype lexicalTypeVariables {deterministicCount, env} on ProductionRHSElem;
+
 aspect production productionDcl
 top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::ProductionBody
 {

--- a/grammars/silver/driver/GrammarAction.sv
+++ b/grammars/silver/driver/GrammarAction.sv
@@ -10,10 +10,10 @@ grammar silver:driver;
  -}
 
 {- Orders:
- - 0: parsing errors
+ - 0: parsing errors (also flow graph emitting)
  - 1: binding errors
- - 3: interfaces
- - 4: classes
+ - 3: interfaces and classes
+ - 4: doc
  - 5: copper_mda
  - 6: buildxml
  - 7: impide
@@ -23,80 +23,22 @@ aspect production compilation
 top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::BuildEnv
 {
   top.postOps <- [printAllParsingErrors(g.grammarList ++ r.grammarList)];
-  top.postOps <- [doInterfaces(grammarsToTranslate, benv.silverGen)] ++
-    map(touchIface(_, benv.silverGen), r.grammarList);
   top.postOps <- if top.config.noBindingChecking then [] else
     [printAllBindingErrors(g.grammarList ++ r.grammarList)]; 
+  top.postOps <- [touchIfaces(r.grammarList, benv.silverGen)];
 }
 
-abstract production doInterfaces
-top::DriverAction ::= u::[Decorated RootSpec] genPath::String
+abstract production touchIfaces
+top::DriverAction ::= r::[Decorated RootSpec] genPath::String
 {
-  top.order = 3;
-  top.io = writeInterfaces(print("Writing updated interface files\n", top.ioIn), u, genPath);
-  top.code = 0;
-}
-
-function writeInterfaces
-IO ::= iIn::IO r::[Decorated RootSpec] genPath::String
-{
-  return if null(r) then iIn else writeInterfaces(writeInterface(iIn, head(r), genPath), tail(r), genPath);
-}
-
-function writeInterface
-IO ::= iIn::IO r::Decorated RootSpec genPath::String
-{
-  local pathName :: String =
-    genPath ++ "src/" ++ grammarToPath(r.declaredName);
-
-  local mkiotest :: IOVal<Boolean> =
-    isDirectory(pathName, iIn);
-  
-  local mkio :: IOVal<Boolean> =
-    if mkiotest.iovalue
-    then mkiotest
-    else mkdir(pathName, mkiotest.io);
-  
-  local pr :: IO =
-    if mkio.iovalue
-    then print("\t[" ++ r.declaredName ++ "]\n", mkio.io)
-    else exit(-5, print("\nUnrecoverable Error: Unable to create directory: " ++ pathName ++ "\nWarning: if some interface file writes were successful, but others not, Silver's temporaries are in an inconsistent state. Use the --clean flag next run.\n\n", mkio.io));
-  
-  local rm :: IO = deleteStaleData(pr, genPath, r.declaredName);
-  
-  local wr :: IO = writeFile(pathName ++ "Silver.svi", unparseRootSpec(r), rm);
-  
-  return wr;
-}
-
-abstract production touchIface
-top::DriverAction ::= r::Decorated RootSpec genPath::String
-{
-  top.io = touchFile(genPath ++ "src/" ++ grammarToPath(r.declaredName) ++ "Silver.svi", top.ioIn);
+  top.io = touchFiles(map(sviPath(_, genPath), r), top.ioIn);
   top.code = 0;
   top.order = 3;
 }
-
-function deleteStaleData
-IO ::= iIn::IO genPath::String gram::String
+function sviPath
+String ::= r::Decorated RootSpec genPath::String
 {
-  local srcPath :: String = genPath ++ "src/" ++ grammarToPath(gram);
-  local binPath :: String = genPath ++ "bin/" ++ grammarToPath(gram);
-  
-  local srcFiles :: IOVal<[String]> = listContents(srcPath, iIn);
-  local binFiles :: IOVal<[String]> = listContents(binPath, srcFiles.io);
-  
-  return deleteStaleDataFiles( deleteStaleDataFiles(binFiles.io, binPath, binFiles.iovalue), srcPath, srcFiles.iovalue);
-         
-}
-function deleteStaleDataFiles
-IO ::= iIn::IO path::String files::[String]
-{
-  local isf :: IOVal<Boolean> = isFile(path ++ head(files), iIn);
-  
-  return if null(files) then iIn
-         else if !isf.iovalue then deleteStaleDataFiles(isf.io, path, tail(files))
-         else deleteStaleDataFiles( deleteFile(path ++ head(files), isf.io).io, path, tail(files));
+  return genPath ++ "src/" ++ grammarToPath(r.declaredName) ++ "Silver.svi";
 }
 
 abstract production printAllBindingErrors

--- a/grammars/silver/driver/util/Compilation.sv
+++ b/grammars/silver/driver/util/Compilation.sv
@@ -2,6 +2,8 @@ grammar silver:driver:util;
 
 nonterminal Compilation with config, postOps, grammarList, recheckGrammars, allGrammars;
 
+flowtype postOps {config} on Compilation;
+
 synthesized attribute postOps :: [DriverAction] with ++;
 synthesized attribute grammarList :: [Decorated RootSpec];
 synthesized attribute recheckGrammars :: [String];
@@ -52,7 +54,7 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::Build
   
   top.allGrammars = g.grammarList ++ r.grammarList;
 
-  top.postOps := []; -- TODO: need to make depend on top.config
+  top.postOps := [];
 }
 
 nonterminal Grammars with config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, grammarList, recheckGrammars, translateGrammars;

--- a/grammars/silver/extension/convenience/Productions.sv
+++ b/grammars/silver/extension/convenience/Productions.sv
@@ -15,7 +15,10 @@ concrete production productionDclC
 top::AGDcl ::= 'concrete' 'productions' lhs::ProductionLHS stmts::ProductionDclStmts 
 {
   top.pp = "concrete productions " ++ lhs.pp ++ stmts.pp;
+  top.moduleNames = [];
+  
   stmts.lhsdcl = lhs;
+  
   forwards to stmts.proddcls;
 }
 

--- a/grammars/silver/extension/doc/driver/BuildProcess.sv
+++ b/grammars/silver/extension/doc/driver/BuildProcess.sv
@@ -113,8 +113,6 @@ function deleteStaleDocs
 IO ::= iIn::IO outputLoc::String gram::String
 {
   local docPath :: String = outputLoc ++ "doc/" ++ grammarToPath(gram);
-  local docFiles :: IOVal<[String]> = listContents(docPath, iIn);
   
-  return deleteStaleDataFiles(docFiles.io, docPath, docFiles.iovalue);
-         
+  return deleteDirFiles(docPath, iIn).io;
 }

--- a/grammars/silver/modification/copper/BuildProcess.sv
+++ b/grammars/silver/modification/copper/BuildProcess.sv
@@ -61,6 +61,19 @@ String ::= p::ParserSpec  a::Decorated CmdArgs
 """;
 }
 
+{--
+ - At first, it might seem that parsers could be generated along with anything else in a grammar.
+ - (i.e. genFiles a .copper file)
+ - Unfortunately, it turns out this is not the case, due to a possibly over-aggressive
+ - build optimization we do: if the grammar was not directly modified, we assume it doesn't need
+ - to be re-translated. (TECHNICALLY, this isn't always the case...)
+ -
+ - So, parsers can change as a result of the grammars they depend on changing, so these
+ - DO need re-translation. So we treat them specially.
+ -
+ - If we ever fix the overall build process to re-translate grammars that depend on changed grammars,
+ - then we might be able to merge this into the normal process, maybe.
+ -}
 abstract production parserSpecUnit
 top::DriverAction ::= spec::ParserSpec  cg::EnvTree<Decorated RootSpec>  silverGen::String
 {

--- a/grammars/silver/translation/java/core/RootSpec.sv
+++ b/grammars/silver/translation/java/core/RootSpec.sv
@@ -20,7 +20,8 @@ aspect production grammarRootSpec
 top::RootSpec ::= g::Grammar  _ _ _
 {
   top.genFiles := g.genFiles ++
-  [pair("Init.java",
+  [pair("Silver.svi", unparseRootSpec(top)),
+  pair("Init.java",
 "package " ++ makeName(g.declaredName) ++ ";\n\n" ++
 
 "public class Init{\n\n" ++

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -141,14 +141,21 @@ public final class Util {
 	}
 	
 	public static IOToken touchFile(String sb) {
-		return setFileTime(sb, currentTime());
-	}
-	
-	public static IOToken setFileTime(String sb, int time) {
-		new File(sb).setLastModified(((long)time) * 1000);
+		setFileTime(sb, currentTime());
 		return IOToken.singleton;
 	}
-	
+
+	public static void setFileTime(String sb, int time) {
+		new File(sb).setLastModified(((long)time) * 1000);
+	}
+
+	public static IOToken touchFiles(ConsCell files) {
+		while(!files.nil()) {
+			setFileTime(files.head().toString(), currentTime());
+		}
+		return IOToken.singleton;
+	}
+
 	public static int currentTime() {
 		return (int)(System.currentTimeMillis() / 1000);
 	}
@@ -167,6 +174,40 @@ public final class Util {
 
 	public static boolean deleteFile(String sb) {
 		return new File(sb).delete();
+	}
+
+	public static boolean deleteFiles(ConsCell files) {
+		boolean result = true;
+		while(!files.nil()) {
+			StringCatter f = (StringCatter)files.head();
+			result = result && new File(f.toString()).delete();
+		}
+		return result;
+	}
+
+	public static boolean deleteDirFiles(String dir) {
+		try {
+			File f = new File(dir);
+			String[] files = f.list();
+
+			boolean result = true;
+			
+			if(files == null) return result;
+			
+			for(String filename : files) {
+				File file = new File(filename);
+				// Only files, no directories
+				if(file.isFile()) {
+					result = result && file.delete();
+				}
+					
+			}
+			
+			return result;
+			
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 	
 	public static IOToken deleteTree(String path) {

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -152,6 +152,7 @@ public final class Util {
 	public static IOToken touchFiles(ConsCell files) {
 		while(!files.nil()) {
 			setFileTime(files.head().toString(), currentTime());
+			files = files.tail();
 		}
 		return IOToken.singleton;
 	}
@@ -181,6 +182,7 @@ public final class Util {
 		while(!files.nil()) {
 			StringCatter f = (StringCatter)files.head();
 			result = result && new File(f.toString()).delete();
+			files = files.tail();
 		}
 		return result;
 	}


### PR DESCRIPTION
This generates Silver interface files in the same pass as generating other files during translation.

This cuts down the on translating output by half.

I branched this off my last branch, so the best way to look at this diff would be here:

https://github.com/melt-umn/silver/compare/feature/flowspecuse...feature/verbose

rather than the changed files tab on this pull request.

Also, NOTE TO SELF: I have to merge the first commit before merging the rest, otherwise I'll have to do a publish-jars. Forgot to make two branches.