### PR TITLE
New warning: lower-case production names. Refactor regex.

### DIFF
--- a/grammars/silver/definition/concrete_syntax/TerminalDcl.sv
+++ b/grammars/silver/definition/concrete_syntax/TerminalDcl.sv
@@ -62,10 +62,10 @@ top::AGDcl ::= t::TerminalKeywordModifier 'terminal' id::Name r::RegExpr tm::Ter
  -}
 nonterminal RegExpr with config, location, grammarName, pp, terminalRegExprSpec;
 
-synthesized attribute terminalRegExprSpec :: Regex_R;
+synthesized attribute terminalRegExprSpec :: Regex;
 
 concrete production regExpr
-top::RegExpr ::= '/' r::Regex_R '/'
+top::RegExpr ::= '/' r::Regex '/'
 {
   top.pp = "/" ++ r.regString ++ "/";
   top.terminalRegExprSpec = r;

--- a/grammars/silver/definition/concrete_syntax/ast/Regex.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Regex.sv
@@ -1,12 +1,149 @@
 grammar silver:definition:concrete_syntax:ast;
 
-attribute xmlCopper occurs on Regex_R, Regex_DR, Regex_UR, Regex_RR, Regex_G, Regex_RG, Regex_UG, Regex_CHAR;
-{--
- - Used to prevent unneeded nesting of concatenations.
- -}
-synthesized attribute unwrappedXML :: String occurs on Regex_DR, Regex_RR;
+-- Translation of regex to Copper XML format.
+attribute xmlCopper occurs on Regex, RegexSeq, RegexRepetition, RegexItem, RegexCharSet, RegexCharSetItem, RegexChar;
 
-{-- String to emit to represent the character 'ch' -}
+{--
+ - Used to prevent unneeded nesting of the same operator. (choices, sequences)
+ -}
+synthesized attribute unwrappedXML :: String occurs on Regex, RegexSeq;
+
+
+---------------------------------------------------------------------------------
+aspect production regexEpsilon
+top::Regex ::=
+{
+  top.xmlCopper = "<EmptyString/>";
+  top.unwrappedXML = top.xmlCopper;
+}
+aspect production regexSeq
+top::Regex ::= h::RegexSeq
+{
+  top.xmlCopper = h.xmlCopper;
+  top.unwrappedXML = top.xmlCopper;
+}
+aspect production regexChoice
+top::Regex ::= h::RegexSeq _ t::Regex
+{
+  top.xmlCopper = "<Choice>" ++ h.xmlCopper ++ t.unwrappedXML ++ "</Choice>";
+  top.unwrappedXML = h.xmlCopper ++ t.unwrappedXML;
+}
+
+
+aspect production regexSeqSnoc
+top::RegexSeq ::= h::RegexSeq t::RegexRepetition
+{
+  top.xmlCopper = "<Concatenation>" ++ h.unwrappedXML ++ t.xmlCopper ++ "</Concatenation>";
+  top.unwrappedXML = h.unwrappedXML ++ t.xmlCopper;
+}
+aspect production regexSeqOne
+top::RegexSeq ::= t::RegexRepetition
+{
+  top.xmlCopper = t.xmlCopper;
+  top.unwrappedXML = top.xmlCopper;
+}
+
+
+aspect production regexKleene
+top::RegexRepetition ::= i::RegexItem _
+{
+  top.xmlCopper = "<KleeneStar>" ++ i.xmlCopper ++ "</KleeneStar>";
+}
+aspect production regexPlus
+top::RegexRepetition ::= i::RegexItem _
+{
+  -- Copper has no direct translation of +
+  top.xmlCopper = "<Concatenation>" ++ i.xmlCopper ++ "<KleeneStar>" ++ i.xmlCopper ++ "</KleeneStar></Concatenation>";
+}
+aspect production regexOptional
+top::RegexRepetition ::= i::RegexItem _
+{
+  -- Copper has no direct translation of ?
+  top.xmlCopper = "<Choice>" ++ i.xmlCopper ++ "<EmptyString/></Choice>";
+}
+aspect production regexOnce
+top::RegexRepetition ::= i::RegexItem
+{
+  top.xmlCopper = i.xmlCopper;
+}
+
+
+aspect production regexCharItem
+top::RegexItem ::= char::RegexChar
+{
+  top.xmlCopper = "<CharacterSet><SingleCharacter char=\"" ++ char.xmlCopper ++ "\"/></CharacterSet>";
+}
+aspect production regexWildcard
+top::RegexItem ::= _
+{
+  -- Copper has no direct representation of dot.
+  -- Dot represents everything EXCEPT \n
+  top.xmlCopper = "<CharacterSet invert=\"true\"><SingleCharacter char=\"&#10;\"/></CharacterSet>";
+}
+aspect production regexSet
+top::RegexItem ::= _ g::RegexCharSet _
+{
+  top.xmlCopper = "<CharacterSet>" ++ g.xmlCopper ++ "</CharacterSet>";
+}
+aspect production regexSetInverted
+top::RegexItem ::= _ _ g::RegexCharSet _
+{
+  top.xmlCopper = "<CharacterSet invert=\"true\">" ++ g.xmlCopper ++ "</CharacterSet>";
+}
+aspect production regexGroup
+top::RegexItem ::= _ r::Regex _
+{
+  -- As an AST, Copper has no need to represent groups ()
+  top.xmlCopper = r.xmlCopper;
+}
+
+
+aspect production regexCharSetSnoc
+top::RegexCharSet ::= h::RegexCharSet  t::RegexCharSetItem
+{
+  top.xmlCopper = h.xmlCopper ++ t.xmlCopper;
+}
+aspect production regexCharSetOne
+top::RegexCharSet ::= t::RegexCharSetItem
+{
+  top.xmlCopper = t.xmlCopper;
+}
+
+
+aspect production regexSetChar
+top::RegexCharSetItem ::= char::RegexChar
+{
+  top.xmlCopper = "<SingleCharacter char=\"" ++ char.xmlCopper ++ "\"/>";
+}
+aspect production regexSetRange
+top::RegexCharSetItem ::= l::RegexChar _ u::RegexChar
+{
+  top.xmlCopper = "<CharacterRange lower=\"" ++ l.xmlCopper ++ "\" upper=\"" ++ u.xmlCopper ++ "\"/>";
+}
+
+
+aspect production regexChar
+top::RegexChar ::= char::RegexChar_t
+{
+  -- Can be special characters like &
+  top.xmlCopper = xmlEscapeChar(char.lexeme);
+}
+aspect production regexEscapedChar
+top::RegexChar ::= esc::EscapedChar_t
+{
+  -- These are ESCAPED character (e.g. \n) we need to represent as XML.
+  -- We only animate \r\n\t. Otherwise, literal translation.
+  top.xmlCopper =
+    if esc.lexeme == "\\r" then "&#13;"
+    else if esc.lexeme == "\\n" then "&#10;"
+    else if esc.lexeme == "\\t" then "&#9;"
+    else xmlEscapeChar(substring(1, 2, esc.lexeme));
+}
+
+-----------------------------------------------------------------------------------
+
+
+{-- XML String to emit to represent the character 'ch' -}
 function xmlEscapeChar
 String ::= ch::String
 {
@@ -22,171 +159,4 @@ String ::= ch::String
     else ch;
 }
 
-function literalNRegexToXML
-String ::= s::String
-{
-  return if length(s) == 0 then ""
-    else 
-      getSingleCharNRegexXML(xmlEscapeChar(substring(0, 1, s))) ++
-        literalNRegexToXML(substring(1, length(s), s));
-}
-
-function getSingleCharNRegexXML
-String ::= s::String
-{
-  -- Copper XML doesn't like plain characters for some reason, they have to be wrapped in a characterset.
-  return "<CharacterSet><SingleCharacter char=\"" ++ s ++ "\"/></CharacterSet>";
-}
-
-
-aspect production literalRegex
-r::Regex_R ::= s::String
-{
-  r.xmlCopper = if length(s) == 0 then "<EmptyString/>"
-                else if length(s) == 1 then literalNRegexToXML(s)
-                else "<Concatenation>" ++ literalNRegexToXML(s) ++ "</Concatenation>";
-}
-
-aspect production Rtoeps
-r::Regex_R ::=
-{
-  r.xmlCopper = "<EmptyString/>";
-}
-
-aspect production RtoDR
-r::Regex_R ::= dr::Regex_DR
-{
-  r.xmlCopper = dr.xmlCopper;
-}
-
-aspect production RtoDR_bar_R
-r::Regex_R ::= first::Regex_DR sep::Choice_t rest::Regex_R
-{
-  r.xmlCopper = "<Choice>" ++ first.xmlCopper ++ rest.xmlCopper ++ "</Choice>";
-}
-
-aspect production DRtoUR_RR
-dr::Regex_DR ::= first::Regex_UR rest::Regex_RR
-{
-  dr.xmlCopper = 
-    case rest of
-    | RRtoeps() -> first.xmlCopper
-    | RRtoDR(_) -> "<Concatenation>" ++ first.xmlCopper ++ rest.unwrappedXML ++ "</Concatenation>"
-    end;
-  dr.unwrappedXML = first.xmlCopper ++ rest.unwrappedXML;
-}
-
-aspect production regex_kleene_of
-dr::Regex_UR ::= r::Regex_UR
-{
-  dr.xmlCopper = "<KleeneStar>" ++ r.xmlCopper ++ "</KleeneStar>";
-}
-
-aspect production regex_plus_of
-dr::Regex_UR ::= r::Regex_UR
-{
-  dr.xmlCopper = "<Concatenation>" ++ r.xmlCopper ++ "<KleeneStar>" ++ r.xmlCopper ++ "</KleeneStar></Concatenation>";
-}
-
-aspect production regex_opt_of
-dr::Regex_UR ::= r::Regex_UR
-{
-  dr.xmlCopper = "<Choice>" ++ r.xmlCopper ++ "<EmptyString/></Choice>";
-}
-
-aspect production RRtoDR
-rr::Regex_RR ::= dr::Regex_DR
-{
-  rr.xmlCopper = dr.xmlCopper;
-  rr.unwrappedXML = dr.unwrappedXML;
-}
-
-aspect production RRtoeps
-rr::Regex_RR ::=
-{
-  rr.xmlCopper = "<EmptyString/>";
-  rr.unwrappedXML = "";
-}
-
-
-aspect production URtoCHAR
-ur::Regex_UR ::= char::Regex_CHAR
-{
-  ur.xmlCopper = getSingleCharNRegexXML(char.xmlCopper);
-}
-
-aspect production URtowildcard
-ur::Regex_UR ::= wildcard::RegexWildcard_t
-{
-  -- dot represents everything EXCEPT \n
-  ur.xmlCopper = "<CharacterSet invert=\"true\"><SingleCharacter char=\"&#10;\"/></CharacterSet>";
-}
-
-aspect production URtolb_G_rb
-ur::Regex_UR ::= lb::RegexLBrack_t g::Regex_G rb::RegexRBrack_t
-{
-  ur.xmlCopper = "<CharacterSet>" ++ g.xmlCopper ++ "</CharacterSet>";
-}
-
-aspect production URtolb_not_G_rb
-ur::Regex_UR ::= lb::RegexLBrack_t sep::RegexNot_t g::Regex_G rb::RegexRBrack_t
-{
-  ur.xmlCopper = "<CharacterSet invert=\"true\">" ++ g.xmlCopper ++ "</CharacterSet>";
-}
-
-aspect production URtolp_R_rp
-ur::Regex_UR ::= lp::RegexLParen_t r::Regex_R rp::RegexRParen_t
-{
-  ur.xmlCopper = r.xmlCopper;
-}
-
-aspect production GtoUG_RG
-g::Regex_G ::= ug::Regex_UG rg::Regex_RG
-{
-  g.xmlCopper = ug.xmlCopper ++ rg.xmlCopper;
-}
-
-aspect production UGtoCHAR
-ug::Regex_UG ::= char::Regex_CHAR
-{
-  ug.xmlCopper = "<SingleCharacter char=\"" ++ char.xmlCopper ++ "\"/>";
-}
-
-aspect production UGtoCHAR_dash_CHAR
-ug::Regex_UG ::= leastchar::Regex_CHAR sep::Range_t greatestchar::Regex_CHAR
-{
-  ug.xmlCopper = "<CharacterRange lower=\"" ++ leastchar.xmlCopper ++ "\" upper=\"" ++ greatestchar.xmlCopper ++ "\"/>";
-}
-
-aspect production RGtoG
-rg::Regex_RG ::= g::Regex_G
-{
-  rg.xmlCopper = g.xmlCopper;
-}
-
-aspect production RGtoeps
-rg::Regex_RG ::=
-{
-  rg.xmlCopper = "";
-}
-
-aspect production CHARtochar
-top::Regex_CHAR ::= char::RegexChar_t
-{
-  -- recall these are literal characters we need to represent as XML
-  top.xmlCopper = xmlEscapeChar(char.lexeme);
-}
-
-aspect production CHARtoescaped
-top::Regex_CHAR ::= esc::EscapedChar_t
-{
-  -- recall these are ESCAPED character (e.g. \n) we need to represent as XML
-  -- current semantics are that escaped anything represents a literal
-  -- except escaped rnt which we translate.
-  top.xmlCopper =
-    if esc.lexeme == "\\r" then "&#13;"
-    else if esc.lexeme == "\\n" then "&#10;"
-    else if esc.lexeme == "\\t" then "&#9;"
-    else xmlEscapeChar(substring(1,2,esc.lexeme));
-}
 

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -107,7 +107,7 @@ top::SyntaxDcl ::= t::TypeExp subdcls::Syntax --modifiers::SyntaxNonterminalModi
  - A terminal, and regular expression.
  -}
 abstract production syntaxTerminal
-top::SyntaxDcl ::= n::String regex::Regex_R modifiers::SyntaxTerminalModifiers
+top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
 {
   top.sortKey = "CCC" ++ n;
   top.cstDcls = [pair(n, top)];

--- a/grammars/silver/definition/concrete_syntax/ast/env_parser/Parser.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/env_parser/Parser.sv
@@ -147,7 +147,7 @@ top::ISyntaxDcl ::= 'nt' '(' td::ITyVarDcls ',' t::ITypeRep ')'
   top.syntaxAst = [syntaxNonterminal(t.typerep, nilSyntax())];
 }
 concrete production aSyntaxTerm
-top::ISyntaxDcl ::= 'term' '(' n::IName ',' '/' r::Regex_R '/' ',' tm::ITerminalModifiers ')'
+top::ISyntaxDcl ::= 'term' '(' n::IName ',' '/' r::Regex '/' ',' tm::ITerminalModifiers ')'
 {
   top.syntaxAst = [syntaxTerminal(n.aname, r, foldr(consTerminalMod, nilTerminalMod(), tm.terminalModifiers))];
 }

--- a/grammars/silver/definition/core/ProductionDcl.sv
+++ b/grammars/silver/definition/core/ProductionDcl.sv
@@ -31,18 +31,22 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
     else [prodOccursDef(top.grammarName, id.location, namedSig, body.productionAttributes)];
 
   top.errors <-
-        if length(getValueDclAll(fName, top.env)) > 1
-        then [err(id.location, "Value '" ++ fName ++ "' is already bound.")]
+    if length(getValueDclAll(fName, top.env)) > 1
+    then [err(id.location, "Value '" ++ fName ++ "' is already bound.")]
 
-        -- TODO: Narrow this down to just a list of productions of the same nonterminal before deciding to error.
-        else if length(getValueDclAll(id.name, top.env)) > 1
-        then [err(top.location, "Production " ++ id.pp ++ " shares a name with another production from an imported grammar. Either this production is meant to be an aspect, or you should use 'import ... with " ++ id.pp ++ " as ...' to change the other production's apparent name.")]
-        else [];
+    -- TODO: Narrow this down to just a list of productions of the same nonterminal before deciding to error.
+    else if length(getValueDclAll(id.name, top.env)) > 1
+    then [err(top.location, "Production " ++ id.pp ++ " shares a name with another production from an imported grammar. Either this production is meant to be an aspect, or you should use 'import ... with " ++ id.pp ++ " as ...' to change the other production's apparent name.")]
+    else [];
   
   top.errors <-
-        if length(body.uniqueSignificantExpression) > 1
-        then [err(top.location, "Production '" ++ id.name ++ "' has more than one forward declaration.")]
-        else [];
+    if length(body.uniqueSignificantExpression) > 1
+    then [err(top.location, "Production '" ++ id.name ++ "' has more than one forward declaration.")]
+    else [];
+
+  top.errors <-
+    if isLower(substring(0,1,id.name)) then []
+    else [wrn(id.location, s"(future) ${id.name}: productions may be required to begin with a lower-case letter.")];
 
   top.errors := ns.errors ++ body.errors;
 

--- a/grammars/silver/definition/env/DclInfo.sv
+++ b/grammars/silver/definition/env/DclInfo.sv
@@ -209,7 +209,7 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::TypeExp c
   top.dclBoundVars = bound;
 }
 abstract production termDcl
-top::DclInfo ::= sg::String sl::Location fn::String regex::Regex_R
+top::DclInfo ::= sg::String sl::Location fn::String regex::Regex
 {
   top.sourceGrammar = sg;
   top.sourceLocation = sl;

--- a/grammars/silver/definition/env/Defs.sv
+++ b/grammars/silver/definition/env/Defs.sv
@@ -140,7 +140,7 @@ Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::TypeExp
   return typeDef(defaultEnvItem(ntDcl(sg,sl,fn,bound,ty,true)));
 }
 function termDef
-Def ::= sg::String  sl::Location  fn::String  regex::Regex_R
+Def ::= sg::String  sl::Location  fn::String  regex::Regex
 {
   return typeDef(defaultEnvItem(termDcl(sg,sl,fn,regex)));
 }

--- a/grammars/silver/definition/env/env_parser/Parser.sv
+++ b/grammars/silver/definition/env/env_parser/Parser.sv
@@ -422,7 +422,7 @@ top::IDclInfo ::= 'nt' '(' l::ILocation ',' s::IName ',' td::ITyVarDcls ',' t::I
 }
 
 concrete production aDclInfoTerminal
-top::IDclInfo ::= 'term' '(' l::ILocation ',' n::IName ',' '/' r::Regex_R '/' ')'
+top::IDclInfo ::= 'term' '(' l::ILocation ',' n::IName ',' '/' r::Regex '/' ')'
 {
   top.defs = [termDef(top.grammarName, l.alocation, n.aname, r)];
 }

--- a/grammars/silver/driver/CompileGrammar.sv
+++ b/grammars/silver/driver/CompileGrammar.sv
@@ -119,7 +119,7 @@ String ::= files::[String]  depth::Integer
 {
   return
     if null(files) then "" else
-    if depth >= 9 then "\n\t " ++ renderFileNames(files, 0) else
+    if depth >= 7 then "\n\t " ++ renderFileNames(files, 0) else
     head(files) ++
     if null(tail(files)) then "" else " " ++ renderFileNames(tail(files), depth + 1);
 }

--- a/grammars/silver/driver/GrammarAction.sv
+++ b/grammars/silver/driver/GrammarAction.sv
@@ -98,7 +98,7 @@ top::DriverAction ::= specs::[Decorated RootSpec]
   top.io = if null(specs) then top.ioIn else recurse.io;
 
   top.code = 
-    if null(specs) || recurse.code == 0
+    if null(specs) || (null(errs) && recurse.code == 0)
     then 0
     else 21;
 

--- a/grammars/silver/extension/convenience/Productions.sv
+++ b/grammars/silver/extension/convenience/Productions.sv
@@ -44,18 +44,17 @@ top::ProductionDclStmt ::= optn::OptionalName v::ProdVBar
 {
   top.pp = "| " ++ rhs.pp ++ mods.pp ++ body.pp; -- TODO missing some here...
   -- Either we have a name, or we generate an appropriate one.
-  local attribute nme :: Name;
-  nme = case optn of
-        | noOptionalName() ->
-            name(
-              "P_"
-              ++ substitute(":", "_", top.grammarName)
-              ++ substitute(".", "_", top.location.filename)
-              -- substitute(":", "_", top.lhsdcl.outputElement.typerep.typeName) TODO
-              ++ "_" ++ toString(v.line) ++ "_" ++ toString(v.column),
-              v.location)
-        | anOptionalName(_, n, _) -> n
-        end;
+  local nme :: Name =
+    case optn of
+    | noOptionalName() ->
+        name(
+          "p_"
+           ++ substitute(":", "_", top.grammarName)
+           ++ "_" ++ substitute(".", "_", top.location.filename)
+           ++ "_" ++ toString(v.line) ++ "_" ++ toString(v.column),
+           v.location)
+    | anOptionalName(_, n, _) -> n
+    end;
 
   local newSig :: ProductionSignature =
     productionSignature(top.lhsdcl, '::=', rhs, location=rhs.location);

--- a/grammars/silver/extension/easyterminal/TerminalDcl.sv
+++ b/grammars/silver/extension/easyterminal/TerminalDcl.sv
@@ -5,7 +5,7 @@ import silver:definition:env;
 import silver:definition:type;
 import silver:definition:type:syntax;
 import silver:definition:concrete_syntax;
-import silver:definition:regex only Regex_R, regString, literalRegex;
+import silver:definition:regex only Regex, regString, regexLiteral;
 
 terminal Terminal_t /\'[^\'\r\n]*\'/ lexer classes {LITERAL};
 
@@ -26,7 +26,7 @@ top::RegExpr ::= t::Terminal_t
 {
   top.pp = t.lexeme;
   
-  top.terminalRegExprSpec = literalRegex(substring(1, length(t.lexeme) - 1, t.lexeme));
+  top.terminalRegExprSpec = regexLiteral(substring(1, length(t.lexeme) - 1, t.lexeme));
   
   forwards to regExpr('/', top.terminalRegExprSpec, '/', location=top.location);
 }
@@ -44,7 +44,7 @@ top::EasyTerminalRef ::= t::Terminal_t
   top.easyString = substring(1, length(t.lexeme) - 1, t.lexeme);
 
   -- TODO: This is necessary because the environment is still populated using the regex, so we have to look up the corresponding regex.
-  local regHack :: Regex_R = literalRegex(top.easyString);
+  local regHack :: Regex = regexLiteral(top.easyString);
 
   top.dcls = getTerminalRegexDclAll(regHack.regString, top.env);
 

--- a/grammars/silver/modification/copper/Prefix.sv
+++ b/grammars/silver/modification/copper/Prefix.sv
@@ -72,7 +72,7 @@ top::TerminalPrefix ::= t::String_t
     end;
   local givenPrefix::String = substring(1, length(t.lexeme) - 1, t.lexeme);
   local regex::RegExpr =
-    regExpr('/', literalRegex(givenPrefix ++ seperator), '/', location=top.location);
+    regExpr('/', regexLiteral(givenPrefix ++ seperator), '/', location=top.location);
   top.errors <- 
     case seperatorLookup of
       prefixSeparatorDcl(sg, sl, s) :: _ -> []

--- a/grammars/silver/modification/impide/cstast/Syntax.sv
+++ b/grammars/silver/modification/impide/cstast/Syntax.sv
@@ -35,7 +35,7 @@ top::SyntaxDcl ::= t::TypeExp subdcls::Syntax --modifiers::SyntaxNonterminalModi
 }
 
 aspect production syntaxTerminal
-top::SyntaxDcl ::= n::String regex::Regex_R modifiers::SyntaxTerminalModifiers
+top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
 {
   top.termFontPairList = [
     -- First element: full qualifier name. E.g. host$silver_definition_core_Ident_t

--- a/test/cstast/Test.sv
+++ b/test/cstast/Test.sv
@@ -26,7 +26,7 @@ global obj::SyntaxRoot =
   cstRoot("lol", "Foo",
     foldr(consSyntax, nilSyntax(), 
      [syntaxNonterminal(nonterminalTypeExp("Foo", []), nilSyntax()),
-      syntaxTerminal("XTerm", literalRegex("x"), nilTerminalMod()),
+      syntaxTerminal("XTerm", regexLiteral("x"), nilTerminalMod()),
       syntaxProduction(
         namedSignature("foo", [],
           namedSignatureElement("asdf", nonterminalTypeExp("Foo", [])), []),
@@ -48,7 +48,7 @@ global obj3::SyntaxRoot =
   cstRoot("lol", "Foo",
     foldr(consSyntax, nilSyntax(), [
       syntaxNonterminal(nonterminalTypeExp("Foo", []), nilSyntax()),
-      syntaxTerminal("XTerm", literalRegex("x"), 
+      syntaxTerminal("XTerm", regexLiteral("x"), 
         foldr(consTerminalMod, nilTerminalMod(), [
           termIgnore(),
           termPrecedence(3),
@@ -73,7 +73,7 @@ global obj3::SyntaxRoot =
           lexerClassSubmits(["C"])
         ])),
       syntaxLexerClass("B", nilLexerClassMod()),
-      syntaxTerminal("C", literalRegex("y"), nilTerminalMod()),
+      syntaxTerminal("C", regexLiteral("y"), nilTerminalMod()),
       syntaxParserAttribute("asdf", stringTypeExp(), "asdf = 'asfd';"),
       syntaxDisambiguationGroup("g23", ["XTerm", "C"], "return C;")
      ]), []);


### PR DESCRIPTION
I probably should have titled this "Sunday afternoon yac-shaving" :/

@ericvanwyk : Thoughts on introducing the warning in the first commit? Raising a warning on productions that start with anything but a lower-case letter?

Presently, this raised no warnings in Silver (except regex, which I then fixed) and none in ableC either. I think this is a pretty universally observed convention, and enforcing it would fix #46.

...then I decided to fix the regex grammar, and it made me angry enough that I did a complete refactoring of it, giving everything nice names, and fixing kludges.

...then I fixed a bug where silver was trying to continue compiling in the presence of parse errors. No one reported this? :(

...then I decided maybe we were printing slightly long lines listing filenames, and reduced that.