### PR TITLE
alter dont-translate to work in a more useful fashion

### DIFF
--- a/grammars/silver/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/translation/java/driver/BuildProcess.sv
@@ -77,21 +77,25 @@ top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
     if null(top.config.buildXmlLocation) then "build.xml"
     else head(top.config.buildXmlLocation);
   
-  top.postOps <- if top.config.noJavaGeneration then [] else 
-    [genJava(top.config, grammarsToTranslate, benv.silverGen), 
-     genBuild(buildXmlLocation, buildXml)]; 
+  top.postOps <-
+    [genBuild(buildXmlLocation, buildXml)] ++
+    (if top.config.noJavaGeneration then [] else [genJava(top.config, grammarsToTranslate, benv.silverGen)]);
 
   -- From here on, it's all build.xml stuff:
 
+  -- Presently, copper, copper_mda, and impide all contribute new targets into build.xml:
   production attribute extraTopLevelDecls :: [String] with ++;
   extraTopLevelDecls := [];
 
+  -- Presently, impide and copper_mda introduce a new top-level goal:
   production attribute extraDistDeps :: [String] with ++;
-  extraDistDeps := ["jars"];
+  extraDistDeps := if top.config.noJavaGeneration then [] else ["jars"];
   
+  -- Presently, unused?
   production attribute extraJarsDeps :: [String] with ++;
   extraJarsDeps := ["grammars"];
 
+  -- Presently, copper and copper_mda
   production attribute extraGrammarsDeps :: [String] with ++;
   extraGrammarsDeps := ["init"];
   


### PR DESCRIPTION
We have an existing option that suppressed java translation, but it wasn't the most useful implementation. This cleans it up.

New behavior is to:

1. Check for errors.
2. Run MDA analysis, if any.
3. No java translation or compilation or jar files or interface files. Also no parser building. Wasn't sure about that last one, but it seems to be the behavior we usually want when using this option.

Here is an example of a change we need to make to take advantage of it:

https://github.com/melt-umn/ableC-condition-tables/compare/feature/notranslation

I call "NOT IT" on having to make this change to all the extensions... :P

Fixes #248 