### PR TITLE
Fix/disambiguateRefactor

### DIFF
--- a/grammars/silver/modification/copper/DisambiguationGroup.sv
+++ b/grammars/silver/modification/copper/DisambiguationGroup.sv
@@ -7,8 +7,7 @@ top::AGDcl ::= 'disambiguate' terms::TermList acode::ActionCode_c
 {
   top.pp = "disambiguate " ++ terms.pp ++ " " ++ acode.pp;
 
-  top.errors := terms.errors;
-  top.errors <- acode.errors;
+  top.errors := terms.errors ++ acode.errors;
 
   acode.env = newScopeEnv(disambigLexemeDef(top.grammarName, top.location) ::
                             acode.defs ++ terms.defs, top.env);
@@ -19,55 +18,4 @@ top::AGDcl ::= 'disambiguate' terms::TermList acode::ActionCode_c
   acode.frame = disambiguationContext();
 
   top.syntaxAst = [syntaxDisambiguationGroup(fName,terms.termList,acode.actionCode)];
-}
-
-
-nonterminal TermList with config, grammarName, pp, location, termList, defs, errors, env;
-
-synthesized attribute termList :: [String];
-
-concrete production termListOne
-terms::TermList ::= t::QName
-{
-   forwards to termList(t,termListNull(location=t.location), location=t.location);
-}
-
-concrete production termListCons
-terms::TermList ::= t::QName ',' terms_tail::TermList
-{
-   forwards to termList(t,terms_tail,location=terms.location);
-}
-
-
-abstract production termList
-top::TermList ::= h::QName t::TermList
-{
-  top.pp = if t.pp == ""
-             then h.pp
-             else h.pp ++ ", " ++ t.pp;
-
-  production fName::String = h.lookupType.dcl.fullName;
-
-  top.termList = [fName] ++ t.termList ;
-  
-  -- Itd be nice if we didnt need this guard
-  top.defs = if null(h.lookupType.dcls) then t.defs 
-             else pluckTermDef(top.grammarName, h.location, fName) :: t.defs;
-  top.errors := t.errors;
-  
-  -- Since were looking it up in two ways, do the errors ourselves
-  top.errors <- if null(h.lookupType.dcls)
-                then [err(h.location, "Undeclared terminal '" ++ h.name ++ "'.")]
-                else if length(h.lookupType.dcls) > 1
-                then [err(h.location, "Ambiguous reference to terminal '" ++ h.name ++ "'. Possibilities are:\n" ++ printPossibilities(h.lookupType.dcls))]
-                else [];
-}
-
-abstract production termListNull
-top::TermList ::=
-{
-  top.termList = [];
-  top.defs = [];
-  top.pp = "";
-  top.errors := [];
 }

--- a/grammars/silver/modification/copper/DisambiguationGroup.sv
+++ b/grammars/silver/modification/copper/DisambiguationGroup.sv
@@ -2,25 +2,69 @@ grammar silver:modification:copper;
 
 terminal Disambiguation_kwd 'disambiguate' lexer classes {KEYWORD};
 
--- TODO Separate 'TermPrecList'. That allows lexer classes which is nonsense here
-
 concrete production disambiguationGroupDcl
-top::AGDcl ::= 'disambiguate' terms::TermPrecList acode::ActionCode_c
+top::AGDcl ::= 'disambiguate' terms::TermList acode::ActionCode_c
 {
   top.pp = "disambiguate " ++ terms.pp ++ " " ++ acode.pp;
 
-  top.errors := acode.errors ++ terms.errors;
+  top.errors := terms.errors;
+  top.errors <- acode.errors;
 
   acode.env = newScopeEnv(disambigLexemeDef(top.grammarName, top.location) ::
                             acode.defs ++ terms.defs, top.env);
 
   -- Give the group a name, deterministically, based on line number
-  production attribute fName :: String;
-  fName = top.grammarName ++ ":__disam" ++ toString(top.location.line);
+  production fName :: String = top.grammarName ++ ":__disam" ++ toString(top.location.line);
   
   acode.frame = disambiguationContext();
 
-  top.syntaxAst = [syntaxDisambiguationGroup(fName,terms.precTermList,acode.actionCode)];
+  top.syntaxAst = [syntaxDisambiguationGroup(fName,terms.termList,acode.actionCode)];
 }
 
 
+nonterminal TermList with config, grammarName, pp, location, termList, defs, errors, env;
+
+synthesized attribute termList :: [String];
+
+concrete production termListOne
+terms::TermList ::= t::QName
+{
+   forwards to termList(t,termListNull(location=t.location), location=t.location);
+}
+
+concrete production termListCons
+terms::TermList ::= t::QName ',' terms_tail::TermList
+{
+   forwards to termList(t,terms_tail,location=terms.location);
+}
+
+
+abstract production termList
+top::TermList ::= h::QName t::TermList
+{
+  top.pp = if t.pp == ""
+             then h.pp
+             else h.pp ++ ", " ++ t.pp;
+
+  production fName::String = h.lookupType.dcl.fullName;
+
+  top.termList = [fName] ++ t.termList ;
+  top.defs = pluckTermDef(top.grammarName, h.location, fName) :: t.defs;
+  top.errors := t.errors;
+  
+  -- Since were looking it up in two ways, do the errors ourselves
+  top.errors <- if null(h.lookupType.dcls)
+                then [err(h.location, "Undeclared terminal '" ++ h.name ++ "'.")]
+                else if length(h.lookupType.dcls) > 1
+                then [err(h.location, "Ambiguous reference to terminal '" ++ h.name ++ "'. Possibilities are:\n" ++ printPossibilities(h.lookupType.dcls))]
+                else [];
+}
+
+abstract production termListNull
+top::TermList ::=
+{
+  top.termList = [];
+  top.defs = [];
+  top.pp = "";
+  top.errors := [];
+}

--- a/grammars/silver/modification/copper/DisambiguationGroup.sv
+++ b/grammars/silver/modification/copper/DisambiguationGroup.sv
@@ -49,7 +49,10 @@ top::TermList ::= h::QName t::TermList
   production fName::String = h.lookupType.dcl.fullName;
 
   top.termList = [fName] ++ t.termList ;
-  top.defs = pluckTermDef(top.grammarName, h.location, fName) :: t.defs;
+  
+  -- Itd be nice if we didnt need this guard
+  top.defs = if null(h.lookupType.dcls) then t.defs 
+             else pluckTermDef(top.grammarName, h.location, fName) :: t.defs;
   top.errors := t.errors;
   
   -- Since were looking it up in two ways, do the errors ourselves

--- a/grammars/silver/modification/copper/Prefix.sv
+++ b/grammars/silver/modification/copper/Prefix.sv
@@ -145,7 +145,7 @@ terminal Prefer_t 'prefer' lexer classes {KEYWORD, RESERVED};
 terminal Over_t   'over'   lexer classes {KEYWORD}; -- not RESERVED
 
 concrete production disambiguateParserComponent
-top::ParserComponent ::= 'prefer' t::QName 'over' ts::TermPrecList ';'
+top::ParserComponent ::= 'prefer' t::QName 'over' ts::TermList ';'
 {
   top.pp = "prefer " ++ t.pp ++ " over " ++ ts.pp;
   top.errors := t.lookupType.errors ++ ts.errors;
@@ -154,7 +154,7 @@ top::ParserComponent ::= 'prefer' t::QName 'over' ts::TermPrecList ';'
   top.liftedAGDcls =
     disambiguationGroupDcl(
       'disambiguate',
-      termPrecListCons(t, ',', ts, location=top.location),
+      termListCons(t, ',', ts, location=top.location),
       actionCode_c(
         '{',
         productionStmtsSnoc(

--- a/grammars/silver/modification/copper/TermList.sv
+++ b/grammars/silver/modification/copper/TermList.sv
@@ -1,0 +1,58 @@
+grammar silver:modification:copper;
+
+-- This structure mirrors the structure of TermPrecList.
+-- TermPrecList notes that it is poorly structured, perhaps
+-- specifically with refernce how abstract / concrete is deliniated.
+-- if TermPrecList has its structure refactored, so should TermList.
+
+nonterminal TermList with config, grammarName, pp, location, termList, defs, errors, env;
+
+synthesized attribute termList :: [String];
+
+concrete production termListOne
+terms::TermList ::= t::QName
+{
+   forwards to termList(t,termListNull(location=t.location), location=t.location);
+}
+
+concrete production termListCons
+terms::TermList ::= t::QName ',' terms_tail::TermList
+{
+   forwards to termList(t,terms_tail,location=terms.location);
+}
+
+
+abstract production termList
+top::TermList ::= h::QName t::TermList
+{
+  top.pp = if t.pp == ""
+             then h.pp
+             else h.pp ++ ", " ++ t.pp;
+
+  production fName::String = h.lookupType.dcl.fullName;
+
+  top.termList = [fName] ++ t.termList ;
+  
+  -- Itd be nice if we didnt need this guard
+  top.defs = if null(h.lookupType.dcls) then t.defs 
+             else pluckTermDef(top.grammarName, h.location, fName) :: t.defs;
+  
+  top.errors := t.errors;
+  -- Since were looking it up in two ways, do the errors ourselves
+  -- Todo: Consider: should this report a different error if the element of the list 
+  -- exists but is not a terminal, i.e "Expected a terminal but got a _____"?
+  top.errors <- if null(h.lookupType.dcls)
+                then [err(h.location, "Undeclared terminal '" ++ h.name ++ "'.")]
+                else if length(h.lookupType.dcls) > 1
+                then [err(h.location, "Ambiguous reference to terminal '" ++ h.name ++ "'. Possibilities are:\n" ++ printPossibilities(h.lookupType.dcls))]
+                else [];
+}
+
+abstract production termListNull
+top::TermList ::=
+{
+  top.termList = [];
+  top.defs = [];
+  top.pp = "";
+  top.errors := [];
+}

--- a/grammars/silver/modification/copper/TerminalDcl.sv
+++ b/grammars/silver/modification/copper/TerminalDcl.sv
@@ -51,7 +51,7 @@ top::TerminalModifier ::=
   top.lexerClasses = [];
 }
 
-nonterminal TermPrecList with config, grammarName, pp, location, precTermList, defs, errors, env;
+nonterminal TermPrecList with config, grammarName, pp, location, precTermList, errors, env;
 
 synthesized attribute precTermList :: [String];
 
@@ -81,10 +81,6 @@ top::TermPrecList ::= h::QName t::TermPrecList
 
   top.precTermList = [fName] ++ t.precTermList ;
 
-  -- This is just for disambiguation groups. TODO: remove and make it separate concrete syntax!
-  top.defs = if null(h.lookupType.dcls) then t.defs
-             else pluckTermDef(top.grammarName, h.location, h.lookupType.dcl.fullName) :: t.defs;
-
   top.errors := t.errors;
   
   -- Since we're looking it up in two ways, do the errors ourselves
@@ -99,7 +95,6 @@ abstract production termPrecListNull
 top::TermPrecList ::=
 {
   top.precTermList = [];
-  top.defs = [];
   top.pp = "";
   top.errors := [];
 }


### PR DESCRIPTION
This resolves a few TODOs related to disambiguate groups. 

Previously you could put a lexer class into a disambiguate group. This would result in a rather unhelpful copper error message with line numbers meaningless to the source .sv file:

```
   [copper] Parser_disambLexer_p.copper:58.70: cvc-complex-type.2.4.a: Invalid content was found starting with element 'TerminalClassRef'. One of '{"http://melt.cs.umn.edu/copper/xmlns":TerminalRef}' is expected.
   [copper] Parser_disambLexer_p.copper:57.54 [parser disambLexer_p]: Disambiguation function disambLexer___disam20 is missing the following required attributes: [code or disambiguateTo, members]
   [copper] Parser_disambLexer_p.copper:7.73 [parser disambLexer_p]: Undefined reference to disambLexer_Root
```

This PR creates a new nonterminal `TermList` which replaces the previous `TermPrecList` in disambiguate groups. `TermPrecList` no longer has a `defs` attribute, as that was only there for the benefit of disambiguate groups. 

The above error message now looks like this, in an example where `A_l` is a defined lexer class:
`Artifact.sv:20:13: error: Undeclared terminal 'A_l'.`

Because `A_l` is declared, this error message could be improved to something like: `error: Expected terminal, found lexer class 'A_l'.`, but that sort of error message would be helpful in a lot of places in Silver so that might be for a different issue. 
