### PR TITLE
Adds multiple NT support for annotation occurs on statements

### DIFF
--- a/grammars/core/Location.sv
+++ b/grammars/core/Location.sv
@@ -89,7 +89,7 @@ Location ::=
 function locationLte
 Boolean ::= l1::Location l2::Location
 {
-  -- TODO: We could probaly just compare based on filename and index
+  -- TODO: We could probably just compare based on filename and index
   -- For the moment, though, use line & column instead.
   return l1.filename < l2.filename || (l1.filename == l2.filename &&
     (l1.line < l2.line || (l1.line == l2.line &&

--- a/grammars/silver/extension/convenience/Convenience.sv
+++ b/grammars/silver/extension/convenience/Convenience.sv
@@ -6,6 +6,7 @@ imports silver:definition:concrete_syntax;
 imports silver:definition:type;
 imports silver:definition:type:syntax;
 
+-- Multiple attribute occurs on statements
 concrete production multipleAttributionDclsManyMany
 top::AGDcl ::= 'attribute' a::QNames2 'occurs' 'on' nts::QNames2 ';'
 {
@@ -24,6 +25,27 @@ top::AGDcl ::= 'attribute' a::QNames2 'occurs' 'on' nts::QNameWithTL ';'
   top.pp = "attribute " ++ a.pp ++ " occurs on " ++ nts.pp ++ " ;" ;
   forwards to makeOccursDcls(top.location, a.qnames, [nts]);
 }
+
+-- Multiple annotation occurs on statements
+concrete production multipleAnnotationDclsManyMany
+top::AGDcl ::= 'annotation' a::QNames2 'occurs' 'on' nts::QNames2 ';'
+{
+  top.pp = "annotation " ++ a.pp ++ " occurs on " ++ nts.pp ++ " ;" ;
+  forwards to makeOccursDcls(top.location, a.qnames, nts.qnames);
+}
+concrete production multipleAnnotationDclsSingleMany
+top::AGDcl ::= 'annotation' a::QName tl::BracketedOptTypeExprs 'occurs' 'on' nts::QNames2 ';' 
+{
+  top.pp = "annotation " ++ a.pp ++ " occurs on " ++ nts.pp ++ " ;" ;
+  forwards to makeOccursDcls(top.location, [qNameWithTL(a, tl)], nts.qnames);
+}
+concrete production multipleAnnotationDclsManySingle
+top::AGDcl ::= 'annotation' a::QNames2 'occurs' 'on' nts::QNameWithTL ';'
+{
+  top.pp = "annotation " ++ a.pp ++ " occurs on " ++ nts.pp ++ " ;" ;
+  forwards to makeOccursDcls(top.location, a.qnames, [nts]);
+}
+
 
 
 concrete production nonterminalWithDcl


### PR DESCRIPTION
This is a simple change to fix #195, it duplicates the existing convenience productions for attributes to work for annotations as well.

If this isn't a desired feature we don't need to merge this, this is a little spontaneous on my part.