### PR TITLE
Avoid computing flow types without MWDA

### DIFF
--- a/grammars/silver/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/definition/flow/syntax/FlowSpec.sv
@@ -8,6 +8,10 @@ imports silver:definition:type;
 imports silver:driver:util only isExportedBy;
 imports silver:util:raw:treeset as set;
 
+-- unfortunate...
+import silver:analysis:warnings only warnAll;
+import silver:analysis:warnings:defs only warnMissingInh;
+
 terminal Flowtype 'flowtype' lexer classes {KEYWORD};
 
 concrete production flowtypeDcl
@@ -83,6 +87,7 @@ top::FlowSpec ::= attr::FlowSpecId  '{' inhs::FlowSpecInhs '}'
 
   top.errors <-
     if !null(attr.errors) ||
+       !(top.config.warnAll || top.config.warnMissingInh) || -- we don't want to compute flow graphs unless told to
        isExportedBy(attr.authorityGrammar, [hackGramFromFName(top.onNt.typeName)], top.compiledGrammars) ||
        null(missingFt)
     then []

--- a/test/cstast/silver-compile
+++ b/test/cstast/silver-compile
@@ -7,7 +7,7 @@
 
 export SILVER_HOME=../..
 
-java -Xss4M -Xmx1000M -jar $SILVER_HOME/jars/RunSilver.jar $@  -o test.jar \
+java -Xss4M -Xmx1500M -jar $SILVER_HOME/jars/RunSilver.jar $@  -o test.jar \
      -I .. cstast \
      && ant
 


### PR DESCRIPTION
This quick fix checks to see if we're doing the MWDA before enforcing the rule for `flowtype` declarations requiring extension synthesized attributes to have flow types that are a super set of the forward flow type.

Also, increase memory for the cstast test, which failed due to lack of memory because of this, and because it builds a lot of the silver compiler along with itself.