### PR TITLE
Unparse correctly prefix separators

### DIFF
--- a/grammars/silver/modification/copper/DclInfo.sv
+++ b/grammars/silver/modification/copper/DclInfo.sv
@@ -119,7 +119,7 @@ top::DclInfo ::= sg::String sl::Location sep::String
   top.sourceLocation = sl;
   top.fullName = "_prefix_seperator";
 
-  top.unparse = "_prefix_seperator(" ++ sl.unparse ++ ", \"" ++ escapeString(sep) ++ "\")";
+  top.unparse = "prefix_seperator(" ++ sl.unparse ++ ", \"" ++ escapeString(sep) ++ "\")";
 
   top.typerep = error("_prefix_seperator does not have a type");
 }


### PR DESCRIPTION
Fix a typo.

cc @krame505 