### PR TITLE
Minor hack to reduce generated files: make nils more built-in.

### DIFF
--- a/grammars/silver/extension/list/java/Type.sv
+++ b/grammars/silver/extension/list/java/Type.sv
@@ -5,6 +5,7 @@ import silver:definition:type;
 import silver:definition:env;
 import silver:definition:core;
 import silver:translation:java:type;
+import silver:translation:java:core; -- for the nil hack
 
 aspect production listType
 top::Type ::= el::Type
@@ -14,3 +15,19 @@ top::Type ::= el::Type
   top.transFreshTypeRep = s"new common.ListTypeRep(${el.transFreshTypeRep})";
 }
 
+
+-- A wonderous hack
+aspect production emptyList
+top::Expr ::= '[' ']'
+{
+  -- Technically, this is interfering, however it's hardly the worst violation
+  -- in the Silver compiler, and it's not too bad: we do the same thing, just
+  -- slightly more efficiently.
+  -- For the time being, this is easier than (and as effective as) amending
+  -- function calls with special optimization cases.
+
+  -- This makes `[]` act like a constant literal (e.g. a number) instead of
+  -- a function call.
+  top.translation = "(common.ConsCell)common.ConsCell.nil";
+  top.lazyTranslation = top.translation;
+}


### PR DESCRIPTION
This is a pretty simple one: `[]` in Silver currently forwards to a function call that returns the nil element. This patch changes it to act like a constant literal instead.

The effect is pretty decent. This data is from running `deep-rebuild`:

`du -h generated/bin` goes from 84MB to 79MB, about 5MB reduction.
`find generated/bin -type f | wc -l` goes from 19110 to 17704, 1400 fewer generated files.
`ls -la jars/silver.composed.Default.jar` drops jar size from 18.6M to 18.0M, 600KB savings.
