### PR TITLE
Refactoring of Thunks, expression translation

### DIFF
--- a/grammars/silver/modification/let_fix/java/Let.sv
+++ b/grammars/silver/modification/let_fix/java/Let.sv
@@ -18,13 +18,12 @@ top::Expr ::= la::AssignExpr  e::Expr
   local finTy :: Type = finalType(top);
 
   -- We need to create these nested locals, so we have no choice but to create a thunk object so we can declare these things.
-  -- TODO: more specific types here would be nice!
   local closureExpr :: String =
-    "new common.Thunk<Object>(context) { public final Object doEval(final common.DecoratedNode context) { " ++
-    la.let_translation ++
-    "return " ++ e.translation ++ "; } }";
+    s"new common.Thunk<${finTy.transType}>(new common.Thunk.Evaluable() { public final ${finTy.transType} eval() { ${la.let_translation} return ${e.translation}; } })";
+    --TODO: java lambdas are bugged
+    --s"new common.Thunk<${finTy.transType}>(() -> { ${la.let_translation} return ${e.translation};\n})";
   
-  top.translation = "((" ++ finTy.transType ++ ")(" ++ closureExpr ++ ").eval())";
+  top.translation = s"${closureExpr}.eval()";
 
   top.lazyTranslation = 
     if top.frame.lazyApplication
@@ -49,14 +48,18 @@ top::AssignExpr ::= a1::AssignExpr a2::AssignExpr
 aspect production assignExpr
 top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
 {
+  -- We must use `finalSubst` in translation.
+  -- "let abuse" means type variables can appear in `t`, and if we don't
+  -- use `finalSubst` we get confusion with `ntOrDecType` not knowing
+  -- it's being used undecorated later.
+  local finalTy :: Type = performSubstitution(t.typerep, top.finalSubst);
   top.let_translation = makeSpecialLocalBinding(fName, e.translation, finalTy.transType);
 }
 
 function makeSpecialLocalBinding
 String ::= fn::String  et::String  ty::String
 {
-  -- TODO: more specific types here would be nice!
-  return "final common.Thunk<Object> " ++ makeLocalValueName(fn) ++ " = " ++ wrapThunkText("context", et, "Object") ++ ";\n";
+  return s"final common.Thunk<${ty}> ${makeLocalValueName(fn)} = ${wrapThunkText(et, ty)};\n";
 }
 
 aspect production lexicalLocalReference

--- a/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
@@ -425,10 +425,16 @@ top::PrimPattern ::= h::Name t::Name e::Expr
   
   e.env = newScopeEnv(consdefs, top.env);
   
-  top.translation = "if(!scrutineeIter.nil()) {" ++
-  makeSpecialLocalBinding(h_fName, "scrutinee.head()", performSubstitution(elemType, top.finalSubst).transType) ++
-  makeSpecialLocalBinding(t_fName, "scrutinee.tail()", performSubstitution(top.scrutineeType, top.finalSubst).transType) ++
-  "return " ++ e.translation ++ "; }";
+  top.translation =
+    let
+      elemTrans :: String = performSubstitution(elemType, top.finalSubst).transType,
+      listTrans :: String = performSubstitution(top.scrutineeType, top.finalSubst).transType
+    in
+      "if(!scrutineeIter.nil()) {" ++
+      makeSpecialLocalBinding(h_fName, s"(${elemTrans})scrutinee.head()", elemTrans) ++
+      makeSpecialLocalBinding(t_fName, s"(${listTrans})scrutinee.tail()", listTrans) ++
+      "return " ++ e.translation ++ "; }"
+    end;
 }
 
 

--- a/grammars/silver/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/translation/java/core/FunctionDcl.sv
@@ -133,7 +133,8 @@ ${whatResult}
 		}
 	}
 
-	public static final common.NodeFactory<${whatSig.outputElement.typerep.transType}> factory = new Factory();
+	// Use of ? to permit casting to more specific types
+	public static final common.NodeFactory<? extends ${whatSig.outputElement.typerep.transType}> factory = new Factory();
 
 	public static final class Factory extends common.NodeFactory<${whatSig.outputElement.typerep.transType}> {
 		@Override

--- a/grammars/silver/translation/java/core/GlobalDcl.sv
+++ b/grammars/silver/translation/java/core/GlobalDcl.sv
@@ -3,8 +3,6 @@ grammar silver:translation:java:core;
 aspect production globalValueDclConcrete
 top::AGDcl ::= 'global' id::Name '::' t::TypeExpr '=' e::Expr ';'
 {
-  -- TODO: would be nice to use more specific types. double TODO: figure out what the problem was?
   top.initValues :=
-      s"\tpublic static final common.Thunk<Object> ${id.name}" ++
-      s" = ${wrapThunkText("common.TopNode.singleton", e.translation, "Object")};\n";
+    s"\tpublic static final common.Thunk<${t.typerep.transType}> ${id.name} = ${wrapThunkText(e.translation, t.typerep.transType)};\n";
 }

--- a/grammars/silver/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/translation/java/core/ProductionDcl.sv
@@ -165,11 +165,11 @@ ${makeTyVarDecls(2, namedSig.typerep.freeVariables)}
 		return new ${className}(${namedSig.refInvokeTrans});
 	}
 
-	public static final common.NodeFactory<${className}> factory = new Factory();
+	public static final common.NodeFactory<${fnnt}> factory = new Factory();
 
-	public static final class Factory extends common.NodeFactory<${className}> {
+	public static final class Factory extends common.NodeFactory<${fnnt}> {
 		@Override
-		public final ${className} invoke(final Object[] children, final Object[] annotations) {
+		public final ${fnnt} invoke(final Object[] children, final Object[] annotations) {
 			return new ${className}(${implode(", ", unpackChildren(0, namedSig.inputElements) ++ unpackAnnotations(0, namedSig.namedInputElements))});
 		}
 		

--- a/grammars/silver/translation/java/core/RootSpec.sv
+++ b/grammars/silver/translation/java/core/RootSpec.sv
@@ -60,6 +60,7 @@ ${g.initProd}
 
 ${g.initWeaving}
 ${g.valueWeaving}
+	final static common.DecoratedNode context = common.TopNode.singleton; // For globals
 ${g.initValues}
 }
 """)];

--- a/runtime/java/src/common/AppendCell.java
+++ b/runtime/java/src/common/AppendCell.java
@@ -99,7 +99,7 @@ public class AppendCell extends ConsCell {
 				// We MUST grab the tail of leftap now. If we do not, then it may mutate (becomeLiteralConsCell) before we
 				// evaluate the thunk! If that happens, we get duplication.
 				final Object leftaptail = leftap.tail;
-				return append(leftap.head, new Thunk<Object>(TopNode.singleton) { public final Object doEval(final DecoratedNode context) { return append(leftaptail, rightap); }});
+				return append(leftap.head, new Thunk(() -> append(leftaptail, rightap)));
 			}
 		}
 		// Okay, we're a real append of a real, literal ConsCell on the LHS.
@@ -111,14 +111,8 @@ public class AppendCell extends ConsCell {
 		// By invariants, head is ConsCell
 		final ConsCell left = (ConsCell)head;
 		head = left.head();
-		// append is strict in its LHS, so calling left.tail() is okay.
-		// STRICTLY SPEAKING, however, this whole assignment to tail a bug:
-		// we should be creating this as a CLOSURE.
-		// TODO: investigate what consequences appear here?
-		// TODO: depends on fixing the bug that makes all FFI calls strict anyway!
-		//tail = append(left.tail(), tail);
 		final Object oldtail = tail;
-		tail = new Thunk<Object>(TopNode.singleton) { public final Object doEval(final DecoratedNode context) { return append(left.tail(), oldtail); } };
+		tail = new Thunk(() -> append(left.tail(), oldtail));
 		literalConsCell = true;
 	}
 	

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -477,12 +477,7 @@ public class DecoratedNode implements Typed {
 		if(childrenValues[child] != null)
 			return childrenValues[child];
 		
-		return new Thunk<Object>(this) {
-			@Override
-			public final Object doEval(final DecoratedNode context) {
-				return context.childDecorated(child);
-			}
-		};
+		return new Thunk(() -> this.childDecorated(child));
 	}
 	public final Object childAsIsLazy(final int child) {
 		// childAsIs does not store in the childrenValues array, so...
@@ -493,23 +488,13 @@ public class DecoratedNode implements Typed {
 		if(localValues[index] != null)
 			return localValues[index];
 		
-		return new Thunk<Object>(this) {
-			@Override
-			public final Object doEval(final DecoratedNode context) {
-				return context.localDecorated(index);
-			}
-		};
+		return new Thunk(() -> this.localDecorated(index));
 	}
 	public final Object localAsIsLazy(final int index) {
 		if(localValues[index] != null)
 			return localValues[index];
 
-		return new Thunk<Object>(this) {
-			@Override
-			public final Object doEval(final DecoratedNode context) {
-				return context.localAsIs(index);
-			}
-		};
+		return new Thunk(() -> this.localAsIs(index));
 	}
 	public final Object childDecoratedSynthesizedLazy(final int child, final int index) {
 		Object v = childrenValues[child];
@@ -517,12 +502,7 @@ public class DecoratedNode implements Typed {
 			return ((DecoratedNode)v).contextSynthesizedLazy(index);
 		}
 
-		return new Thunk<Object>(this) {
-			@Override
-			public final Object doEval(final DecoratedNode context) {
-				return context.childDecorated(child).synthesized(index);
-			}
-		};
+		return new Thunk(() -> this.childDecorated(child).synthesized(index));
 	}
 	public final Object childAsIsSynthesizedLazy(final int child, final int index) {
 		// For as-is children, we do not store in childrenValues
@@ -531,35 +511,20 @@ public class DecoratedNode implements Typed {
 			return ((DecoratedNode)v).contextSynthesizedLazy(index);
 		}
 
-		return new Thunk<Object>(this) {
-			@Override
-			public final Object doEval(final DecoratedNode context) {
-				return ((DecoratedNode)context.childAsIs(child)).synthesized(index);
-			}
-		};
+		return new Thunk(() -> ((DecoratedNode)this.childAsIs(child)).synthesized(index));
 	}
 	public final Object contextSynthesizedLazy(final int index) {
 		if(synthesizedValues[index] != null) {
 			return synthesizedValues[index];
 		}
 		
-		return new Thunk<Object>(this) {
-			@Override
-			public final Object doEval(final DecoratedNode context) {
-				return context.synthesized(index);
-			}
-		};
+		return new Thunk(() -> this.synthesized(index));
 	}
 	public final Object contextInheritedLazy(final int index) {
 		if(inheritedValues[index] != null)
 			return inheritedValues[index];
 		
-		return new Thunk<Object>(this) {
-			@Override
-			public final Object doEval(final DecoratedNode context) {
-				return context.inherited(index);
-			}
-		};
+		return new Thunk(() -> this.inherited(index));
 	}
 	
 	@Override

--- a/runtime/java/src/common/Thunk.java
+++ b/runtime/java/src/common/Thunk.java
@@ -7,53 +7,31 @@ package common;
  * 
  * @author tedinski
  */
-public abstract class Thunk<T> {
+public class Thunk<T> {
 	
-	// Explicitly no visibility modifer here. We want the subclasses below to see this, but nothing outside.
-	T data;
-	DecoratedNode ctx;
-	
-	/**
-	 * Construct a thunk, to be evaluated in context.
-	 * 
-	 * @param ctx {@link DecoratedNode} to use as context for evaluating thunk
-	 */
-	public Thunk(final DecoratedNode ctx) {
-		assert(ctx != null);
-		this.ctx = ctx;
+	// Instances should never escape this class
+	public static interface Evaluable<T> {
+		public T eval();
 	}
 	
-	/**
-	 * Either evaluates the closure to obtain a value, or returns the already evaluated result.
-	 * 
-	 * @return The value wrapped by this Thunk.
-	 */
+	// Either T or Evaluable<T>
+	private Object o;
+
+	public Thunk(final Evaluable<T> e) {
+		assert(e != null);
+		o = e;
+	}
+	
 	public T eval() {
-		if(ctx != null) {
-			data = doEval(ctx);
-
-			assert(data != null);
-
-			ctx = null;
+		if(o instanceof Evaluable) {
+			o = ((Evaluable<T>)o).eval();
+			assert(o != null);
 		}
-		return data;
+		return (T)o;
 	}
 	
-	/**
-	 * Does the real evaluation of the Thunk.
-	 */
-	protected abstract T doEval(final DecoratedNode context);
-	// N.B. We must explicitly pass 'context' into doEval, instead of allowing it to use
-	// our member variable 'ctx' as a context, because we mutate 'ctx'.
-	// You'd *THINK* Java variable capture rules would mean this doesn't matter, but
-	// apparently everything is happily capturing 'this' as a final variable and then
-	// we run afoul of 'this.context' suddenly becoming null!
-	
-	/**
-	 * Constructs a Thunk from a Lazy and a DecoratedNode context.
-	 */
 	public static Thunk<Object> fromLazy(Lazy l, DecoratedNode ctx) {
-		return new FromLazy(l,ctx);
+		return new Thunk(() -> l.eval(ctx));
 	}
 	
 	/**
@@ -62,44 +40,18 @@ public abstract class Thunk<T> {
 	 * @param t  Either a DecoratedNode or a Thunk<DecoratedNode>
 	 * @return  Either a Node or a Thunk<Node>
 	 */
-	public static Object transformUndecorate(Object t) {
+	public static Object transformUndecorate(final Object t) {
+		// DecoratedNode
 		if(t instanceof DecoratedNode)
 			return ((DecoratedNode)t).undecorate();
-		else if(/* instance of Thunk */ ((Thunk)t).ctx == null) // already evaluated!
-			return ((DecoratedNode)((Thunk)t).data).undecorate();
-		// This second check is important, otherwise doEval needs modifying for this class...
-		
-		return new TransformUndecorate((Thunk<DecoratedNode>)t);
+		// Thunk
+		return transformUndecorateThunk((Thunk<DecoratedNode>)t);
 	}
-	
-	private static class FromLazy extends Thunk<Object> {
-
-		public FromLazy(Lazy l, DecoratedNode ctx) {
-			super(ctx);
-			data = l;
-		}
-		
-		@Override
-		protected Object doEval(final DecoratedNode context) {
-			return ((Lazy)data).eval(ctx);
-		}
-		
+	private static Object transformUndecorateThunk(final Thunk<DecoratedNode> t) {
+		// Unevaluated Thunk
+		if(t.o instanceof Evaluable)
+			return new Thunk(() -> t.eval().undecorate());
+		// Evaluated Thunk, eagerly undecorate:
+		return t.eval().undecorate();
 	}
-	
-	private static class TransformUndecorate extends Thunk<Object> {
-
-		public TransformUndecorate(Thunk<DecoratedNode> t) {
-			super(t.ctx); // We don't need a context, so use a dummy value.
-			// Note that the check for context == null in transformUndecorate
-			// becomes important here, because otherwise doEval won't be called!
-			data = t;
-		}
-
-		@Override
-		protected Object doEval(final DecoratedNode context) {
-			return ((Thunk<DecoratedNode>)data).eval().undecorate();
-		}
-		
-	}
-	
 }

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -688,15 +688,13 @@ public final class Util {
 		try {
 			Method getTokens = parserClass.getMethod("getTokens");
 			List<common.Terminal> tokens = (List) getTokens.invoke(parser);
-			return new Thunk<Object>(TopNode.singleton) {
-				public final Object doEval(final DecoratedNode context) {
-					List<NTerminalDescriptor> tds = tokens
-						.stream()
-						.map(Util::terminalToTerminalDescriptor)
-						.collect(Collectors.toList());
-					return ConsCellCollection.fromList(tds);
-				}
-			};
+			return new Thunk(() -> {
+				List<NTerminalDescriptor> tds = tokens
+					.stream()
+					.map(Util::terminalToTerminalDescriptor)
+					.collect(Collectors.toList());
+				return ConsCellCollection.fromList(tds);
+			});
 		} catch(Throwable t) {
 			throw new TraceException("Failed to reflect to getTokens()", t);
 		}


### PR DESCRIPTION
This branch started off as a test to see if we could use Java lambda instead of anonymous classes. That effort failed. You'll find two spots in the first commit that read `--TODO: java lambdas are bugged`. If you uncomment one, then `javac` infinite loops (or otherwise needs too much time/RAM), if you uncomment the other, I believe it produces code that fails bytecode verification. Oops. So, useless, kinda.

That said, maybe these bugs will get fixed in the future and then we'll be ready for lambdas. I believe the commented lines would reduce jar file sizes by a lot, if only they worked. We do get to adopt lambdas in a couple spots in the runtime, which you can see in the patch. Those are nice.

The only downsides to merging:

1. This means our minimum is Java 8 now. But we've been compiling to that version for a while accidentally, and no one noticed. So probably fine.
2. It might use slightly more memory than the old implementation, but not enough to be detectable. (Like maybe 10MB more out of 1.5GB)

While attempting this, I ran into a lot of issues with expression translations having inexact types. So I also did some investigation into this problem, and fixed (I think) all the issues. The `translation` of `Expr` should now always have the appropriate Java type. I was also able to simplify a bunch of the expression translations as a result of this (numeric stuff especially, which, as a bonus, might actually get more efficient!)

It's conceivable I missed something though, especially since the function translation was so tricky (see odd change in `FunctionDcl`.)