### PR TITLE
Properly check flow type within functions

### DIFF
--- a/grammars/silver/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/analysis/typechecking/core/ProductionBody.sv
@@ -60,7 +60,7 @@ top::ProductionStmt ::= 'forwards' 'to' e::Expr ';'
   errCheck1.downSubst = e.upSubst;
   top.upSubst = errCheck1.upSubst;
 
-  errCheck1 = check(e.typerep, top.signature.outputElement.typerep);
+  errCheck1 = check(e.typerep, top.frame.signature.outputElement.typerep);
   top.errors <- if errCheck1.typeerror
                 then [err(e.location, "Forward's expected type is " ++ errCheck1.rightpp ++ ", but the actual type supplied is " ++ errCheck1.leftpp)]
                 else [];
@@ -127,7 +127,7 @@ top::ProductionStmt ::= 'return' e::Expr ';'
   errCheck1.downSubst = e.upSubst;
   top.upSubst = errCheck1.upSubst;
   
-  errCheck1 = check(e.typerep, top.signature.outputElement.typerep);
+  errCheck1 = check(e.typerep, top.frame.signature.outputElement.typerep);
   top.errors <-
        if errCheck1.typeerror
        then [err(top.location, "Expected return type is " ++ errCheck1.rightpp ++ ", but the expression has actual type " ++ errCheck1.leftpp)]

--- a/grammars/silver/analysis/warnings/defs/EqDef.sv
+++ b/grammars/silver/analysis/warnings/defs/EqDef.sv
@@ -28,10 +28,10 @@ aspect production synthesizedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur e::Expr
 {
   local attribute prodDefGram :: String;
-  prodDefGram = substring(0, lastIndexOf(":", top.signature.fullName), top.signature.fullName);
+  prodDefGram = substring(0, lastIndexOf(":", top.frame.fullName), top.frame.fullName);
 
   local exportedBy :: [String] = 
-    if top.blockContext.hasPartialSignature
+    if top.frame.hasPartialSignature
     then [prodDefGram, attr.dcl.sourceGrammar]
     else [attr.dcl.sourceGrammar]; -- defaults can only be listed together with occurs.
 
@@ -40,13 +40,13 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur e::
     if null(attr.errors ++ attr.errors)
     && (top.config.warnAll || top.config.warnEqdef)
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [wrn(top.location, "Orphaned equation: " ++ attr.pp ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.signature.fullName)]
+    then [wrn(top.location, "Orphaned equation: " ++ attr.pp ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
     else [];
   
   -- Duplicate equation check
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [wrn(top.location, "Duplicate equation for " ++ attr.pp ++ " in production " ++ top.signature.fullName)]
+    then [wrn(top.location, "Duplicate equation for " ++ attr.pp ++ " in production " ++ top.frame.fullName)]
     else [];
 }
 
@@ -54,7 +54,7 @@ aspect production inheritedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
   local attribute prodDefGram :: String;
-  prodDefGram = substring(0, lastIndexOf(":", top.signature.fullName), top.signature.fullName);
+  prodDefGram = substring(0, lastIndexOf(":", top.frame.fullName), top.frame.fullName);
 
   local exportedBy :: [String] = 
     case dl of
@@ -68,13 +68,13 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     if null(attr.errors ++ attr.errors ++ dl.errors)
     && (top.config.warnAll || top.config.warnEqdef)
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [wrn(top.location, "Orphaned equation: " ++ attr.pp ++ " on " ++ dl.pp ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.signature.fullName)]
+    then [wrn(top.location, "Orphaned equation: " ++ attr.pp ++ " on " ++ dl.pp ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
     -- Now, check for duplicate equations!
     else [];
     
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [wrn(top.location, "Duplicate equation for " ++ attr.pp ++ " on " ++ dl.pp ++ " in production " ++ top.signature.fullName)]
+    then [wrn(top.location, "Duplicate equation for " ++ attr.pp ++ " on " ++ dl.pp ++ " in production " ++ top.frame.fullName)]
     else [];
 }
 
@@ -85,10 +85,10 @@ aspect production synBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
   local attribute prodDefGram :: String;
-  prodDefGram = substring(0, lastIndexOf(":", top.signature.fullName), top.signature.fullName);
+  prodDefGram = substring(0, lastIndexOf(":", top.frame.fullName), top.frame.fullName);
 
   local exportedBy :: [String] = 
-    if top.blockContext.hasPartialSignature
+    if top.frame.hasPartialSignature
     then [prodDefGram, attr.dcl.sourceGrammar]
     else [attr.dcl.sourceGrammar]; -- defaults can only be listed together with occurs.
 
@@ -97,20 +97,20 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     if null(attr.errors ++ attr.errors)
     && (top.config.warnAll || top.config.warnEqdef)
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [wrn(top.location, "Orphaned equation: " ++ attr.pp ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.signature.fullName)]
+    then [wrn(top.location, "Orphaned equation: " ++ attr.pp ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
     else [];
   
   -- Duplicate equation check
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [wrn(top.location, "Duplicate equation for " ++ attr.pp ++ " in production " ++ top.signature.fullName)]
+    then [wrn(top.location, "Duplicate equation for " ++ attr.pp ++ " in production " ++ top.frame.fullName)]
     else [];
 }
 aspect production inhBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
   local attribute prodDefGram :: String;
-  prodDefGram = substring(0, lastIndexOf(":", top.signature.fullName), top.signature.fullName);
+  prodDefGram = substring(0, lastIndexOf(":", top.frame.fullName), top.frame.fullName);
 
   local exportedBy :: [String] = 
     case dl of
@@ -124,13 +124,13 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     if null(attr.errors ++ attr.errors ++ dl.errors)
     && (top.config.warnAll || top.config.warnEqdef)
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [wrn(top.location, "Orphaned equation: " ++ attr.pp ++ " on " ++ dl.pp ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.signature.fullName)]
+    then [wrn(top.location, "Orphaned equation: " ++ attr.pp ++ " on " ++ dl.pp ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
     -- Now, check for duplicate equations!
     else [];
     
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [wrn(top.location, "Duplicate equation for " ++ attr.pp ++ " on " ++ dl.pp ++ " in production " ++ top.signature.fullName)]
+    then [wrn(top.location, "Duplicate equation for " ++ attr.pp ++ " on " ++ dl.pp ++ " in production " ++ top.frame.fullName)]
     else [];
 }
 
@@ -146,31 +146,31 @@ aspect production childDefLHS
 top::DefLHS ::= q::Decorated QName
 {
   -- prod, child, attr
-  top.lookupEqDefLHS = lookupInh(top.signature.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
+  top.lookupEqDefLHS = lookupInh(top.frame.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production lhsDefLHS
 top::DefLHS ::= q::Decorated QName
 {
   -- prod, attr
-  top.lookupEqDefLHS = lookupSyn(top.signature.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
+  top.lookupEqDefLHS = lookupSyn(top.frame.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production localDefLHS
 top::DefLHS ::= q::Decorated QName
 {
   -- prod, local, attr
-  top.lookupEqDefLHS = lookupLocalInh(top.signature.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
+  top.lookupEqDefLHS = lookupLocalInh(top.frame.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production forwardDefLHS
 top::DefLHS ::= q::Decorated QName
 {
   -- prod, attr
-  top.lookupEqDefLHS = lookupFwdInh(top.signature.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
+  top.lookupEqDefLHS = lookupFwdInh(top.frame.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production defaultLhsDefLHS
 top::DefLHS ::= q::Decorated QName
 {
   -- nt, attr
-  top.lookupEqDefLHS = lookupDef(top.signature.outputElement.typerep.typeName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
+  top.lookupEqDefLHS = lookupDef(top.frame.lhsNtName, top.defLHSattr.attrDcl.fullName, top.flowEnv);
 }
 aspect production errorDefLHS
 top::DefLHS ::= q::Decorated QName

--- a/grammars/silver/analysis/warnings/defs/EqDef.sv
+++ b/grammars/silver/analysis/warnings/defs/EqDef.sv
@@ -27,12 +27,9 @@ Either<String  Decorated CmdArgs> ::= args::[String]
 aspect production synthesizedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur e::Expr
 {
-  local attribute prodDefGram :: String;
-  prodDefGram = substring(0, lastIndexOf(":", top.frame.fullName), top.frame.fullName);
-
   local exportedBy :: [String] = 
     if top.frame.hasPartialSignature
-    then [prodDefGram, attr.dcl.sourceGrammar]
+    then [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
     else [attr.dcl.sourceGrammar]; -- defaults can only be listed together with occurs.
 
   -- Orphaned equation check
@@ -53,15 +50,12 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur e::
 aspect production inheritedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
-  local attribute prodDefGram :: String;
-  prodDefGram = substring(0, lastIndexOf(":", top.frame.fullName), top.frame.fullName);
-
   local exportedBy :: [String] = 
     case dl of
     -- Exported by the declaration of the thing we're giving inh to, or to the occurs
     | localDefLHS(q) -> [q.lookupValue.dcl.sourceGrammar, attr.dcl.sourceGrammar]
     -- For rhs or forwards, that's the production.
-    | _ -> [prodDefGram, attr.dcl.sourceGrammar]
+    | _ -> [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
     end;
 
   top.errors <-
@@ -84,12 +78,9 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 aspect production synBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
-  local attribute prodDefGram :: String;
-  prodDefGram = substring(0, lastIndexOf(":", top.frame.fullName), top.frame.fullName);
-
   local exportedBy :: [String] = 
     if top.frame.hasPartialSignature
-    then [prodDefGram, attr.dcl.sourceGrammar]
+    then [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
     else [attr.dcl.sourceGrammar]; -- defaults can only be listed together with occurs.
 
   -- Orphaned equation check
@@ -109,15 +100,12 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 aspect production inhBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
-  local attribute prodDefGram :: String;
-  prodDefGram = substring(0, lastIndexOf(":", top.frame.fullName), top.frame.fullName);
-
   local exportedBy :: [String] = 
     case dl of
     -- Exported by the declaration of the thing we're giving inh to, or to the occurs
     | localDefLHS(q) -> [q.lookupValue.dcl.sourceGrammar, attr.dcl.sourceGrammar]
     -- For rhs or forwards, that's the production.
-    | _ -> [prodDefGram, attr.dcl.sourceGrammar]
+    | _ -> [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
     end;
 
   top.errors <-

--- a/grammars/silver/analysis/warnings/defs/Inh.sv
+++ b/grammars/silver/analysis/warnings/defs/Inh.sv
@@ -106,7 +106,7 @@ Boolean ::= sigName::String  e::Decorated Env
  - @param v  A value we need an equation for.
  - @param l  Where to report an error, if it's missing
  - @param prodName  The full name of the production we're in
- - @param prodNt  The nonterminal is production belongs to
+ - @param prodNt  The nonterminal is production belongs to. (For functions, a dummy value is ok)
  - @param flowEnv  The local flow environment
  - @param realEnv  The local real environment
  - @returns  Errors for missing equations
@@ -173,10 +173,9 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.frame.lhsNtName, myFlow)));
@@ -184,7 +183,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   top.errors <-
     if null(dl.errors ++ attr.errors)
     && (top.config.warnAll || top.config.warnMissingInh)
-    && (top.frame.hasPartialSignature) -- Default synthesized equations have no production graph to use
+    && top.frame.prodFlowGraph.isJust -- Default synthesized equations have no production graph to use
                           -- TODO: shit. is anything looking at default synthesized equations to make sure
                           -- their flow types aren't messed up?
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
@@ -196,20 +195,14 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 aspect production inheritedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
-  -- oh no again!
-  --local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
-
   local transitiveDeps :: [FlowVertex] = 
-    if top.frame.hasFullSignature
-    then expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs))
-    else e.flowDeps; -- patch for functions lacking a graph
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
   
   -- TODO: if LHS is forward, we have to check that we aren't exceeding flow type!! (BUG)
   
   -- check transitive deps only. Nothing to be done for flow types
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh)
+    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
@@ -220,10 +213,9 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.frame.lhsNtName, myFlow)));
@@ -231,6 +223,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   top.errors <-
     if null(dl.errors ++ attr.errors)
     && (top.config.warnAll || top.config.warnMissingInh)
+    && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
       if null(lhsInhExceedsFlowType) then []
       else [wrn(top.location, "Synthesized equation " ++ attr.pp ++ " exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
@@ -241,10 +234,9 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.frame.lhsNtName, myFlow)));
@@ -252,6 +244,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   top.errors <-
     if null(dl.errors ++ attr.errors)
     && (top.config.warnAll || top.config.warnMissingInh)
+    && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
       if null(lhsInhExceedsFlowType) then []
       else [wrn(top.location, "Synthesized equation " ++ attr.pp ++ " exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
@@ -260,36 +253,24 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 aspect production inhBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
-  -- oh no again!
-  --local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
-
-  local transitiveDeps :: [FlowVertex] = 
-    if top.frame.hasFullSignature
-    then expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs))
-    else e.flowDeps; -- patch for functions lacking a graph
+  local transitiveDeps :: [FlowVertex] =
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
   
   -- check transitive deps only. Nothing to be done for flow types
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh)
+    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
 aspect production inhAppendColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
-  -- oh no again!
-  --local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
-
   local transitiveDeps :: [FlowVertex] = 
-    if top.frame.hasFullSignature
-    then expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs))
-    else e.flowDeps; -- patch for functions lacking a graph
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
   
   -- check transitive deps only. Nothing to be done for flow types
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh)
+    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
@@ -300,15 +281,15 @@ top::ProductionStmt ::= 'forwards' 'to' e::Expr ';'
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
-  local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
+  local transitiveDeps :: [FlowVertex] =
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn("forward", top.frame.lhsNtName, myFlow)));
 
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh)
+    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
          if null(lhsInhExceedsFlowType) then []
          else [wrn(top.location, "Forward equation exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
@@ -319,9 +300,9 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
-  local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
+  local transitiveDeps :: [FlowVertex] =
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   -- problem = lhsinh deps - fwd flow type - this inh attribute
@@ -336,7 +317,7 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
         inhDepsForSyn("forward", top.frame.lhsNtName, myFlow))));
 
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh)
+    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
          if null(lhsInhExceedsFlowType) then []
          else [wrn(top.location, "Forward inherited equation exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
@@ -346,18 +327,12 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
 aspect production localValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
-  -- oh no again!
-  --local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
-
-  local transitiveDeps :: [FlowVertex] = 
-    if top.frame.hasFullSignature
-    then expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs))
-    else e.flowDeps; -- patch for functions lacking a graph
+  local transitiveDeps :: [FlowVertex] =
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
   
   -- check transitive deps only. No worries about flow types.
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh)
+    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
@@ -365,31 +340,19 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 aspect production returnDef
 top::ProductionStmt ::= 'return' e::Expr ';'
 {
-  -- TODO: lacking a graph, we're going to just do this on immediate deps directly.
-  -- This still captures the really necessary case of 'take reference' equations needed
+  local transitiveDeps :: [FlowVertex] =
+    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
 
-  -- without graphs for functions, we don't get any transitive dependencies.
-  -- this means rhs.syn doesn't emit deps on rhs.inh at all. nor for a localEq, any of its deps
-
-  -- Note: "::nolhs" is the nonterminal name of the lhs. This *should* only be used by
-  -- checkEqDeps for default equations and autocopy info, so giving a bogus value here
-  -- should be correct as those are not relevant to functions.
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(e.flowDeps, top.location, top.frame.fullName, "::nolhs", top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
+    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
--- TODO: bug: we don't have graphs for functions, so we have a problem with the above
--- implementation needing those graphs.
 }
 
 aspect production appendCollectionValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
-  -- oh no again!
-  --local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
-
-  local productionFlowGraph :: ProductionGraph = findProductionGraph(top.frame.fullName, myGraphs);
+  local productionFlowGraph :: ProductionGraph = top.frame.prodFlowGraph.fromJust;
   local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, productionFlowGraph);
   
   local originalEqDeps :: [FlowVertex] = 
@@ -406,9 +369,10 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   -- and thus flow types don't need checking (unlike syn defs), but for contributions to locals we do
   -- need to do a check!
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh) &&
+    if (top.config.warnAll || top.config.warnMissingInh)
        -- We can ignore functions. We're checking LHS inhs here... functions don't have any!
-       top.frame.hasFullSignature
+    && top.frame.hasFullSignature
+    && top.frame.prodFlowGraph.isJust
     then if null(lhsInhExceedsFlowType) then []
          else [wrn(top.location, "Local contribution (" ++ val.pp ++ " <-) equation exceeds flow dependencies with: " ++ implode(", ", lhsInhExceedsFlowType))]
     else [];

--- a/grammars/silver/analysis/warnings/defs/Inh.sv
+++ b/grammars/silver/analysis/warnings/defs/Inh.sv
@@ -185,8 +185,8 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     if null(dl.errors ++ attr.errors)
     && (top.config.warnAll || top.config.warnMissingInh)
     && (top.frame.hasPartialSignature) -- Default synthesized equations have no production graph to use
-                                              -- TODO: shit. is anything looking at default synthesized equations to make sure
-                                              -- their flow types aren't messed up?
+                          -- TODO: shit. is anything looking at default synthesized equations to make sure
+                          -- their flow types aren't messed up?
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
       if null(lhsInhExceedsFlowType) then []
       else [wrn(top.location, "Synthesized equation " ++ attr.pp ++ " exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]

--- a/grammars/silver/analysis/warnings/defs/Inh.sv
+++ b/grammars/silver/analysis/warnings/defs/Inh.sv
@@ -176,18 +176,18 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, findProductionGraph(top.signature.fullName, myGraphs));
+    expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
-  local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.signature.outputElement.typerep.typeName, myFlow)));
+  local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.frame.lhsNtName, myFlow)));
 
   top.errors <-
     if null(dl.errors ++ attr.errors)
     && (top.config.warnAll || top.config.warnMissingInh)
-    && (top.blockContext.hasPartialSignature) -- Default synthesized equations have no production graph to use
+    && (top.frame.hasPartialSignature) -- Default synthesized equations have no production graph to use
                                               -- TODO: shit. is anything looking at default synthesized equations to make sure
                                               -- their flow types aren't messed up?
-    then checkAllEqDeps(transitiveDeps, top.location, top.signature.fullName, top.signature.outputElement.typerep.typeName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
       if null(lhsInhExceedsFlowType) then []
       else [wrn(top.location, "Synthesized equation " ++ attr.pp ++ " exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
     else [];
@@ -201,8 +201,8 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] = 
-    if top.blockContext.hasFullSignature
-    then expandGraph(e.flowDeps, findProductionGraph(top.signature.fullName, myGraphs))
+    if top.frame.hasFullSignature
+    then expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs))
     else e.flowDeps; -- patch for functions lacking a graph
   
   -- TODO: if LHS is forward, we have to check that we aren't exceeding flow type!! (BUG)
@@ -210,7 +210,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   -- check transitive deps only. Nothing to be done for flow types
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(transitiveDeps, top.location, top.signature.fullName, top.signature.outputElement.typerep.typeName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
 
@@ -223,15 +223,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, findProductionGraph(top.signature.fullName, myGraphs));
+    expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
-  local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.signature.outputElement.typerep.typeName, myFlow)));
+  local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.frame.lhsNtName, myFlow)));
 
   top.errors <-
     if null(dl.errors ++ attr.errors)
     && (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(transitiveDeps, top.location, top.signature.fullName, top.signature.outputElement.typerep.typeName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
       if null(lhsInhExceedsFlowType) then []
       else [wrn(top.location, "Synthesized equation " ++ attr.pp ++ " exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
     else [];
@@ -244,15 +244,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, findProductionGraph(top.signature.fullName, myGraphs));
+    expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
-  local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.signature.outputElement.typerep.typeName, myFlow)));
+  local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.frame.lhsNtName, myFlow)));
 
   top.errors <-
     if null(dl.errors ++ attr.errors)
     && (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(transitiveDeps, top.location, top.signature.fullName, top.signature.outputElement.typerep.typeName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
       if null(lhsInhExceedsFlowType) then []
       else [wrn(top.location, "Synthesized equation " ++ attr.pp ++ " exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
     else [];
@@ -265,14 +265,14 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] = 
-    if top.blockContext.hasFullSignature
-    then expandGraph(e.flowDeps, findProductionGraph(top.signature.fullName, myGraphs))
+    if top.frame.hasFullSignature
+    then expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs))
     else e.flowDeps; -- patch for functions lacking a graph
   
   -- check transitive deps only. Nothing to be done for flow types
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(transitiveDeps, top.location, top.signature.fullName, top.signature.outputElement.typerep.typeName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
 aspect production inhAppendColAttributeDef
@@ -283,14 +283,14 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] = 
-    if top.blockContext.hasFullSignature
-    then expandGraph(e.flowDeps, findProductionGraph(top.signature.fullName, myGraphs))
+    if top.frame.hasFullSignature
+    then expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs))
     else e.flowDeps; -- patch for functions lacking a graph
   
   -- check transitive deps only. Nothing to be done for flow types
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(transitiveDeps, top.location, top.signature.fullName, top.signature.outputElement.typerep.typeName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
 ------ END AWFUL COPY & PASTE SESSION
@@ -302,14 +302,14 @@ top::ProductionStmt ::= 'forwards' 'to' e::Expr ';'
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
-  local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, findProductionGraph(top.signature.fullName, myGraphs));
+  local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
-  local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn("forward", top.signature.outputElement.typerep.typeName, myFlow)));
+  local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn("forward", top.frame.lhsNtName, myFlow)));
 
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(transitiveDeps, top.location, top.signature.fullName, top.signature.outputElement.typerep.typeName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
          if null(lhsInhExceedsFlowType) then []
          else [wrn(top.location, "Forward equation exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
     else [];
@@ -321,7 +321,7 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
-  local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, findProductionGraph(top.signature.fullName, myGraphs));
+  local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs));
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   -- problem = lhsinh deps - fwd flow type - this inh attribute
@@ -333,11 +333,11 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
          end],
       set:difference(
         lhsInhDeps,
-        inhDepsForSyn("forward", top.signature.outputElement.typerep.typeName, myFlow))));
+        inhDepsForSyn("forward", top.frame.lhsNtName, myFlow))));
 
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(transitiveDeps, top.location, top.signature.fullName, top.signature.outputElement.typerep.typeName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
          if null(lhsInhExceedsFlowType) then []
          else [wrn(top.location, "Forward inherited equation exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
     else [];
@@ -351,14 +351,14 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   local transitiveDeps :: [FlowVertex] = 
-    if top.blockContext.hasFullSignature
-    then expandGraph(e.flowDeps, findProductionGraph(top.signature.fullName, myGraphs))
+    if top.frame.hasFullSignature
+    then expandGraph(e.flowDeps, findProductionGraph(top.frame.fullName, myGraphs))
     else e.flowDeps; -- patch for functions lacking a graph
   
   -- check transitive deps only. No worries about flow types.
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(transitiveDeps, top.location, top.signature.fullName, top.signature.outputElement.typerep.typeName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
+    then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
 
@@ -376,7 +376,7 @@ top::ProductionStmt ::= 'return' e::Expr ';'
   -- should be correct as those are not relevant to functions.
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh)
-    then checkAllEqDeps(e.flowDeps, top.location, top.signature.fullName, "::nolhs", top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
+    then checkAllEqDeps(e.flowDeps, top.location, top.frame.fullName, "::nolhs", top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 -- TODO: bug: we don't have graphs for functions, so we have a problem with the above
 -- implementation needing those graphs.
@@ -389,7 +389,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   --local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
-  local productionFlowGraph :: ProductionGraph = findProductionGraph(top.signature.fullName, myGraphs);
+  local productionFlowGraph :: ProductionGraph = findProductionGraph(top.frame.fullName, myGraphs);
   local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, productionFlowGraph);
   
   local originalEqDeps :: [FlowVertex] = 
@@ -408,7 +408,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh) &&
        -- We can ignore functions. We're checking LHS inhs here... functions don't have any!
-       top.blockContext.hasFullSignature
+       top.frame.hasFullSignature
     then if null(lhsInhExceedsFlowType) then []
          else [wrn(top.location, "Local contribution (" ++ val.pp ++ " <-) equation exceeds flow dependencies with: " ++ implode(", ", lhsInhExceedsFlowType))]
     else [];
@@ -558,10 +558,10 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
             let inhs :: [String] = 
                   -- N.B. we're filtering out autocopies here
                   filter(
-                    ignoreIfAutoCopyOnLhs(top.signature.outputElement.typerep.typeName, top.env, _),
+                    ignoreIfAutoCopyOnLhs(top.frame.lhsNtName, top.env, _),
                     filter(
                       isEquationMissing(
-                        lookupInh(top.signature.fullName, lq.lookupValue.fullName, _, top.flowEnv),
+                        lookupInh(top.frame.fullName, lq.lookupValue.fullName, _, top.flowEnv),
                         _),
                       set:toList(inhDepsForSyn(q.attrDcl.fullName, eTypeName, myFlow))))
              in if null(inhs) then []
@@ -574,7 +574,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
             let inhs :: [String] = 
                   filter(
                     isEquationMissing(
-                      lookupLocalInh(top.signature.fullName, lq.lookupValue.fullName, _, top.flowEnv),
+                      lookupLocalInh(top.frame.fullName, lq.lookupValue.fullName, _, top.flowEnv),
                       _),
                     set:toList(inhDepsForSyn(q.attrDcl.fullName, eTypeName, myFlow)))
              in if null(inhs) then []

--- a/grammars/silver/definition/core/AspectDcl.sv
+++ b/grammars/silver/definition/core/AspectDcl.sv
@@ -51,8 +51,7 @@ top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature bod
              else [];
 
   body.env = newScopeEnv(body.defs ++ sigDefs, newScopeEnv(prodAtts, top.env));
-  body.signature = namedSig;
-  body.blockContext = aspectProductionContext();
+  body.frame = aspectProductionContext(namedSig);
 }
 
 concrete production aspectFunctionDcl
@@ -88,8 +87,7 @@ top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::P
              else [];
 
   body.env = newScopeEnv(body.defs ++ sigDefs, newScopeEnv(prodAtts, top.env));
-  body.signature = namedSig;
-  body.blockContext = aspectFunctionContext();
+  body.frame = aspectFunctionContext(namedSig);
 }
 
 concrete production aspectProductionSignature

--- a/grammars/silver/definition/core/AspectDcl.sv
+++ b/grammars/silver/definition/core/AspectDcl.sv
@@ -51,7 +51,7 @@ top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature bod
              else [];
 
   body.env = newScopeEnv(body.defs ++ sigDefs, newScopeEnv(prodAtts, top.env));
-  body.frame = aspectProductionContext(namedSig);
+  body.frame = aspectProductionContext(namedSig, myFlowGraph); -- graph from flow:env
 }
 
 concrete production aspectFunctionDcl
@@ -87,7 +87,7 @@ top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::P
              else [];
 
   body.env = newScopeEnv(body.defs ++ sigDefs, newScopeEnv(prodAtts, top.env));
-  body.frame = aspectFunctionContext(namedSig);
+  body.frame = aspectFunctionContext(namedSig, myFlowGraph); -- graph from flow:env
 }
 
 concrete production aspectProductionSignature

--- a/grammars/silver/definition/core/BlockContext.sv
+++ b/grammars/silver/definition/core/BlockContext.sv
@@ -3,24 +3,35 @@ grammar silver:definition:core;
 {--
  - Permissions management information for certain features that can appear in production
  - statements, etc.  i.e. "can forward/return/pluck?"
- - TODO: Probably should have a 'real' one for aspects...
  -}
 nonterminal BlockContext with permitReturn, permitForward, permitProductionAttributes, permitLocalAttributes, lazyApplication, hasFullSignature, hasPartialSignature;
 
 
+{-- Are 'return' equations allowed in this context? -}
 synthesized attribute permitReturn :: Boolean;
+{-- Are 'forwards to' equations allowed in this context? -}
 synthesized attribute permitForward :: Boolean;
-synthesized attribute permitProductionAttributes :: Boolean;
+{-- Are 'local' equations allowed in this context? -}
 synthesized attribute permitLocalAttributes :: Boolean;
+{-- Are 'production attribute' equations allowed in this context?
+    DISTINCT from locals, due to action blocks. -}
+synthesized attribute permitProductionAttributes :: Boolean;
 
 {--
  - Whether the signature includes the name of a LHS.
  - Not strictly necessary to set partial to true, but to be expected...
+ - REFACTORING NOTES: Used to:
+ - 1. Figure out how to get a production graph (REPLACE THIS) (i.e. function vs production)
+ - 2. Ignore checking LHS Inhs in functions, which don't have LHS inhs...
  -}
 synthesized attribute hasFullSignature :: Boolean;
 {--
  - Whether the signature includes the type of a LHS & name/type pairs for RHS.
  - And the name. e.g. top.signature.fullName.
+ - REFACTORING NOTES: Used to:
+ - 1. Decide if syn eq should be exported by NT alone (default eq) or OCC/NT (normal syn eq)
+ - 2. Decide if we need to look at deps of syn eqs (i.e. default eqs don't get checked locally)
+ - 3. Decide to emit a default equation or synthesized equation
  -}
 synthesized attribute hasPartialSignature :: Boolean;
 {--

--- a/grammars/silver/definition/core/BlockContext.sv
+++ b/grammars/silver/definition/core/BlockContext.sv
@@ -46,7 +46,8 @@ synthesized attribute lazyApplication :: Boolean;
 synthesized attribute lhsNtName :: String;
 {--
  - The signature of the current context.
- - Not always valid/sensible, dpending on context. Needs care in use.
+ - Not always sensible, depending on context. Needs care in use.
+ - TODO: figure out a way to guard accesses maybe?
  -}
 synthesized attribute signature :: NamedSignature;
 
@@ -54,13 +55,12 @@ synthesized attribute signature :: NamedSignature;
 {- fullName on BlockContext:
  - Used to:
  - 1. Name locals.
- - 2. Equations to know production name.
- - 3. Exprs to emit anon equations flowDefs.
- - 4. Input into makeIdName as a hack for locals
+ - 2. Equations to emit flowDefs
+ - 3. Exprs to emit anon flowDefs.
  -
  - sourceGrammar on BlockContext:
  - Used to:
- - 1. 
+ - 1. Do isExportedBy checks, finding prod origin grammar.
  -}
 
 

--- a/grammars/silver/definition/core/Expr.sv
+++ b/grammars/silver/definition/core/Expr.sv
@@ -3,14 +3,14 @@ grammar silver:definition:core;
 --import silver:analysis:typechecking:core;
 
 nonterminal Expr with
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature, typerep;
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars, typerep;
 nonterminal Exprs with
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature, exprs, rawExprs;
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars, exprs, rawExprs;
 
 nonterminal ExprInhs with
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature, decoratingnt, suppliedInhs;
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars, decoratingnt, suppliedInhs;
 nonterminal ExprInh with
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature, decoratingnt, suppliedInhs;
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars, decoratingnt, suppliedInhs;
 nonterminal ExprLHSExpr with
   config, grammarName, env, location, pp, errors, typerep, decoratingnt, suppliedInhs;
 
@@ -767,11 +767,11 @@ top::Exprs ::= e1::Expr ',' e2::Exprs
  - (partial) function application.
  -}
 nonterminal AppExprs with 
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature, exprs, rawExprs,
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars, exprs, rawExprs,
   isPartial, missingTypereps, appExprIndicies, appExprSize, appExprTypereps, appExprApplied;
 
 nonterminal AppExpr with
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature, exprs, rawExprs,
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars, exprs, rawExprs,
   isPartial, missingTypereps, appExprIndicies, appExprIndex, appExprTyperep, appExprApplied;
 
 synthesized attribute isPartial :: Boolean;
@@ -881,12 +881,12 @@ top::AppExprs ::=
 
 
 nonterminal AnnoAppExprs with
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature,
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars,
   isPartial, appExprApplied, exprs,
   remainingFuncAnnotations, funcAnnotations,
   missingAnnotations, partialAnnoTypereps, annoIndexConverted, annoIndexSupplied;
 nonterminal AnnoExpr with
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature,
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars,
   isPartial, appExprApplied, exprs,
   remainingFuncAnnotations, funcAnnotations,
   missingAnnotations, partialAnnoTypereps, annoIndexConverted, annoIndexSupplied;

--- a/grammars/silver/definition/core/FunctionDcl.sv
+++ b/grammars/silver/definition/core/FunctionDcl.sv
@@ -39,7 +39,7 @@ top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody
   prodAtts = defsFromPADcls(getProdAttrs(fName, top.env), namedSig);
 
   body.env = newScopeEnv(body.defs ++ sigDefs, newScopeEnv(prodAtts, top.env));
-  body.frame = functionContext(namedSig);
+  body.frame = functionContext(namedSig, myFlowGraph); -- graph from flow:env
 }
 
 concrete production functionSignature

--- a/grammars/silver/definition/core/FunctionDcl.sv
+++ b/grammars/silver/definition/core/FunctionDcl.sv
@@ -39,8 +39,7 @@ top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody
   prodAtts = defsFromPADcls(getProdAttrs(fName, top.env), namedSig);
 
   body.env = newScopeEnv(body.defs ++ sigDefs, newScopeEnv(prodAtts, top.env));
-  body.signature = namedSig;
-  body.blockContext = functionContext();
+  body.frame = functionContext(namedSig);
 }
 
 concrete production functionSignature

--- a/grammars/silver/definition/core/GlobalDcl.sv
+++ b/grammars/silver/definition/core/GlobalDcl.sv
@@ -4,6 +4,7 @@ concrete production globalValueDclConcrete
 top::AGDcl ::= 'global' id::Name '::' t::Type '=' e::Expr ';'
 {
   top.pp = "global " ++ id.pp ++ " :: " ++ t.pp ++ " = " ++ e.pp ++ "\n"; 
+  top.errors := t.errors ++ e.errors;
 
   production attribute fName :: String;
   fName = top.grammarName ++ ":" ++ id.name;
@@ -11,10 +12,9 @@ top::AGDcl ::= 'global' id::Name '::' t::Type '=' e::Expr ';'
   top.defs = [globalDef(top.grammarName, id.location, fName, t.typerep)];
 
   top.errors <-
-        if length(getValueDclAll(fName, top.env)) > 1
-        then [err(id.location, "Value '" ++ fName ++ "' is already bound.")]
-        else [];
+    if length(getValueDclAll(fName, top.env)) > 1
+    then [err(id.location, "Value '" ++ fName ++ "' is already bound.")]
+    else [];
 
-  top.errors := t.errors ++ e.errors;
   e.frame = globalExprContext();
 }

--- a/grammars/silver/definition/core/GlobalDcl.sv
+++ b/grammars/silver/definition/core/GlobalDcl.sv
@@ -16,6 +16,5 @@ top::AGDcl ::= 'global' id::Name '::' t::Type '=' e::Expr ';'
         else [];
 
   top.errors := t.errors ++ e.errors;
-  e.blockContext = globalExprContext();
-  e.signature = bogusNamedSignature();
+  e.frame = globalExprContext();
 }

--- a/grammars/silver/definition/core/ProductionBody.sv
+++ b/grammars/silver/definition/core/ProductionBody.sv
@@ -1,43 +1,30 @@
 grammar silver:definition:core;
 
 nonterminal ProductionBody with
-  config, grammarName, env, location, pp, errors, defs, blockContext, compiledGrammars,
-  productionAttributes, signature, uniqueSignificantExpression;
+  config, grammarName, env, location, pp, errors, defs, frame, compiledGrammars,
+  productionAttributes, uniqueSignificantExpression;
 nonterminal ProductionStmts with 
-  config, grammarName, env, location, pp, errors, defs, blockContext, compiledGrammars,
-  productionAttributes, signature, uniqueSignificantExpression;
+  config, grammarName, env, location, pp, errors, defs, frame, compiledGrammars,
+  productionAttributes, uniqueSignificantExpression;
 nonterminal ProductionStmt with
-  config, grammarName, env, location, pp, errors, defs, blockContext, compiledGrammars,
-  productionAttributes, signature, uniqueSignificantExpression;
+  config, grammarName, env, location, pp, errors, defs, frame, compiledGrammars,
+  productionAttributes, uniqueSignificantExpression;
 
 nonterminal DefLHS with 
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature, typerep, defLHSattr;
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars, typerep, defLHSattr;
 
 nonterminal ForwardInhs with 
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature;
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars;
 nonterminal ForwardInh with 
-  config, grammarName, env, location, pp, errors, blockContext, compiledGrammars, signature;
+  config, grammarName, env, location, pp, errors, frame, compiledGrammars;
 nonterminal ForwardLHSExpr with 
-  config, grammarName, env, location, pp, errors, signature, typerep;
+  config, grammarName, env, location, pp, errors, frame, typerep;
 
 {--
- - The signature of this fun/production, given to the production's body.
- - This is mostly for the use of ProductionStmts, almost exclusively.
- - It DOES however, validly occur on Expr. But, on Expr, all uses should be
- - guarded. (e.g. nearly all uses are in productions that can only be
- - forwarded to by a dispatcher using something in the environment
- - provided by the production. Concretely: child reference dcls are only
- - available when a production added them to the env for its children.)
- - It's decorated because why not? We're always looking at a physical signature
- - anyway, so let's just reuse it, to avoid any recomputation.
+ - Context for ProductionStmt blocks. (Indicates function, production, aspect, etc)
+ - Includes singature for those contexts with a signature.
  -}
-autocopy attribute signature :: NamedSignature;
-{--
- - Context for ProductionStmt blocks. (Function, production, other...)
- - At some future time, we should consider the possibility of eliminating
- - signature, and just using this. Or not.
- -}
-autocopy attribute blockContext :: BlockContext;
+autocopy attribute frame :: BlockContext;
 
 {--
  - Defs of attributes that should be wrapped up as production attributes.
@@ -138,7 +125,7 @@ top::ProductionStmt ::= 'return' e::Expr ';'
 
   top.errors := e.errors;
   
-  top.errors <- if !top.blockContext.permitReturn
+  top.errors <- if !top.frame.permitReturn
                 then [err(top.location, "Return is not valid in this context. (They are only permitted in function declarations.)")]
                 else [];
 }
@@ -149,7 +136,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::Type ';'
   top.pp = "\tlocal attribute " ++ a.pp ++ "::" ++ te.pp ++ ";";
 
   production attribute fName :: String;
-  fName = top.signature.fullName ++ ":local:" ++ a.name;
+  fName = top.frame.fullName ++ ":local:" ++ a.name;
 
   top.defs = [localDef(top.grammarName, a.location, fName, te.typerep)];
 
@@ -160,7 +147,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::Type ';'
         then [err(a.location, "Value '" ++ fName ++ "' is already bound.")]
         else [];
 
-  top.errors <- if !top.blockContext.permitLocalAttributes
+  top.errors <- if !top.frame.permitLocalAttributes
                 then [err(top.location, "Local attributes are not valid in this context.")]
                 else [];
 }
@@ -174,7 +161,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::Type ';'
   top.productionAttributes = forward.defs;
   top.defs = [];
 
-  top.errors <- if !top.blockContext.permitProductionAttributes
+  top.errors <- if !top.frame.permitProductionAttributes
                 then [err(top.location, "Production attributes are not valid in this context.")]
                 else [];
 
@@ -186,12 +173,12 @@ top::ProductionStmt ::= 'forwards' 'to' e::Expr ';'
 {
   top.pp = "\tforwards to " ++ e.pp;
 
-  top.productionAttributes = [forwardDef(top.grammarName, top.location, top.signature.outputElement.typerep)];
+  top.productionAttributes = [forwardDef(top.grammarName, top.location, top.frame.signature.outputElement.typerep)];
   top.uniqueSignificantExpression = [e];
 
   top.errors := e.errors;
 
-  top.errors <- if !top.blockContext.permitForward
+  top.errors <- if !top.frame.permitForward
                 then [err(top.location, "Forwarding is not permitted in this context. (Only permitted in non-aspect productions.)")]
                 else [];
 }
@@ -253,7 +240,7 @@ top::ForwardLHSExpr ::= q::QNameAttrOccur
   top.errors := q.errors;
   top.typerep = q.typerep;
   
-  q.attrFor = top.signature.outputElement.typerep;
+  q.attrFor = top.frame.signature.outputElement.typerep;
 }
 
 concrete production attributeDef

--- a/grammars/silver/definition/core/ProductionDcl.sv
+++ b/grammars/silver/definition/core/ProductionDcl.sv
@@ -56,7 +56,7 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
   prodAtts = defsFromPADcls(getProdAttrs(fName, top.env), namedSig);
 
   body.env = newScopeEnv(body.defs ++ sigDefs, newScopeEnv(prodAtts, top.env));
-  body.frame = productionContext(namedSig);
+  body.frame = productionContext(namedSig, myFlowGraph); -- graph from flow:env
 }
 
 concrete production productionSignature

--- a/grammars/silver/definition/core/ProductionDcl.sv
+++ b/grammars/silver/definition/core/ProductionDcl.sv
@@ -56,8 +56,7 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
   prodAtts = defsFromPADcls(getProdAttrs(fName, top.env), namedSig);
 
   body.env = newScopeEnv(body.defs ++ sigDefs, newScopeEnv(prodAtts, top.env));
-  body.signature = namedSig;
-  body.blockContext = productionContext();
+  body.frame = productionContext(namedSig);
 }
 
 concrete production productionSignature

--- a/grammars/silver/definition/env/NamedSignature.sv
+++ b/grammars/silver/definition/env/NamedSignature.sv
@@ -11,8 +11,8 @@ synthesized attribute inputNames :: [String];
 synthesized attribute elementName :: String;
 synthesized attribute toNamedArgType :: NamedArgType;
 
-
 -- inputTypes from the types grammar.
+
 
 -- TODO Make named signatures... not named.
 -- It seems to be largely redundant information.
@@ -41,19 +41,8 @@ top::NamedSignature ::= fn::String ie::[NamedSignatureElement] oe::NamedSignatur
 }
 
 {--
- - Represents the signature of something without parameters.
- - Used for action code. i.e. Stuff that uses ProductionStmt, but
- - isn't in a production/function.
- -}
-abstract production namedNamedSignature
-top::NamedSignature ::= fn::String
-{
-  top.unparse = error("Bogus signatures should never make it into interface files!");
-  forwards to namedSignature(fn, [], bogusNamedSignatureElement(), []);
-}
-
-{--
- - Used ONLY when an error occurs. e.g. aspecting a non-existant production.
+ - Used when an error occurs. e.g. aspecting a non-existant production.
+ - Or, in contexts that have no valid signature, which maybe we should do something about...
  -}
 abstract production bogusNamedSignature
 top::NamedSignature ::= 

--- a/grammars/silver/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/definition/flow/driver/ProductionGraph.sv
@@ -197,13 +197,14 @@ ProductionGraph ::= nt::String  flowEnv::Decorated FlowEnv  realEnv::Decorated E
 
   -- The phantom edges: ext syn -> fwd.eq
   local phantomEdges :: [Pair<FlowVertex FlowVertex>] =
+    -- apparently this alias may sometimes be used. we should get rid of this by making good use of vertex types
+    pair(lhsSynVertex("forward"), forwardEqVertex()) ::
     map(getPhantomEdge, getExtSynsFor(nt, flowEnv));
   
   -- The stitch point: oddball. LHS stitch point. Normally, the LHS is not.
   local stitchPoints :: [StitchPoint] = [nonterminalStitchPoint(nt, lhsVertexType)];
     
-  -- TODO: use of lhsSynVertex("forward") here is part of a hack.
-  local flowTypeVertexes :: [FlowVertex] = [lhsSynVertex("forward")] ++ map(lhsSynVertex, syns);
+  local flowTypeVertexes :: [FlowVertex] = [forwardEqVertex()] ++ map(lhsSynVertex, syns);
   local initialGraph :: g:Graph<FlowVertex> = createFlowGraph(phantomEdges);
   local suspectEdges :: [Pair<FlowVertex FlowVertex>] = [];
 
@@ -214,7 +215,7 @@ function getPhantomEdge
 Pair<FlowVertex FlowVertex> ::= f::FlowDef
 {
   return case f of
-  | extSynFlowDef(_, at) -> pair(lhsSynVertex(at), lhsSynVertex("forward")) -- TODO: this is a hack and "accidentally" works. Fix is to use VertexTypes more. Basically, what matters here is that both this and forwardEqVertex() will have a flowTypeName of just "forward"
+  | extSynFlowDef(_, at) -> pair(lhsSynVertex(at), forwardEqVertex())
   end;
 }
 

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -244,7 +244,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
   -- This means only the deps in 'e', see above conceptual transformation to see why.
   -- N.B. 'inh.flowDefs' will emit 'localInhEq's for this anonymous flow vertex.
   top.flowDefs = e.flowDefs ++ inh.flowDefs ++
-    [anonEq(top.signature.fullName, inh.decorationVertex, performSubstitution(e.typerep, top.finalSubst).typeName, top.location, e.flowDeps)];
+    [anonEq(top.frame.fullName, inh.decorationVertex, performSubstitution(e.typerep, top.finalSubst).typeName, top.location, e.flowDeps)];
 
   -- Now, we represent ourselves to anything that might use us specially
   -- as though we were a reference to this anonymous local
@@ -265,7 +265,7 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e1::Expr ';'
   top.flowDefs = e1.flowDefs ++ 
     if !null(lhs.errors) then [] else
     case lhs of
-    | exprLhsExpr(q) -> [anonInhEq(top.signature.fullName, top.decorationVertex, q.attrDcl.fullName, e1.flowDeps)]
+    | exprLhsExpr(q) -> [anonInhEq(top.frame.fullName, top.decorationVertex, q.attrDcl.fullName, e1.flowDeps)]
     end;
     
 }

--- a/grammars/silver/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/definition/flow/env/FlowEnv.sv
@@ -9,7 +9,7 @@ exports silver:definition:flow:env_parser with silver:definition:env:env_parser;
 autocopy attribute flowEnv :: Decorated FlowEnv;
 synthesized attribute flowDefs :: [FlowDef];
 
-nonterminal FlowEnv with synTree, inhTree, defTree, fwdTree, prodTree, fwdInhTree, refTree, localInhTree, localTree, nonSuspectTree, extSynTree, specTree;
+nonterminal FlowEnv with synTree, inhTree, defTree, fwdTree, prodTree, fwdInhTree, refTree, localInhTree, localTree, nonSuspectTree, extSynTree, specTree, prodGraphTree;
 
 inherited attribute synTree :: EnvTree<FlowDef>;
 inherited attribute inhTree :: EnvTree<FlowDef>;
@@ -23,6 +23,7 @@ inherited attribute localTree :: EnvTree<FlowDef>;
 inherited attribute nonSuspectTree :: EnvTree<[String]>;
 inherited attribute extSynTree :: EnvTree<FlowDef>;
 inherited attribute specTree :: EnvTree<Pair<String [String]>>;
+inherited attribute prodGraphTree :: EnvTree<FlowDef>;
 
 abstract production dummyFlowEnv
 top::FlowEnv ::=
@@ -46,6 +47,7 @@ Decorated FlowEnv ::= d::FlowDefs
   e.nonSuspectTree = directBuildTree(d.nonSuspectContribs);
   e.extSynTree = directBuildTree(d.extSynTreeContribs);
   e.specTree = directBuildTree(d.specContribs);
+  e.prodGraphTree = directBuildTree(d.prodGraphContribs);
   
   return e;
 }
@@ -137,5 +139,11 @@ function getFlowTypeSpecFor
 [Pair<String [String]>] ::= nt::String  e::Decorated FlowEnv
 {
   return searchEnvTree(nt, e.specTree);
+}
+
+function getGraphContribsFor
+[FlowDef] ::= prod::String  e::Decorated FlowEnv
+{
+  return searchEnvTree(prod, e.prodGraphTree);
 }
 

--- a/grammars/silver/definition/flow/env/FunctionDcl.sv
+++ b/grammars/silver/definition/flow/env/FunctionDcl.sv
@@ -1,14 +1,24 @@
 grammar silver:definition:flow:env;
 
+import silver:definition:flow:driver only ProductionGraph, constructFunctionGraph;
+
 aspect production functionDcl
 top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody 
 {
+  {-- Used by core to send down with .frame -}
+  production myFlowGraph :: ProductionGraph = 
+    constructFunctionGraph(namedSig, top.flowEnv);
+
   top.flowDefs = body.flowDefs;
 }
 
 aspect production aspectFunctionDcl
 top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::ProductionBody 
 {
+  {-- Used by core to send down with .frame -}
+  production myFlowGraph :: ProductionGraph = 
+    constructFunctionGraph(namedSig, top.flowEnv);
+
   top.flowDefs = body.flowDefs;
 }
 

--- a/grammars/silver/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/definition/flow/env/ProductionBody.sv
@@ -145,10 +145,10 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     isExportedBy(top.grammarName, srcGrams, top.compiledGrammars);
   
   top.flowDefs = e.flowDefs ++
-    case top.blockContext of -- TODO: this may not be the bestest way to go about doing this....
-    | defaultAspectContext() -> [defaultSynEq(top.signature.outputElement.typerep.typeName, attr.attrDcl.fullName, e.flowDeps)]
-    | _ -> [synEq(top.signature.fullName, attr.attrDcl.fullName, e.flowDeps, mayAffectFlowType)]
-    end;
+    if top.blockContext.hasPartialSignature then 
+      [synEq(top.signature.fullName, attr.attrDcl.fullName, e.flowDeps, mayAffectFlowType)]
+    else
+      [defaultSynEq(top.signature.outputElement.typerep.typeName, attr.attrDcl.fullName, e.flowDeps)];
 }
 aspect production inheritedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
@@ -215,10 +215,10 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     isExportedBy(top.grammarName, srcGrams, top.compiledGrammars);
   
   top.flowDefs = e.flowDefs ++
-    case top.blockContext of -- TODO: this may not be the bestest way to go about doing this....
-    | defaultAspectContext() -> [defaultSynEq(top.signature.outputElement.typerep.typeName, attr.attrDcl.fullName, e.flowDeps)]
-    | _ -> [synEq(top.signature.fullName, attr.attrDcl.fullName, e.flowDeps, mayAffectFlowType)]
-    end;
+    if top.blockContext.hasPartialSignature then 
+      [synEq(top.signature.fullName, attr.attrDcl.fullName, e.flowDeps, mayAffectFlowType)]
+    else
+      [defaultSynEq(top.signature.outputElement.typerep.typeName, attr.attrDcl.fullName, e.flowDeps)];
 }
 aspect production inhBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
@@ -237,6 +237,7 @@ aspect production appendCollectionValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
   local locDefGram :: String = hackGramFromQName(val.lookupValue);
+  -- TODO: possible bug? this would include ":local" in the gram wouldn't it?
 
   local mayAffectFlowType :: Boolean =
     isExportedBy(top.grammarName, [locDefGram], top.compiledGrammars);

--- a/grammars/silver/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/definition/flow/env/ProductionBody.sv
@@ -73,21 +73,21 @@ Boolean ::= prodgram::String  ntgram::String  cg::EnvTree<Decorated RootSpec>  d
 aspect production forwardsTo
 top::ProductionStmt ::= 'forwards' 'to' e::Expr ';'
 {
-  local ntDefGram :: String = hackGramFromFName(top.signature.outputElement.typerep.typeName);
+  local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
   local mayAffectFlowType :: Boolean =
     isExportedBy(top.grammarName, [ntDefGram], top.compiledGrammars);
   
   top.flowDefs = e.flowDefs ++ [
-    fwdEq(top.signature.fullName, e.flowDeps, mayAffectFlowType),
+    fwdEq(top.frame.fullName, e.flowDeps, mayAffectFlowType),
     -- These are attributes that we know, here, occurs on this nonterminal.
     -- The point is, these are the implicit equations we KNOW get generated, so
     -- we regard these as non-suspect. That is, we implicitly insert these copy
     -- equations here.
     -- Currently, we don't bother to filter this to just synthesized, but we should?
-    implicitFwdAffects(top.signature.fullName, map((.attrOccurring),
+    implicitFwdAffects(top.frame.fullName, map((.attrOccurring),
       filter(isAffectable(top.grammarName, ntDefGram, top.compiledGrammars, _),
-        getAttrsOn(top.signature.outputElement.typerep.typeName, top.env))))];
+        getAttrsOn(top.frame.lhsNtName, top.env))))];
 }
 aspect production forwardingWith
 top::ProductionStmt ::= 'forwarding' 'with' '{' inh::ForwardInhs '}' ';'
@@ -112,7 +112,7 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
   -- forward flow type automatically.
   top.flowDefs = e.flowDefs ++ 
     case lhs of
-    | forwardLhsExpr(q) -> [fwdInhEq(top.signature.fullName, q.attrDcl.fullName, e.flowDeps)]
+    | forwardLhsExpr(q) -> [fwdInhEq(top.frame.fullName, q.attrDcl.fullName, e.flowDeps)]
     end;
 }
 
@@ -137,7 +137,7 @@ top::ProductionStmt ::= msg::[Message] dl::Decorated DefLHS  attr::Decorated QNa
 aspect production synthesizedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
-  local ntDefGram :: String = hackGramFromFName(top.signature.outputElement.typerep.typeName);
+  local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
   local srcGrams :: [String] = [ntDefGram, hackGramFromDcl(attr)];
 
@@ -145,19 +145,19 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     isExportedBy(top.grammarName, srcGrams, top.compiledGrammars);
   
   top.flowDefs = e.flowDefs ++
-    if top.blockContext.hasPartialSignature then 
-      [synEq(top.signature.fullName, attr.attrDcl.fullName, e.flowDeps, mayAffectFlowType)]
+    if top.frame.hasPartialSignature then 
+      [synEq(top.frame.fullName, attr.attrDcl.fullName, e.flowDeps, mayAffectFlowType)]
     else
-      [defaultSynEq(top.signature.outputElement.typerep.typeName, attr.attrDcl.fullName, e.flowDeps)];
+      [defaultSynEq(top.frame.lhsNtName, attr.attrDcl.fullName, e.flowDeps)];
 }
 aspect production inheritedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
   top.flowDefs = e.flowDefs ++
     case dl of
-    | childDefLHS(q) -> [inhEq(top.signature.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, e.flowDeps)]
-    | localDefLHS(q) -> [localInhEq(top.signature.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, e.flowDeps)]
-    | forwardDefLHS(q) -> [fwdInhEq(top.signature.fullName, attr.attrDcl.fullName, e.flowDeps)]
+    | childDefLHS(q) -> [inhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, e.flowDeps)]
+    | localDefLHS(q) -> [localInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, e.flowDeps)]
+    | forwardDefLHS(q) -> [fwdInhEq(top.frame.fullName, attr.attrDcl.fullName, e.flowDeps)]
     | _ -> [] -- TODO : this isn't quite extensible... more better way eventually, plz
     end;
 }
@@ -169,7 +169,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   -- technically, it's possible to break this if you declare it in one grammar, but define it in another, but
   -- I think we should forbid that syntactically, later on...
   top.flowDefs = e.flowDefs ++
-    [localEq(top.signature.fullName, val.lookupValue.fullName, val.lookupValue.typerep.typeName, e.flowDeps)];
+    [localEq(top.frame.fullName, val.lookupValue.fullName, val.lookupValue.typerep.typeName, e.flowDeps)];
 }
 aspect production errorValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
@@ -182,13 +182,13 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 aspect production synAppendColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- <- -} e::Expr
 {
-  local ntDefGram :: String = hackGramFromFName(top.signature.outputElement.typerep.typeName);
+  local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
   local mayAffectFlowType :: Boolean =
     isExportedBy(top.grammarName, [ntDefGram, hackGramFromDcl(attr)], top.compiledGrammars);
 
   top.flowDefs = e.flowDefs ++
-    [extraEq(top.signature.fullName, lhsSynVertex(attr.attrDcl.fullName), e.flowDeps, mayAffectFlowType)];
+    [extraEq(top.frame.fullName, lhsSynVertex(attr.attrDcl.fullName), e.flowDeps, mayAffectFlowType)];
 }
 
 aspect production inhAppendColAttributeDef
@@ -202,12 +202,12 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {-
     | _ -> localEqVertex("bogus:value:from:inhcontrib:flow")
     end;
   top.flowDefs = e.flowDefs ++
-    [extraEq(top.signature.fullName, vertex, e.flowDeps, true)];
+    [extraEq(top.frame.fullName, vertex, e.flowDeps, true)];
 }
 aspect production synBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
-  local ntDefGram :: String = hackGramFromFName(top.signature.outputElement.typerep.typeName);
+  local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
   local srcGrams :: [String] = [ntDefGram, hackGramFromDcl(attr)];
 
@@ -215,19 +215,19 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     isExportedBy(top.grammarName, srcGrams, top.compiledGrammars);
   
   top.flowDefs = e.flowDefs ++
-    if top.blockContext.hasPartialSignature then 
-      [synEq(top.signature.fullName, attr.attrDcl.fullName, e.flowDeps, mayAffectFlowType)]
+    if top.frame.hasPartialSignature then 
+      [synEq(top.frame.fullName, attr.attrDcl.fullName, e.flowDeps, mayAffectFlowType)]
     else
-      [defaultSynEq(top.signature.outputElement.typerep.typeName, attr.attrDcl.fullName, e.flowDeps)];
+      [defaultSynEq(top.frame.lhsNtName, attr.attrDcl.fullName, e.flowDeps)];
 }
 aspect production inhBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
   top.flowDefs = e.flowDefs ++
     case dl of
-    | childDefLHS(q) -> [inhEq(top.signature.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, e.flowDeps)]
-    | localDefLHS(q) -> [localInhEq(top.signature.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, e.flowDeps)]
-    | forwardDefLHS(q) -> [fwdInhEq(top.signature.fullName, attr.attrDcl.fullName, e.flowDeps)]
+    | childDefLHS(q) -> [inhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, e.flowDeps)]
+    | localDefLHS(q) -> [localInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, e.flowDeps)]
+    | forwardDefLHS(q) -> [fwdInhEq(top.frame.fullName, attr.attrDcl.fullName, e.flowDeps)]
     | _ -> [] -- TODO : this isn't quite extensible... more better way eventually, plz
     end;
 }
@@ -251,7 +251,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 
   top.flowDefs = e.flowDefs ++
     if mayAffectFlowType
-    then [extraEq(top.signature.fullName, localEqVertex(val.lookupValue.fullName), e.flowDeps, true)]
+    then [extraEq(top.frame.fullName, localEqVertex(val.lookupValue.fullName), e.flowDeps, true)]
     else [];
 }
 ------ FROM COPPER TODO

--- a/grammars/silver/definition/flow/env/ProductionDcl.sv
+++ b/grammars/silver/definition/flow/env/ProductionDcl.sv
@@ -1,10 +1,19 @@
 grammar silver:definition:flow:env;
 
 import silver:modification:defaultattr;
+import silver:definition:flow:driver only ProductionGraph, findProductionGraph;
+import silver:driver:util; -- only for productionFlowGraphs occurrence?
 
 aspect production productionDcl
 top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::ProductionBody
 {
+  -- TODO: bit of a hack, isn't it?
+  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  {-- Used by core to send down with .frame -}
+  production myFlowGraph :: ProductionGraph = 
+    findProductionGraph(fName, myGraphs);
+
   top.flowDefs = body.flowDefs ++ 
     if null(body.uniqueSignificantExpression)
     then [prodFlowDef(namedSig.outputElement.typerep.typeName, fName)]
@@ -14,6 +23,13 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
 aspect production aspectProductionDcl
 top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature body::ProductionBody 
 {
+  -- TODO: bit of a hack, isn't it?
+  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  {-- Used by core to send down with .frame -}
+  production myFlowGraph :: ProductionGraph = 
+    findProductionGraph(id.lookupValue.fullName, myGraphs);
+
   top.flowDefs = body.flowDefs;
 }
 

--- a/grammars/silver/extension/auto_ast/AutoAst.sv
+++ b/grammars/silver/extension/auto_ast/AutoAst.sv
@@ -18,19 +18,19 @@ top::ProductionStmt ::= 'abstract' v::QName ';'
     !null(vty.namedTypes) && head(vty.namedTypes).argName == "location";
   
   local elems :: [NamedSignatureElement] =
-    filter(hasAst(_, top.env), top.signature.inputElements);
+    filter(hasAst(_, top.env), top.frame.signature.inputElements);
     
   local inferredType :: TypeExp =
     functionTypeExp(
-      astType(top.signature.outputElement, top.env),
+      astType(top.frame.signature.outputElement, top.env),
       map(astType(_, top.env), elems),
       (if hasLoc
        then [namedArgType("location", nonterminalTypeExp("core:Location", []))]
        else []));
   
   top.errors <-
-    if hasAst(top.signature.outputElement, top.env) then []
-    else [err(top.location, "This lhs '" ++ top.signature.outputElement.elementName ++ "' does not have the 'silver:langutil:ast' attribute.")];
+    if hasAst(top.frame.signature.outputElement, top.env) then []
+    else [err(top.location, "This lhs '" ++ top.frame.signature.outputElement.elementName ++ "' does not have the 'silver:langutil:ast' attribute.")];
   
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   
@@ -43,12 +43,12 @@ top::ProductionStmt ::= 'abstract' v::QName ';'
     else [err(v.location, "Signature yields ast type " ++ errCheck1.rightpp ++ ", but the supplied ast constructor has type " ++ errCheck1.leftpp)];
   
   top.errors <-
-    if hasLoc && null(getOccursDcl("core:location", top.signature.outputElement.typerep.typeName, top.env))
+    if hasLoc && null(getOccursDcl("core:location", top.frame.lhsNtName, top.env))
     then [err(top.location, "Ast constructor wants 'location' but this nonterminal does not have a location")]
     else [];
   
   local lhsQName :: QName =
-    qName(top.location, top.signature.outputElement.elementName);
+    qName(top.location, top.frame.signature.outputElement.elementName);
   local astQName :: QNameAttrOccur =
     qNameAttrOccur(qName(top.location, "silver:langutil:ast"), location=top.location);
 

--- a/grammars/silver/extension/convenience/Children.sv
+++ b/grammars/silver/extension/convenience/Children.sv
@@ -12,11 +12,11 @@ top::Expr ::= '$' e::Int_t
     -- Will error with "undefined value $x", which is reasonable.
     fromMaybe("$" ++ e.lexeme, 
       -- TODO: horrible method of detemining whether we're not in an appropriate context for $x 
-      if top.signature.outputElement.elementName == "__SV_BOGUS_ELEM" -- TODO hack!
+      if top.frame.signature.outputElement.elementName == "__SV_BOGUS_ELEM" -- TODO hack!
       then nothing()
       else
         findChild(toInt(e.lexeme), 
-          [top.signature.outputElement.elementName] ++ top.signature.inputNames));
+          [top.frame.signature.outputElement.elementName] ++ top.frame.signature.inputNames));
 
   forwards to baseExpr(qName(top.location, ref), location=top.location);
 }

--- a/grammars/silver/extension/functorattrib/ProductionBody.sv
+++ b/grammars/silver/extension/functorattrib/ProductionBody.sv
@@ -106,19 +106,19 @@ top::ProductionStmt ::= a::QName
   -- occuring on the LHS but this should be caught by the forward errors.  
   
   -- Generate the arguments for the constructor
-  local topName::QName = qName(top.location, top.signature.outputElement.elementName);
-  local prodName::QName = qName(top.location, top.signature.fullName);
+  local topName::QName = qName(top.location, top.frame.signature.outputElement.elementName);
+  local prodName::QName = qName(top.location, top.frame.fullName);
   prodName.grammarName = top.grammarName;
   prodName.config = top.config;
   prodName.env = top.env;
   local inputs::AppExprs = 
     foldl(snocAppExprs(_, ',', _, location=top.location),
           emptyAppExprs(location=top.location),
-          makeArgs(top.location, top.env, a, top.signature.inputElements));
+          makeArgs(top.location, top.env, a, top.frame.signature.inputElements));
   local annotations::AnnoAppExprs = 
     foldl(snocAnnoAppExprs(_, ',', _, location=top.location),
           emptyAnnoAppExprs(location=top.location),
-          makeAnnoArgs(top.location, topName, top.signature.namedInputElements));
+          makeAnnoArgs(top.location, topName, top.frame.signature.namedInputElements));
 
   -- Construct an attribute def and call with the generated arguments
   forwards to 

--- a/grammars/silver/extension/patternmatching/Case.sv
+++ b/grammars/silver/extension/patternmatching/Case.sv
@@ -15,7 +15,7 @@ terminal Vbar_kwd '|' lexer classes {SPECOP};
 terminal Opt_Vbar_t /\|?/ lexer classes {SPECOP}; -- optional Coq-style vbar.
 
 -- MR | ...
-nonterminal MRuleList with location, config, pp, signature, env, errors, matchRuleList, matchRulePatternSize;
+nonterminal MRuleList with location, config, pp, env, errors, matchRuleList, matchRulePatternSize;
 
 -- Turns MRuleList (of MatchRules) into [AbstractMatchRule]
 synthesized attribute matchRuleList :: [AbstractMatchRule];
@@ -23,7 +23,7 @@ synthesized attribute matchRuleList :: [AbstractMatchRule];
 autocopy attribute matchRulePatternSize :: Integer;
 
 -- P -> E
-nonterminal MatchRule with location, config, pp, signature, env, errors, matchRuleList, matchRulePatternSize;
+nonterminal MatchRule with location, config, pp, env, errors, matchRuleList, matchRulePatternSize;
 nonterminal AbstractMatchRule with location, headPattern, isVarMatchRule, expandHeadPattern;
 
 -- The head pattern of a match rule

--- a/grammars/silver/extension/testing/EqualityTest.sv
+++ b/grammars/silver/extension/testing/EqualityTest.sv
@@ -63,10 +63,8 @@ ag::AGDcl ::= kwd::'equalityTest'
 
   -- TODO: one of those type error checks above is redundant
 
-  value.signature = bogusNamedSignature();
-  expected.signature = bogusNamedSignature();
-  value.blockContext = globalExprContext();
-  expected.blockContext = globalExprContext();
+  value.frame = globalExprContext();
+  expected.frame = globalExprContext();
   
 
   ag.errors <- forward.errors;

--- a/grammars/silver/modification/collection/Collection.sv
+++ b/grammars/silver/modification/collection/Collection.sv
@@ -177,7 +177,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::Type 'with' q:
   top.productionAttributes = [localColDef(top.grammarName, a.location, fName, te.typerep, q.operation)];
 
   production attribute fName :: String;
-  fName = top.signature.fullName ++ ":local:" ++ a.name;
+  fName = top.frame.fullName ++ ":local:" ++ a.name;
 
   top.defs = [];
 

--- a/grammars/silver/modification/collection/java/Collection.sv
+++ b/grammars/silver/modification/collection/java/Collection.sv
@@ -91,7 +91,7 @@ aspect production collectionAttributeDclProd
 top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::Type 'with' q::NameOrBOperator ';'
 {
   local attribute className :: String;
-  className = makeClassName(top.signature.fullName);
+  className = makeClassName(top.frame.fullName);
 
   local attribute o :: Operation;
   o = q.operation;
@@ -183,7 +183,7 @@ top::AGDcl ::= 'inherited' 'attribute' a::Name tl::BracketedOptTypeList '::' te:
 aspect production baseCollectionValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
-  local className :: String = makeClassName(top.signature.fullName);
+  local className :: String = makeClassName(top.frame.fullName);
 
   -- for locals, the CA object was created already
   top.translation =
@@ -194,7 +194,7 @@ aspect production appendCollectionValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
   local attribute className :: String;
-  className = makeClassName(top.signature.fullName);
+  className = makeClassName(top.frame.fullName);
 
   -- for locals, the CA object was created already
   top.translation = 

--- a/grammars/silver/modification/collection/java/Collection.sv
+++ b/grammars/silver/modification/collection/java/Collection.sv
@@ -90,9 +90,6 @@ top::Operation ::=
 aspect production collectionAttributeDclProd
 top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::Type 'with' q::NameOrBOperator ';'
 {
-  local attribute className :: String;
-  className = makeClassName(top.frame.fullName);
-
   local attribute o :: Operation;
   o = q.operation;
 
@@ -106,7 +103,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::Type 'with' q:
   -- So we'll create the collection attribute object here, and not worry.
 
   top.setupInh <-
-        "\t\t" ++ className ++ ".localAttributes[" ++ ugh_dcl_hack.attrOccursIndex ++ "] = new common.CollectionAttribute(){\n" ++ 
+        "\t\t" ++ top.frame.className ++ ".localAttributes[" ++ ugh_dcl_hack.attrOccursIndex ++ "] = new common.CollectionAttribute(){\n" ++ 
         "\t\t\tpublic Object eval(common.DecoratedNode context) {\n" ++ 
         "\t\t\t\t" ++ te.typerep.transType ++ " result = (" ++ te.typerep.transType ++ ")this.getBase().eval(context);\n" ++ 
         "\t\t\t\tfor(int i = 0; i < this.getPieces().size(); i++){\n" ++ 
@@ -183,23 +180,18 @@ top::AGDcl ::= 'inherited' 'attribute' a::Name tl::BracketedOptTypeList '::' te:
 aspect production baseCollectionValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
-  local className :: String = makeClassName(top.frame.fullName);
-
   -- for locals, the CA object was created already
   top.translation =
         "\t\t// " ++ val.pp ++ " := " ++ e.pp ++ "\n" ++
-        "\t\t((common.CollectionAttribute)" ++ className ++ ".localAttributes[" ++ val.lookupValue.dcl.attrOccursIndex ++ "]).setBase(" ++ wrapLazy(e) ++ ");\n";
+        "\t\t((common.CollectionAttribute)" ++ top.frame.className ++ ".localAttributes[" ++ val.lookupValue.dcl.attrOccursIndex ++ "]).setBase(" ++ wrapLazy(e) ++ ");\n";
 }
 aspect production appendCollectionValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
-  local attribute className :: String;
-  className = makeClassName(top.frame.fullName);
-
   -- for locals, the CA object was created already
   top.translation = 
         "\t\t// " ++ val.pp ++ " <- " ++ e.pp ++ "\n" ++
-        "\t\t((common.CollectionAttribute)" ++ className ++ ".localAttributes[" ++ val.lookupValue.dcl.attrOccursIndex ++ "]).addPiece(" ++ wrapLazy(e) ++ ");\n";
+        "\t\t((common.CollectionAttribute)" ++ top.frame.className ++ ".localAttributes[" ++ val.lookupValue.dcl.attrOccursIndex ++ "]).addPiece(" ++ wrapLazy(e) ++ ");\n";
 }
 
 ---------- SYNTHESIZED ----

--- a/grammars/silver/modification/copper/ActionCode.sv
+++ b/grammars/silver/modification/copper/ActionCode.sv
@@ -16,8 +16,7 @@ top::AGDcl ::= 'concrete' 'production' id::Name ns::ProductionSignature pm::Prod
         prodAction(acode.actionCode) :: pm.productionModifiers))];
 
   ns.signatureName = fName;
-  acode.blockContext = actionContext();
-  acode.signature = namedSig;
+  acode.frame = actionContext(namedSig);
   acode.env = newScopeEnv(
                 addTerminalAttrDefs(
                  acode.defs ++ ns.actionDefs), top.env);
@@ -31,7 +30,7 @@ top::AGDcl ::= 'concrete' 'production' id::Name ns::ProductionSignature pm::Prod
 }
 
 
-nonterminal ActionCode_c with location,config,pp,actionCode,env,defs,grammarName,signature,errors,blockContext, compiledGrammars, flowEnv;
+nonterminal ActionCode_c with location,config,pp,actionCode,env,defs,grammarName,errors,frame, compiledGrammars, flowEnv;
 
 synthesized attribute actionCode :: String;
 

--- a/grammars/silver/modification/copper/BlockContext.sv
+++ b/grammars/silver/modification/copper/BlockContext.sv
@@ -19,7 +19,7 @@ abstract production actionContext
 top::BlockContext ::= sig::NamedSignature
 {
   top.fullName = sig.fullName;
-  top.signature = sig;
+  top.signature = sig; -- TODO: figure out if this is ever used for actions?
 
   top.lazyApplication = false;
   top.permitActions = true;

--- a/grammars/silver/modification/copper/BlockContext.sv
+++ b/grammars/silver/modification/copper/BlockContext.sv
@@ -16,8 +16,11 @@ top::BlockContext ::=
 }
 
 abstract production actionContext
-top::BlockContext ::=
+top::BlockContext ::= sig::NamedSignature
 {
+  top.fullName = sig.fullName;
+  top.signature = sig;
+
   top.lazyApplication = false;
   top.permitActions = true;
   --top.permitProductionAttributes = false; -- denied by default
@@ -26,9 +29,9 @@ top::BlockContext ::=
 }
 
 abstract production disambiguationContext
-top::BlockContext ::=
+top::BlockContext ::= sig::NamedSignature
 {
   top.permitPluck = true;
-  forwards to actionContext();
+  forwards to actionContext(sig);
 }
 

--- a/grammars/silver/modification/copper/BlockContext.sv
+++ b/grammars/silver/modification/copper/BlockContext.sv
@@ -15,12 +15,13 @@ top::BlockContext ::=
   top.permitPluck = false;
 }
 
+{-- Terminal shift, parser attribute initialization -}
 abstract production actionContext
-top::BlockContext ::= sig::NamedSignature
+top::BlockContext ::=
 {
-  top.fullName = sig.fullName;
-  top.signature = sig; -- TODO: figure out if this is ever used for actions?
-
+  top.fullName = "__action__"; -- Used as part of naming locals... maybe we should fix that? TODO
+  top.signature = bogusNamedSignature();
+  
   top.lazyApplication = false;
   top.permitActions = true;
   --top.permitProductionAttributes = false; -- denied by default
@@ -28,10 +29,22 @@ top::BlockContext ::= sig::NamedSignature
   -- TODO: signature? We DO have such info, but unclear what answer should be given...
 }
 
+{-- Disambiguation groups -}
 abstract production disambiguationContext
-top::BlockContext ::= sig::NamedSignature
+top::BlockContext ::=
 {
   top.permitPluck = true;
-  forwards to actionContext(sig);
+  forwards to actionContext();
+}
+
+{-- Production reduce actions -}
+abstract production reduceActionContext
+top::BlockContext ::= sig::NamedSignature
+{
+  top.fullName = sig.fullName;
+  top.signature = sig; -- TODO: figure out if this is ever used for actions?
+  top.className = makeClassName(top.fullName); -- child references in production actions use it
+
+  forwards to actionContext();
 }
 

--- a/grammars/silver/modification/copper/BlockContext.sv
+++ b/grammars/silver/modification/copper/BlockContext.sv
@@ -20,9 +20,9 @@ top::BlockContext ::=
 {
   top.lazyApplication = false;
   top.permitActions = true;
-  top.permitProductionAttributes = false;
+  --top.permitProductionAttributes = false; -- denied by default
   top.permitLocalAttributes = true;
-  -- TODO: signature??
+  -- TODO: signature? We DO have such info, but unclear what answer should be given...
 }
 
 abstract production disambiguationContext

--- a/grammars/silver/modification/copper/DisambiguationGroup.sv
+++ b/grammars/silver/modification/copper/DisambiguationGroup.sv
@@ -18,8 +18,7 @@ top::AGDcl ::= 'disambiguate' terms::TermPrecList acode::ActionCode_c
   production attribute fName :: String;
   fName = top.grammarName ++ ":__disam" ++ toString(top.location.line);
   
-  acode.signature = namedNamedSignature(fName);
-  acode.blockContext = disambiguationContext();
+  acode.frame = disambiguationContext(namedNamedSignature(fName));
 
   top.syntaxAst = [syntaxDisambiguationGroup(fName,terms.precTermList,acode.actionCode)];
 }

--- a/grammars/silver/modification/copper/DisambiguationGroup.sv
+++ b/grammars/silver/modification/copper/DisambiguationGroup.sv
@@ -18,7 +18,7 @@ top::AGDcl ::= 'disambiguate' terms::TermPrecList acode::ActionCode_c
   production attribute fName :: String;
   fName = top.grammarName ++ ":__disam" ++ toString(top.location.line);
   
-  acode.frame = disambiguationContext(namedNamedSignature(fName));
+  acode.frame = disambiguationContext();
 
   top.syntaxAst = [syntaxDisambiguationGroup(fName,terms.precTermList,acode.actionCode)];
 }

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -9,7 +9,7 @@ top::Expr ::= q::Decorated QName
 
   top.typerep = q.lookupValue.typerep;
 
-  top.translation = "((" ++ q.lookupValue.typerep.transType ++ ")((common.Node)RESULT).getChild(" ++ makeClassName(top.frame.fullName) ++ ".i_" ++ q.lookupValue.fullName ++ "))";
+  top.translation = "((" ++ q.lookupValue.typerep.transType ++ ")((common.Node)RESULT).getChild(" ++ top.frame.className ++ ".i_" ++ q.lookupValue.fullName ++ "))";
   top.lazyTranslation = top.translation; -- never, but okay!
 
   top.upSubst = top.downSubst;
@@ -73,11 +73,12 @@ top::Expr ::= q::Decorated QName
   top.typerep = q.lookupValue.typerep;
 
   -- Yeah, it's a big if/then/else block, but these are all very similar and related.
-  top.translation = if q.name == "lexeme" then "new common.StringCatter(lexeme)" else
-                    if q.name == "line" then "virtualLocation.getLine()" else
-                    if q.name == "column" then "virtualLocation.getColumn()" else
-                    if q.name == "filename" then "new common.StringCatter(virtualLocation.getFileName())" else
-                    error("unknown actionTerminalReference " ++ q.name); -- should never be called, but here for safety
+  top.translation =
+    if q.name == "lexeme" then "new common.StringCatter(lexeme)" else
+    if q.name == "line" then "virtualLocation.getLine()" else
+    if q.name == "column" then "virtualLocation.getColumn()" else
+    if q.name == "filename" then "new common.StringCatter(virtualLocation.getFileName())" else
+    error("unknown actionTerminalReference " ++ q.name); -- should never be called, but here for safety
   top.lazyTranslation = top.translation; -- never, but okay!
 
   top.upSubst = top.downSubst;

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -9,7 +9,7 @@ top::Expr ::= q::Decorated QName
 
   top.typerep = q.lookupValue.typerep;
 
-  top.translation = "((" ++ q.lookupValue.typerep.transType ++ ")((common.Node)RESULT).getChild(" ++ makeClassName(top.signature.fullName) ++ ".i_" ++ q.lookupValue.fullName ++ "))";
+  top.translation = "((" ++ q.lookupValue.typerep.transType ++ ")((common.Node)RESULT).getChild(" ++ makeClassName(top.frame.fullName) ++ ".i_" ++ q.lookupValue.fullName ++ "))";
   top.lazyTranslation = top.translation; -- never, but okay!
 
   top.upSubst = top.downSubst;
@@ -51,7 +51,7 @@ top::Expr ::= q::Decorated QName
 {
   top.pp = q.pp;
 
-  top.errors := if !top.blockContext.permitActions
+  top.errors := if !top.frame.permitActions
                 then [err(top.location, "References to parser attributes can only be made in action blocks")]
                 else [];
 

--- a/grammars/silver/modification/copper/ParserAttributes.sv
+++ b/grammars/silver/modification/copper/ParserAttributes.sv
@@ -16,8 +16,7 @@ top::AGDcl ::= 'parser' 'attribute' a::Name '::' te::Type 'action' acode::Action
 
   top.errors := te.errors ++ acode.errors;
   
-  acode.signature = namedNamedSignature(fName);
-  acode.blockContext = actionContext();
+  acode.frame = actionContext(namedNamedSignature(fName));
   acode.env = newScopeEnv(acode.defs, top.env);
   
   top.syntaxAst = [syntaxParserAttribute(fName, te.typerep, acode.actionCode)];

--- a/grammars/silver/modification/copper/ParserAttributes.sv
+++ b/grammars/silver/modification/copper/ParserAttributes.sv
@@ -16,7 +16,7 @@ top::AGDcl ::= 'parser' 'attribute' a::Name '::' te::Type 'action' acode::Action
 
   top.errors := te.errors ++ acode.errors;
   
-  acode.frame = actionContext(namedNamedSignature(fName));
+  acode.frame = actionContext();
   acode.env = newScopeEnv(acode.defs, top.env);
   
   top.syntaxAst = [syntaxParserAttribute(fName, te.typerep, acode.actionCode)];

--- a/grammars/silver/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/modification/copper/ProductionStmt.sv
@@ -23,7 +23,7 @@ top::ProductionStmt ::= 'pluck' e::Expr ';'
   -- Perhaps this problem can be resolved by using a proper type in this situation.
   top.translation = "return (Integer)" ++ e.translation ++ ";\n";
 
-  top.errors := (if !top.blockContext.permitPluck
+  top.errors := (if !top.frame.permitPluck
                then [err(top.location, "'pluck' allowed only in disambiguation-group parser actions.")]
                else [])
                ++ e.errors;
@@ -41,7 +41,7 @@ top::ProductionStmt ::= 'print' e::Expr ';'
 
   top.translation = "System.err.println(" ++ e.translation ++ ");\n";
 
-  top.errors := (if !top.blockContext.permitActions
+  top.errors := (if !top.frame.permitActions
                then [err(top.location, "'print' statement allowed only in parser action blocks. You may be looking for print(String,IO) :: IO.")]
                else [])
                ++ e.errors;
@@ -71,7 +71,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   top.pp = "\t" ++ val.pp ++ " = " ++ e.pp ++ ";";
 
   top.errors := e.errors ++
-               (if !top.blockContext.permitActions
+               (if !top.frame.permitActions
                 then [err(top.location, "Assignment to parser attributes only permitted in parser action blocks")]
                 else []);
 
@@ -103,7 +103,7 @@ top::ProductionStmt ::= 'pushToken' '(' val::QName ',' lexeme::Expr ')' 'if' con
   top.pp = "\t" ++ "pushToken(" ++ val.pp ++ ", " ++ lexeme.pp ++ ") if " ++ condition.pp ++ ";";
 
   top.errors := lexeme.errors ++ condition.errors ++
-               (if !top.blockContext.permitActions
+               (if !top.frame.permitActions
                 then [err(top.location, "Tokens may only be pushed in action blocks")]
                 else []);
 
@@ -141,7 +141,7 @@ top::DefLHS ::= q::Decorated QName
   top.pp = q.pp;
   
   -- Note this is always erroring!
-  top.errors := if !top.blockContext.permitActions
+  top.errors := if !top.frame.permitActions
                 then [err(q.location, "Parser attributes can only be used in action blocks")]
                 else [err(q.location, "Parser action blocks are imperative, not declarative. You cannot modify the attributes of " ++ q.name ++ ". If you are trying to set inherited attributes, you should use 'decorate ... with { ... }' when you create it.")];
 

--- a/grammars/silver/modification/copper/TerminalDcl.sv
+++ b/grammars/silver/modification/copper/TerminalDcl.sv
@@ -39,8 +39,7 @@ top::TerminalModifier ::= 'action' acode::ActionCode_c
 
   top.terminalModifiers = [termAction(acode.actionCode)];
 
-  -- TODO: better name than this dummy one?
-  acode.frame = actionContext(namedNamedSignature(top.grammarName ++ ":__ta" ++ toString($1.line)));
+  acode.frame = actionContext();
   acode.env = newScopeEnv(addTerminalAttrDefs(acode.defs), top.env);
   
   top.errors := acode.errors;

--- a/grammars/silver/modification/copper/TerminalDcl.sv
+++ b/grammars/silver/modification/copper/TerminalDcl.sv
@@ -39,11 +39,9 @@ top::TerminalModifier ::= 'action' acode::ActionCode_c
 
   top.terminalModifiers = [termAction(acode.actionCode)];
 
-  acode.blockContext = actionContext();
-  acode.env = newScopeEnv(addTerminalAttrDefs(acode.defs), top.env);
-
   -- TODO: better name than this dummy one?
-  acode.signature = namedNamedSignature(top.grammarName ++ ":__ta" ++ toString($1.line));
+  acode.frame = actionContext(namedNamedSignature(top.grammarName ++ ":__ta" ++ toString($1.line)));
+  acode.env = newScopeEnv(addTerminalAttrDefs(acode.defs), top.env);
   
   top.errors := acode.errors;
 }

--- a/grammars/silver/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/modification/defaultattr/DefaultAttr.sv
@@ -32,8 +32,7 @@ top::AGDcl ::= 'aspect' 'default' 'production'
     addNewLexicalTyVars_ActuallyVariables(top.grammarName, top.location, te.lexicalTypeVariables);
 
   body.env = newScopeEnv(fakedDefs ++ sigDefs, top.env);
-  body.signature = namedSig;
-  body.blockContext = defaultAspectContext();
+  body.frame = defaultAspectContext(namedSig);
 
   body.downSubst = emptySubst();
 
@@ -73,11 +72,14 @@ top::DefLHS ::= q::Decorated QName
 
   top.typerep = q.lookupValue.typerep;
 
-  top.translation = makeNTClassName(top.signature.outputElement.typerep.typeName) ++ ".defaultSynthesizedAttributes";
+  top.translation = makeNTClassName(top.frame.lhsNtName) ++ ".defaultSynthesizedAttributes";
 }
 
 abstract production defaultAspectContext
-top::BlockContext ::=
+top::BlockContext ::= sig::NamedSignature  -- okay, sorta has a sig?
 {
+  top.fullName = sig.fullName;
+  top.lhsNtName = sig.outputElement.typerep.typeName;
+  top.signature = sig;
 }
 

--- a/grammars/silver/modification/ffi/FunctionDcl.sv
+++ b/grammars/silver/modification/ffi/FunctionDcl.sv
@@ -2,8 +2,8 @@ grammar silver:modification:ffi;
 
 terminal FFI_kwd 'foreign' lexer classes {KEYWORD,RESERVED};
 
-nonterminal FFIDefs with config, location, grammarName, errors, signature, env, pp;
-nonterminal FFIDef with config, location, grammarName, errors, signature, env, pp;
+nonterminal FFIDefs with config, location, grammarName, errors, env, pp;
+nonterminal FFIDef with config, location, grammarName, errors, env, pp;
 
 concrete production functionDclFFI
 top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody 'foreign' '{' ffidefs::FFIDefs '}'

--- a/grammars/silver/modification/let_fix/Let.sv
+++ b/grammars/silver/modification/let_fix/Let.sv
@@ -56,9 +56,9 @@ top::Expr ::= la::AssignExpr  e::Expr
   e.env = newScopeEnv(la.defs, top.env);
 }
 
-nonterminal AssignExpr with location, config, grammarName, env, compiledGrammars, signature, 
+nonterminal AssignExpr with location, config, grammarName, env, compiledGrammars, 
                             pp, defs, errors, upSubst, 
-                            downSubst, finalSubst, blockContext;
+                            downSubst, finalSubst, frame;
 
 abstract production appendAssignExpr
 top::AssignExpr ::= a1::AssignExpr a2::AssignExpr

--- a/grammars/silver/modification/let_fix/java/Let.sv
+++ b/grammars/silver/modification/let_fix/java/Let.sv
@@ -27,7 +27,7 @@ top::Expr ::= la::AssignExpr  e::Expr
   top.translation = "((" ++ finTy.transType ++ ")(" ++ closureExpr ++ ").eval())";
 
   top.lazyTranslation = 
-    if top.blockContext.lazyApplication
+    if top.frame.lazyApplication
     then closureExpr
     else top.translation;
 }
@@ -76,7 +76,7 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
     else "((" ++ finalType(top).transType ++ ")(" ++ makeLocalValueName(q.lookupValue.fullName) ++ ".eval()))";
 
   top.lazyTranslation = 
-    if !top.blockContext.lazyApplication then top.translation
+    if !top.frame.lazyApplication then top.translation
     else if needsUndecorating
     then "common.Thunk.transformUndecorate(" ++ makeLocalValueName(q.lookupValue.fullName) ++ ")"
     else makeLocalValueName(q.lookupValue.fullName);

--- a/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
@@ -19,12 +19,12 @@ import silver:extension:list; -- Oh no, this is a hack! TODO
 terminal Match_kwd 'match' lexer classes {KEYWORD,RESERVED}; -- temporary!!!
 
 nonterminal PrimPatterns with 
-  config, grammarName, env, compiledGrammars, signature, blockContext,
+  config, grammarName, env, compiledGrammars, frame,
   location, pp, errors,
   downSubst, upSubst, finalSubst,
   scrutineeType, returnType, translation;
 nonterminal PrimPattern with 
-  config, grammarName, env, compiledGrammars, signature, blockContext,
+  config, grammarName, env, compiledGrammars, frame,
   location, pp, errors,
   downSubst, upSubst, finalSubst,
   scrutineeType, returnType, translation;
@@ -121,7 +121,7 @@ top::Expr ::= e::Expr t::Type pr::PrimPatterns f::Expr
         "return " ++ f.translation ++ ";" ++ 
     "}}.eval(context, (" ++ scrutineeTransType ++")" ++ e.translation ++ ")";
 
-  top.lazyTranslation = wrapThunk(top.translation, top.blockContext.lazyApplication); 
+  top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication); 
   -- TODO there seems to be an opportunity here to avoid an anon class somehow...
 }
 

--- a/grammars/silver/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/modification/primitivepattern/VarBinders.sv
@@ -7,12 +7,12 @@ import silver:modification:let_fix only makeSpecialLocalBinding, lexicalLocalDef
 import silver:definition:flow:ast only noVertex;
 
 nonterminal VarBinders with 
-  config, grammarName, env, compiledGrammars, signature, blockContext,
+  config, grammarName, env, compiledGrammars, frame,
   location, pp, errors, defs,
   bindingTypes, bindingIndex, translation, varBinderCount,
   finalSubst;
 nonterminal VarBinder with
-  config, grammarName, env, compiledGrammars, signature, blockContext,
+  config, grammarName, env, compiledGrammars, frame,
   location, pp, errors, defs,
   bindingType, bindingIndex, translation,
   finalSubst;

--- a/grammars/silver/translation/java/core/BlockContext.sv
+++ b/grammars/silver/translation/java/core/BlockContext.sv
@@ -8,6 +8,7 @@ attribute className, prodLocalCountName occurs on BlockContext;
  -
  - Valid to access only within productions/functions.
  - (used by equations. exprs, but only in flowDefs, which shouldn't be accessed outside productions)
+ - (Also used by production action blocks to access children)
  -}
 synthesized attribute className :: String;
 {--

--- a/grammars/silver/translation/java/core/BlockContext.sv
+++ b/grammars/silver/translation/java/core/BlockContext.sv
@@ -1,0 +1,48 @@
+grammar silver:translation:java:core;
+
+attribute className, prodLocalCountName occurs on BlockContext;
+
+{--
+ - The name of the class for the current context.
+ - e.g. "silver.definition.core.PbaseExpr"
+ -
+ - Valid to access only within productions/functions.
+ - (used by equations. exprs, but only in flowDefs, which shouldn't be accessed outside productions)
+ -}
+synthesized attribute className :: String;
+{--
+ - The name to access a production's local count.
+ - e.g. "silver.definition.core.Init.count_local__ON__silver_definition_core_PbaseExpr"
+ -
+ - Also valid only in prod/func. Used only by local declarations.
+ -}
+synthesized attribute prodLocalCountName :: String;
+
+aspect default production
+top::BlockContext ::=
+{
+  top.className = error("context does not have a className");
+  top.prodLocalCountName = error("prodLocalCountName in context without locals");
+}
+
+aspect production functionContext
+top::BlockContext ::= sig::NamedSignature
+{
+  top.className = makeClassName(top.fullName);
+  top.prodLocalCountName =
+    makeName(top.sourceGrammar) ++ ".Init.count_local__ON__" ++ makeIdName(top.fullName);
+}
+
+aspect production productionContext
+top::BlockContext ::= sig::NamedSignature
+{
+  top.className = makeClassName(top.fullName);
+  top.prodLocalCountName =
+    makeName(top.sourceGrammar) ++ ".Init.count_local__ON__" ++ makeIdName(top.fullName);
+}
+
+aspect production globalExprContext
+top::BlockContext ::=
+{
+}
+

--- a/grammars/silver/translation/java/core/BlockContext.sv
+++ b/grammars/silver/translation/java/core/BlockContext.sv
@@ -27,7 +27,7 @@ top::BlockContext ::=
 }
 
 aspect production functionContext
-top::BlockContext ::= sig::NamedSignature
+top::BlockContext ::= sig::NamedSignature  _
 {
   top.className = makeClassName(top.fullName);
   top.prodLocalCountName =
@@ -35,7 +35,7 @@ top::BlockContext ::= sig::NamedSignature
 }
 
 aspect production productionContext
-top::BlockContext ::= sig::NamedSignature
+top::BlockContext ::= sig::NamedSignature  _
 {
   top.className = makeClassName(top.fullName);
   top.prodLocalCountName =

--- a/grammars/silver/translation/java/core/BuiltInFunctions.sv
+++ b/grammars/silver/translation/java/core/BuiltInFunctions.sv
@@ -12,7 +12,7 @@ top::Expr ::= e::Decorated Expr
 {
   top.translation = "Integer.valueOf(((common.StringCatter)" ++ e.translation ++ ").length())";
 
-  top.lazyTranslation = wrapThunk(top.translation, top.blockContext.lazyApplication);
+  top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
 
 aspect production toIntFunction
@@ -25,7 +25,7 @@ top::Expr ::= 'toInt' '(' e::Expr ')'
                     | t -> error("INTERNAL ERROR: no toInt translation for type " ++ prettyType(t))
                     end;
 
-  top.lazyTranslation = wrapThunk(top.translation, top.blockContext.lazyApplication);
+  top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
 aspect production toFloatFunction
 top::Expr ::= 'toFloat' '(' e::Expr ')'
@@ -37,14 +37,14 @@ top::Expr ::= 'toFloat' '(' e::Expr ')'
                     | t -> error("INTERNAL ERROR: no toFloat translation for type " ++ prettyType(t))
                     end;
 
-  top.lazyTranslation = wrapThunk(top.translation, top.blockContext.lazyApplication);
+  top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
 aspect production toStringFunction
 top::Expr ::= 'toString' '(' e::Expr ')'
 {
   top.translation = "new common.StringCatter(String.valueOf(" ++ e.translation ++ "))";
 
-  top.lazyTranslation = wrapThunk(top.translation, top.blockContext.lazyApplication);
+  top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
 
 aspect production newFunction
@@ -52,7 +52,7 @@ top::Expr ::= 'new' '(' e::Expr ')'
 {
   top.translation = "((" ++ finalType(top).transType ++ ")" ++ e.translation ++ ".undecorate())";
   
-  top.lazyTranslation = wrapThunk(top.translation, top.blockContext.lazyApplication);
+  top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
 
 aspect production terminalConstructor
@@ -60,5 +60,5 @@ top::Expr ::= 'terminal' '(' t::Type ',' es::Expr ',' el::Expr ')'
 {
   top.translation = "new " ++ makeTerminalName(t.typerep.typeName) ++ "(" ++ es.translation ++ ", (core.NLocation)" ++ el.translation ++ ")";
 
-  top.lazyTranslation = wrapThunk(top.translation, top.blockContext.lazyApplication);
+  top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }

--- a/grammars/silver/translation/java/core/Expr.sv
+++ b/grammars/silver/translation/java/core/Expr.sv
@@ -42,7 +42,7 @@ aspect production childReference
 top::Expr ::= q::Decorated QName
 {
   local attribute childIDref :: String;
-  childIDref = makeClassName(top.frame.fullName) ++ ".i_" ++ q.lookupValue.fullName;
+  childIDref = top.frame.className ++ ".i_" ++ q.lookupValue.fullName;
 
   top.translation =
     if q.lookupValue.typerep.isDecorable
@@ -210,16 +210,18 @@ top::Expr ::= e::Decorated Expr es::Decorated AppExprs annos::Decorated AnnoAppE
 aspect production attributeSection
 top::Expr ::= '(' '.' q::QName ')'
 {
-  top.translation = if inputType.isDecorated
-                    then "new common.AttributeSection(" ++ occursCheck.dcl.attrOccursIndex ++ ")"
-                    -- Please note: context is not actually required here, we do so to make runtime error messages
-                    -- more comprehensible. This is a similar situation to the code for 'decorate E with {}'.
-                    -- Rather pin more memory than necessary than make errors bad. For now.
-                    -- TODO: This is a good candidate for removing if we make the well-definedness error check required, though!
-                    -- That error would be more comprehensible! (the trouble with this is that we're reporting as context the
-                    -- function/production we appear within here. The function *may* be applied elsewhere. However, the most common
-                    -- case is something like map((.attr), list) so, that's probably best to report here instead of within map.)
-                    else "new common.AttributeSection.Undecorated(" ++ occursCheck.dcl.attrOccursIndex ++ ", context)";
+  top.translation =
+    if inputType.isDecorated then
+      "new common.AttributeSection(" ++ occursCheck.dcl.attrOccursIndex ++ ")"
+    else
+      -- Please note: context is not actually required here, we do so to make runtime error messages
+      -- more comprehensible. This is a similar situation to the code for 'decorate E with {}'.
+      -- Rather pin more memory than necessary than make errors bad. For now.
+      -- TODO: This is a good candidate for removing if we make the well-definedness error check required, though!
+      -- That error would be more comprehensible! (the trouble with this is that we're reporting as context the
+      -- function/production we appear within here. The function *may* be applied elsewhere. However, the most common
+      -- case is something like map((.attr), list) so, that's probably best to report here instead of within map.)
+      "new common.AttributeSection.Undecorated(" ++ occursCheck.dcl.attrOccursIndex ++ ", context)";
 
   top.lazyTranslation = top.translation;
 }
@@ -255,9 +257,9 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     | childReference(cqn), true -> 
         if cqn.lookupValue.typerep.isDecorable
         then
-          "context.childDecoratedSynthesizedLazy(" ++ makeClassName(top.frame.fullName) ++ ".i_" ++ cqn.lookupValue.fullName ++ ", " ++ q.dcl.attrOccursIndex ++ ")"
+          "context.childDecoratedSynthesizedLazy(" ++ top.frame.className ++ ".i_" ++ cqn.lookupValue.fullName ++ ", " ++ q.dcl.attrOccursIndex ++ ")"
         else
-          "context.childAsIsSynthesizedLazy(" ++ makeClassName(top.frame.fullName) ++ ".i_" ++ cqn.lookupValue.fullName ++ ", " ++ q.dcl.attrOccursIndex ++ ")"
+          "context.childAsIsSynthesizedLazy(" ++ top.frame.className ++ ".i_" ++ cqn.lookupValue.fullName ++ ", " ++ q.dcl.attrOccursIndex ++ ")"
     | lhsReference(_), true ->
         "context.contextSynthesizedLazy(" ++ q.dcl.attrOccursIndex ++ ")"
     | _, _ -> wrapThunk(top.translation, top.frame.lazyApplication)

--- a/grammars/silver/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/translation/java/core/ProductionBody.sv
@@ -77,7 +77,7 @@ aspect production forwardInh
 top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
 {
   local attribute className :: String;
-  className = makeClassName(top.signature.fullName);
+  className = makeClassName(top.frame.fullName);
 
   top.translation = 
 	"\t\t//" ++ top.pp ++ "\n" ++
@@ -107,18 +107,18 @@ aspect production localAttributeDcl
 top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::Type ';'
 {
   local attribute prod_orig_grammar :: String;
-  prod_orig_grammar = substring(0, lastIndexOf(":", top.signature.fullName), top.signature.fullName);
+  prod_orig_grammar = substring(0, lastIndexOf(":", top.frame.fullName), top.frame.fullName);
   local attribute prod_orig_name :: String;
-  prod_orig_name = substring(lastIndexOf(":", top.signature.fullName)+1, length(top.signature.fullName), top.signature.fullName);
+  prod_orig_name = substring(lastIndexOf(":", top.frame.fullName)+1, length(top.frame.fullName), top.frame.fullName);
   local attribute ugh_dcl_hack :: DclInfo;
   ugh_dcl_hack = head(getValueDclAll(fName, top.env)); -- TODO really, we should have a DclInfo for ourselves no problem. but out current approach of constructing it via localDef makes this annoyingly difficult. this suggests a probably environment refactoring...
   
-  top.valueWeaving := "public static final int " ++ ugh_dcl_hack.attrOccursIndexName ++ " = " ++ makeName(prod_orig_grammar) ++ ".Init.count_local__ON__" ++ makeIdName(top.signature.fullName) ++ "++;\n";
+  top.valueWeaving := "public static final int " ++ ugh_dcl_hack.attrOccursIndexName ++ " = " ++ makeName(prod_orig_grammar) ++ ".Init.count_local__ON__" ++ makeIdName(top.frame.fullName) ++ "++;\n";
 
   top.setupInh := 
     if !te.typerep.isDecorable then  "" else
     "\t\t//" ++ top.pp ++ "\n" ++
-    "\t\t" ++ makeClassName(top.signature.fullName) ++ ".localInheritedAttributes[" ++ ugh_dcl_hack.attrOccursIndex ++ "] = " ++ 
+    "\t\t" ++ makeClassName(top.frame.fullName) ++ ".localInheritedAttributes[" ++ ugh_dcl_hack.attrOccursIndex ++ "] = " ++ 
       "new common.Lazy[" ++ makeNTClassName(te.typerep.typeName) ++ ".num_inh_attrs];\n";
 
   top.setupInh <- "\t\t" ++ makeName(prod_orig_grammar) ++ ".P" ++ prod_orig_name ++ ".occurs_local[" ++ ugh_dcl_hack.attrOccursIndex ++ "] = \"" ++ fName ++ "\";\n";
@@ -130,7 +130,7 @@ aspect production childDefLHS
 top::DefLHS ::= q::Decorated QName
 {
   local attribute className :: String;
-  className = makeClassName(top.signature.fullName);
+  className = makeClassName(top.frame.fullName);
 
   top.translation = className ++ ".childInheritedAttributes[" ++ className ++ ".i_" ++ q.lookupValue.fullName ++ "]";
 }
@@ -138,19 +138,19 @@ top::DefLHS ::= q::Decorated QName
 aspect production lhsDefLHS
 top::DefLHS ::= q::Decorated QName
 {
-  top.translation = makeClassName(top.signature.fullName) ++ ".synthesizedAttributes";
+  top.translation = makeClassName(top.frame.fullName) ++ ".synthesizedAttributes";
 }
 
 aspect production localDefLHS
 top::DefLHS ::= q::Decorated QName
 {
-  top.translation = makeClassName(top.signature.fullName) ++ ".localInheritedAttributes[" ++ q.lookupValue.dcl.attrOccursIndex ++ "]";
+  top.translation = makeClassName(top.frame.fullName) ++ ".localInheritedAttributes[" ++ q.lookupValue.dcl.attrOccursIndex ++ "]";
 }
 
 aspect production forwardDefLHS
 top::DefLHS ::= q::Decorated QName
 {
-  top.translation = makeClassName(top.signature.fullName) ++ ".forwardInheritedAttributes";
+  top.translation = makeClassName(top.frame.fullName) ++ ".forwardInheritedAttributes";
 }
 
 aspect production errorDefLHS
@@ -192,7 +192,7 @@ aspect production localValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
   local attribute className :: String;
-  className = makeClassName(top.signature.fullName);
+  className = makeClassName(top.frame.fullName);
 
   top.translation =
 	"\t\t// " ++ val.pp ++ " = " ++ e.pp ++ "\n" ++


### PR DESCRIPTION
Fixes #160 

This pull request does 3 things:
1. Fix a flow vertex confusion bug in phantom productions that was causing extension synthesized attributes to not necessarily get their minimum flow type set.
2. A ton of refactoring eliminating `top.signature` and `top.blockContext` merging into `top.frame`.
3. Using this to send the local production graph down, including constructing them for functions, so functions can do flow analysis somewhat more normally.

There is a possibility that the Silver compiler may be more prone to crashes when compiling broken code. (There were some previously silently-wrong dummy-values being used, where now it `error()`s out.) If you run into one, send a bug report!

This patch is pretty extensive I think, so reviewing should be hard. I recommend going commit by commit rather than all changes at once. And probably just skimming it mostly. @krame505 ?