### PR TITLE
Flow analysis on pattern matching

### DIFF
--- a/grammars/silver/definition/flow/ast/Flow.sv
+++ b/grammars/silver/definition/flow/ast/Flow.sv
@@ -422,7 +422,7 @@ nonterminal PatternVarProjection with unparse;
 abstract production patternVarProjection
 top::PatternVarProjection ::= child::String  typeName::String  patternVar::String
 {
-  top.unparse = s"(${child}, ${typeName}, ${patternVar})";
+  top.unparse = s"('${child}', '${typeName}', '${patternVar}')";
 }
 
 --

--- a/grammars/silver/definition/flow/ast/Flow.sv
+++ b/grammars/silver/definition/flow/ast/Flow.sv
@@ -445,7 +445,11 @@ function collectAnonOriginItem
 [Pair<String  Location>] ::= f::FlowDef  rest::[Pair<String  Location>]
 {
   return case f of
-  | anonEq(_, fN, _, l, _) -> pair(fN, l) :: rest
+  | anonEq(_, fN, _, l, _) ->
+      -- Small hack to improve error messages. Ignore anonEq's that come from patterns
+      if startsWith("__scrutinee", fN)
+      then rest
+      else pair(fN, l) :: rest
   | _ -> rest
   end;
 }

--- a/grammars/silver/definition/flow/ast/Flow.sv
+++ b/grammars/silver/definition/flow/ast/Flow.sv
@@ -2,8 +2,18 @@ grammar silver:definition:flow:ast;
 
 imports silver:definition:env only quoteString,unparseStrings, unparse;
 
-nonterminal FlowDefs with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, unparses, prodTreeContribs, prodGraphContribs, refTreeContribs, localInhTreeContribs, extSynTreeContribs, nonSuspectContribs, localTreeContribs, specContribs;
+
+{--
+ - Info for constructing production flow graphs.
+ - Follows Figure 5.12 (p138, pdf p154 of Kaminski's PhD)
+ - with notable additions of:
+ -  - ntRef, specification (for dealing with 'flowtype' decls and the ref set)
+ -  - implicitFwdAffects (for improving accuracy of inference)
+ -  - extraEq (handling collections '<-')
+ - which the thesis does not address.
+ -}
 nonterminal FlowDef with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, unparses, prodTreeContribs, prodGraphContribs, flowEdges, refTreeContribs, localInhTreeContribs, suspectFlowEdges, extSynTreeContribs, nonSuspectContribs, localTreeContribs, specContribs;
+nonterminal FlowDefs with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, unparses, prodTreeContribs, prodGraphContribs, refTreeContribs, localInhTreeContribs, extSynTreeContribs, nonSuspectContribs, localTreeContribs, specContribs;
 
 {-- lookup (production, attribute) to find synthesized equations
  - Used to ensure a necessary lhs.syn equation exists.
@@ -147,21 +157,6 @@ top::FlowDef ::= nt::String  prod::String
 }
 
 {--
- - Declaration of the inherited attributes known from the host language
- -
- - @param nt  The full name of a nonterminal declaration
- - @param inhs  The Blessed Ref Set, to be used for decorated nodes of this type.
- -}
-abstract production ntRefFlowDef
-top::FlowDef ::= nt::String  inhs::[String]
-{
-  top.refTreeContribs = [pair(nt, top)];
-  top.prodGraphContribs = [];
-  top.flowEdges = error("Internal compiler error: this sort of def should not be in a context where edges are requested.");
-  top.unparses = ["ntRefFlowDef(" ++ quoteString(nt)++ ", " ++ unparseStrings(inhs) ++ ")"];
-}
-
-{--
  - Declaration that a synthesized attribute *occurrence* is not in the host
  - and therefore subject to the forward flow type's whims. (i.e. must be ft(syn) >= ft(fwd))
  -
@@ -175,6 +170,38 @@ top::FlowDef ::= nt::String  attr::String
   top.prodGraphContribs = [];
   top.flowEdges = error("Internal compiler error: this sort of def should not be in a context where edges are requested.");
   top.unparses = ["nonHostSyn(" ++ quoteString(attr) ++ ", " ++ quoteString(nt) ++ ")"];
+}
+
+{--
+ - The definition of a default equation for a synthesized attribute on a nonterminal.
+ -
+ - @param nt  the full name of the *nonterminal*
+ - @param attr  the full name of the attribute
+ - @param deps  the dependencies of this equation on other flow graph elements
+ - CONTRIBUTIONS ARE POSSIBLE
+ -}
+abstract production defaultSynEq
+top::FlowDef ::= nt::String  attr::String  deps::[FlowVertex]
+{
+  top.defTreeContribs = [pair(crossnames(nt, attr), top)];
+  top.prodGraphContribs = []; -- defaults don't show up in the prod graph!!
+  top.flowEdges = map(pair(lhsSynVertex(attr), _), deps); -- but their edges WILL end up added to graphs in fixup-phase!!
+  top.unparses = ["def(" ++ implode(", ", [quoteString(nt), quoteString(attr), unparseVertices(deps)]) ++ ")"];
+}
+
+{--
+ - Declaration of the inherited attributes known from the host language
+ -
+ - @param nt  The full name of a nonterminal declaration
+ - @param inhs  The Blessed Ref Set, to be used for decorated nodes of this type.
+ -}
+abstract production ntRefFlowDef
+top::FlowDef ::= nt::String  inhs::[String]
+{
+  top.refTreeContribs = [pair(nt, top)];
+  top.prodGraphContribs = [];
+  top.flowEdges = error("Internal compiler error: this sort of def should not be in a context where edges are requested.");
+  top.unparses = ["ntRefFlowDef(" ++ quoteString(nt)++ ", " ++ unparseStrings(inhs) ++ ")"];
 }
 
 {--
@@ -232,23 +259,6 @@ top::FlowDef ::= prod::String  sigName::String  attr::String  deps::[FlowVertex]
   top.prodGraphContribs = [pair(prod, top)];
   top.flowEdges = map(pair(rhsVertex(sigName, attr), _), deps);
   top.unparses = ["inh(" ++ implode(", ", [quoteString(prod), quoteString(sigName), quoteString(attr), unparseVertices(deps)]) ++ ")"];
-}
-
-{--
- - The definition of a default equation for a synthesized attribute on a nonterminal.
- -
- - @param nt  the full name of the *nonterminal*
- - @param attr  the full name of the attribute
- - @param deps  the dependencies of this equation on other flow graph elements
- - CONTRIBUTIONS ARE POSSIBLE
- -}
-abstract production defaultSynEq
-top::FlowDef ::= nt::String  attr::String  deps::[FlowVertex]
-{
-  top.defTreeContribs = [pair(crossnames(nt, attr), top)];
-  top.prodGraphContribs = []; -- defaults don't show up in the prod graph!!
-  top.flowEdges = map(pair(lhsSynVertex(attr), _), deps); -- but their edges WILL end up added to graphs in fixup-phase!!
-  top.unparses = ["def(" ++ implode(", ", [quoteString(nt), quoteString(attr), unparseVertices(deps)]) ++ ")"];
 }
 
 {--
@@ -391,6 +401,28 @@ top::FlowDef ::= prod::String  fName::String  attr::String  deps::[FlowVertex]
   top.prodGraphContribs = [pair(prod, top)];
   top.flowEdges = map(pair(anonVertex(fName, attr), _), deps);
   top.unparses = ["anonInh(" ++ implode(", ", [quoteString(prod), quoteString(fName), quoteString(attr), unparseVertices(deps)]) ++ ")"];
+}
+
+{--
+ - A match rule from a pattern matching equation.
+ - Matching against 'scrutinee' this rule matches 'matchProd'. It extracts the pattern variables in 'vars'.
+ - This info is used, not to directly create edges, but to inform which stitch points are needed.
+ -}
+abstract production patternRuleEq
+top::FlowDef ::= prod::String  matchProd::String  scrutinee::VertexType  vars::[PatternVarProjection]
+{
+  top.prodGraphContribs = [pair(prod, top)];
+  top.flowEdges = [];
+  top.unparses = ["patternRuleEq(" ++ implode(", ", [quoteString(prod), quoteString(matchProd), scrutinee.unparse, "[" ++ implode(", ", map((.unparse), vars)) ++ "]"]) ++ ")"];
+}
+
+
+nonterminal PatternVarProjection with unparse;
+
+abstract production patternVarProjection
+top::PatternVarProjection ::= child::String  typeName::String  patternVar::String
+{
+  top.unparse = s"(${child}, ${typeName}, ${patternVar})";
 }
 
 --

--- a/grammars/silver/definition/flow/ast/VertexType.sv
+++ b/grammars/silver/definition/flow/ast/VertexType.sv
@@ -7,7 +7,7 @@ grammar silver:definition:flow:ast;
  - lhsVertexType, rhsVertexType(sigName), localVertexType(fName),
  - forwardVertexType, anonVertexType(x)
  -}
-nonterminal VertexType with synVertex, inhVertex, fwdVertex, eqVertex;
+nonterminal VertexType with synVertex, inhVertex, fwdVertex, eqVertex, unparse;
 
 {-- FlowVertex for a synthesized attribute for this FlowVertex -}
 synthesized attribute synVertex :: (FlowVertex ::= String);
@@ -37,6 +37,7 @@ top::VertexType ::=
   top.inhVertex = lhsInhVertex;
   top.fwdVertex = forwardEqVertex_singleton;
   top.eqVertex = [];
+  top.unparse = "lhs";
 }
 
 {--
@@ -49,6 +50,7 @@ top::VertexType ::= sigName::String
   top.inhVertex = rhsVertex(sigName, _);
   top.fwdVertex = rhsVertex(sigName, "forward");
   top.eqVertex = [];
+  top.unparse = s"rhs('${sigName}')";
 }
 
 {--
@@ -61,6 +63,7 @@ top::VertexType ::= fName::String
   top.inhVertex = localVertex(fName, _);
   top.fwdVertex = localVertex(fName, "forward");
   top.eqVertex = [localEqVertex(fName)];
+  top.unparse = s"local('${fName}')";
 }
 
 {--
@@ -73,6 +76,7 @@ top::VertexType ::=
   top.inhVertex = localVertex("forward", _);
   top.fwdVertex = localVertex("forward", "forward");
   top.eqVertex = [forwardEqVertex_singleton];
+  top.unparse = s"fwd";
 }
 
 {--
@@ -85,6 +89,7 @@ top::VertexType ::= x::String
   top.inhVertex = anonVertex(x, _);
   top.fwdVertex = anonVertex(x, "forward");
   top.eqVertex = [anonEqVertex(x)];
+  top.unparse = s"anon('${x}')";
 }
 
 

--- a/grammars/silver/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/definition/flow/driver/FlowTypes.sv
@@ -88,14 +88,9 @@ Pair<Boolean
   prodEnv::EnvTree<ProductionGraph>
   ntEnv::EnvTree<FlowType>
 {
-  local graph :: ProductionGraph = head(graphs);
-  graph.flowTypes = ntEnv;
-  graph.prodGraphs = prodEnv;
-  local stitchedGraph :: ProductionGraph = graph.stitchedGraph;
-  stitchedGraph.flowTypes = ntEnv;
-  local updatedGraph :: ProductionGraph = stitchedGraph.cullSuspect;
+  local updatedGraph :: ProductionGraph = updateGraph(head(graphs), prodEnv, ntEnv);
 
-  local currentFlowType :: FlowType = findFlowType(graph.lhsNt, ntEnv);
+  local currentFlowType :: FlowType = findFlowType(updatedGraph.lhsNt, ntEnv);
   
   -- The New Improved Flow Type
   local synExpansion :: [Pair<String [String]>] =
@@ -111,7 +106,7 @@ Pair<Boolean
   -- any new additions... so we'd need something added to graph to support that.
   
   local recurse :: Pair<Boolean Pair<[ProductionGraph] EnvTree<FlowType>>> =
-    solveFlowTypes(tail(graphs), prodEnv, rtm:update(graph.lhsNt, [newFlowType], ntEnv));
+    solveFlowTypes(tail(graphs), prodEnv, rtm:update(updatedGraph.lhsNt, [newFlowType], ntEnv));
     
   return if null(graphs) then pair(false, pair([], ntEnv))
   else pair(!null(brandNewEdges) || recurse.fst, pair(updatedGraph :: recurse.snd.fst, recurse.snd.snd));

--- a/grammars/silver/definition/flow/driver/StitchPoint.sv
+++ b/grammars/silver/definition/flow/driver/StitchPoint.sv
@@ -16,8 +16,6 @@ top::StitchPoint ::= nt::String  vertexType::VertexType
       g:toList(findFlowType(nt, top.flowTypes)));
 }
 
--- TODO: use the below, somehow. it's for pattern matching, right?
-
 
 {--
  - Given production 'prod :: LHS ::= rhs1::RHS1'

--- a/grammars/silver/definition/flow/env/FunctionDcl.sv
+++ b/grammars/silver/definition/flow/env/FunctionDcl.sv
@@ -7,7 +7,7 @@ top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody
 {
   {-- Used by core to send down with .frame -}
   production myFlowGraph :: ProductionGraph = 
-    constructFunctionGraph(namedSig, top.flowEnv);
+    constructFunctionGraph(namedSig, top.flowEnv, top.env);
 
   top.flowDefs = body.flowDefs;
 }
@@ -17,7 +17,7 @@ top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::P
 {
   {-- Used by core to send down with .frame -}
   production myFlowGraph :: ProductionGraph = 
-    constructFunctionGraph(namedSig, top.flowEnv);
+    constructFunctionGraph(namedSig, top.flowEnv, top.env);
 
   top.flowDefs = body.flowDefs;
 }

--- a/grammars/silver/definition/flow/env/FunctionDcl.sv
+++ b/grammars/silver/definition/flow/env/FunctionDcl.sv
@@ -1,13 +1,18 @@
 grammar silver:definition:flow:env;
 
-import silver:definition:flow:driver only ProductionGraph, constructFunctionGraph;
+import silver:definition:flow:driver only ProductionGraph, FlowType, constructFunctionGraph;
+import silver:driver:util only RootSpec; -- actually we just want the occurrences
 
 aspect production functionDcl
 top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody 
 {
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
   {-- Used by core to send down with .frame -}
   production myFlowGraph :: ProductionGraph = 
-    constructFunctionGraph(namedSig, top.flowEnv, top.env);
+    constructFunctionGraph(namedSig, top.flowEnv, top.env, myProds, myFlow);
 
   top.flowDefs = body.flowDefs;
 }
@@ -15,9 +20,13 @@ top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody
 aspect production aspectFunctionDcl
 top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::ProductionBody 
 {
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
   {-- Used by core to send down with .frame -}
   production myFlowGraph :: ProductionGraph = 
-    constructFunctionGraph(namedSig, top.flowEnv, top.env);
+    constructFunctionGraph(namedSig, top.flowEnv, top.env, myProds, myFlow);
 
   top.flowDefs = body.flowDefs;
 }

--- a/grammars/silver/definition/flow/env_parser/Parser.sv
+++ b/grammars/silver/definition/flow/env_parser/Parser.sv
@@ -27,6 +27,9 @@ terminal AnonVTerm 	 'anonV' lexer classes {C_1};
 terminal AnonTerm 	 'anon' lexer classes {C_1}; 
 terminal AnonInhTerm 	 'anonInh' lexer classes {C_1};
 terminal SpecFlow        'specFlow' lexer classes {C_1};
+terminal RhsFlow         'rhs' lexer classes {C_1};
+terminal LhsFlow         'lhs' lexer classes {C_1};
+terminal PatRulEqTerm    'patternRuleEq' lexer classes {C_1};
 
 attribute flowDefs occurs on IRoot, IRootPart;
 
@@ -229,5 +232,76 @@ concrete production aFlowAnonInhEq
 top::IFlow ::= 'anonInh' '(' prod::IName ',' fname::IName ',' attr::IName ',' fv::IFlowVertexes ')'
 {
   top.flowDefs = [anonInhEq(prod.aname, fname.aname, attr.aname, fv.flowDeps)];
+}
+concrete production aPatternRuleEq
+top::IFlow ::= 'patternRuleEq' '(' prod::IName ',' matchProd::IName ',' scrutinee::IVertexType ',' vars::IPatternVarProjections ')'
+{
+  top.flowDefs = [patternRuleEq(prod.aname, matchProd.aname, scrutinee.aVertexType, vars.aPatternVarProjection)];
+}
+
+
+synthesized attribute aVertexType :: VertexType;
+
+nonterminal IVertexType with aVertexType;
+
+concrete production alhsVertexType
+top::IVertexType ::= 'lhs'
+{
+  top.aVertexType = lhsVertexType;
+}
+concrete production arhsVertexType
+top::IVertexType ::= 'rhs' '(' child::IName ')'
+{
+  top.aVertexType = rhsVertexType(child.aname);
+}
+concrete production alocalVertexType
+top::IVertexType ::= 'local' '(' child::IName ')'
+{
+  top.aVertexType = localVertexType(child.aname);
+}
+concrete production aanonVertexType
+top::IVertexType ::= 'anon' '(' child::IName ')'
+{
+  top.aVertexType = anonVertexType(child.aname);
+}
+concrete production aforwardVertexType
+top::IVertexType ::= 'fwd'
+{
+  top.aVertexType = forwardVertexType;
+}
+
+
+synthesized attribute aPatternVarProjection :: [PatternVarProjection];
+
+nonterminal IPatternVarProjections with aPatternVarProjection;
+nonterminal IPatternVarProjectionsInner with aPatternVarProjection;
+
+concrete production aFlowsNone_proj
+top::IPatternVarProjections ::= '[' ']'
+{
+  top.aPatternVarProjection = [];
+}
+concrete production aFlowsSome_proj
+top::IPatternVarProjections ::= '[' l::IPatternVarProjectionsInner ']'
+{
+  top.aPatternVarProjection = l.aPatternVarProjection;
+}
+concrete production aFlowsOne_proj
+top::IPatternVarProjectionsInner ::= l::IPatternVarProjection
+{
+  top.aPatternVarProjection = l.aPatternVarProjection;
+}
+concrete production aFlowsCons_proj
+top::IPatternVarProjectionsInner ::= l::IPatternVarProjectionsInner ',' r::IPatternVarProjection
+{
+  top.aPatternVarProjection = l.aPatternVarProjection ++ r.aPatternVarProjection;
+}
+
+nonterminal IPatternVarProjection with aPatternVarProjection;
+
+concrete production aPatternVarProjection
+top::IPatternVarProjection ::= '(' child::IName ',' typeName::IName ',' patternVar::IName ')'
+{
+  top.aPatternVarProjection = [patternVarProjection(child.aname, typeName.aname, patternVar.aname)];
 }
 

--- a/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
@@ -234,8 +234,8 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   
   top.errors := qn.lookupValue.errors ++ ns.errors ++ chk ++ e.errors;
 
-  local attribute prod_type :: Type;
-  prod_type = fullySkolemizeProductionType(qn.lookupValue.typerep); -- that says FULLY. See the comments on that function.
+  local prod_type :: Type =
+    fullySkolemizeProductionType(qn.lookupValue.typerep); -- that says FULLY. See the comments on that function.
   
   ns.bindingTypes = prod_type.inputTypes;
   ns.bindingIndex = 0;

--- a/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
@@ -197,6 +197,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   ns.bindingTypes = prod_type.inputTypes;
   ns.bindingIndex = 0;
   ns.bindingNames = if null(qn.lookupValue.dcls) then [] else qn.lookupValue.dcl.namedSignature.inputNames;
+  ns.matchingAgainst = if null(qn.lookupValue.dcls) then nothing() else just(qn.lookupValue.dcl);
   
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
@@ -240,6 +241,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   ns.bindingTypes = prod_type.inputTypes;
   ns.bindingIndex = 0;
   ns.bindingNames = if null(qn.lookupValue.dcls) then [] else qn.lookupValue.dcl.namedSignature.inputNames;
+  ns.matchingAgainst = if null(qn.lookupValue.dcls) then nothing() else just(qn.lookupValue.dcl);
   
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = composeSubst(errCheck2.upSubst, top.finalSubst); -- part of the
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = composeSubst(errCheck2.upSubst, top.finalSubst); -- threading hack

--- a/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
@@ -418,7 +418,7 @@ top::PrimPattern ::= h::Name t::Name e::Expr
   top.upSubst = errCheck2.upSubst;
   
   local consdefs :: [Def] =
-    [lexicalLocalDef(top.grammarName, top.location, h_fName, elemType, noVertex(), []), -- TODO these deps??
+    [lexicalLocalDef(top.grammarName, top.location, h_fName, elemType, noVertex(), []),
      lexicalLocalDef(top.grammarName, top.location, t_fName, top.scrutineeType, noVertex(), [])];
   
   e.env = newScopeEnv(consdefs, top.env);

--- a/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
@@ -31,7 +31,6 @@ nonterminal PrimPattern with
 
 autocopy attribute scrutineeType :: Type;
 autocopy attribute returnType :: Type;
-inherited attribute bindingTypes :: [Type];
 
 
 concrete production matchPrimitiveConcrete
@@ -190,13 +189,14 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   top.errors := qn.lookupValue.errors ++ ns.errors ++ chk ++ e.errors;
 
   -- Turns the existential variables existential
-  local attribute prod_type :: Type;
-  prod_type = skolemizeProductionType(qn.lookupValue.typerep);
+  local prod_type :: Type =
+    skolemizeProductionType(qn.lookupValue.typerep);
   -- Note that we're going to check prod_type against top.scrutineeType shortly.
   -- This is where the type variables become unified.
   
   ns.bindingTypes = prod_type.inputTypes;
   ns.bindingIndex = 0;
+  ns.bindingNames = if null(qn.lookupValue.dcls) then [] else qn.lookupValue.dcl.namedSignature.inputNames;
   
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
@@ -239,6 +239,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   
   ns.bindingTypes = prod_type.inputTypes;
   ns.bindingIndex = 0;
+  ns.bindingNames = if null(qn.lookupValue.dcls) then [] else qn.lookupValue.dcl.namedSignature.inputNames;
   
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = composeSubst(errCheck2.upSubst, top.finalSubst); -- part of the
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = composeSubst(errCheck2.upSubst, top.finalSubst); -- threading hack

--- a/grammars/silver/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/modification/primitivepattern/VarBinders.sv
@@ -10,12 +10,12 @@ nonterminal VarBinders with
   config, grammarName, env, compiledGrammars, frame,
   location, pp, errors, defs,
   bindingTypes, bindingIndex, translation, varBinderCount,
-  finalSubst;
+  finalSubst, flowProjections;
 nonterminal VarBinder with
   config, grammarName, env, compiledGrammars, frame,
   location, pp, errors, defs,
   bindingType, bindingIndex, translation,
-  finalSubst;
+  finalSubst, flowProjections;
 
 inherited attribute bindingType :: Type;
 inherited attribute bindingIndex :: Integer;
@@ -32,6 +32,7 @@ top::VarBinders ::= v::VarBinder
 
   top.translation = v.translation;
   top.varBinderCount = 1;
+  top.flowProjections = v.flowProjections;
 
   v.bindingIndex = top.bindingIndex;
   v.bindingType = if null(top.bindingTypes)
@@ -47,6 +48,7 @@ top::VarBinders ::= v::VarBinder ',' vs::VarBinders
 
   top.translation = v.translation ++ vs.translation;
   top.varBinderCount = 1 + vs.varBinderCount;
+  top.flowProjections = v.flowProjections ++ vs.flowProjections;
 
   v.bindingIndex = top.bindingIndex;
   vs.bindingIndex = top.bindingIndex + 1;
@@ -67,6 +69,7 @@ top::VarBinders ::=
   
   top.translation = "";
   top.varBinderCount = 0;
+  top.flowProjections = [];
 }
 
 concrete production varVarBinder
@@ -85,7 +88,9 @@ top::VarBinder ::= n::Name
     then decoratedType(top.bindingType)
     else top.bindingType;
 
-  local fName :: String = toString(genInt()) ++ ":" ++ n.name;
+  local fName :: String = "__pv" ++ toString(genInt()) ++ ":" ++ n.name;
+  
+  top.flowProjections = [patternVarProjection()];
 
   top.defs = [lexicalLocalDef(top.grammarName, n.location, fName, ty, noVertex(), [])]; -- TODO: these deps??
 

--- a/grammars/silver/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/modification/primitivepattern/VarBinders.sv
@@ -4,21 +4,30 @@ import silver:translation:java:core;
 import silver:translation:java:type;
 
 import silver:modification:let_fix only makeSpecialLocalBinding, lexicalLocalDef;
-import silver:definition:flow:ast only noVertex;
+
+import silver:definition:flow:ast only hasVertex, noVertex, PatternVarProjection, patternVarProjection, anonVertexType, ExprVertexInfo;
 
 nonterminal VarBinders with 
   config, grammarName, env, compiledGrammars, frame,
   location, pp, errors, defs,
   bindingTypes, bindingIndex, translation, varBinderCount,
-  finalSubst, flowProjections;
+  finalSubst, flowProjections, bindingNames;
 nonterminal VarBinder with
   config, grammarName, env, compiledGrammars, frame,
   location, pp, errors, defs,
   bindingType, bindingIndex, translation,
-  finalSubst, flowProjections;
+  finalSubst, flowProjections, bindingName;
 
+--- Types of each child
+inherited attribute bindingTypes :: [Type];
 inherited attribute bindingType :: Type;
+--- Index of each child
 inherited attribute bindingIndex :: Integer;
+--- Names of each child (for flow analysis)
+inherited attribute bindingNames :: [String];
+inherited attribute bindingName :: String;
+--- Extractions of decoration sites from children
+synthesized attribute flowProjections :: [PatternVarProjection];
 
 synthesized attribute varBinderCount :: Integer;
 
@@ -35,9 +44,14 @@ top::VarBinders ::= v::VarBinder
   top.flowProjections = v.flowProjections;
 
   v.bindingIndex = top.bindingIndex;
-  v.bindingType = if null(top.bindingTypes)
-                  then errorType()
-                  else head(top.bindingTypes);
+  v.bindingType =
+    if null(top.bindingTypes)
+    then errorType()
+    else head(top.bindingTypes);
+  v.bindingName =
+    if null(top.bindingNames)
+    then "__NONAME"
+    else head(top.bindingNames);
 }
 concrete production consVarBinder
 top::VarBinders ::= v::VarBinder ',' vs::VarBinders
@@ -53,12 +67,22 @@ top::VarBinders ::= v::VarBinder ',' vs::VarBinders
   v.bindingIndex = top.bindingIndex;
   vs.bindingIndex = top.bindingIndex + 1;
 
-  v.bindingType = if null(top.bindingTypes)
-                  then errorType()
-                  else head(top.bindingTypes);
-  vs.bindingTypes = if null(top.bindingTypes)
-                  then []
-                  else tail(top.bindingTypes);
+  v.bindingType =
+    if null(top.bindingTypes)
+    then errorType()
+    else head(top.bindingTypes);
+  vs.bindingTypes =
+    if null(top.bindingTypes)
+    then []
+    else tail(top.bindingTypes);
+  v.bindingName =
+    if null(top.bindingNames)
+    then "__NONAME"
+    else head(top.bindingNames);
+  vs.bindingNames =
+    if null(top.bindingNames)
+    then []
+    else tail(top.bindingNames);
 }
 concrete production nilVarBinder
 top::VarBinders ::=
@@ -90,9 +114,18 @@ top::VarBinder ::= n::Name
 
   local fName :: String = "__pv" ++ toString(genInt()) ++ ":" ++ n.name;
   
-  top.flowProjections = [patternVarProjection()];
+  -- If it's decorable, then we do projections through the production
+  -- if it's not, then we treat it like a generic reference.
+  top.flowProjections =
+    if top.bindingType.isDecorable
+    then [patternVarProjection(top.bindingName, top.bindingType.typeName, fName)]
+    else [];
+  local vt :: ExprVertexInfo =
+    if top.bindingType.isDecorable
+    then hasVertex(anonVertexType(fName))
+    else noVertex();
 
-  top.defs = [lexicalLocalDef(top.grammarName, n.location, fName, ty, noVertex(), [])]; -- TODO: these deps??
+  top.defs = [lexicalLocalDef(top.grammarName, n.location, fName, ty, vt, [])];
 
   -- finalSubst is not necessary, downSubst would work fine, but is not threaded through here.
   -- the point is that 'ty' for Pair<String Integer> would currently show Pair<a b>
@@ -132,6 +165,7 @@ top::VarBinder ::= '_'
   top.pp = "_";
   top.defs = [];
   top.errors := [];
+  top.flowProjections = [];
   top.translation = "";
 }
 

--- a/grammars/silver/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/modification/primitivepattern/VarBinders.sv
@@ -12,12 +12,12 @@ nonterminal VarBinders with
   config, grammarName, env, compiledGrammars, frame,
   location, pp, errors, defs,
   bindingTypes, bindingIndex, translation, varBinderCount,
-  finalSubst, flowProjections, bindingNames, flowEnv;
+  finalSubst, flowProjections, bindingNames, flowEnv, matchingAgainst;
 nonterminal VarBinder with
   config, grammarName, env, compiledGrammars, frame,
   location, pp, errors, defs,
   bindingType, bindingIndex, translation,
-  finalSubst, flowProjections, bindingName, flowEnv;
+  finalSubst, flowProjections, bindingName, flowEnv, matchingAgainst;
 
 --- Types of each child
 inherited attribute bindingTypes :: [Type];
@@ -29,6 +29,9 @@ inherited attribute bindingNames :: [String];
 inherited attribute bindingName :: String;
 --- Extractions of decoration sites from children
 synthesized attribute flowProjections :: [PatternVarProjection];
+
+-- The name of the production we're matching against
+autocopy attribute matchingAgainst :: Maybe<DclInfo>;
 
 synthesized attribute varBinderCount :: Integer;
 
@@ -113,7 +116,7 @@ top::VarBinder ::= n::Name
     then decoratedType(top.bindingType)
     else top.bindingType;
 
-  local fName :: String = "__pv" ++ toString(genInt()) ++ ":" ++ n.name;
+  production fName :: String = "__pv" ++ toString(genInt()) ++ ":" ++ n.name;
   
   -- If it's decorable, then we do projections through the production
   -- if it's not, then we treat it like a generic reference.
@@ -121,6 +124,8 @@ top::VarBinder ::= n::Name
     if top.bindingType.isDecorable
     then [patternVarProjection(top.bindingName, top.bindingType.typeName, fName)]
     else [];
+  -- because we don't have an 'anonEq' (the nonterminal stitch point gets generated for us by the above contribution) we won't be reported as missing in this production. Checks for presence in remote productions have to be done explicitly
+
   -- Recall that we emit (vertex, [reference set]) for expressions with a vertex.
   -- and the correct value is computed based on how this gets used.
   -- (e.g. if 'new'

--- a/self-compile
+++ b/self-compile
@@ -4,7 +4,7 @@
 set -eu
 
 # Defaults overridable by setting an environment variable:
-SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx1800M -Xss6M"}
+SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx2000M -Xss8M"}
   # These can be fun sometimes:
   # -XX:+PrintCompilation -verbose:gc -XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:-PrintGC
 SV_BUILD_TARGET=${SV_BUILD_TARGET:-"silver:composed:Default"}


### PR DESCRIPTION
This is probably the only thing that should block a Silver 0.4 release.

This pull request:

1. Introduces "projection stitch points" as described in my thesis. The data type was already there, but we weren't yet generating them as FlowDefs.
2. Checks for pattern matching on references for transitive dependencies outside the "ref set" of that reference.
3. Checks for dependencies involving pattern variables if the appropriate inherited equation exist in the remote productions.
4. Fixes a bug related to flow graphs for functions: I forgot to add in the "stitch points" to the graph, so it was incomplete.

In base AbleC it exposed a few new minor flow errors reported here: https://github.com/melt-umn/ableC/issues/70

I have not yet tried the AbleC extensions.

@ericvanwyk  @krame505 @TravisCarlson Is it okay if I merge this, or would it upset anything if suddenly there's possibly more flow errors in ablec/extensions? I think it'd be a good idea to get this in ASAP, so we can do a release and get things fixed...
