### PR TITLE
dc no longer passes a terminal to the intLiteral abstract production.

### DIFF
--- a/tutorials/dc/AbstractSyntax.sv
+++ b/tutorials/dc/AbstractSyntax.sv
@@ -57,9 +57,9 @@ quo::Expr ::= l::Expr r::Expr
 }
 
 abstract production integerConstant
-e::Expr ::= i::IntLit_t
+e::Expr ::= i::Integer
 {
- e.pp = i.lexeme ;
- e.value = toInt(i.lexeme);
+ e.pp = toString(i);
+ e.value = i;
 }
 

--- a/tutorials/dc/BetterPP.sv
+++ b/tutorials/dc/BetterPP.sv
@@ -108,7 +108,7 @@ quo::Expr ::= l::Expr r::Expr
 }
 
 aspect production integerConstant
-e::Expr ::= i::IntLit_t
+e::Expr ::= i::Integer
 {
- e.bpp = i.lexeme ;
+ e.bpp = toString(i);
 }

--- a/tutorials/dc/ConcreteSyntax.sv
+++ b/tutorials/dc/ConcreteSyntax.sv
@@ -84,7 +84,7 @@ concrete production integerConstant_c
 ic::Factor_c ::= i::IntLit_t
 {
  ic.pp = i.lexeme ;
- ic.ast_Expr = integerConstant(i);
+ ic.ast_Expr = integerConstant(toInt(i.lexeme));
 }
 
 


### PR DESCRIPTION
Also, should I change the left-hand-sides of all the productions to `top`, to fit with what we do in other grammars?