### PR TITLE
Further tweaks to silver-custom script

### DIFF
--- a/support/bin/silver
+++ b/support/bin/silver
@@ -24,5 +24,3 @@ export SILVER_HOME=${ME/support\/bin\/silver/}
 SILVER="$SILVER_HOME/jars/silver.composed.Default.jar"
 
 silver-custom "$SILVER" "$@"
-
-

--- a/support/bin/silver
+++ b/support/bin/silver
@@ -23,4 +23,5 @@ export SILVER_HOME=${ME/support\/bin\/silver/}
 # Find the silver jar
 SILVER="$SILVER_HOME/jars/silver.composed.Default.jar"
 
-silver-custom "$SILVER" "$@"
+# Invoke silver-custom with the found jar
+"$ME-custom" "$SILVER" "$@"

--- a/support/bin/silver
+++ b/support/bin/silver
@@ -23,14 +23,6 @@ export SILVER_HOME=${ME/support\/bin\/silver/}
 # Find the silver jar
 SILVER="$SILVER_HOME/jars/silver.composed.Default.jar"
 
-if [ ! -f "$SILVER" ]; then
-  echo "Couldn't find the Silver jars to execute, aborting."
-  exit 2
-fi
-
-# Set flags if not overriden in environment
-SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx2500M -Xss10M"}
-
-java $SVJVM_FLAGS -jar "$SILVER" "$@" && ant
+silver-custom "$SILVER" "$@"
 
 

--- a/support/bin/silver-custom
+++ b/support/bin/silver-custom
@@ -14,7 +14,7 @@ case `uname` in
   ;;
 esac
 
-# ~/bin/silver should be a link to somewhere, find out where!
+# ~/bin/silver-custom should be a link to somewhere, find out where!
 ME=$(${READLINK} -f "${BASH_SOURCE}")
 
 # Set our home
@@ -30,6 +30,6 @@ if [ ! -f "$SILVER" ]; then
 fi
 
 # Set flags if not overriden in environment
-SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx2500M -Xss10M"}
+SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx3000M -Xss10M"}
 
 java $SVJVM_FLAGS -jar "$SILVER" "$@" && ant


### PR DESCRIPTION
This makes the `silver` script call the `silver-custom` script to avoid having the JVM parameters in 2 different places.  Also further bump the default heap space, since I was crashing things when doing a clean build of Silver+ableC.  