### PR TITLE
Better Silver Jenkinsfile

### DIFF
--- a/support/nailgun/sv-nailgun
+++ b/support/nailgun/sv-nailgun
@@ -5,6 +5,9 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
   exit 5
 fi
 
+# Try to avoid colliding with other users of nailgun: 1/32k chance
+export NAILGUN_PORT=$(($RANDOM + 20000))
+
 # Try a few possible locations, pick the first
 SV_NAILGUN_CANDIDATES=$(shopt -s nullglob; echo /project/melt4/People/ted/nailgun/bin/nailgun-*.jar /usr/share/java/nailgun-server*.jar /usr/share/java/nailgun-*.jar)
 SV_NAILGUN_ARRAY=($SV_NAILGUN_CANDIDATES)
@@ -56,7 +59,7 @@ function sv-serve {
     return 4
   fi
 
-  java -Xmx2G -Xms1G -Xss8M -jar "$SV_NAILGUN_JAR" > /dev/null 2> /dev/null &
+  java -Xmx2G -Xms1G -Xss8M -jar "$SV_NAILGUN_JAR" $NAILGUN_PORT > /dev/null 2> /dev/null &
   
   # Unfortunately no good way to determine when the server has started, afaik
   sleep 2


### PR DESCRIPTION
This change:

1. Uses a new `melt.trynode` abstraction that does the node/try/catch/handle/finally/notify dance for us.
2. Adds a check for branch existence in the bootstrapping logic that can avoid spurious failures.
3. Starts to use `melt.annotate` to put little annotations on builds to notify users of special things about each build. This is already in use automatically by all AbleC extensions because I've modified things in `jenkins-lib`. (See: http://coldpress.cs.umn.edu:8080/job/melt-umn/job/ableC/job/develop/ on the left you can see the job with the "Custom Silver" annotation, indicating it's downstream and has `SILVER_BASE` set.)
4. Fixes up some old obsolete deployment logic.
5. Uses `melt.buildProject` to abstract out the "build things with branches of the same name" logic into the jenkins library.

This build is marked a failure, but I think it's due to an unrelated change with AbleC templating that needs fixing. @krame505 could you confirm that, fix it, and review this change briefly?