### PR TITLE
Fixes to built-in type conversion functions

### DIFF
--- a/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
@@ -17,6 +17,18 @@ top::Expr ::= e::Decorated Expr
   top.upSubst = top.downSubst;
 }
 
+aspect production toBooleanFunction
+top::Expr ::= 'toBoolean' '(' e1::Expr ')'
+{
+  e1.downSubst = top.downSubst;
+  top.upSubst = e1.upSubst;
+  
+  top.errors <-
+       if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
+       then []
+       else [err(top.location, "Operand to toBoolean must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+}
+
 aspect production toIntFunction
 top::Expr ::= 'toInt' '(' e1::Expr ')'
 {
@@ -26,7 +38,7 @@ top::Expr ::= 'toInt' '(' e1::Expr ')'
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
        then []
-       else [err(top.location, "Operand to toInt must be concrete types String, Integer, or Float.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+       else [err(top.location, "Operand to toInt must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 aspect production toFloatFunction
@@ -38,7 +50,7 @@ top::Expr ::= 'toFloat' '(' e1::Expr ')'
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
        then []
-       else [err(top.location, "Operand to toFloat must be concrete types String, Integer, or Float.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+       else [err(top.location, "Operand to toFloat must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 aspect production toStringFunction

--- a/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
@@ -29,8 +29,8 @@ top::Expr ::= 'toBoolean' '(' e1::Expr ')'
        else [err(top.location, "Operand to toBoolean must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
-aspect production toIntFunction
-top::Expr ::= 'toInt' '(' e1::Expr ')'
+aspect production toIntegerFunction
+top::Expr ::= 'toInteger' '(' e1::Expr ')'
 {
   e1.downSubst = top.downSubst;
   top.upSubst = e1.upSubst;
@@ -38,7 +38,7 @@ top::Expr ::= 'toInt' '(' e1::Expr ')'
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
        then []
-       else [err(top.location, "Operand to toInt must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+       else [err(top.location, "Operand to toInteger must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 aspect production toFloatFunction

--- a/grammars/silver/definition/core/BuiltInFunctions.sv
+++ b/grammars/silver/definition/core/BuiltInFunctions.sv
@@ -57,7 +57,7 @@ top::Expr ::= 'toBoolean' '(' e::Expr ')'
   top.pp = "toBoolean(" ++ e.pp ++ ")";
 
   top.errors := e.errors;
-  top.typerep = intType();
+  top.typerep = boolType();
 }
 
 concrete production toFloatFunction

--- a/grammars/silver/definition/core/BuiltInFunctions.sv
+++ b/grammars/silver/definition/core/BuiltInFunctions.sv
@@ -43,6 +43,15 @@ top::Expr ::= 'toInt' '(' e::Expr ')'
   top.typerep = intType();
 }
 
+concrete production toBooleanFunction
+top::Expr ::= 'toBoolean' '(' e::Expr ')'
+{
+  top.pp = "toBoolean(" ++ e.pp ++ ")";
+
+  top.errors := e.errors;
+  top.typerep = intType();
+}
+
 concrete production toFloatFunction
 top::Expr ::= 'toFloat' '(' e::Expr ')'
 {

--- a/grammars/silver/definition/core/BuiltInFunctions.sv
+++ b/grammars/silver/definition/core/BuiltInFunctions.sv
@@ -34,10 +34,18 @@ top::Expr ::= e::Decorated Expr
   top.errors := [];
 }
 
+-- Legacy, TODO: deprecate this eventually
 concrete production toIntFunction
 top::Expr ::= 'toInt' '(' e::Expr ')'
 {
   top.pp = "toInt(" ++ e.pp ++ ")";
+  forwards to toIntegerFunction('toInteger', '(', e, ')', location=top.location);
+}
+
+concrete production toIntegerFunction
+top::Expr ::= 'toInteger' '(' e::Expr ')'
+{
+  top.pp = "toInteger(" ++ e.pp ++ ")";
 
   top.errors := e.errors;
   top.typerep = intType();

--- a/grammars/silver/definition/core/Terminals.sv
+++ b/grammars/silver/definition/core/Terminals.sv
@@ -57,9 +57,10 @@ terminal With_kwd        'with'         lexer classes {KEYWORD,RESERVED};
 terminal Global_kwd      'global'       lexer classes {KEYWORD,RESERVED};
 
 terminal Length_kwd    'length'    lexer classes {BUILTIN,RESERVED};
-terminal ToBOolean_kwd 'toBoolean' lexer classes {BUILTIN,RESERVED};
+terminal ToBoolean_kwd 'toBoolean' lexer classes {BUILTIN,RESERVED};
 terminal ToFloat_kwd   'toFloat'   lexer classes {BUILTIN,RESERVED};
-terminal ToInt_kwd     'toInt'     lexer classes {BUILTIN,RESERVED};
+terminal ToInt_kwd     'toInt'     lexer classes {BUILTIN,RESERVED}; -- Legacy
+terminal ToInteger_kwd 'toInteger' lexer classes {BUILTIN,RESERVED};
 terminal ToString_kwd  'toString'  lexer classes {BUILTIN,RESERVED};
 terminal Reify_kwd     'reify'     lexer classes {BUILTIN,RESERVED};
 

--- a/grammars/silver/definition/core/Terminals.sv
+++ b/grammars/silver/definition/core/Terminals.sv
@@ -57,6 +57,7 @@ terminal With_kwd        'with'         lexer classes {KEYWORD,RESERVED};
 terminal Global_kwd      'global'       lexer classes {KEYWORD,RESERVED};
 
 terminal Length_kwd    'length'    lexer classes {BUILTIN,RESERVED};
+terminal ToBOolean_kwd 'toBoolean' lexer classes {BUILTIN,RESERVED};
 terminal ToFloat_kwd   'toFloat'   lexer classes {BUILTIN,RESERVED};
 terminal ToInt_kwd     'toInt'     lexer classes {BUILTIN,RESERVED};
 terminal ToString_kwd  'toString'  lexer classes {BUILTIN,RESERVED};

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -539,6 +539,13 @@ top::Expr ::= e::Decorated Expr
   top.flowDefs = e.flowDefs;
 }
 
+aspect production toBooleanFunction
+top::Expr ::= 'toBoolean' '(' e1::Expr ')'
+{
+  top.flowDeps = e1.flowDeps;
+  top.flowDefs = e1.flowDefs;
+}
+
 aspect production toIntFunction
 top::Expr ::= 'toInt' '(' e1::Expr ')'
 {

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -546,8 +546,8 @@ top::Expr ::= 'toBoolean' '(' e1::Expr ')'
   top.flowDefs = e1.flowDefs;
 }
 
-aspect production toIntFunction
-top::Expr ::= 'toInt' '(' e1::Expr ')'
+aspect production toIntegerFunction
+top::Expr ::= 'toInteger' '(' e1::Expr ')'
 {
   top.flowDeps = e1.flowDeps;
   top.flowDefs = e1.flowDefs;

--- a/grammars/silver/translation/java/core/BuiltInFunctions.sv
+++ b/grammars/silver/translation/java/core/BuiltInFunctions.sv
@@ -28,8 +28,8 @@ top::Expr ::= 'toBoolean' '(' e::Expr ')'
 
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
-aspect production toIntFunction
-top::Expr ::= 'toInt' '(' e::Expr ')'
+aspect production toIntegerFunction
+top::Expr ::= 'toInteger' '(' e::Expr ')'
 {
   top.translation = case finalType(e) of
                     | boolType() -> s"Integer.valueOf(${e.translation}? 1 : 0)"

--- a/grammars/silver/translation/java/core/BuiltInFunctions.sv
+++ b/grammars/silver/translation/java/core/BuiltInFunctions.sv
@@ -45,7 +45,7 @@ aspect production toFloatFunction
 top::Expr ::= 'toFloat' '(' e::Expr ')'
 {
   top.translation = case finalType(e) of
-                    | boolType() -> s"Float.valueOf(${e.translation}? 1.0 : 0.0)"
+                    | boolType() -> s"Float.valueOf(${e.translation}? 1.0f : 0.0f)"
                     | intType() -> s"Float.valueOf(((Integer)${e.translation}).floatValue())"
                     | floatType() -> e.translation
                     | stringType() -> s"Float.valueOf(${e.translation}.toString())"

--- a/grammars/silver/translation/java/core/BuiltInFunctions.sv
+++ b/grammars/silver/translation/java/core/BuiltInFunctions.sv
@@ -15,10 +15,24 @@ top::Expr ::= e::Decorated Expr
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
 
+aspect production toBooleanFunction
+top::Expr ::= 'toBoolean' '(' e::Expr ')'
+{
+  top.translation = case finalType(e) of
+                    | boolType() -> e.translation
+                    | intType() -> s"Boolean.valueOf(${e.translation} != 0)"
+                    | floatType() -> s"Boolean.valueOf(${e.translation} != 0.0)"
+                    | stringType() -> s"Boolean.valueOf(${e.translation}.toString())"
+                    | t -> error("INTERNAL ERROR: no toBoolean translation for type " ++ prettyType(t))
+                    end;
+
+  top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
+}
 aspect production toIntFunction
 top::Expr ::= 'toInt' '(' e::Expr ')'
 {
   top.translation = case finalType(e) of
+                    | boolType() -> s"Integer.valueOf(${e.translation}? 1 : 0)"
                     | intType() -> e.translation
                     | floatType() -> s"Integer.valueOf(((Float)${e.translation}).intValue())"
                     | stringType() -> s"Integer.valueOf(${e.translation}.toString())"
@@ -31,6 +45,7 @@ aspect production toFloatFunction
 top::Expr ::= 'toFloat' '(' e::Expr ')'
 {
   top.translation = case finalType(e) of
+                    | boolType() -> s"Float.valueOf(${e.translation}? 1.0 : 0.0)"
                     | intType() -> s"Float.valueOf(((Integer)${e.translation}).floatValue())"
                     | floatType() -> e.translation
                     | stringType() -> s"Float.valueOf(${e.translation}.toString())"

--- a/test/silver_features/Conversions.sv
+++ b/test/silver_features/Conversions.sv
@@ -1,0 +1,26 @@
+grammar silver_features;
+
+equalityTest(toInteger(3.14), 3, Integer, silver_tests);
+equalityTest(toInteger(1), 1, Integer, silver_tests);
+equalityTest(toInteger(true), 1, Integer, silver_tests);
+equalityTest(toInteger(false), 0, Integer, silver_tests);
+equalityTest(toInteger("42"), 42, Integer, silver_tests);
+
+equalityTest(toFloat(3.14), 3.14, Float, silver_tests);
+equalityTest(toFloat(1), 1.0, Float, silver_tests);
+equalityTest(toFloat(true), 1.0, Float, silver_tests);
+equalityTest(toFloat(false), 0.0, Float, silver_tests);
+equalityTest(toFloat("12.34"), 12.34, Float, silver_tests);
+
+equalityTest(toBoolean(3.14), true, Boolean, silver_tests);
+equalityTest(toBoolean(1), true, Boolean, silver_tests);
+equalityTest(toBoolean(true), true, Boolean, silver_tests);
+equalityTest(toBoolean(false), false, Boolean, silver_tests);
+equalityTest(toBoolean("true"), true, Boolean, silver_tests);
+equalityTest(toBoolean("false"), false, Boolean, silver_tests);
+
+equalityTest(toString(3.14), "3.14", String, silver_tests);
+equalityTest(toString(1), "1", String, silver_tests);
+equalityTest(toString(true), "true", String, silver_tests);
+equalityTest(toString(false), "false", String, silver_tests);
+equalityTest(toString("hello"), "hello", String, silver_tests);


### PR DESCRIPTION
I ran into a bug where Silver crashes when translating `toInt(Boolean)`, so I decided to actually fix this.  I also implemented the `toBoolean` builtin function, converting `Integer`, `Float`, or `String` values to `Boolean` values.  

This still needs tests, but I figured I'd open a PR first to check if I'm on the right track.  

While I'm fixing these conversion things, I've also been thinking of renaming `toInt` -> `toInteger` to be consistent, and depericating `toInt`.  Thoughts?  