### PR TITLE
Direct support for terminals in reflection library, introduce Silver construction extension

### DIFF
--- a/grammars/core/Either.sv
+++ b/grammars/core/Either.sv
@@ -1,5 +1,10 @@
 grammar core;
 
+synthesized attribute fromLeft<a> :: a;
+synthesized attribute fromRight<a> :: a;
+synthesized attribute isLeft :: Boolean;
+synthesized attribute isRight :: Boolean;
+
 {--
  - The basic sum type, counterpart to Pair.
  -
@@ -8,12 +13,7 @@ grammar core;
  - expected return value is the second.
  - e.g. Either<String Tree>
  -}
-synthesized attribute fromLeft<a> :: a;
-synthesized attribute fromRight<a> :: a;
-synthesized attribute isLeft :: Boolean;
-synthesized attribute isRight :: Boolean;
 nonterminal Either<a b> with fromLeft<a>, fromRight<b>, isLeft, isRight;
-
 
 abstract production left
 top::Either<a b> ::= value::a

--- a/grammars/core/Either.sv
+++ b/grammars/core/Either.sv
@@ -8,17 +8,29 @@ grammar core;
  - expected return value is the second.
  - e.g. Either<String Tree>
  -}
-nonterminal Either<a b>;
+synthesized attribute fromLeft<a> :: a;
+synthesized attribute fromRight<a> :: a;
+synthesized attribute isLeft :: Boolean;
+synthesized attribute isRight :: Boolean;
+nonterminal Either<a b> with fromLeft<a>, fromRight<b>, isLeft, isRight;
 
 
 abstract production left
 top::Either<a b> ::= value::a
 {
+  top.fromLeft = value;
+  top.fromRight = error("fromRight accessed on a Either that was actually left!");
+  top.isLeft = true;
+  top.isRight = false;
 }
 
 abstract production right
 top::Either<a b> ::= value::b
 {
+  top.fromLeft = error("fromRight accessed on a Either that was actually left!");
+  top.fromRight = value;
+  top.isLeft = false;
+  top.isRight = true;
 }
 
 

--- a/grammars/core/reflect/AST.sv
+++ b/grammars/core/reflect/AST.sv
@@ -9,6 +9,10 @@ abstract production nonterminalAST
 top::AST ::= prodName::String children::ASTs annotations::NamedASTs
 {}
 
+abstract production terminalAST
+top::AST ::= terminalName::String lexeme::String location::Location
+{}
+
 abstract production listAST
 top::AST ::= vals::ASTs
 {}

--- a/grammars/silver/composed/Default/Main.sv
+++ b/grammars/silver/composed/Default/Main.sv
@@ -24,6 +24,7 @@ parser svParse::Root {
   silver:extension:doc;
   silver:extension:functorattrib;
   silver:extension:monad;
+  silver:extension:silverconstruction;
 --  silver:extension:concreteSyntaxForTrees ;
 
   silver:modification:let_fix;

--- a/grammars/silver/composed/Default/Main.sv
+++ b/grammars/silver/composed/Default/Main.sv
@@ -24,6 +24,7 @@ parser svParse::Root {
   silver:extension:doc;
   silver:extension:functorattrib;
   silver:extension:monad;
+  silver:extension:reflection;
   silver:extension:silverconstruction;
 --  silver:extension:concreteSyntaxForTrees ;
 

--- a/grammars/silver/definition/core/QName.sv
+++ b/grammars/silver/definition/core/QName.sv
@@ -43,6 +43,17 @@ top::QName ::= id::Name ':' qn::QName
   top.lookupAttribute = decorate customLookup("attribute", getAttrDcl(top.name, top.env), top.name, top.location) with {};
 }
 
+abstract production qNameError
+top::QName ::= msg::[Message]
+{
+  top.name = "err";
+  top.pp = "<err>";
+  
+  top.lookupValue = decorate errorLookup(msg) with {};
+  top.lookupType = decorate errorLookup(msg) with {};
+  top.lookupAttribute = decorate errorLookup(msg) with {};
+}
+
 nonterminal QNameLookup with fullName, typerep, errors, dcls, dcl, dclBoundVars, found;
 
 synthesized attribute lookupValue :: Decorated QNameLookup occurs on QName;
@@ -71,6 +82,17 @@ top::QNameLookup ::= kindOfLookup::String dcls::[DclInfo] name::String l::Locati
      else [err(l, "Undeclared " ++ kindOfLookup ++ " '" ++ name ++ "'.")]) ++
     (if length(top.dcls) <= 1 then []
      else [err(l, "Ambiguous reference to " ++ kindOfLookup ++ " '" ++ name ++ "'. Possibilities are:\n" ++ printPossibilities(top.dcls))]);
+}
+
+abstract production errorLookup
+top::QNameLookup ::= msg::[Message]
+{
+  top.dcls = [];
+  top.found = true;
+  top.fullName = "err";
+  top.typerep = errorType();
+  top.dclBoundVars = [];
+  top.errors := msg;
 }
 
 function printPossibilities

--- a/grammars/silver/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/definition/type/syntax/TypeExpr.sv
@@ -33,6 +33,18 @@ function addNewLexicalTyVars
                   addNewLexicalTyVars(gn, sl, tail(l));
 }
 
+abstract production errorTypeExpr
+top::TypeExpr ::= e::[Message]
+{
+  top.pp = s"{- Errors:\n${foldMessages(e)} -}";
+  
+  top.typerep = errorType();
+  
+  top.errors := e;
+  
+  top.lexicalTypeVariables = [];
+}
+
 abstract production typerepTypeExpr
 top::TypeExpr ::= t::Type
 {

--- a/grammars/silver/extension/reflection/BuiltinFunctions.sv
+++ b/grammars/silver/extension/reflection/BuiltinFunctions.sv
@@ -8,6 +8,16 @@ imports silver:modification:let_fix;
 
 terminal Deserialize_kwd 'deserialize' lexer classes {BUILTIN,RESERVED};
 
+{--
+ - This production deserializes a string to what it represents, in contrast to
+ - `reify` which "deserializes" an `AST` to what it represents, and in contrast to
+ - `deserializeAST` which deserializes a string to an `AST`.
+ - i.e. this function is `reify . deserializeAST` so to speak.
+ -
+ - This also has to be a built-in function because reification requires an
+ - explicit concrete type at its call site, which makes it difficult to write ordinary
+ - functions for. Something we might someday be able to solve with a typeclass?
+-}
 concrete production deserializeFunction
 top::Expr ::= 'deserialize' '(' fileName::Expr ',' text::Expr ')'
 {

--- a/grammars/silver/extension/reflection/BuiltinFunctions.sv
+++ b/grammars/silver/extension/reflection/BuiltinFunctions.sv
@@ -1,0 +1,46 @@
+grammar silver:extension:reflection;
+
+imports silver:definition:core;
+imports silver:definition:type;
+imports silver:definition:env;
+imports silver:extension:patternmatching;
+imports silver:modification:let_fix;
+
+terminal Deserialize_kwd 'deserialize' lexer classes {BUILTIN,RESERVED};
+
+concrete production deserializeFunction
+top::Expr ::= 'deserialize' '(' fileName::Expr ',' text::Expr ')'
+{
+  top.pp = s"deserialize(${fileName.pp}, ${text.pp})";
+  
+  local errCheck1::TypeCheck = check(fileName.typerep, stringType());
+  errCheck1.finalSubst = top.finalSubst;
+  local errCheck2::TypeCheck = check(text.typerep, stringType());
+  errCheck2.finalSubst = top.finalSubst;
+  
+  fileName.downSubst = top.downSubst;
+  text.downSubst = fileName.upSubst;
+  errCheck1.downSubst = text.upSubst;
+  errCheck2.downSubst = errCheck1.upSubst;
+  --top.upSubst = errCheck2.upSubst;
+  
+  local localErrors::[Message] =
+    (if errCheck1.typeerror
+     then [err(fileName.location, "First operand to 'deserialize(fileName, text)' must be a String, instead it is " ++ errCheck1.leftpp)]
+     else []) ++
+    (if errCheck2.typeerror
+     then [err(text.location, "Second operand to 'deserialize(fileName, text)' must be a String, instead it is " ++ errCheck2.leftpp)]
+     else []);
+  
+  local fwrd::Expr =
+    Silver_Expr {
+      case deserializeAST($Expr {exprRef(fileName, location=builtin)}, $Expr {exprRef(text, location=builtin)}) of
+      | left(msg) -> left(msg)
+      | right(ast) -> reify(ast)
+      end
+    };
+  
+  forwards to if !null(localErrors) then errorExpr(localErrors, location=top.location) else fwrd;
+}
+
+global builtin::Location = builtinLoc("reflection");

--- a/grammars/silver/extension/silverconstruction/Syntax.sv
+++ b/grammars/silver/extension/silverconstruction/Syntax.sv
@@ -1,0 +1,26 @@
+grammar silver:extension:silverconstruction;
+
+imports silver:langutil;
+imports silver:langutil:pp;
+
+imports silver:definition:core;
+imports silver:definition:env;
+imports silver:definition:type:syntax;
+imports silver:extension:list;
+
+-- Silver-to-ableC bridge productions
+concrete production silverExprLiteral
+top::Expr ::= 'Silver_Expr' LCurly_t ast::Expr RCurly_t
+{
+  top.pp = s"Silver_Expr {${ast.pp}}";
+  forwards to translate(top.location, reflect(new(ast)));
+}
+
+concrete production escapeExpr
+top::Expr ::= '$Expr' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+{
+  forwards to
+    errorExpr(
+      [err(top.location, "$Expr should not occur outside of Silver_Expr")],
+      location=top.location);
+}

--- a/grammars/silver/extension/silverconstruction/Syntax.sv
+++ b/grammars/silver/extension/silverconstruction/Syntax.sv
@@ -8,7 +8,6 @@ imports silver:definition:env;
 imports silver:definition:type:syntax;
 imports silver:extension:list;
 
--- Silver-to-ableC bridge productions
 concrete production silverExprLiteral
 top::Expr ::= 'Silver_Expr' LCurly_t ast::Expr RCurly_t
 {
@@ -23,4 +22,45 @@ top::Expr ::= '$Expr' silver:definition:core:LCurly_t e::Expr silver:definition:
     errorExpr(
       [err(top.location, "$Expr should not occur outside of Silver_Expr")],
       location=top.location);
+}
+
+concrete production escapeTypeExpr
+top::TypeExpr ::= '$TypeExpr' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+{
+  forwards to
+    errorTypeExpr(
+      [err(top.location, "$TypeExpr should not occur outside of Silver_Expr")],
+      location=top.location);
+}
+
+concrete production escapeQName
+top::QName ::= '$QName' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+{
+  forwards to
+    qNameError(
+      [err(top.location, "$QName should not occur outside of Silver_Expr")],
+      location=top.location);
+}
+
+concrete production escapeName
+top::Name ::= '$Name' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+{
+  -- TODO: [err(top.location, "$Name should not occur outside of Silver_Expr")]
+  forwards to name("err", top.location);
+}
+
+concrete production escape_qName
+top::QName ::= '$qName' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+{
+  forwards to
+    qNameError(
+      [err(top.location, "$qName should not occur outside of Silver_Expr")],
+      location=top.location);
+}
+
+concrete production escape_name
+top::Name ::= '$name' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+{
+  -- TODO: [err(top.location, "$Name should not occur outside of Silver_Expr")]
+  forwards to name("err", top.location);
 }

--- a/grammars/silver/extension/silverconstruction/Syntax.sv
+++ b/grammars/silver/extension/silverconstruction/Syntax.sv
@@ -18,6 +18,7 @@ top::Expr ::= 'Silver_Expr' LCurly_t ast::Expr RCurly_t
 concrete production escapeExpr
 top::Expr ::= '$Expr' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
 {
+  top.pp = s"$$Expr{${e.pp}}";
   forwards to
     errorExpr(
       [err(top.location, "$Expr should not occur outside of Silver_Expr")],
@@ -27,6 +28,7 @@ top::Expr ::= '$Expr' silver:definition:core:LCurly_t e::Expr silver:definition:
 concrete production escapeTypeExpr
 top::TypeExpr ::= '$TypeExpr' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
 {
+  top.pp = s"$$TypeExpr{${e.pp}}";
   forwards to
     errorTypeExpr(
       [err(top.location, "$TypeExpr should not occur outside of Silver_Expr")],
@@ -36,6 +38,7 @@ top::TypeExpr ::= '$TypeExpr' silver:definition:core:LCurly_t e::Expr silver:def
 concrete production escapeQName
 top::QName ::= '$QName' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
 {
+  top.pp = s"$$QName{${e.pp}}";
   forwards to
     qNameError(
       [err(top.location, "$QName should not occur outside of Silver_Expr")],
@@ -45,6 +48,7 @@ top::QName ::= '$QName' silver:definition:core:LCurly_t e::Expr silver:definitio
 concrete production escapeName
 top::Name ::= '$Name' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
 {
+  top.pp = s"$$Name{${e.pp}}";
   -- TODO: [err(top.location, "$Name should not occur outside of Silver_Expr")]
   forwards to name("err", top.location);
 }
@@ -52,6 +56,7 @@ top::Name ::= '$Name' silver:definition:core:LCurly_t e::Expr silver:definition:
 concrete production escape_qName
 top::QName ::= '$qName' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
 {
+  top.pp = s"$$qName{${e.pp}}";
   forwards to
     qNameError(
       [err(top.location, "$qName should not occur outside of Silver_Expr")],
@@ -61,6 +66,7 @@ top::QName ::= '$qName' silver:definition:core:LCurly_t e::Expr silver:definitio
 concrete production escape_name
 top::Name ::= '$name' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
 {
+  top.pp = s"$$name{${e.pp}}";
   -- TODO: [err(top.location, "$Name should not occur outside of Silver_Expr")]
   forwards to name("err", top.location);
 }

--- a/grammars/silver/extension/silverconstruction/Terminals.sv
+++ b/grammars/silver/extension/silverconstruction/Terminals.sv
@@ -1,0 +1,16 @@
+grammar silver:extension:silverconstruction;
+
+--imports silver:definition:regex;
+
+marking terminal SilverExpr_t 'Silver_Expr' lexer classes {KEYWORD, RESERVED};
+
+temp_imp_ide_font font_escape color(160, 32, 240) bold italic;
+lexer class Escape font=font_escape;
+
+terminal EscapeExprs_t             '$Exprs'             lexer classes {Escape};
+terminal EscapeExpr_t              '$Expr'              lexer classes {Escape};
+terminal EscapeTypeExpr_t          '$TypeExpr'          lexer classes {Escape};
+terminal EscapeQName_t             '$QName'             lexer classes {Escape};
+terminal EscapeName_t              '$Name'              lexer classes {Escape};
+terminal Escape_qName_t            '$qName'             lexer classes {Escape};
+terminal Escape_name_t             '$name'              lexer classes {Escape};

--- a/grammars/silver/extension/silverconstruction/Terminals.sv
+++ b/grammars/silver/extension/silverconstruction/Terminals.sv
@@ -1,13 +1,10 @@
 grammar silver:extension:silverconstruction;
 
---imports silver:definition:regex;
-
 marking terminal SilverExpr_t 'Silver_Expr' lexer classes {KEYWORD, RESERVED};
 
 temp_imp_ide_font font_escape color(160, 32, 240) bold italic;
 lexer class Escape font=font_escape;
 
-terminal EscapeExprs_t             '$Exprs'             lexer classes {Escape};
 terminal EscapeExpr_t              '$Expr'              lexer classes {Escape};
 terminal EscapeTypeExpr_t          '$TypeExpr'          lexer classes {Escape};
 terminal EscapeQName_t             '$QName'             lexer classes {Escape};

--- a/grammars/silver/extension/silverconstruction/Translation.sv
+++ b/grammars/silver/extension/silverconstruction/Translation.sv
@@ -1,0 +1,221 @@
+grammar silver:extension:silverconstruction;
+
+imports silver:reflect;
+
+function translate
+Expr ::= loc::Location ast::AST
+{
+  ast.givenLocation = loc;
+  return ast.translation;
+}
+
+synthesized attribute translation<a>::a;
+synthesized attribute foundLocation::Maybe<Location>;
+autocopy attribute givenLocation::Location;
+
+attribute givenLocation, translation<Expr> occurs on AST;
+
+aspect production nonterminalAST
+top::AST ::= prodName::String children::ASTs annotations::NamedASTs
+{
+  production givenLocation::Location =
+    fromMaybe(top.givenLocation, orElse(children.foundLocation, annotations.foundLocation));
+  top.translation =
+    -- "Direct" escape productions
+    if
+      containsBy(
+        stringEq, prodName,
+        ["silver:extension:silverconstruction:escapeExpr"])
+    then
+      case children of
+      | consAST(_, consAST(_, consAST(a, consAST(_, nilAST())))) ->
+          case reify(a) of
+          | right(e) -> e
+          | left(msg) -> error(s"Error in reifying child of production ${prodName}:\n${msg}")
+          end
+      | _ -> error(s"Unexpected escape production arguments: ${show(80, top.pp)}")
+      end
+    else 
+      application(
+        baseExpr(makeQName(prodName, givenLocation), location=givenLocation),
+        '(',
+        foldAppExprs(givenLocation, reverse(children.translation)),
+        ',',
+        foldl(
+          snocAnnoAppExprs(_, ',', _, location=givenLocation),
+          emptyAnnoAppExprs(location=givenLocation),
+          reverse(annotations.translation)),
+        ')', location=givenLocation);
+    
+    children.givenLocation = givenLocation;
+    annotations.givenLocation = givenLocation;
+}
+
+aspect production terminalAST
+top::AST ::= terminalName::String lexeme::String location::Location
+{
+  local locationAST::AST = reflect(new(location));
+  locationAST.givenLocation = top.givenLocation;
+
+  top.translation =
+    terminalConstructor(
+      'terminal', '(',
+      nominalTypeExpr(
+        makeQNameType(terminalName, top.givenLocation), botlNone(location=top.givenLocation),
+        location=top.givenLocation),
+      ',',
+      stringConst(
+        terminal(String_t, s"\"${escapeString(lexeme)}\"", top.givenLocation),
+        location=top.givenLocation),
+      ',',
+      locationAST.translation,
+      ')', location=top.givenLocation);
+}
+
+aspect production listAST
+top::AST ::= vals::ASTs
+{
+  top.translation =
+    fullList(
+      '[',
+      foldr(
+        exprsCons(_, ',', _, location=top.givenLocation),
+        exprsEmpty(location=top.givenLocation),
+        vals.translation),
+      ']', location=top.givenLocation);
+}
+
+aspect production stringAST
+top::AST ::= s::String
+{
+  top.translation =
+    stringConst(
+      terminal(String_t, s"\"${escapeString(s)}\"", top.givenLocation),
+      location=top.givenLocation);
+}
+
+aspect production integerAST
+top::AST ::= i::Integer
+{
+  top.translation =
+    intConst(terminal(Int_t, toString(i), top.givenLocation), location=top.givenLocation);
+}
+
+aspect production floatAST
+top::AST ::= f::Float
+{
+  top.translation =
+    floatConst(terminal(Float_t, toString(f), top.givenLocation), location=top.givenLocation);
+}
+
+aspect production booleanAST
+top::AST ::= b::Boolean
+{
+  top.translation =
+    if b
+    then trueConst('true', location=top.givenLocation)
+    else falseConst('false', location=top.givenLocation);
+}
+
+aspect production anyAST
+top::AST ::= x::a
+{
+  top.translation =
+    case reflectTypeName(x) of
+      just(n) -> error(s"Can't translate anyAST (type ${n})")
+    | nothing() -> error("Can't translate anyAST")
+    end;
+}
+
+attribute givenLocation, translation<[Expr]>, foundLocation occurs on ASTs;
+
+aspect production consAST
+top::ASTs ::= h::AST t::ASTs
+{
+  top.translation = h.translation :: t.translation;
+  top.foundLocation =
+    -- Try to reify the last child as a location
+    case t of
+    | nilAST() ->
+        case reify(h) of
+        | right(l) -> just(l)
+        | left(_) -> nothing()
+        end
+    | _ -> t.foundLocation
+    end;
+}
+
+aspect production nilAST
+top::ASTs ::=
+{
+  top.translation = [];
+  top.foundLocation = nothing();
+}
+
+attribute givenLocation, translation<[AnnoExpr]>, foundLocation occurs on NamedASTs;
+
+aspect production consNamedAST
+top::NamedASTs ::= h::NamedAST t::NamedASTs
+{
+  top.translation = h.translation :: t.translation;
+  top.foundLocation = orElse(h.foundLocation, t.foundLocation);
+}
+
+aspect production nilNamedAST
+top::NamedASTs ::=
+{
+  top.translation = [];
+  top.foundLocation = nothing();
+}
+
+attribute givenLocation, translation<AnnoExpr>, foundLocation occurs on NamedAST;
+
+aspect production namedAST
+top::NamedAST ::= n::String v::AST
+{
+  top.translation =
+    annoExpr(
+      qNameId(makeName(last(explode(":", n)), top.givenLocation), location=top.givenLocation),
+      '=',
+      presentAppExpr(v.translation, location=top.givenLocation),
+      location=top.givenLocation);
+  top.foundLocation =
+    if n == "core:location"
+    then
+      case reify(v) of
+      | right(l) -> just(l)
+      | left(msg) -> error(s"Error in reifying location:\n${msg}")
+      end
+    else nothing();
+}
+
+function makeName
+Name ::= n::String loc::Location
+{
+  return
+    if isUpper(head(explode("", n)))
+    then nameIdUpper(terminal(IdUpper_t, n, loc), location=loc)
+    else nameIdLower(terminal(IdLower_t, n, loc), location=loc);
+}
+
+function makeQName
+QName ::= n::String loc::Location
+{
+  local ns::[Name] = map(makeName(_, loc), explode(":", n));
+  return
+    foldr(
+      qNameCons(_, ':', _, location=loc),
+      qNameId(last(ns), location=loc),
+      init(ns));
+}
+
+function makeQNameType
+QNameType ::= n::String loc::Location
+{
+  local ns::[String] = explode(":", n);
+  return
+    foldr(
+      qNameTypeCons(_, ':', _, location=loc),
+      qNameTypeId(terminal(IdUpper_t, last(ns), loc), location=loc),
+      map(makeName(_, loc), init(ns)));
+}

--- a/grammars/silver/extension/silverconstruction/Translation.sv
+++ b/grammars/silver/extension/silverconstruction/Translation.sv
@@ -9,7 +9,14 @@ Expr ::= loc::Location ast::AST
   return ast.translation;
 }
 
+{--
+ - This attribute transforms an AST representing a piece of Silver code into a Silver
+ - Expr constructing the abstract syntax of that code.  Escape productions wrapping
+ - Silver Exprs that should be included directly in the translation are handled
+ - specially by reifying their contents.
+ -}
 synthesized attribute translation<a>::a;
+
 synthesized attribute foundLocation::Maybe<Location>;
 autocopy attribute givenLocation::Location;
 

--- a/grammars/silver/langutil/reflect/AST.sv
+++ b/grammars/silver/langutil/reflect/AST.sv
@@ -12,6 +12,12 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
   top.pp = cat(text(prodName), parens(ppImplode(pp", ", children.pps ++ annotations.pps)));
 }
 
+aspect production terminalAST
+top::AST ::= terminalName::String lexeme::String location::Location
+{
+  top.pp = pp"terminal(${text(terminalName)}, \"${text(escapeString(lexeme))}\", ${text(location.unparse)})";
+}
+
 aspect production listAST
 top::AST ::= vals::ASTs
 {

--- a/grammars/silver/reflect/AST.sv
+++ b/grammars/silver/reflect/AST.sv
@@ -25,7 +25,7 @@ top::AST ::= terminalName::String lexeme::String location::Location
 {
   top.serialize =
     do (bindEither, returnEither) {
-      locationSerialize::String <- reflect(new(location)).serialize;
+      locationSerialize::String <- serialize(new(location));
       return s"terminal(${terminalName}, \"${escapeString(lexeme)}\", ${locationSerialize})";
     }; 
 }

--- a/grammars/silver/reflect/AST.sv
+++ b/grammars/silver/reflect/AST.sv
@@ -20,6 +20,16 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
     };
 }
 
+aspect production terminalAST
+top::AST ::= terminalName::String lexeme::String location::Location
+{
+  top.serialize =
+    do (bindEither, returnEither) {
+      locationSerialize::String <- reflect(new(location)).serialize;
+      return s"terminal(${terminalName}, \"${escapeString(lexeme)}\", ${locationSerialize})";
+    }; 
+}
+
 aspect production listAST
 top::AST ::= vals::ASTs
 {

--- a/grammars/silver/reflect/Util.sv
+++ b/grammars/silver/reflect/Util.sv
@@ -35,9 +35,12 @@ function deserializeAST
 Either<String AST> ::= fileName::String text::String
 {
   local result::ParseResult<AST_c> = astParser(text, fileName);
+  local parseTree::AST_c = result.parseTree;
 
   return
-    if result.parseSuccess
-    then right(result.parseTree.ast)
-    else left(result.parseErrors);
+    if !result.parseSuccess
+    then left(result.parseErrors)
+    else if !null(parseTree.errors)
+    then left(messagesToString(parseTree.errors))
+    else right(parseTree.ast);
 }

--- a/grammars/silver/reflect/Util.sv
+++ b/grammars/silver/reflect/Util.sv
@@ -27,6 +27,12 @@ String ::= x::a
   "java" : return "(new common.StringCatter(%x%.toString()))";
 }
 
+function serialize
+Either<String String> ::= x::a
+{
+  return reflect(x).serialize;
+}
+
 parser astParser :: AST_c {
   silver:reflect:concretesyntax;
 }

--- a/grammars/silver/reflect/concretesyntax/ConcreteSyntax.sv
+++ b/grammars/silver/reflect/concretesyntax/ConcreteSyntax.sv
@@ -12,6 +12,9 @@ terminal LSqr_t        '[';
 terminal RSqr_t        ']';
 
 terminal Id_t /[A-Za-z][A-Za-z0-9\_]*/;
+
+terminal Terminal_kwd 'terminal' dominates {Id_t};
+
 terminal True_kwd  'true' dominates {Id_t};
 terminal False_kwd 'false' dominates {Id_t};
 terminal Int_t     /[\-]?[0-9]+/;
@@ -20,53 +23,113 @@ terminal String_t  /[\"]([^\r\n\"\\]|[\\][\"]|[\\][\\]|[\\]b|[\\]n|[\\]r|[\\]f|[
 
 ignore terminal WhiteSpace /[\r\n\t\ ]+/;
 
-nonterminal AST_c with ast<AST>;
+nonterminal AST_c with ast<AST>, errors, location;
 
 concrete productions top::AST_c
 | prodName::QName_c '(' children::ASTs_c ',' annotations::NamedASTs_c ')'
-  { top.ast = nonterminalAST(prodName.ast, foldr(consAST, nilAST(), children.ast), foldr(consNamedAST, nilNamedAST(), annotations.ast)); }
+  {
+    top.ast =
+      nonterminalAST(prodName.ast, foldr(consAST, nilAST(), children.ast), foldr(consNamedAST, nilNamedAST(), annotations.ast));
+    top.errors := children.errors ++ annotations.errors;
+  }
 | prodName::QName_c '(' children::ASTs_c ')'
-  { top.ast = nonterminalAST(prodName.ast, foldr(consAST, nilAST(), children.ast), nilNamedAST()); }
+  {
+    top.ast = nonterminalAST(prodName.ast, foldr(consAST, nilAST(), children.ast), nilNamedAST());
+    top.errors := children.errors;
+  }
 | prodName::QName_c '(' annotations::NamedASTs_c ')'
-  { top.ast = nonterminalAST(prodName.ast, nilAST(), foldr(consNamedAST, nilNamedAST(), annotations.ast)); }
+  {
+    top.ast = nonterminalAST(prodName.ast, nilAST(), foldr(consNamedAST, nilNamedAST(), annotations.ast));
+    top.errors := annotations.errors;
+  }
 | prodName::QName_c '(' ')'
-  { top.ast = nonterminalAST(prodName.ast, nilAST(), nilNamedAST()); }
+  {
+    top.ast = nonterminalAST(prodName.ast, nilAST(), nilNamedAST());
+    top.errors := [];
+  }
+| 'terminal' '(' terminalName::QName_c ',' lexeme::String_t ',' location::AST_c ')'
+  {
+    local locReifyRes::Either<String Location> = reify(location.ast);
+    top.ast =
+      terminalAST(
+        terminalName.ast,
+        unescapeString(substring(1, length(lexeme.lexeme) - 1, lexeme.lexeme)),
+        fromRight(locReifyRes, bogusLoc()));
+    top.errors :=
+      case locReifyRes of
+      | left(msg) -> [err(location.location, msg)]
+      | right(_) -> []
+      end;
+  }
 | '[' vals::ASTs_c ']'
-  { top.ast = listAST(foldr(consAST, nilAST(), vals.ast)); }
+  {
+    top.ast = listAST(foldr(consAST, nilAST(), vals.ast));
+    top.errors := vals.errors;
+  }
 | s::String_t
-{ top.ast = stringAST(unescapeString(substring(1, length(s.lexeme) - 1, s.lexeme))); }
+  {
+    top.ast = stringAST(unescapeString(substring(1, length(s.lexeme) - 1, s.lexeme)));
+    top.errors := [];
+  }
 | i::Int_t
-  { top.ast = integerAST(toInt(i.lexeme)); }
+  {
+    top.ast = integerAST(toInt(i.lexeme));
+    top.errors := [];
+  }
 | f::Float_t
-  { top.ast = floatAST(toFloat(f.lexeme)); }
+  {
+    top.ast = floatAST(toFloat(f.lexeme));
+    top.errors := [];
+  }
 | 'true'
-  { top.ast = booleanAST(true); }
+  {
+    top.ast = booleanAST(true);
+    top.errors := [];
+  }
 | 'false'
-  { top.ast = booleanAST(false); }
+  {
+    top.ast = booleanAST(false);
+    top.errors := [];
+  }
 
-nonterminal ASTs_c with ast<[AST]>;
+nonterminal ASTs_c with ast<[AST]>, errors;
 
 concrete productions top::ASTs_c
 | t::ASTs_c ',' h::AST_c
-  { top.ast = t.ast ++ [h.ast]; }
+  {
+    top.ast = t.ast ++ [h.ast];
+    top.errors := h.errors ++ t.errors;
+  }
 | h::AST_c
-  { top.ast = [h.ast]; }
+  {
+    top.ast = [h.ast];
+    top.errors := [];
+  }
 
-nonterminal NamedASTs_c with ast<[NamedAST]>;
+nonterminal NamedASTs_c with ast<[NamedAST]>, errors;
 
 concrete productions top::NamedASTs_c
 | t::NamedASTs_c ',' h::NamedAST_c
-  { top.ast = t.ast ++ [h.ast]; }
+  {
+    top.ast = t.ast ++ [h.ast];
+    top.errors := h.errors ++ t.errors;
+  }
 | h::NamedAST_c
-  { top.ast = [h.ast]; }
+  {
+    top.ast = [h.ast];
+    top.errors := [];
+  }
 
-nonterminal NamedAST_c with ast<NamedAST>;
+nonterminal NamedAST_c with ast<NamedAST>, errors, location;
 
 concrete productions top::NamedAST_c
 | n::QName_c '=' v::AST_c
-  { top.ast = namedAST(n.ast, v.ast); }
+  {
+    top.ast = namedAST(n.ast, v.ast);
+    top.errors := v.errors;
+  }
 
-nonterminal QName_c with ast<String>;
+nonterminal QName_c with ast<String>, location;
 
 concrete productions top::QName_c
 | id::Id_t

--- a/grammars/silver/reflect/concretesyntax/ConcreteSyntax.sv
+++ b/grammars/silver/reflect/concretesyntax/ConcreteSyntax.sv
@@ -66,6 +66,11 @@ concrete productions top::AST_c
     top.ast = listAST(foldr(consAST, nilAST(), vals.ast));
     top.errors := vals.errors;
   }
+| '[' ']'
+  {
+    top.ast = listAST(nilAST());
+    top.errors := [];
+  }
 | s::String_t
   {
     top.ast = stringAST(unescapeString(substring(1, length(s.lexeme) - 1, s.lexeme)));

--- a/grammars/silver/translation/java/core/BuiltInFunctions.sv
+++ b/grammars/silver/translation/java/core/BuiltInFunctions.sv
@@ -78,8 +78,8 @@ top::Expr ::= 'reify'
 s"""(new common.NodeFactory<core.NEither>() {
 				@Override
 				public final core.NEither invoke(final Object[] args, final Object[] namedArgs) {
-					assert args.length == 1;
-					assert namedArgs.length == 0;
+					assert args != null && args.length == 1;
+					assert namedArgs == null || namedArgs.length == 0;
 					
 ${makeTyVarDecls(5, resultType.freeVariables)}
 					common.TypeRep resultType = ${resultType.transTypeRep};

--- a/runtime/java/src/common/Reflection.java
+++ b/runtime/java/src/common/Reflection.java
@@ -85,6 +85,9 @@ public final class Reflection {
 				annotations = new PconsNamedAST(new PnamedAST(new StringCatter(name), value), annotations);
 			}
 			return new PnonterminalAST(new StringCatter(n.getName()), children, annotations);
+		} else if(o instanceof Terminal) {
+			Terminal t = (Terminal)o;
+			return new PterminalAST(new StringCatter(t.getName()), t.lexeme, t.location);
 		} else if(o instanceof ConsCell) {
 			return new PlistAST(reflectList((ConsCell)o));
 		} else if(o instanceof StringCatter) {
@@ -178,7 +181,8 @@ public final class Reflection {
 			path[path.length - 1] = "P" + path[path.length - 1];
 			final String className = String.join(".", path);
 			try {
-				Method prodReify = Class.forName(className).getMethod("reify", TypeRep.class, NAST[].class, String[].class, NAST[].class);
+				Method prodReify =
+						((Class<Node>)Class.forName(className)).getMethod("reify", TypeRep.class, NAST[].class, String[].class, NAST[].class);
 				return prodReify.invoke(null, resultType, childASTs, annotationNames, annotationASTs);
 			} catch (ClassNotFoundException e) {
 				throw new SilverError("Undefined production " + prodName);
@@ -189,6 +193,31 @@ public final class Reflection {
 					throw (SilverException)e.getTargetException();
 				} else {
 					throw new SilverInternalError("Error invoking reify for class " + className, e.getTargetException());
+				}
+			}
+		} else if (ast.getName().equals("core:reflect:terminalAST")) {
+			// Unpack components
+			final String terminalName = ((StringCatter)ast.getChild(0)).toString();
+			final StringCatter lexeme = (StringCatter)ast.getChild(1);
+			final NLocation location = (NLocation)ast.getChild(2);
+			
+			// Invoke the reify function for the appropriate terminal class
+			final String[] path = terminalName.split(":");
+			path[path.length - 1] = "T" + path[path.length - 1];
+			final String className = String.join(".", path);
+			try {
+				Constructor<Terminal> terminalConstructor =
+						((Class<Terminal>)Class.forName(className)).getConstructor(StringCatter.class, NLocation.class);
+				return terminalConstructor.newInstance(lexeme, location);
+			} catch (ClassNotFoundException e) {
+				throw new SilverError("Undefined terminal " + terminalName);
+			} catch (NoSuchMethodException | InstantiationException | IllegalAccessException e) {
+				throw new SilverInternalError("Error constructing class " + className, e);
+			} catch (InvocationTargetException e) {
+				if (e.getTargetException() instanceof SilverException) {
+					throw (SilverException)e.getTargetException();
+				} else {
+					throw new SilverInternalError("Error constructing class " + className, e.getTargetException());
 				}
 			}
 		} else if (ast.getName().equals("core:reflect:listAST")) {

--- a/runtime/java/src/common/Reflection.java
+++ b/runtime/java/src/common/Reflection.java
@@ -201,6 +201,11 @@ public final class Reflection {
 			final StringCatter lexeme = (StringCatter)ast.getChild(1);
 			final NLocation location = (NLocation)ast.getChild(2);
 			
+			// Perform unification with the expected type
+			if (!TypeRep.unify(resultType, new BaseTypeRep(terminalName))) {
+				throw new SilverError("reify is constructing " + resultType.toString() + ", but found terminal " + terminalName + " AST.");
+			}
+			
 			// Invoke the reify function for the appropriate terminal class
 			final String[] path = terminalName.split(":");
 			path[path.length - 1] = "T" + path[path.length - 1];

--- a/test/silver_features/Reflection.sv
+++ b/test/silver_features/Reflection.sv
@@ -231,7 +231,22 @@ equalityTest(reifyResToString(terminalReifyRes), lessHackyUnparse(terminalTestVa
 global reifyRes10::Either<String Baz> = reify(terminalAST("silver_features:Foo_t", "foo", txtLoc("test")));
 equalityTest(reifyResToString(reifyRes10), "Reification error at ?:\nreify is constructing silver_features:Baz, but found terminal silver_features:Foo_t AST.", String, silver_tests);
 
+global reifyRes11::Either<String Pair<String Location>> = reify(reflect(pair("asdf", 'foo')));
+equalityTest(reifyResToString(reifyRes11), "Reification error at core:pair(_, ?):\nreify is constructing core:Location, but found terminal silver_features:Foo_t AST.", String, silver_tests);
+
 equalityTest(
   case deserializeAST("test", "terminal(asdf, \"a\", core:loc(\"a\", 2, 3.14, 4, 5, 6, 7))") of left(msg) -> msg | right(a) -> show(80, a.pp) end,
   "test:1:20: error: Reification error at core:loc(_, _, ?, _, _, _, _):\nreify is constructing Integer, but found Float AST.",
+  String, silver_tests);
+
+global serializeRes1::Either<String String> = serialize(pair("hello", [1, 2, 3, 4]));
+global reifyRes12::Either<String Pair<String [Integer]>> = deserialize("test", fromRight(serializeRes1, ""));
+
+equalityTest(
+  case serializeRes1 of left(msg) -> msg | right(a) -> a end,
+  s"""core:pair("hello", [1, 2, 3, 4])""",
+  String, silver_tests);
+equalityTest(
+  reifyResToString(reifyRes12),
+  s"""core:pair("hello", [1, 2, 3, 4])""",
   String, silver_tests);

--- a/test/silver_features/Reflection.sv
+++ b/test/silver_features/Reflection.sv
@@ -185,18 +185,18 @@ Either<String (a ::= Integer)> ::=
 equalityTest(case reifySkolem2() of left(_) -> false | right(_) -> true end, true, Boolean, silver_tests);
 
 global testValue::Pair<[Expr] Baz> = pair([testExpr, intConstExpr(5, lineNum=4)], baz(anno1=1, anno2=2.0));
-global deserializeRes::Either<String String> = reflect(testValue).serialize;
-global serializeRes::Either<String AST> = deserializeAST(lessHackyUnparse(testValue), case deserializeRes of left(msg) -> msg | right(a) -> a end);
+global serializeRes::Either<String String> = reflect(testValue).serialize;
+global deserializeRes::Either<String AST> = deserializeAST(lessHackyUnparse(testValue), case serializeRes of left(msg) -> msg | right(a) -> a end);
 
-equalityTest(case deserializeRes of left(msg) -> msg | right(a) -> a end, lessHackyUnparse(testValue), String, silver_tests);
-equalityTest(case serializeRes of left(msg) -> msg | right(a) -> show(80, a.pp) end, lessHackyUnparse(testValue), String, silver_tests);
+equalityTest(case serializeRes of left(msg) -> msg | right(a) -> a end, lessHackyUnparse(testValue), String, silver_tests);
+equalityTest(case deserializeRes of left(msg) -> msg | right(a) -> show(80, a.pp) end, lessHackyUnparse(testValue), String, silver_tests);
 
 equalityTest(
   case anyAST(\ i::Integer -> i).serialize of left(msg) -> msg | right(a) -> a end,
   "Can't serialize anyAST (type (Integer ::= Integer))",
   String, silver_tests);
 
-global reifyRes9::Either<String Pair<[Expr] Baz>> = reify(fromRight(serializeRes, reflect(pair([], baz(anno1=-3, anno2=-4.3242)))));
+global reifyRes9::Either<String Pair<[Expr] Baz>> = reify(fromRight(deserializeRes, reflect(pair([], baz(anno1=-3, anno2=-4.3242)))));
 
 equalityTest(reifyResToString(reifyRes9), lessHackyUnparse(testValue), String, silver_tests);
 
@@ -207,4 +207,28 @@ equalityTest(
 equalityTest(
   case deserializeAST("test", "\"\\n\\r\\t\\t2as\\bd1'\\f\\\\\\\\\\\"\\\\\"") of left(msg) -> msg | right(stringAST(s)) -> s | _ -> "Unexpected case" end,
   "\n\r\t	2as\bd1'\f\\\\\"\\",
+  String, silver_tests);
+
+terminal Foo_t 'foo';
+terminal Bar_t /bar[0-9]+/;
+
+global terminalTestValue::Pair<[Foo_t] Maybe<Bar_t>> = pair(['foo', 'foo'], just(terminal(Bar_t, "bar42", loc("a", 1, 2, 3, 4, 5, 6))));
+global terminalSerializeRes::Either<String String> = reflect(terminalTestValue).serialize;
+global terminalDeserializeRes::Either<String AST> = deserializeAST(lessHackyUnparse(terminalTestValue), case terminalSerializeRes of left(msg) -> msg | right(a) -> a end);
+global terminalReifyRes::Either<String Pair<[Foo_t] Maybe<Bar_t>>> = reify(case terminalDeserializeRes of left(msg) -> integerAST(37) | right(a) -> a end);
+
+equalityTest(
+  lessHackyUnparse(terminalTestValue),
+  s"""core:pair([terminal(silver_features:Foo_t, "foo", ??:-1:-1), terminal(silver_features:Foo_t, "foo", ??:-1:-1)], core:just(terminal(silver_features:Bar_t, "bar42", a:1:2)))""",
+  String, silver_tests);
+equalityTest(
+  case terminalSerializeRes of left(msg) -> msg | right(a) -> a end,
+  s"""core:pair([terminal(silver_features:Foo_t, "foo", core:loc("??", -1, -1, -1, -1, -1, -1)), terminal(silver_features:Foo_t, "foo", core:loc("??", -1, -1, -1, -1, -1, -1))], core:just(terminal(silver_features:Bar_t, "bar42", core:loc("a", 1, 2, 3, 4, 5, 6))))""",
+  String, silver_tests);
+equalityTest(case terminalDeserializeRes of left(msg) -> msg | right(a) -> show(80, a.pp) end, lessHackyUnparse(terminalTestValue), String, silver_tests);
+equalityTest(reifyResToString(terminalReifyRes), lessHackyUnparse(terminalTestValue), String, silver_tests);
+
+equalityTest(
+  case deserializeAST("test", "terminal(asdf, \"a\", core:loc(\"a\", 2, 3.14, 4, 5, 6, 7))") of left(msg) -> msg | right(a) -> show(80, a.pp) end,
+  "test:1:20: error: Reification error at core:loc(_, _, ?, _, _, _, _):\nreify is constructing Integer, but found Float AST.",
   String, silver_tests);

--- a/test/silver_features/Reflection.sv
+++ b/test/silver_features/Reflection.sv
@@ -228,6 +228,9 @@ equalityTest(
 equalityTest(case terminalDeserializeRes of left(msg) -> msg | right(a) -> show(80, a.pp) end, lessHackyUnparse(terminalTestValue), String, silver_tests);
 equalityTest(reifyResToString(terminalReifyRes), lessHackyUnparse(terminalTestValue), String, silver_tests);
 
+global reifyRes10::Either<String Baz> = reify(terminalAST("silver_features:Foo_t", "foo", txtLoc("test")));
+equalityTest(reifyResToString(reifyRes10), "Reification error at ?:\nreify is constructing silver_features:Baz, but found terminal silver_features:Foo_t AST.", String, silver_tests);
+
 equalityTest(
   case deserializeAST("test", "terminal(asdf, \"a\", core:loc(\"a\", 2, 3.14, 4, 5, 6, 7))") of left(msg) -> msg | right(a) -> show(80, a.pp) end,
   "test:1:20: error: Reification error at core:loc(_, _, ?, _, _, _, _):\nreify is constructing Integer, but found Float AST.",


### PR DESCRIPTION
A few different interrelated things here:
* Add `terminalAST` production on `AST` in reflection library, instead of shoving all terminals into `anyAST`.  This allows for serialization/deserialization of trees containing terminals, better `pp` of such trees for debugging purposes, as well as for users of the reflection library to handle terminals specially.  
* Implement a Silver construction extension, `silver:extension:silverconstruction`.  This is analogous to silver-ableC, but instead for other Silver extensions to use in constructing Silver ASTs.  Currently this is very basic and in need of further development.  I don't think we need any unit tests here, but we should use this extension in some of the existing Silver extensions before this is merged, at least.  
* Add helper utilities for direct serialization and deserialization of trees, to avoid repeated boilerplate in going through the intermediate `AST` representation.  This consists of:
  * A function `serialize :: (Either<String String> ::= a)` that converts any value into either `left(error message)` or `right(text)`
  * A new Silver extension construct `deserialize(fileName, text) :: Either<String a>` returning either `left(error message)` or `right(value)`.  This is a part of the language and not a function because of how reification works; the translation of the `reify` constant involves the inferred result type, so a polymorphic function wrapping `reify` would attempt to reify to a skolem type variable and always fail at runtime.  This extension is defined in `silver:extension:reflection`, and uses the Silver construction extension.  