### PR TITLE
Improve error message for flowspecs to say what nonterminal is causin…

### DIFF
--- a/grammars/silver/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/definition/flow/syntax/FlowSpec.sv
@@ -201,7 +201,7 @@ top::FlowSpecInh ::= 'decorate'
   
   top.errors :=
     if decSpec.isJust then []
-    else [err(top.location, "to use 'decorate' in a flow type, it must also have an explicit flow type")];
+    else [err(top.location, s"to use 'decorate' in a flow type for nonterminal ${top.onNt.typeName}, 'decorate' must also have an explicit flow type")];
   
   top.inhList = fromMaybe([], decSpec);
 }


### PR DESCRIPTION
Minor fix, actually say what nonterminal has its ref set undefined when using `decorate` in a flowtype, so we can tell what to fix when writing, e.g.
```
flowtype host {decorate} on
  Expr, Stmt, Decls, Decl, TypeName, BaseTypeExpr, TypeModifierExpr ...;
```
We should also probably fix the locations somehow to actually highlight the nonterminal that is causing the problem (similar for some other errors related to flowspecs), but I couldn't figure out an easy way of doing that because of how the grammar is structured.  