### PR TITLE
Refactoring IDE: fold, build, postbuild, export

### DIFF
--- a/grammars/silver/modification/impide/spec/IdeFunction.sv
+++ b/grammars/silver/modification/impide/spec/IdeFunction.sv
@@ -1,6 +1,9 @@
 grammar silver:modification:impide:spec;
 
-nonterminal IdeFunctions with package, visibleName, implang, bundle, svIdeInterface, pluginXml, pluginXmlActions;
+nonterminal IdeFunctions with package, visibleName, implang, bundle, svIdeInterface, pluginXml, pluginXmlActions, pluginXmlBuilders, markerFullName;
+
+synthesized attribute pluginXmlBuilders :: String;
+autocopy attribute markerFullName :: String;
 
 abstract production consIdeFunction
 top::IdeFunctions ::= h::IdeFunction  t::IdeFunctions
@@ -8,6 +11,7 @@ top::IdeFunctions ::= h::IdeFunction  t::IdeFunctions
   top.svIdeInterface = h.svIdeInterface ++ t.svIdeInterface;
   top.pluginXml = h.pluginXml ++ t.pluginXml;
   top.pluginXmlActions = h.pluginXmlActions ++ t.pluginXmlActions;
+  top.pluginXmlBuilders = h.pluginXmlBuilders ++ t.pluginXmlBuilders;
 }
 
 abstract production nilIdeFunction
@@ -16,9 +20,10 @@ top::IdeFunctions ::=
   top.svIdeInterface = "";
   top.pluginXml = "";
   top.pluginXmlActions = "";
+  top.pluginXmlBuilders = "";
 }
 
-nonterminal IdeFunction with package, visibleName, implang, bundle, svIdeInterface, pluginXml, pluginXmlActions;
+nonterminal IdeFunction with package, visibleName, implang, bundle, svIdeInterface, pluginXml, pluginXmlActions, pluginXmlBuilders, markerFullName;
 
 aspect default production
 top::IdeFunction ::=
@@ -26,41 +31,31 @@ top::IdeFunction ::=
   top.svIdeInterface = "";
   top.pluginXml = "";
   top.pluginXmlActions = "";
+  top.pluginXmlBuilders = "";
 }
 
 abstract production builderFunction
 top::IdeFunction ::= fName::String
 {
-  top.svIdeInterface =
+  top.pluginXmlBuilders =
     s"""
-	@Override
-	public NIOVal build(IProject project, ConsCell properties, common.IOToken iotoken) {
-		return (NIOVal)${makeClassName(fName)}.invoke(project, properties, iotoken);
-	}
-""";
+      <parameter name="silver_build" value="${fName}" />""";
+  top.svIdeInterface = "";
 }
 
 abstract production postbuilderFunction
 top::IdeFunction ::= fName::String
 {
-  top.svIdeInterface =
+  top.pluginXmlBuilders =
     s"""
-	@Override
-	public NIOVal postbuild(IProject project, ConsCell properties, common.IOToken iotoken) {
-		return (NIOVal)${makeClassName(fName)}.invoke(project, properties, iotoken);
-	}
-""";
+      <parameter name="silver_postbuild" value="${fName}" />""";
+  top.svIdeInterface = "";
 }
 
 abstract production exporterFunction
 top::IdeFunction ::= fName::String
 {
-  top.svIdeInterface = s"""
-	@Override
-	public NIOVal export(IProject project, ConsCell properties, common.IOToken iotoken) {
-		return (NIOVal)${makeClassName(fName)}.invoke(project, properties, iotoken);
-	}
-""";
+  top.svIdeInterface = "";
   
   top.pluginXmlActions = s"""
     <action
@@ -69,6 +64,8 @@ top::IdeFunction ::= fName::String
         id="${top.bundle}.${extid_action_export}">
       <class class="edu.umn.cs.melt.ide.imp.builders.Exporter">
         <parameter name="name" value="${top.visibleName}" />
+        <parameter name="markerName" value="${top.markerFullName}" />
+        <parameter name="silver_export" value="${fName}" />
       </class>
     </action>
 """;

--- a/grammars/silver/modification/impide/spec/IdeFunction.sv
+++ b/grammars/silver/modification/impide/spec/IdeFunction.sv
@@ -77,18 +77,14 @@ top::IdeFunction ::= fName::String
 abstract production folderFunction
 top::IdeFunction ::= fName::String
 {
-  top.svIdeInterface = s"""
-	@Override
-	public ConsCell getFolds(Node root) {
-		return (ConsCell)${makeClassName(fName)}.invoke(root);
-	}
-""";
+  top.svIdeInterface = "";
 
   top.pluginXml = s"""
 <extension point="org.eclipse.imp.runtime.foldingUpdater">
   <foldingUpdater
       class="edu.umn.cs.melt.ide.imp.services.FoldingProvider"
       language="${top.implang}">
+    <silvercall function="${fName}" />
   </foldingUpdater>
 </extension>
 """;

--- a/grammars/silver/modification/impide/spec/IdeSpec.sv
+++ b/grammars/silver/modification/impide/spec/IdeSpec.sv
@@ -73,6 +73,7 @@ top::IdeSpec ::=
   funcs.implang = implang;
   funcs.visibleName = ideName;
   funcs.package = package;
+  funcs.markerFullName = s"${bundle}.${extid_problem}";
   
   local wizs :: IdeWizards = foldr(consIdeWizard, nilIdeWizard(), wizards);
   wizs.bundle = bundle;
@@ -169,6 +170,8 @@ ${wizs.svIdeInterface}
 <extension point="org.eclipse.core.resources.builders" id="${extid_builder}" name="${ideName} builder">
   <builder hasNature="true">
     <run class="edu.umn.cs.melt.ide.imp.builders.Builder">
+      <parameter name="markerName" value="${bundle}.${extid_problem}" />
+      ${funcs.pluginXmlBuilders}
     </run>
   </builder>
 </extension>
@@ -258,6 +261,10 @@ ${funcs.pluginXml}
 
 </plugin>
 """),
+-- TODO: we could probably do away with the following Plugin generation by using
+-- context.getBundle().getHeaders().get("Silver-Eclipse-Grammar")
+-- and then using that to call Init and new SVIdeInterface.
+-- (Plus adding that line to the MANIFEST.MF, with the appropriate value...)
   pair(s"${pluginPkgPath}Plugin.java",
     s"""
 package ${package};

--- a/runtime/imp/main/META-INF/MANIFEST.MF
+++ b/runtime/imp/main/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Export-Package: edu.umn.cs.melt.ide.copper;version="1.0.0",
  edu.umn.cs.melt.ide.silver.property;version="1.0.0",
  edu.umn.cs.melt.ide.util;version="1.0.0",
  edu.umn.cs.melt.ide.silver.property.ui;version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources, 

--- a/runtime/imp/main/src/edu/umn/cs/melt/ide/imp/builders/Builder.java
+++ b/runtime/imp/main/src/edu/umn/cs/melt/ide/imp/builders/Builder.java
@@ -9,6 +9,8 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExecutableExtension;
 
 import common.ConsCell;
 import common.DecoratedNode;
@@ -20,24 +22,63 @@ import common.javainterop.ConsCellCollection;
 import core.NIOVal;
 import silver.langutil.NMessage;
 
-import edu.umn.cs.melt.ide.impl.SVInterface;
-import edu.umn.cs.melt.ide.impl.SVRegistry;
 import edu.umn.cs.melt.ide.silver.misc.Problem;
 import edu.umn.cs.melt.ide.silver.property.ProjectProperties;
 
+import edu.umn.cs.melt.ide.util.ReflectedCall;
+
 /**
- * Standard eclipse builder implementation.
+ * Standard eclipse builder implementation. Example configuration:
+    <extension point="org.eclipse.core.resources.builders" id="builder" name="Silver builder">
+      <builder hasNature="true">
+        <run class="edu.umn.cs.melt.ide.imp.builders.Builder">
+          <parameter name="markerName" value="silver.composed.idetest.builder.problem" />
+          <parameter name="silver_build" value="silver:composed:idetest:analyze" />
+          <parameter name="silver_postbuild" value="silver:composed:idetest:generate" />
+        </run>
+      </builder>
+    </extension>
+ *
+ * Runs `build` and optionally `postbuild`.
+ * These should have Silver type `IOVal<[Message]> ::= IdeProject [IdeProperty] IO`.
  */
-public class Builder extends IncrementalProjectBuilder {
+public class Builder extends IncrementalProjectBuilder implements IExecutableExtension {
+
+	private ReflectedCall<NIOVal> sv_build;
+	private ReflectedCall<NIOVal> sv_postbuild;
+	private String markerName;
+	
+	@Override
+	public void setInitializationData(IConfigurationElement config,
+			String propertyName, Object data) throws CoreException {
+		if(!(data instanceof java.util.Hashtable))
+			return;
+		
+		java.util.Hashtable<String, String> d = (java.util.Hashtable<String, String>)data;
+		
+		markerName = d.get("markerName");
+		String build = d.get("silver_build");
+		if(build != null)
+			sv_build = new ReflectedCall<NIOVal>(build, 3);
+		String postbuild = d.get("silver_postbuild");
+		if(postbuild != null)
+			sv_postbuild = new ReflectedCall<NIOVal>(postbuild, 3);
+	}
 
 	public Builder() {}
 	
+	/**
+	 * General process:
+	 * 1. Constructed.
+	 * 2. `setInitializationData` with data from plugin.xml
+	 * 3. Base class stuff gets initialized, e.g. `setProject`
+	 * 4. We get called.
+	 */
 	@Override
 	synchronized protected IProject[] build(int kind, Map/*<String, String> - mvn build complains??*/ args,
 			IProgressMonitor monitor) throws CoreException {
 		
 		final IProject project = getProject();
-		final SVInterface sv = SVRegistry.get();
 		
 		// TODO: I'm not sure if this should be here, but it was the behavior of the old builder to create this
 		IFolder gen_folder = project.getFolder("bin");
@@ -52,8 +93,9 @@ public class Builder extends IncrementalProjectBuilder {
 				ProjectProperties.getPropertyPersister(project.getLocation().toString());
 		
 		// Run the build
-		final NIOVal undecorated_build_result = sv.build(project, properties.serializeToSilverType(), IOToken.singleton);
-		final DecoratedNode build_result = undecorated_build_result.decorate(TopNode.singleton, (Lazy[])null);
+		final NIOVal undecorated_build_result =
+			sv_build.invoke(new Object[]{project, properties.serializeToSilverType(), IOToken.singleton});
+		final DecoratedNode build_result = undecorated_build_result.decorate();
 		// demand evaluation of io actions
 		build_result.synthesized(core.Init.core_io__ON__core_IOVal);
 		
@@ -61,11 +103,11 @@ public class Builder extends IncrementalProjectBuilder {
 		
 		// Clear old markers this builder had perhaps created.
 		// TODO: we should preserve existing markers that haven't changed as much as possible. oh well.
-		project.deleteMarkers(sv.markerErrorName(), true, IResource.DEPTH_INFINITE);
+		project.deleteMarkers(markerName, true, IResource.DEPTH_INFINITE);
 		
-		boolean stopBuild = renderMessages(errors, project, sv); 
+		boolean stopBuild = renderMessages(errors, project, markerName); 
 		
-		if(stopBuild)
+		if(stopBuild || sv_postbuild == null)
 			return new IProject[0];
 		
 		// TODO: look up what to do with monitor. this is a point where we could throw if canceled.
@@ -84,8 +126,9 @@ public class Builder extends IncrementalProjectBuilder {
 			public void run() {
 				// Now, invoke the post-builder.
 				synchronized(lock) {
-					final NIOVal undecorate_post_result = sv.postbuild(project, properties.serializeToSilverType(), IOToken.singleton);
-					final DecoratedNode post_result = undecorate_post_result.decorate(TopNode.singleton, (Lazy[])null);
+					final NIOVal undecorate_post_result = 
+						sv_postbuild.invoke(new Object[]{project, properties.serializeToSilverType(), IOToken.singleton});
+					final DecoratedNode post_result = undecorate_post_result.decorate();
 					post_result.synthesized(core.Init.core_io__ON__core_IOVal);
 					
 					final ConsCell post_errors = (ConsCell)post_result.synthesized(core.Init.core_iovalue__ON__core_IOVal);
@@ -97,7 +140,7 @@ public class Builder extends IncrementalProjectBuilder {
 					// otoh, this should be used very rarely: normal errors are already created
 					// this is just special post build failures only.
 					try {
-						renderMessages(post_errors, project, sv);
+						renderMessages(post_errors, project, markerName);
 					} catch (CoreException e) {
 						// TODO: who knows.
 						e.printStackTrace();
@@ -113,14 +156,14 @@ public class Builder extends IncrementalProjectBuilder {
 		return new IProject[0];
 	}
 
-	public static boolean renderMessages(ConsCell errors, IProject project, SVInterface sv) throws CoreException {
+	public static boolean renderMessages(ConsCell errors, IProject project, String markerName) throws CoreException {
 		boolean stopBuild = false;
 		for(NMessage msg : new ConsCellCollection<NMessage>(errors)) {
 			// it seems we do not need to worry about batching changes, as a builder gets called
 			// with AVOID_UPDATE. apparently. I'm guessing. from the fact that markers don't appear
 			// until this function returns.
 			Problem p = Problem.extractProblem(msg);
-			p.createMarker(project, sv.markerErrorName());
+			p.createMarker(project, markerName);
 			stopBuild = stopBuild || p.buildBlocker();
 		}
 		return stopBuild;

--- a/runtime/imp/main/src/edu/umn/cs/melt/ide/imp/builders/EnableNature.java
+++ b/runtime/imp/main/src/edu/umn/cs/melt/ide/imp/builders/EnableNature.java
@@ -14,15 +14,47 @@ import org.eclipse.ui.IWorkbenchPart;
 /**
  * Action performed via menu.
  * 
- * Gets its configuration via the info from plugin.xml, through setInitializationData
+ * Example configuration:
+    <extension point="org.eclipse.ui.popupMenus">
+      <objectContribution objectClass="org.eclipse.core.resources.IProject" adaptable="true" nameFilter="*" id="silver.composed.idetest.actions.projectmenu">
+        <action
+            label="Enable Silver Builder"
+            tooltip="Enable the Silver builder for this project"
+            id="silver.composed.idetest.actions.nature">
+          <class class="edu.umn.cs.melt.ide.imp.builders.EnableNature">
+            <parameter name="nature" value="silver.composed.idetest.nature" />
+          </class>
+        </action>
+ *
+ * Here we get `nature` passed as a hastable in `setInitializationData`.
  */
 public class EnableNature implements IObjectActionDelegate, IExecutableExtension {
 
-	public EnableNature() {}
-	
 	private IProject project;
 	private String natureID;
 	
+	@Override
+	public void setInitializationData(IConfigurationElement config, String property,
+			Object data) throws CoreException {
+		if(!(data instanceof java.util.Hashtable))
+			return;
+		
+		java.util.Hashtable<String, String> d = (java.util.Hashtable<String, String>)data;
+		
+		natureID = d.get("nature");
+	}
+
+	public EnableNature() {}
+	
+	/**
+	 * General invocation process:
+	 * 1. Construct
+	 * 2. `setInitializationData`
+	 * 3. unclear! `selectionChanged` must get called?
+	 * 4. `run` gets called.
+	 *
+	 * Then we do this thing.
+	 */
 	@Override
 	public void run(IAction arg0) {
 		if(natureID == null) {
@@ -57,17 +89,6 @@ public class EnableNature implements IObjectActionDelegate, IExecutableExtension
 
 	@Override
 	public void setActivePart(IAction arg0, IWorkbenchPart arg1) {
-	}
-
-	@Override
-	public void setInitializationData(IConfigurationElement config, String property,
-			Object data) throws CoreException {
-		if(!(data instanceof java.util.Hashtable))
-			return;
-		
-        java.util.Hashtable<String, String> d = (java.util.Hashtable<String, String>)data;
-        
-        natureID = d.get("nature");
 	}
 
 

--- a/runtime/imp/main/src/edu/umn/cs/melt/ide/imp/builders/Exporter.java
+++ b/runtime/imp/main/src/edu/umn/cs/melt/ide/imp/builders/Exporter.java
@@ -8,6 +8,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -22,26 +23,52 @@ import common.TopNode;
 
 import core.NIOVal;
 
-import edu.umn.cs.melt.ide.impl.SVInterface;
-import edu.umn.cs.melt.ide.impl.SVRegistry;
 import edu.umn.cs.melt.ide.silver.property.ProjectProperties;
+import edu.umn.cs.melt.ide.util.ReflectedCall;
 
 /**
- * Action performed via menu.
+ * Action performed via menu. Example configuration:
+    <extension point="org.eclipse.ui.popupMenus">
+      <objectContribution objectClass="org.eclipse.core.resources.IProject" adaptable="true" nameFilter="*" id="silver.composed.idetest.actions.projectmenu">
+        <action
+            label="Export as Silver target"
+            tooltip="Export the project as Silver distributable"
+            id="silver.composed.idetest.actions.export">
+          <class class="edu.umn.cs.melt.ide.imp.builders.Exporter">
+            <parameter name="name" value="Silver" />
+            <parameter name="markerName" value="silver.composed.idetest.builder.problem" />
+            <parameter name="silver_export" value="silver:composed:idetest:export" />
+          </class>
+        </action>
  * 
- * Gets its configuration via the info from plugin.xml, through setInitializationData
+ * The export function should have Silver type `IOVal<[Message]> ::= IdeProject [IdeProperty] IO`
  */
 public class Exporter implements IObjectActionDelegate, IExecutableExtension {
 
 	private IProject project;
-	private String name;
 	
+	private String name; // Language / Project name. e.g. "Silver"
+	private ReflectedCall<NIOVal> sv_export;
+	private String markerName;
+	
+	@Override
+	public void setInitializationData(IConfigurationElement config, String property,
+			Object data) throws CoreException {
+		if(!(data instanceof java.util.Hashtable))
+			return;
+		
+		java.util.Hashtable<String, String> d = (java.util.Hashtable<String, String>)data;
+
+		name = d.get("name");
+		markerName = d.get("markerName");
+		sv_export = new ReflectedCall<NIOVal>(d.get("silver_export"), 3);
+	}
+
 	@Override
 	public void run(IAction ignored) {
 		if(project == null)
 			return;
 		
-		final SVInterface sv = SVRegistry.get();
 		final ProjectProperties properties =
 				ProjectProperties.getPropertyPersister(project.getLocation().toString());
 		
@@ -50,15 +77,16 @@ public class Exporter implements IObjectActionDelegate, IExecutableExtension {
 			@Override
 			protected IStatus run(final IProgressMonitor monitor) {
 
-				final NIOVal undecorated_export_result = sv.export(project, properties.serializeToSilverType(), IOToken.singleton);
-				final DecoratedNode export_result = undecorated_export_result.decorate(TopNode.singleton, (Lazy[])null);
+				final NIOVal undecorated_export_result =
+					sv_export.invoke(new Object[]{project, properties.serializeToSilverType(), IOToken.singleton});
+				final DecoratedNode export_result = undecorated_export_result.decorate();
 				// demand evaluation of io actions
 				export_result.synthesized(core.Init.core_io__ON__core_IOVal);
 				
 				final ConsCell errors = (ConsCell)export_result.synthesized(core.Init.core_iovalue__ON__core_IOVal);
 
 				try {
-					Builder.renderMessages(errors, project, sv);
+					Builder.renderMessages(errors, project, markerName);
 				} catch (CoreException e) {
 					// TODO who knows
 					e.printStackTrace();
@@ -88,17 +116,6 @@ public class Exporter implements IObjectActionDelegate, IExecutableExtension {
 
 	@Override
 	public void setActivePart(IAction arg0, IWorkbenchPart arg1) {
-	}
-
-	@Override
-	public void setInitializationData(IConfigurationElement config, String property,
-			Object data) throws CoreException {
-		if(!(data instanceof java.util.Hashtable))
-			return;
-		
-        java.util.Hashtable<String, String> d = (java.util.Hashtable<String, String>)data;
-
-        name = d.get("name");
 	}
 
 }

--- a/runtime/imp/main/src/edu/umn/cs/melt/ide/imp/builders/Nature.java
+++ b/runtime/imp/main/src/edu/umn/cs/melt/ide/imp/builders/Nature.java
@@ -15,39 +15,74 @@ import org.eclipse.imp.runtime.IPluginLog;
  * Adds the builder it is told to via the extension declaration of that nature that uses this class.
  * 
  * Does essentially nothing else.
+ *
+ * Example configuration:
+    <extension point="org.eclipse.core.resources.natures" id="nature" name="Silver Nature">
+      <builder id="silver.composed.idetest.builder" />
+      <runtime>
+        <run class="edu.umn.cs.melt.ide.imp.builders.Nature">
+          <parameter name="builder" value="silver.composed.idetest.builder" />
+        </run>
+      </runtime>
+    </extension>
+ * 
+ * `parameter` objects are passed in as a hashtable to `setInitializationData`.
  */
 public class Nature implements IProjectNature, IExecutableExtension {
-
-    /**
-     * Actually a fully generic function for adding a nature to a project.
-     * Seems odd something like this doesn't exist already somewhere.
-     * 
-     * @param project  The project to affect.
-     * @param natureID  The ID of the nature to add.
-     */
-    public static void addToProject(IProject project, String natureID) throws CoreException {
-        IProjectDescription description = project.getDescription();
-        String[] natures = description.getNatureIds();
-        
-        for(int i = 0; i < natures.length; i++) {
-        	if(natures[i].equals(natureID)) {
-        		System.out.println("nature " + natureID + " already present.");
-        		return;
-        	}
-        }
-        
-        String[] newNatures = new String[natures.length + 1];
-
-        System.arraycopy(natures, 0, newNatures, 0, natures.length);
-        newNatures[natures.length] = natureID;
-
-        description.setNatureIds(newNatures);
-        project.setDescription(description, null);
-    }
 
 	private IProject project;
 	private String builderID;
 
+	@Override
+	public void setInitializationData(IConfigurationElement config, String property,
+			Object data) throws CoreException {
+		if(!(data instanceof java.util.Hashtable))
+			return;
+		
+		java.util.Hashtable<String, String> d = (java.util.Hashtable<String, String>)data;
+		
+		builderID = d.get("builder");
+		// maybe this nature should actually know what natureID it has? no need yet though...
+	}
+
+	/**
+	 * Actually a fully generic function for adding a nature to a project.
+	 * Seems odd something like this doesn't exist already somewhere.
+	 * 
+	 * @param project  The project to affect.
+	 * @param natureID  The ID of the nature to add.
+	 */
+	public static void addToProject(IProject project, String natureID) throws CoreException {
+		IProjectDescription description = project.getDescription();
+		String[] natures = description.getNatureIds();
+		
+		for(int i = 0; i < natures.length; i++) {
+			if(natures[i].equals(natureID)) {
+				System.out.println("nature " + natureID + " already present.");
+				return;
+			}
+		}
+		
+		String[] newNatures = new String[natures.length + 1];
+
+		System.arraycopy(natures, 0, newNatures, 0, natures.length);
+		newNatures[natures.length] = natureID;
+
+		description.setNatureIds(newNatures);
+		project.setDescription(description, null);
+	}
+
+	/**
+	 * The actual action. This method is usually called like so:
+	 * 1. This object is instantiated
+	 * 2. `setInitializationData` is called with data from plugin.xml
+	 * 3. `setProject` is called
+	 * 4. `configure` is called
+	 *
+	 * So here's all the action: we add the builder to the list of 
+	 * "build commands" we find in the "project description" if it's not
+	 * already present. That's all.
+	 */
 	@Override
 	public void configure() throws CoreException {
 		// TODO: should probably log better somehow. this whole function.
@@ -57,26 +92,26 @@ public class Nature implements IProjectNature, IExecutableExtension {
 			return; // welp,
 		}
 		
-        IProjectDescription desc = getProject().getDescription();
-        ICommand[] cmds = desc.getBuildSpec();
+		IProjectDescription desc = getProject().getDescription();
+		ICommand[] cmds = desc.getBuildSpec();
 
-        for(int i = 0; i < cmds.length; i++) {
-            if (cmds[i].getBuilderName().equals(builderID)) {
-            	System.out.println("odd, the builder is already present.");
-                return;
-            }
-        }
+		for(int i = 0; i < cmds.length; i++) {
+			if (cmds[i].getBuilderName().equals(builderID)) {
+				System.out.println("odd, the builder is already present.");
+				return;
+			}
+		}
 
-        ICommand buildCmd = desc.newCommand();
-        buildCmd.setBuilderName(builderID);
+		ICommand buildCmd = desc.newCommand();
+		buildCmd.setBuilderName(builderID);
 
-        ICommand[] newCmds = new ICommand[cmds.length+1];
+		ICommand[] newCmds = new ICommand[cmds.length+1];
 
-        System.arraycopy(cmds, 0, newCmds, 0, cmds.length);
-        newCmds[cmds.length] = buildCmd;
+		System.arraycopy(cmds, 0, newCmds, 0, cmds.length);
+		newCmds[cmds.length] = buildCmd;
 
-        desc.setBuildSpec(newCmds);
-        project.setDescription(desc, null);
+		desc.setBuildSpec(newCmds);
+		project.setDescription(desc, null);
 
 	}
 
@@ -97,15 +132,4 @@ public class Nature implements IProjectNature, IExecutableExtension {
 		project = arg0;
 	}
 
-	@Override
-	public void setInitializationData(IConfigurationElement config, String property,
-			Object data) throws CoreException {
-		if(!(data instanceof java.util.Hashtable))
-			return;
-		
-        java.util.Hashtable<String, String> d = (java.util.Hashtable<String, String>)data;
-		
-        builderID = d.get("builder");
-        // TODO: you know, mayyybe this nature should actually know what natureID it has? no need yet though...
-	}
 }

--- a/runtime/imp/main/src/edu/umn/cs/melt/ide/impl/SVDefault.java
+++ b/runtime/imp/main/src/edu/umn/cs/melt/ide/impl/SVDefault.java
@@ -47,29 +47,6 @@ public abstract class SVDefault implements SVInterface {
 	public abstract IdeParseResult<Node> parse(Reader input, String filename) throws CopperParserException, IOException;
 	
 	@Override
-	public NIOVal build(IProject project, ConsCell properties, IOToken iotoken) {
-		// Introducing the bit to plugin.xml that results in the code being run
-		// that eventually calls this is a result of a 'builder' function being given.
-		// It should never be the case that this is unimplemented and then called.
-		throw new UnsupportedOperationException("Build should only be called if supplied by the plugin in the silver ide declaration.");
-	}
-
-	@Override
-	public NIOVal postbuild(IProject project, ConsCell properties, IOToken iotoken) {
-		// An entirely valid course of action is to do nothing. Do so by default.
-		// Seamlessly handles a 'builder' given but not a 'postbuilder'.
-		return new Pioval(iotoken, ConsCell.nil);
-	}
-
-	@Override
-	public NIOVal export(IProject project, ConsCell properties, IOToken iotoken) {
-		// Introducing the bit to plugin.xml that results in the code being run
-		// that eventually calls this is a result of a 'exporter' function being given.
-		// It should never be the case that this is unimplemented and then called.
-		throw new UnsupportedOperationException("Export should only be called if supplied by the plugin in the silver ide declaration.");
-	}
-
-	@Override
 	public IPropertyControlsProvider getNewFileProperties() {
 		// Should be provided if the wizard ends up in plugin.xml
 		throw new UnsupportedOperationException("new file properties requested by not provided by plugin");

--- a/runtime/imp/main/src/edu/umn/cs/melt/ide/impl/SVDefault.java
+++ b/runtime/imp/main/src/edu/umn/cs/melt/ide/impl/SVDefault.java
@@ -70,13 +70,6 @@ public abstract class SVDefault implements SVInterface {
 	}
 
 	@Override
-	public ConsCell getFolds(Node root) {
-		// Introducing the bit to plugin.xml that results in the code being run
-		// that eventually calls this is a result of a 'folder' function being given.
-		// It should never be the case that this is unimplemented and then called.
-		throw new UnsupportedOperationException("GetFolds should only be called if supplied by the plugin in the silver ide declaration.");
-	}
-	@Override
 	public IPropertyControlsProvider getNewFileProperties() {
 		// Should be provided if the wizard ends up in plugin.xml
 		throw new UnsupportedOperationException("new file properties requested by not provided by plugin");

--- a/runtime/imp/main/src/edu/umn/cs/melt/ide/impl/SVInterface.java
+++ b/runtime/imp/main/src/edu/umn/cs/melt/ide/impl/SVInterface.java
@@ -59,48 +59,6 @@ public interface SVInterface {
 	public String fileExtension();
 	
 	/**
-	 * IOVal<[Message]> ::= IdeProject [IdeProperty] IO
-	 * 
-	 * Run when a build action is requested. e.g. a file is saved, if auto-build is on.
-	 * 
-	 * @param project  The project being built
-	 * @param properties  The IDE project properties.
-	 * @param iotoken  An input IO token.
-	 * @return An IO object that contains a list of error messages to raise.
-	 */
-	public NIOVal build(IProject project, ConsCell properties, IOToken iotoken); 
-
-	/**
-	 * IOVal<[Message]> ::= IdeProject [IdeProperty] IO
-	 * 
-	 * <p>Run when a build action *has succeeded without errors*.
-	 * 
-	 * <p>Why do we bother with this? In order to report errors to the user faster.
-	 * 'build' can return empty list, the user's red-squigglies are updated, then this is run to
-	 * actually accomplish longer running stuff in the build.
-	 * 
-	 * <p>An entirely valid implementation does nothing.
-	 * 
-	 * @param project  The project being built
-	 * @param properties  The IDE project properties.
-	 * @param iotoken  An input IO token.
-	 * @return An IO object that contains a list of *additional* error messages to raise.
-	 */
-	public NIOVal postbuild(IProject project, ConsCell properties, IOToken iotoken);
-	
-	/**
-	 * IOVal<[Message]> ::= IdeProject [IdeProperty] IO
-	 * 
-	 * Run when the user requests an export? (TODO: uh, figure some stuff out here)
-	 * 
-	 * @param project  The project being built
-	 * @param properties  The IDE project properties.
-	 * @param iotoken  An input IO token.
-	 * @return  Any additional errors to raise (usually sys errors, rather than for files)
-	 */
-	public NIOVal export(IProject project, ConsCell properties, IOToken iotoken);
-	
-	/**
 	 * Obtains a list of properties to request in order to create a new file via wizard.
 	 */
 	public IPropertyControlsProvider getNewFileProperties();

--- a/runtime/imp/main/src/edu/umn/cs/melt/ide/impl/SVInterface.java
+++ b/runtime/imp/main/src/edu/umn/cs/melt/ide/impl/SVInterface.java
@@ -101,16 +101,6 @@ public interface SVInterface {
 	public NIOVal export(IProject project, ConsCell properties, IOToken iotoken);
 	
 	/**
-	 * [Location] ::= <<CST root's type>>
-	 * 
-	 * Given a tree from parsing, return a list of locations that can be folded.
-	 * 
-	 * @param root  The CST tree
-	 * @return  A list of extents that should fold.
-	 */
-	public ConsCell getFolds(Node root);
-	
-	/**
 	 * Obtains a list of properties to request in order to create a new file via wizard.
 	 */
 	public IPropertyControlsProvider getNewFileProperties();

--- a/runtime/imp/main/src/edu/umn/cs/melt/ide/util/ReflectedCall.java
+++ b/runtime/imp/main/src/edu/umn/cs/melt/ide/util/ReflectedCall.java
@@ -1,0 +1,62 @@
+package edu.umn.cs.melt.ide.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import common.Node;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Status;
+
+import core.NIOVal;
+import core.NMaybe;
+import core.Pioval;
+import core.Pjust;
+import core.Pnothing;
+
+/**
+ * Helper to call a Silver function from Java code.
+ *
+ * Intention is for this object to be instantiated from `setInitializationData`
+ * where CoreException is reasonable. We get as far as we can in the constructor
+ * and then jam and error from the later call into RuntimeException.
+ */
+public final class ReflectedCall<T> {
+	private Method method;
+	
+	public ReflectedCall(String silver_function, int arity) throws CoreException {
+		int i = silver_function.lastIndexOf(":");
+		String before = silver_function.substring(0, i);
+		String after = silver_function.substring(i + 1, silver_function.length());
+		
+		// 'a:b:c' to 'a.b.Pc'
+		String class_name = before.replace(":", ".") + ".P" + after;
+		
+		try {
+			Class<Node> cls = (Class<Node>)Class.forName(class_name);
+			Class[] arg_types = new Class[arity];
+			Arrays.fill(arg_types, Object.class);
+		
+			method = cls.getMethod("invoke", arg_types);
+		} catch (ClassNotFoundException e) {
+			// TODO: figure out correct pluginId?
+			throw new CoreException(
+				new Status(Status.ERROR, "edu.umn.cs.melt.eclipse", "Cannot find " + silver_function, e));
+		} catch (NoSuchMethodException e) {
+			// TODO: figure out correct pluginId?
+			throw new CoreException(
+				new Status(Status.ERROR, "edu.umn.cs.melt.eclipse", "Cannot find valid invocation for " + silver_function, e));
+		}
+	}
+	
+	public T invoke(Object[] args) {
+		try {
+			return (T) method.invoke(null, args);
+		} catch (InvocationTargetException | IllegalAccessException e) {
+			// We don't do CoreException here because we might not be called in a context where
+			// that's acceptable to throw (it's a checked exception).
+			throw new RuntimeException("Reflected call failed", e);
+		}
+	}
+}


### PR DESCRIPTION
Following #264 I continue that strategy with several more functions moved over to the new style.

After this, the next step is likely `parse`, and after that a more difficult step of figuring out all the awful properties/wizards junk. But I suspect those are doable as well.

I'm likely to stop looking at this stuff for awhile at that point. But the next step would be to untangle "actions" in silver code from having to do eclipse-specific things. Basically, all references to the `ide` grammar are a problem of some sort...