### PR TITLE
Add conditional statements to action blocks

### DIFF
--- a/grammars/silver/definition/core/Terminals.sv
+++ b/grammars/silver/definition/core/Terminals.sv
@@ -35,7 +35,7 @@ terminal Attribute_kwd   'attribute'    lexer classes {KEYWORD,RESERVED};
 terminal Closed_kwd      'closed'       lexer classes {KEYWORD};
 terminal Concrete_kwd    'concrete'     lexer classes {KEYWORD,RESERVED};
 terminal Decorate_kwd    'decorate'     lexer classes {KEYWORD,RESERVED};
-terminal Else_kwd        'else'         lexer classes {KEYWORD,RESERVED}, precedence = 4;
+terminal Else_kwd        'else'         lexer classes {KEYWORD,RESERVED}, precedence = 4, association = left; -- Association needed for dangling else in action code.
 terminal Forwarding_kwd  'forwarding'   lexer classes {KEYWORD,RESERVED};
 terminal Forward_kwd     'forward'      lexer classes {KEYWORD,RESERVED};
 terminal Forwards_kwd    'forwards'     lexer classes {KEYWORD,RESERVED};
@@ -82,7 +82,7 @@ terminal Divide_t      '/'  precedence = 12, association = left;
 terminal Modulus_t     '%'  precedence = 12, association = left;
 terminal ColonColon_t  '::' precedence = 14, association = right; -- HasType AND cons. right due to cons.
 terminal LParen_t      '('  precedence = 24;
-terminal RParen_t      ')'  ;
+terminal RParen_t      ')'  precedence = 1, association = left; -- Precedence and association eeded for dangling else in action code.
 terminal LCurly_t      '{'  ;
 terminal RCurly_t      '}'  ;
 terminal Dot_t         '.'  precedence = 25, association = left;

--- a/grammars/silver/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/definition/flow/env/ProductionBody.sv
@@ -279,10 +279,20 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
   top.flowDefs = e.flowDefs;
 }
-aspect production pushTokenIfStmt
-top::ProductionStmt ::= 'pushToken' '(' val::QName ',' lexeme::Expr ')' 'if' condition::Expr ';'
+aspect production blockStmt
+top::ProductionStmt ::= '{' stmts::ProductionStmts '}'
 {
-  top.flowDefs = lexeme.flowDefs ++ condition.flowDefs;
+  top.flowDefs = stmts.flowDefs;
+}
+aspect production ifElseStmt
+top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt 'else' el::ProductionStmt
+{
+  top.flowDefs = condition.flowDefs ++ th.flowDefs ++ el.flowDefs;
+}
+aspect production pushTokenStmt
+top::ProductionStmt ::= 'pushToken' '(' val::QName ',' lexeme::Expr ')' ';'
+{
+  top.flowDefs = lexeme.flowDefs;
 }
 
 

--- a/grammars/silver/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/modification/copper/ProductionStmt.sv
@@ -126,7 +126,8 @@ top::ProductionStmt ::= '{' stmts::ProductionStmts '}'
   top.translation = stmts.translation;
   
   stmts.downSubst = top.downSubst;
-  top.upSubst = top.downSubst;
+  top.upSubst = error("Shouldn't ever be needed anywhere. (Should only ever be fed back here as top.finalSubst)");
+  -- Of course, this means do not use top.finalSubst here!
 }
 
 concrete production ifElseStmt
@@ -147,10 +148,10 @@ top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt 'else' e
   errCheck1.downSubst = condition.upSubst;
   top.upSubst = errCheck1.upSubst;
   
-  th.downSubst = top.finalSubst;
+  th.downSubst = top.downSubst;
   th.finalSubst = th.upSubst;
   
-  el.downSubst = top.finalSubst;
+  el.downSubst = top.downSubst;
   el.finalSubst = el.upSubst;
 
   errCheck1 = check(condition.typerep, boolType());

--- a/test/copper_features/token_pushing/TokenPush.sv
+++ b/test/copper_features/token_pushing/TokenPush.sv
@@ -9,8 +9,9 @@ nonterminal Contents;
 
 terminal A 'A';
 terminal B 'B' 
-action{ 
-   pushToken(C, "C") if (1==1);
+action{
+   if (1==1)
+     pushToken(C, "C");
 };
 terminal C 'C';
 


### PR DESCRIPTION
This adds if/else and { } statements to action blocks, inspired by C syntax (which fits fairly well here.)  These are basically pieces of imperative code, and this will make things a bit cleaner for some of the more complex tasks we are planning for modifying the parser context when parsing ableC.  I suppose we could also in theory add while loops, but I don't see that as generally useful.  
Currently we have the syntax `pushToken(...) if (...);` to conditionally push a token, this lets us get rid of that production and just do `if (...) pushToken(...);` instead.  We are also thinking of adding `include <lexerclass>;` and `exclude <lexerclass>;` action statements, this allows us to avoid adding conditional forms of those as well.  
Thoughts?  Also @tedinski I'm not sure if I got the substitution threading right in the new productions, could you take a look?  