### PR TITLE
Fix/cst errors

### DIFF
--- a/grammars/core/Location.sv
+++ b/grammars/core/Location.sv
@@ -89,10 +89,6 @@ Location ::=
 function locationLte
 Boolean ::= l1::Location l2::Location
 {
-  -- TODO: We could probaly just compare based on filename and index
-  -- For the moment, though, use line & column instead.
-  return l1.filename < l2.filename || (l1.filename == l2.filename &&
-    (l1.line < l2.line || (l1.line == l2.line &&
-    (l1.column < l2.column))));
+  return l1.filename < l2.filename || (l1.filename == l2.filename && (l1.index < l2.index));
 }
 

--- a/grammars/core/Location.sv
+++ b/grammars/core/Location.sv
@@ -89,6 +89,11 @@ Location ::=
 function locationLte
 Boolean ::= l1::Location l2::Location
 {
-  return l1.filename < l2.filename || (l1.filename == l2.filename && (l1.index < l2.index));
+  -- TODO: We could probaly just compare based on filename and index
+  -- For the moment, though, use line & column instead.
+  return l1.filename < l2.filename || (l1.filename == l2.filename &&
+    (l1.line < l2.line || (l1.line == l2.line &&
+    (l1.column < l2.column))));
 }
+
 

--- a/grammars/silver/analysis/warnings/defs/Fwd.sv
+++ b/grammars/silver/analysis/warnings/defs/Fwd.sv
@@ -32,7 +32,7 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
     end;
 
   top.errors <-
-    if null(body.errors ++ ns.errors{-TODO-})
+    if null(body.errors ++ ns.errors)
     && (top.config.warnAll || top.config.warnFwd)
     -- If this production does not forward
     && null(body.uniqueSignificantExpression)

--- a/grammars/silver/analysis/warnings/defs/Syn.sv
+++ b/grammars/silver/analysis/warnings/defs/Syn.sv
@@ -31,7 +31,7 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
       getAttrsOn(namedSig.outputElement.typerep.typeName, top.env));
 
   top.errors <-
-    if null(body.errors ++ ns.errors{-TODO-})
+    if null(body.errors ++ ns.errors)
     && (top.config.warnAll || top.config.warnMissingSyn)
     && null(body.uniqueSignificantExpression) -- no forward
     then raiseMissingAttrs(top.location, fName, attrs, top.flowEnv)

--- a/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -42,7 +42,7 @@ top::SyntaxLexerClassModifier ::=
   --top.cstErrors := [];
   top.dominatesXML = "";
   top.submitsXML = "";
-  --top.unparses -- do not default unparses
+  --top.unparses -- don't default unparses
 }
 
 {--

--- a/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -42,7 +42,7 @@ top::SyntaxLexerClassModifier ::=
   --top.cstErrors := [];
   top.dominatesXML = "";
   top.submitsXML = "";
-  --top.unparses -- don't default unparses
+  --top.unparses -- do not default unparses
 }
 
 {--
@@ -53,7 +53,11 @@ top::SyntaxLexerClassModifier ::= sub::[String]
 {
   production subRefs :: [[Decorated SyntaxDcl]] = lookupStrings(sub, top.cstEnv);
 
-  top.cstErrors := []; -- TODO error checking!
+  top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
+                     if !null(a.snd) then []
+                     else ["Terminal / Lexer Class " ++ a.fst ++ " was referenced but " ++
+                           "this grammar was not included in this parser. (Referenced from submit clause for lexer class)"], --TODO: come up with a way to reference a given lexer class (line numbers would be great)
+                   zipWith(pair, sub, subRefs)); 
   top.submitsXML = implode("", map(xmlCopperRef, map(head, subRefs)));
   top.unparses = ["sub(" ++ unparseStrings(sub) ++ ")"];
 }
@@ -65,7 +69,11 @@ top::SyntaxLexerClassModifier ::= dom::[String]
 {
   production domRefs :: [[Decorated SyntaxDcl]] = lookupStrings(dom, top.cstEnv);
 
-  top.cstErrors := []; -- TODO error checking!
+  top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
+                     if !null(a.snd) then []
+                     else ["Terminal / Lexer Class " ++ a.fst ++ " was referenced but " ++
+                           "this grammar was not included in this parser. (Referenced from dominates clause for lexer class)"],
+                   zipWith(pair, dom, domRefs));
   top.dominatesXML = implode("", map(xmlCopperRef, map(head, domRefs)));
   top.unparses = ["dom(" ++ unparseStrings(dom) ++ ")"];
 }

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -115,7 +115,6 @@ top::SyntaxDcl ::= n::String regex::Regex_R modifiers::SyntaxTerminalModifiers
   top.cstErrors <- if length(searchEnvTree(n, top.cstEnv)) == 1 then []
                    else ["Name conflict with terminal " ++ n];
   
-  -- Consider: makeTerminalName(n)?
   modifiers.terminalName = n;
 
   top.cstNormalize = [top];

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -111,9 +111,12 @@ top::SyntaxDcl ::= n::String regex::Regex_R modifiers::SyntaxTerminalModifiers
 {
   top.sortKey = "CCC" ++ n;
   top.cstDcls = [pair(n, top)];
-  -- TODO get errors from modifiers
-  top.cstErrors := if length(searchEnvTree(n, top.cstEnv)) == 1 then []
+  top.cstErrors := modifiers.cstErrors;
+  top.cstErrors <- if length(searchEnvTree(n, top.cstEnv)) == 1 then []
                    else ["Name conflict with terminal " ++ n];
+  
+  -- Consider: makeTerminalName(n)?
+  modifiers.terminalName = n;
 
   top.cstNormalize = [top];
   top.allIgnoreTerminals = if modifiers.ignored then [top] else [];

--- a/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -116,7 +116,11 @@ top::SyntaxTerminalModifier ::= cls::[String]
   local clsRefsL :: [[Decorated SyntaxDcl]] = lookupStrings(cls, top.cstEnv);
   production clsRefs :: [Decorated SyntaxDcl] = map(head, clsRefsL);
 
-  top.cstErrors := []; -- TODO error checking!
+  top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
+                     if !null(a.snd) then []
+                     else ["Lexer Class " ++ a.fst ++ " was referenced but " ++
+                           "this grammar was not included in this parser. (Referenced from lexer class on terminal " ++ top.terminalName ++")"], 
+                   zipWith(pair, cls, clsRefsL)); 
   -- We "translate away" lexer classes dom/sub, by moving that info to the terminals (here)
   top.dominatesXML = implode("", map((.classDomContribs), clsRefs));
   top.submitsXML = implode("", map((.classSubContribs), clsRefs));

--- a/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -8,12 +8,13 @@ synthesized attribute marking :: Boolean;
 synthesized attribute acode :: String;
 synthesized attribute opPrecedence :: Maybe<Integer>;
 synthesized attribute opAssociation :: Maybe<String>; -- TODO type?
+autocopy attribute terminalName :: String;
 
 
 {--
  - Modifiers for terminals.
  -}
-nonterminal SyntaxTerminalModifiers with cstEnv, cstErrors, dominatesXML, submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, unparses, marking;
+nonterminal SyntaxTerminalModifiers with cstEnv, cstErrors, dominatesXML, submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, unparses, marking, terminalName;
 
 abstract production consTerminalMod
 top::SyntaxTerminalModifiers ::= h::SyntaxTerminalModifier  t::SyntaxTerminalModifiers
@@ -50,7 +51,7 @@ top::SyntaxTerminalModifiers ::=
 {--
  - Modifiers for terminals.
  -}
-nonterminal SyntaxTerminalModifier with cstEnv, cstErrors, dominatesXML, submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, unparses, marking;
+nonterminal SyntaxTerminalModifier with cstEnv, cstErrors, dominatesXML, submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, unparses, marking, terminalName;
 
 {- We default ALL attributes, so we can focus only on those that are interesting in each case... -}
 aspect default production
@@ -107,7 +108,7 @@ top::SyntaxTerminalModifier ::= direction::String
   top.unparses = ["assoc(" ++ quoteString(direction) ++ ")"];
 }
 {--
- - The terminal's lexer classes.
+ - The terminals lexer classes.
  -}
 abstract production termClasses
 top::SyntaxTerminalModifier ::= cls::[String]
@@ -130,7 +131,11 @@ top::SyntaxTerminalModifier ::= sub::[String]
 {
   production subRefs :: [[Decorated SyntaxDcl]] = lookupStrings(sub, top.cstEnv);
 
-  top.cstErrors := []; -- TODO error checking!
+  top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
+                     if !null(a.snd) then []
+                     else ["Terminal / Lexer Class " ++ a.fst ++ " was referenced but " ++
+                           "this grammar was not included in this parser. (Referenced from submit clause on terminal " ++ top.terminalName ++")"], 
+                   zipWith(pair, sub, subRefs)); 
   top.submitsXML = implode("", map(xmlCopperRef, map(head, subRefs)));
   top.unparses = ["sub(" ++ unparseStrings(sub) ++ ")"];
 }
@@ -142,7 +147,11 @@ top::SyntaxTerminalModifier ::= dom::[String]
 {
   production domRefs :: [[Decorated SyntaxDcl]] = lookupStrings(dom, top.cstEnv);
 
-  top.cstErrors := []; -- TODO error checking!
+  top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
+                     if !null(a.snd) then []
+                     else ["Terminal / Lexer Class " ++ a.fst ++ " was referenced but " ++
+                           "this grammar was not included in this parser. (Referenced from dominates clause on terminal " ++ top.terminalName ++")"],
+                   zipWith(pair, dom, domRefs)); 
   top.dominatesXML = implode("", map(xmlCopperRef, map(head, domRefs)));
   top.unparses = ["dom(" ++ unparseStrings(dom) ++ ")"];
 }

--- a/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -108,7 +108,7 @@ top::SyntaxTerminalModifier ::= direction::String
   top.unparses = ["assoc(" ++ quoteString(direction) ++ ")"];
 }
 {--
- - The terminals lexer classes.
+ - The terminal's lexer classes.
  -}
 abstract production termClasses
 top::SyntaxTerminalModifier ::= cls::[String]

--- a/grammars/silver/modification/copper/TerminalDcl.sv
+++ b/grammars/silver/modification/copper/TerminalDcl.sv
@@ -77,9 +77,7 @@ top::TermPrecList ::= h::QName t::TermPrecList
              then h.pp
              else h.pp ++ ", " ++ t.pp;
 
-
-  production attribute fName :: String;
-  fName = if null(h.lookupType.dcls) then h.lookupLexerClass.dcl.fullName else h.lookupType.dcl.fullName;
+  production fName::String = if null(h.lookupType.dcls) then h.lookupLexerClass.dcl.fullName else h.lookupType.dcl.fullName;
 
   top.precTermList = [fName] ++ t.precTermList ;
 

--- a/test/csterrors/lexerDominate/Artifact.sv
+++ b/test/csterrors/lexerDominate/Artifact.sv
@@ -1,0 +1,12 @@
+grammar lexerDominate;
+
+imports test:term_b;
+
+exports host;
+
+parser extendedParser :: Root {
+    host;
+    lexerDominate;
+} 
+
+lexer class A dominates B_t;

--- a/test/csterrors/lexerSubmit/Artifact.sv
+++ b/test/csterrors/lexerSubmit/Artifact.sv
@@ -1,0 +1,12 @@
+grammar lexerSubmit;
+
+imports test:term_b;
+
+exports host;
+
+parser extendedParser :: Root {
+    host;
+    lexerSubmit;
+} 
+
+lexer class A submits to B_t;

--- a/test/csterrors/silver-compile
+++ b/test/csterrors/silver-compile
@@ -10,6 +10,12 @@ silver --clean mda | grep "nonterm_b:B" > /dev/null || ((count++))
 silver --clean missingLHS | grep "nonterm_b:B" > /dev/null || ((count++))
 # terminalLHS doesn't contain a reference to B_t or B
 silver --clean terminalLHS | grep "terminalLHS:terminalLHS" > /dev/null || ((count++))
+silver --clean terminalSubmit | grep "B_t" > /dev/null || ((count++))
+silver --clean terminalDominate | grep "B_t" > /dev/null || ((count++))
+silver --clean terminalLexer | grep "lexer_b:B" > /dev/null || ((count++))
+silver --clean lexerSubmit | grep "B_t" > /dev/null || ((count++))
+silver --clean lexerDominate | grep "B_t" > /dev/null || ((count++))
+
 
 rm -f build.xml
 

--- a/test/csterrors/terminalDominate/Artifact.sv
+++ b/test/csterrors/terminalDominate/Artifact.sv
@@ -1,0 +1,11 @@
+grammar terminalDominate;
+
+imports test:term_b;
+exports host;
+
+parser extendedParser :: Root {
+    host;
+    terminalDominate;
+} 
+
+terminal A_t 'A' dominates {B_t};

--- a/test/csterrors/terminalLexer/Artifact.sv
+++ b/test/csterrors/terminalLexer/Artifact.sv
@@ -1,0 +1,12 @@
+grammar terminalLexer;
+
+imports test:lexer_b;
+
+exports host;
+
+parser extendedParser :: Root {
+    host;
+    terminalLexer;
+} 
+
+terminal A_t 'A' lexer classes {B};

--- a/test/csterrors/terminalSubmit/Artifact.sv
+++ b/test/csterrors/terminalSubmit/Artifact.sv
@@ -1,0 +1,12 @@
+grammar terminalSubmit;
+
+imports test:term_b;
+
+exports host;
+
+parser extendedParser :: Root {
+    host;
+    terminalSubmit;
+} 
+
+terminal A_t 'A' submits to {B_t};

--- a/test/csterrors/test/lexer_b/b.sv
+++ b/test/csterrors/test/lexer_b/b.sv
@@ -1,0 +1,3 @@
+grammar test:lexer_b;
+
+lexer class B;


### PR DESCRIPTION
This adds in more cstErrors and tests that were missed in #177, relating to dominates, submits and lexer class clauses.  

One thing that could be considered would be passing in some sort of name to use for `lexer class` declarations. Right now it just says `(Referenced from dominates clause for lexer class)` with no identifier, but this could go on the same back burner as improving the naming for `concrete productions` and `disambiguate` blocks.