### PR TITLE
Reduce output slightly, and print error messages better

### DIFF
--- a/grammars/silver/composed/idetest/Analyze.sv
+++ b/grammars/silver/composed/idetest/Analyze.sv
@@ -106,8 +106,8 @@ function getIdeMessages
 {
   return map(rewriteMessage(path, _), 
     if !null(spec.parsingErrors)
-    then spec.parsingErrors
-    else spec.errors);
+    then flatMap(snd, spec.parsingErrors)
+    else flatMap(snd, spec.grammarErrors));
 }
 
 function rewriteMessage

--- a/grammars/silver/definition/core/GrammarParts.sv
+++ b/grammars/silver/definition/core/GrammarParts.sv
@@ -7,7 +7,7 @@ nonterminal Grammar with
   grammarName, env, globalImports, grammarDependencies,
   -- Synthesized attributes
   declaredName, moduleNames, exportedGrammars, optionalGrammars, condBuild,
-  defs, importedDefs, errors;
+  defs, importedDefs, grammarErrors;
 
 {--
 - A list of grammars that this grammar depends upon,
@@ -26,6 +26,10 @@ autocopy attribute globalImports :: Decorated Env;
  - At the top of a grammar, these are echoed down as globalImports
  -}
 synthesized attribute importedDefs :: [Def];
+{--
+ - An overall listing of error messages for a grammar
+ -}
+synthesized attribute grammarErrors :: [Pair<String [Message]>];
 
 abstract production nilGrammar
 top::Grammar ::=
@@ -40,7 +44,7 @@ top::Grammar ::=
   
   top.importedDefs = [];
   top.defs = [];
-  top.errors := [];
+  top.grammarErrors = [];
 }
 
 abstract production consGrammar
@@ -54,6 +58,8 @@ top::Grammar ::= h::Root  t::Grammar
 
   top.importedDefs = h.importedDefs ++ t.importedDefs;
   top.defs = h.defs ++ t.defs;
-  top.errors := h.errors ++ t.errors;
+  top.grammarErrors =
+    if null(h.errors) then t.grammarErrors
+    else pair(h.location.filename, h.errors) :: t.grammarErrors;
 
 }

--- a/grammars/silver/definition/core/QName.sv
+++ b/grammars/silver/definition/core/QName.sv
@@ -82,7 +82,7 @@ function dclinfo2possibility
 String ::= dcl::DclInfo
 {
   -- TODO: perhaps some way of including types, when they are relevant (attributes, values)
-  return "\t" ++ dcl.fullName ++ " (" ++ dcl.sourceLocation.filename ++ ":" ++ toString(dcl.sourceLocation.line) ++ ")\n";
+  return "\t" ++ dcl.fullName ++ " (" ++ dcl.sourceLocation.filename ++ ":" ++ toString(dcl.sourceLocation.line) ++ ")";
 }
 
 

--- a/grammars/silver/driver/CompileFiles.sv
+++ b/grammars/silver/driver/CompileFiles.sv
@@ -15,7 +15,7 @@ IOVal<Pair<[Root] [ParseError]>> ::= svParser::SVParser  gpath::String  files::[
   
   -- Print the path we're reading, and read the file.
   local text :: IOVal<String> =
-    readFile(gpath ++ file, print("\t[" ++ gpath ++ file ++ "]\n", ioin));
+    readFile(gpath ++ file, ioin);
 
   -- This is where a .sv file actually gets parsed:
   local r :: ParseResult<Root> = svParser(text.iovalue, file);

--- a/grammars/silver/driver/CompileInterface.sv
+++ b/grammars/silver/driver/CompileInterface.sv
@@ -2,12 +2,15 @@ grammar silver:driver;
 
 
 function compileInterface
-IOVal<ParseResult<IRoot>> ::= sviParser::SVIParser  genPath::String  ioin::IO
+IOVal<ParseResult<IRoot>> ::= sviParser::SVIParser  grammarName::String  genPath::String  ioin::IO
 {
   local file :: String = "Silver.svi";
   
+  local pr :: IO = 
+    print("Found " ++ grammarName ++ "\n\t[" ++ genPath ++ file ++ "]\n", ioin);
+
   local text :: IOVal<String> =
-    readFile(genPath ++ file, print("\t[" ++ genPath ++ file ++ "]\n", ioin));
+    readFile(genPath ++ file, pr);
 
   local ir :: ParseResult<IRoot> = sviParser(text.iovalue, file);
 

--- a/grammars/silver/driver/GrammarAction.sv
+++ b/grammars/silver/driver/GrammarAction.sv
@@ -44,6 +44,15 @@ String ::= r::Decorated RootSpec genPath::String
 abstract production printAllBindingErrors
 top::DriverAction ::= specs::[Decorated RootSpec]
 {
+  -- Force printing of status before doing error checks
+  top.code = unsafeTrace(forward.code, forward.ioIn);
+  -- For anyone encountering this hack for the first time,
+  -- IO-token passing can force linearity of actions, but
+  -- interleaves pure computation in annoying ways.
+  -- Without the above, all the error checking work gets done
+  -- (to compute return code) before something tries to do IO,
+  -- so we wouldn't print first.
+
   forwards to printAllBindingErrorsHelp(specs)
   with {
     ioIn = print("Checking For Errors.\n", top.ioIn);

--- a/grammars/silver/driver/util/RootSpec.sv
+++ b/grammars/silver/driver/util/RootSpec.sv
@@ -23,7 +23,7 @@ synthesized attribute translateGrammars :: [Decorated RootSpec];
 {--
  - Parse errors present in this grammar (only for errorRootSpec!)
  -}
-synthesized attribute parsingErrors :: [Message];
+synthesized attribute parsingErrors :: [Pair<String [Message]>];
 
 {--
  - Create a RootSpec from a real grammar, a set of .sv files.
@@ -126,15 +126,17 @@ top::RootSpec ::= e::[ParseError]  grammarName::String  grammarSource::String  g
 }
 
 function parseErrorToMessage
-Message ::= grammarSource::String  e::ParseError
+Pair<String [Message]> ::= grammarSource::String  e::ParseError
 {
   return case e of
   | syntaxError(str, locat, _, _) ->
-      err(loc(locat.filename, locat.line, locat.column, locat.endLine, locat.endColumn, locat.index, locat.endIndex),
-          "Syntax error:\n" ++ str)
+      pair(locat.filename, 
+        [err(locat,
+          "Syntax error:\n" ++ str)])
   | unknownParseError(str, file) ->
-      err(loc(grammarSource ++ file, -1, -1, -1, -1, -1, -1),
-          "Unknown error while parsing:\n" ++ str)
+      pair(file,
+        [err(loc(grammarSource ++ file, -1, -1, -1, -1, -1, -1),
+          "Unknown error while parsing:\n" ++ str)])
   end;
 }
 

--- a/grammars/silver/driver/util/RootSpec.sv
+++ b/grammars/silver/driver/util/RootSpec.sv
@@ -1,6 +1,6 @@
 grammar silver:driver:util;
 
-import silver:definition:core only Grammar, errors, grammarName, importedDefs, grammarDependencies, globalImports, Message, err;
+import silver:definition:core only Grammar, grammarErrors, grammarName, importedDefs, grammarDependencies, globalImports, Message, err;
 import silver:definition:env:env_parser only IRoot;
 import silver:definition:flow:env only flowEnv, flowDefs, fromFlowDefs;
 import silver:definition:flow:ast only nilFlow, consFlow, FlowDef;
@@ -13,7 +13,7 @@ nonterminal RootSpec with
   config, compiledGrammars, productionFlowGraphs, grammarFlowTypes,
   -- synthesized attributes
   declaredName, moduleNames, exportedGrammars, optionalGrammars, condBuild, allGrammarDependencies,
-  defs, errors, grammarSource, grammarTime, interfaceTime, recheckGrammars, translateGrammars, parsingErrors;
+  defs, grammarErrors, grammarSource, grammarTime, interfaceTime, recheckGrammars, translateGrammars, parsingErrors;
 
 {--
  - Grammars that were read from source.
@@ -68,7 +68,7 @@ top::RootSpec ::= g::Grammar  grammarName::String  grammarSource::String  gramma
   top.allGrammarDependencies = actualDependencies;
   
   top.defs = g.defs;
-  top.errors := g.errors;
+  top.grammarErrors = g.grammarErrors;
   top.parsingErrors = [];
 }
 
@@ -96,7 +96,7 @@ top::RootSpec ::= p::IRoot  interfaceTime::Integer
   top.allGrammarDependencies = p.allGrammarDependencies;
 
   top.defs = p.defs;
-  top.errors := []; -- TODO: consider getting grammarName and comparing against declaredName?
+  top.grammarErrors = []; -- TODO: consider getting grammarName and comparing against declaredName?
   top.parsingErrors = [];
 }
 
@@ -121,7 +121,7 @@ top::RootSpec ::= e::[ParseError]  grammarName::String  grammarSource::String  g
   top.allGrammarDependencies = [];
 
   top.defs = [];
-  top.errors := [];
+  top.grammarErrors = [];
   top.parsingErrors = map(parseErrorToMessage(grammarSource, _), e);
 }
 


### PR DESCRIPTION
This isn't a huge reduction, but it helps a bit. I'd give an example of the new output but my VM has mysteriously stopped syncing copy & paste... >:(

The biggest change, really, is that errors now print out the full path of a file before that file's contents.

When compiling grammars, we now print out the path we found the grammar at, and then each of the files within it. This saves some lines.

Parser errors now report full path as well, where they previously were a bit mysterious (though usually those would be in a file you're already editing...)

Fixes #151 
