### PR TITLE
fixes #209, incorrect type in lambda translation

### DIFF
--- a/grammars/silver/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/modification/lambda_fn/java/Lambda.sv
@@ -18,8 +18,8 @@ top::Expr ::= params::ProductionRHS e::Expr
   local finTy :: Type = finalType(top);
   
   top.translation = 
-s"""(new common.NodeFactory<${e.typerep.transType}>() {
-  public final ${e.typerep.transType} invoke(final Object[] args, final Object[] namedArgs) {
+s"""(new common.NodeFactory<${finTy.outputType.transType}>() {
+  public final ${finTy.outputType.transType} invoke(final Object[] args, final Object[] namedArgs) {
     ${params.lambdaTranslation}
     return ${e.translation};
   }

--- a/test/silver_features/Globals.sv
+++ b/test/silver_features/Globals.sv
@@ -28,13 +28,13 @@ equalityTest ( globalbool2, false, Boolean, silver_tests ) ;
 nonterminal Tglob with strGlob;
 synthesized attribute strGlob :: String;
 
-abstract production Tfoo
+abstract production tfoo
 t::Tglob ::=
 {
   t.strGlob = globstring1;
 }
 
-global unT :: Tglob = Tfoo();
+global unT :: Tglob = tfoo();
 
 equalityTest ( unT.strGlob, "Hi", String, silver_tests ) ;
 
@@ -43,7 +43,7 @@ global deT :: Decorated Tglob = decorate unT with {};
 equalityTest ( deT.strGlob, "Hi", String, silver_tests ) ;
 
 wrongCode "initialization expression with type" {
-  global badT :: Decorated Tglob = Tfoo();
+  global badT :: Decorated Tglob = tfoo();
 }
 
 wrongCode "does not have the right signature." { -- TODO: this error message should be improved!!

--- a/test/silver_features/Lambda.sv
+++ b/test/silver_features/Lambda.sv
@@ -34,3 +34,16 @@ global fn::([Integer] ::=) = \ -> [4];
 equalityTest(null(tail(fn())), true, Boolean, silver_tests);
 -- The essential parts are Thunk -> Nodefactory (which captures context) -> Thunk
 
+-- Issue #209 - code gen bug involving casts
+nonterminal LambdaType;
+
+abstract production lambdaType
+f::LambdaType ::=
+{}
+
+function failsLambdaType
+(String ::= LambdaType) ::=
+{
+    return (\ f::LambdaType -> case f of lambdaType() -> "str" end);
+}
+-- End Issue #209


### PR DESCRIPTION
Use post-inference types in the translation of lambdas. Fixes bug where Object gets used instead of a more accurate type, and Java generics are invariant so `Foo<A>` is not compatible with `Foo<Object>`.

Fixes #209 

Hey @200sc can you glance at this? If it looks okay to you, we'll merge.

