### PR TITLE
Pay attention to "host language attributes"

### DIFF
--- a/grammars/silver/analysis/warnings/defs/Syn.sv
+++ b/grammars/silver/analysis/warnings/defs/Syn.sv
@@ -30,6 +30,12 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
     filter(isOccursSynthesized(_, top.env),
       getAttrsOn(namedSig.outputElement.typerep.typeName, top.env));
 
+  -- TODO: Strictly speaking, non-forwarding productions will always be checked by
+  -- the attribute occurrence, we don't need to "double check" here.
+  -- However, because the fix would be here, we *DO* want to raise the error message
+  -- in this location. We should instead suppress the error from the attribute,
+  -- if we know this would raise it instead.
+
   top.errors <-
     if null(body.errors ++ ns.errors)
     && (top.config.warnAll || top.config.warnMissingSyn)
@@ -68,7 +74,9 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
   -- Lookup all productions for this nonterminal
   -- ensure an equation exists for each production or the production forwards
   
-  production prods :: [FlowDef] = getProdsOn(nt.lookupType.typerep.typeName, top.flowEnv);
+  -- TODO: FIXME: these are nonforwarding, but raiseMissingProds is trying to filter out forwarding.
+  -- I guess that's not wrong, but it could be improved.
+  production prods :: [FlowDef] = getNonforwardingProds(nt.lookupType.typerep.typeName, top.flowEnv);
 
   top.errors <-
     if nt.lookupType.found && at.lookupAttribute.found

--- a/grammars/silver/analysis/warnings/defs/Syn.sv
+++ b/grammars/silver/analysis/warnings/defs/Syn.sv
@@ -19,85 +19,112 @@ Either<String  Decorated CmdArgs> ::= args::[String]
   flags <- [pair("--warn-missing-syn", flag(warnMissingSynFlag))];
 }
 
-aspect production productionDcl
-top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::ProductionBody
-{
-  -- stop if this production forwards
-  -- Lookup all attribute that occurs on our LHS (filter to SYN!)
-  -- Ensure there exists an equation for each on this production
-  
-  production attrs :: [DclInfo] = 
-    filter(isOccursSynthesized(_, top.env),
-      getAttrsOn(namedSig.outputElement.typerep.typeName, top.env));
-
-  -- TODO: Strictly speaking, non-forwarding productions will always be checked by
-  -- the attribute occurrence, we don't need to "double check" here.
-  -- However, because the fix would be here, we *DO* want to raise the error message
-  -- in this location. We should instead suppress the error from the attribute,
-  -- if we know this would raise it instead.
-
-  top.errors <-
-    if null(body.errors ++ ns.errors)
-    && (top.config.warnAll || top.config.warnMissingSyn)
-    && null(body.uniqueSignificantExpression) -- no forward
-    then raiseMissingAttrs(top.location, fName, attrs, top.flowEnv)
-    else [];
-}
-
 function isOccursSynthesized
 Boolean ::= occs::DclInfo  e::Decorated Env
 {
   return case getAttrDcl(occs.attrOccurring, e) of
-         | at :: _ -> at.isSynthesized
-         | _ -> false
-         end;
+  | at :: _ -> at.isSynthesized
+  | _ -> false
+  end;
 }
 
-function raiseMissingAttrs
-[Message] ::= l::Location  fName::String  attrs::[DclInfo]  e::Decorated FlowEnv
-{
-  return if null(attrs) then []
-  else (
-       if null(lookupDef(head(attrs).fullName, head(attrs).attrOccurring, e)) -- no default eq!
-       then
-         case lookupSyn(fName, head(attrs).attrOccurring, e) of
-         | eq :: _ -> []
-         | [] -> [wrn(l, "production " ++ fName ++ " lacks synthesized equation for " ++ head(attrs).attrOccurring)]
-         end
-       else []) ++ raiseMissingAttrs(l, fName, tail(attrs), e);
-}
-
+{- This is the primary check for missing synthesized equations.
+ - In theory, this is the only check necessary to spot them all.
+ -}
 aspect production attributionDcl
 top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' nt::QName nttl::BracketedOptTypeExprs ';'
 {
-  -- ensure we're looking at a syn attribute
-  -- Lookup all productions for this nonterminal
-  -- ensure an equation exists for each production or the production forwards
-  
-  -- TODO: FIXME: these are nonforwarding, but raiseMissingProds is trying to filter out forwarding.
-  -- I guess that's not wrong, but it could be improved.
-  production prods :: [FlowDef] = getNonforwardingProds(nt.lookupType.typerep.typeName, top.flowEnv);
+  -- All non-forwarding productions for this nonterminal:
+  local nfprods :: [String] = getNonforwardingProds(nt.lookupType.typerep.typeName, top.flowEnv);
+
+  -- The check we're writing in this aspect can find all instances of missing
+  -- synthesized equations, but in the interest of improved error messages, we
+  -- will omit raising an error if we know it can be raised by `productionDcl`
+  -- below instead. That's closer to where the fix should be applied.
+  local suppress_this_error :: Boolean =
+    -- This could be done using `isExportedBy` but I'm lazy and this is by far the common case.
+    nt.lookupType.dcl.sourceGrammar == top.grammarName; 
 
   top.errors <-
     if nt.lookupType.found && at.lookupAttribute.found
     && (top.config.warnAll || top.config.warnMissingSyn)
+    -- We only care about synthesized attributes:
     && at.lookupAttribute.dcl.isSynthesized
-    && null(lookupDef(nt.lookupType.fullName, at.lookupAttribute.fullName, top.flowEnv)) -- no default eq!
-    then raiseMissingProds(top.location, at.lookupAttribute.fullName, prods, top.flowEnv)
+    -- This error message won't be redundant:
+    && !suppress_this_error
+    -- And we can ignore any attribute that has a default equation:
+    && null(lookupDef(nt.lookupType.fullName, at.lookupAttribute.fullName, top.flowEnv))
+    -- Otherwise, examine them all:
+    then flatMap(raiseMissingProds(top.location, at.lookupAttribute.fullName, _, top.flowEnv), nfprods)
     else [];
 }
 
+{--
+ - Examine a non-forwarding production `prod` to see if it is missing an equation
+ - for the synthesized attribute `attr`.
+ -
+ - @param l      Location to raise the error message (of the attribute occurence)
+ - @param attr   Full name of a synthesized attribute
+ - @param prod   Full name of non-forwarding production to examine
+ - @param e      The local flow environment
+ -}
 function raiseMissingProds
-[Message] ::= l::Location  fName::String  prods::[FlowDef]  e::Decorated FlowEnv
+[Message] ::= l::Location  attr::String  prod::String  e::Decorated FlowEnv
 {
-  local headProdName :: String = case head(prods) of prodFlowDef(_, p) -> p end;
-  
-  return if null(prods) then []
-  else case lookupSyn(headProdName, fName, e),  lookupFwd(headProdName, e) of
-       | _ :: _, _ -> [] -- eq present
-       | [], _ :: _ -> [] -- prod forwards
-       | [], [] -> [wrn(l, "attribute "  ++ fName ++ " missing equation for production " ++ headProdName)]
-       end ++ raiseMissingProds(l, fName, tail(prods), e);
+  -- Because the location is of the attribute occurrence, deliberately use the attribute's shortname
+  local shortName :: String = substring(lastIndexOf(":", attr) + 1, length(attr), attr);
 
+  return case lookupSyn(prod, attr, e) of
+  | _ :: _ -> [] -- equation exists
+  | [] -> [wrn(l, "attribute "  ++ shortName ++ " missing equation for production " ++ prod)]
+  end;
+
+}
+
+{- In the interest of improving error messages, we additionally check from production
+ - declarations, to all locally known synthesized attributes.
+ - This check is not necessary to catch additional mistakes, merely to move the error
+ - closer to the location where a fix would be requird.
+ -}
+aspect production productionDcl
+top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::ProductionBody
+{
+  -- All locally known synthesized attributes. This does not need to be exhaustive,
+  -- because this error message is a courtesy, not the basis of the analysis.
+  local attrs :: [DclInfo] = 
+    filter(isOccursSynthesized(_, top.env),
+      getAttrsOn(namedSig.outputElement.typerep.typeName, top.env));
+
+  top.errors <-
+    if null(body.errors ++ ns.errors)
+    && (top.config.warnAll || top.config.warnMissingSyn)
+    -- Forwarding productions do no have missing synthesized equations:
+    && null(body.uniqueSignificantExpression)
+    -- Otherwise, examine them all:
+    then flatMap(raiseMissingAttrs(top.location, fName, _, top.flowEnv), attrs)
+    else [];
+}
+
+{--
+ -
+ -}
+function raiseMissingAttrs
+[Message] ::= l::Location  prod::String  attr::DclInfo  e::Decorated FlowEnv
+{
+  -- Because the location is of the production, deliberately use the production's shortname
+  local shortName :: String = substring(lastIndexOf(":", prod) + 1, length(prod), prod);
+
+  local lacks_default_equation :: Boolean = 
+    null(lookupDef(attr.fullName, attr.attrOccurring, e));
+
+  local missing_explicit_equation :: Boolean =
+    case lookupSyn(prod, attr.attrOccurring, e) of
+    | eq :: _ -> false
+    | [] -> true
+    end;
+ 
+  return if lacks_default_equation && missing_explicit_equation
+  then [wrn(l, "production " ++ shortName ++ " lacks synthesized equation for " ++ attr.attrOccurring)]
+  else [];
 }
 

--- a/grammars/silver/definition/env/Env.sv
+++ b/grammars/silver/definition/env/Env.sv
@@ -192,21 +192,32 @@ function getProdAttrs
   return searchEnvScope(fnprod, e.prodOccursTree);
 }
 
--- Do not rely on this just yet, it's wonky.
--- It'll find all productions known locally to construct a nt.
--- This ought to be more limited than that... perhaps only those know to the nt declaration, or only those non-forwarding.
-function getProdsForNt
+{--
+ - Get all productions for a nonterminal known to local environment.
+ - (forwarding and non-forwarding.)
+ - Current known use cases:
+ -  1. Interference testing code generation (randomly generate trees)
+ -       - Because we test each production independently, we may not actually need this?
+ -  2. MWDA checking known forwarding productions on attribute occurrence declaration.
+ -       - We need to be able to look from forwarding to occurs, and from
+ -         occurs to forwarding to cover all cases.
+ - You should probably have a good reason for using this, and document it here if you do.
+ -}
+function getKnownProds
 [DclInfo] ::= fnnt::String e::Decorated Env
 {
   return searchEnvAll(fnnt, e.prodsForNtTree);
 }
 
+-- The list of non-forwarding productions may contain productions from `options` not
+-- imported locally, and so we must consult the "flow environment" for that information:
+--function getNonforwardingProds
 
--- It's never possible to know "all" attributes, so the next function is okay,
--- but it is possible to know all non-forwarding productions, but the normal
--- environment can't do it.  So you should consult the flow env for that info.
---function getProdsOn
-
+{--
+ - Returns all attributes known locally to occur on a nonterminal.
+ - Obviously we can never know all attributes, but we generally don't need to for
+ - any reason.
+ -}
 function getAttrsOn
 [DclInfo] ::= fnnt::String e::Decorated Env
 {

--- a/grammars/silver/definition/flow/ast/Flow.sv
+++ b/grammars/silver/definition/flow/ast/Flow.sv
@@ -10,8 +10,8 @@ grammar silver:definition:flow:ast;
  -  - extraEq (handling collections '<-')
  - which the thesis does not address.
  -}
-nonterminal FlowDef with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, prodTreeContribs, prodGraphContribs, flowEdges, refTreeContribs, localInhTreeContribs, suspectFlowEdges, extSynTreeContribs, nonSuspectContribs, localTreeContribs, specContribs;
-nonterminal FlowDefs with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, prodTreeContribs, prodGraphContribs, refTreeContribs, localInhTreeContribs, extSynTreeContribs, nonSuspectContribs, localTreeContribs, specContribs;
+nonterminal FlowDef with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, prodTreeContribs, prodGraphContribs, flowEdges, refTreeContribs, localInhTreeContribs, suspectFlowEdges, hostSynTreeContribs, nonSuspectContribs, localTreeContribs, specContribs;
+nonterminal FlowDefs with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, prodTreeContribs, prodGraphContribs, refTreeContribs, localInhTreeContribs, hostSynTreeContribs, nonSuspectContribs, localTreeContribs, specContribs;
 
 {-- lookup (production, attribute) to find synthesized equations
  - Used to ensure a necessary lhs.syn equation exists.
@@ -65,7 +65,7 @@ synthesized attribute flowEdges :: [Pair<FlowVertex FlowVertex>];
 synthesized attribute suspectFlowEdges :: [Pair<FlowVertex FlowVertex>];
 
 {-- A list of extension syn attr occurrences, subject to ft lower bounds. -}
-synthesized attribute extSynTreeContribs :: [Pair<String FlowDef>];
+synthesized attribute hostSynTreeContribs :: [Pair<String FlowDef>];
 
 {-- A list of attributes for a production that are non-suspect -}
 synthesized attribute nonSuspectContribs :: [Pair<String [String]>];
@@ -86,7 +86,7 @@ top::FlowDefs ::= h::FlowDef  t::FlowDefs
   top.refTreeContribs = h.refTreeContribs ++ t.refTreeContribs;
   top.localInhTreeContribs = h.localInhTreeContribs ++ t.localInhTreeContribs;
   top.localTreeContribs = h.localTreeContribs ++ t.localTreeContribs;
-  top.extSynTreeContribs = h.extSynTreeContribs ++ t.extSynTreeContribs;
+  top.hostSynTreeContribs = h.hostSynTreeContribs ++ t.hostSynTreeContribs;
   top.nonSuspectContribs = h.nonSuspectContribs ++ t.nonSuspectContribs;
   top.specContribs = h.specContribs ++ t.specContribs;
 }
@@ -104,7 +104,7 @@ top::FlowDefs ::=
   top.refTreeContribs = [];
   top.localInhTreeContribs = [];
   top.localTreeContribs = [];
-  top.extSynTreeContribs = [];
+  top.hostSynTreeContribs = [];
   top.nonSuspectContribs = [];
   top.specContribs = [];
 }
@@ -127,7 +127,7 @@ top::FlowDef ::=
   top.refTreeContribs = [];
   top.localInhTreeContribs = [];
   top.localTreeContribs = [];
-  top.extSynTreeContribs = [];
+  top.hostSynTreeContribs = [];
   top.nonSuspectContribs = [];
   top.specContribs = [];
   top.suspectFlowEdges = []; -- flowEdges is required, but suspect is typically not!
@@ -150,16 +150,17 @@ top::FlowDef ::= nt::String  prod::String
 }
 
 {--
- - Declaration that a synthesized attribute *occurrence* is not in the host
- - and therefore subject to the forward flow type's whims. (i.e. must be ft(syn) >= ft(fwd))
+ - Declaration that a synthesized attribute occurrence is in the host language
+ - (exported by the nonterminal) and therefore is *NOT* subject to the restriction
+ - for extensions synthesized attributes (i.e. must be ft(syn) >= ft(fwd)).
  -
  - @param nt  the full name of the nonterminal
  - @param attr  the full name of the synthesized attribute
  -}
-abstract production extSynFlowDef
+abstract production hostSynFlowDef
 top::FlowDef ::= nt::String  attr::String
 {
-  top.extSynTreeContribs = [pair(nt, top)];
+  top.hostSynTreeContribs = [pair(nt, top)];
   top.prodGraphContribs = [];
   top.flowEdges = error("Internal compiler error: this sort of def should not be in a context where edges are requested.");
 }

--- a/grammars/silver/definition/flow/driver/FlowGraph.sv
+++ b/grammars/silver/definition/flow/driver/FlowGraph.sv
@@ -23,12 +23,31 @@ function expandGraph
 [FlowVertex] ::= v::[FlowVertex]  e::ProductionGraph
 {
   -- look up each vertex, uniq it down.
-  return set:toList(set:add(v, foldr(set:union, set:empty(compareFlowVertex), map(e.edgeMap, v))));
+  local initial :: set:Set<FlowVertex> =
+    set:add(v, foldr(set:union, set:empty(compareFlowVertex), map(e.edgeMap, v)));
+
+  return set:toList(expandSuspectEdges(set:toList(initial), initial, e));
 }
 function onlyLhsInh
 set:Set<String> ::= s::[FlowVertex]
 {
   return set:add(filterLhsInh(s), set:empty(compareString));
+}
+
+-- suspect edges are not in the standard graph, so iteratively add them
+-- call like expandSuspectEdges(p.edges.toList, p.edges, p)
+function expandSuspectEdges
+set:Set<FlowVertex> ::= todolist::[FlowVertex]  current::set:Set<FlowVertex>  p::ProductionGraph
+{
+  -- examine this flow vertex
+  local thisvertex :: FlowVertex = head(todolist);
+  -- get any suspect edges from this vertex
+  local result :: [FlowVertex] = p.suspectEdgeMap(thisvertex);
+  -- remove anything we're already considering/considered
+  local filtered :: [FlowVertex] = filter(\v::FlowVertex -> !set:contains(v, current), result);
+  
+  return if null(todolist) then current
+  else expandSuspectEdges(tail(todolist) ++ filtered, set:add(filtered, current), p);
 }
 
 {--

--- a/grammars/silver/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/definition/flow/env/FlowEnv.sv
@@ -8,7 +8,7 @@ imports silver:definition:core;
 autocopy attribute flowEnv :: Decorated FlowEnv;
 synthesized attribute flowDefs :: [FlowDef];
 
-nonterminal FlowEnv with synTree, inhTree, defTree, fwdTree, prodTree, fwdInhTree, refTree, localInhTree, localTree, nonSuspectTree, extSynTree, specTree, prodGraphTree;
+nonterminal FlowEnv with synTree, inhTree, defTree, fwdTree, prodTree, fwdInhTree, refTree, localInhTree, localTree, nonSuspectTree, hostSynTree, specTree, prodGraphTree;
 
 inherited attribute synTree :: EnvTree<FlowDef>;
 inherited attribute inhTree :: EnvTree<FlowDef>;
@@ -20,7 +20,7 @@ inherited attribute refTree :: EnvTree<FlowDef>;
 inherited attribute localInhTree ::EnvTree<FlowDef>;
 inherited attribute localTree :: EnvTree<FlowDef>;
 inherited attribute nonSuspectTree :: EnvTree<[String]>;
-inherited attribute extSynTree :: EnvTree<FlowDef>;
+inherited attribute hostSynTree :: EnvTree<FlowDef>;
 inherited attribute specTree :: EnvTree<Pair<String [String]>>;
 inherited attribute prodGraphTree :: EnvTree<FlowDef>;
 
@@ -44,7 +44,7 @@ Decorated FlowEnv ::= d::FlowDefs
   e.localInhTree = directBuildTree(d.localInhTreeContribs);
   e.localTree = directBuildTree(d.localTreeContribs);
   e.nonSuspectTree = directBuildTree(d.nonSuspectContribs);
-  e.extSynTree = directBuildTree(d.extSynTreeContribs);
+  e.hostSynTree = directBuildTree(d.hostSynTreeContribs);
   e.specTree = directBuildTree(d.specContribs);
   e.prodGraphTree = directBuildTree(d.prodGraphContribs);
   
@@ -101,7 +101,7 @@ function lookupLocalEq
 }
 
 -- all (non-forwarding) productions constructing a nonterminal
-function getProdsOn
+function getNonforwardingProds
 [FlowDef] ::= nt::String  e::Decorated FlowEnv
 {
   return searchEnvTree(nt, e.prodTree);
@@ -122,11 +122,20 @@ function getNonSuspectAttrsForProd
 }
 
 -- Ext Syns subject to ft lower bound
-function getExtSynsFor
-[FlowDef] ::= nt::String  e::Decorated FlowEnv
+function getHostSynsFor
+[String] ::= nt::String  e::Decorated FlowEnv
 {
-  return searchEnvTree(nt, e.extSynTree);
+  return map(extractHostSynName, searchEnvTree(nt, e.hostSynTree));
 }
+-- Helper for above
+function extractHostSynName
+String ::= f::FlowDef
+{
+  return case f of
+  | hostSynFlowDef(_, at) -> at
+  end;
+}
+
 
 -- Get syns (and "forward") that have flow types specified
 function getSpecifiedSynsForNt

--- a/grammars/silver/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/definition/flow/env/FlowEnv.sv
@@ -100,13 +100,6 @@ function lookupLocalEq
   return searchEnvTree(crossnames(prod, fName), e.localTree);
 }
 
--- all (non-forwarding) productions constructing a nonterminal
-function getNonforwardingProds
-[FlowDef] ::= nt::String  e::Decorated FlowEnv
-{
-  return searchEnvTree(nt, e.prodTree);
-}
-
 -- "blessed set" of inherited attribute required/assumed to exist for references
 function getInhsForNtRef
 [FlowDef] ::= nt::String  e::Decorated FlowEnv
@@ -121,21 +114,25 @@ function getNonSuspectAttrsForProd
   return concat(searchEnvTree(prod, e.nonSuspectTree));
 }
 
+-- all (non-forwarding) productions constructing a nonterminal
+function getNonforwardingProds
+[String] ::= nt::String  e::Decorated FlowEnv
+{
+  local extractProdName :: (String ::= FlowDef) =
+    \p::FlowDef -> case p of prodFlowDef(_, p) -> p end;
+
+  return map(extractProdName, searchEnvTree(nt, e.prodTree));
+}
+
 -- Ext Syns subject to ft lower bound
 function getHostSynsFor
 [String] ::= nt::String  e::Decorated FlowEnv
 {
+  local extractHostSynName :: (String ::= FlowDef) =
+    \f::FlowDef -> case f of hostSynFlowDef(_, at) -> at end;
+
   return map(extractHostSynName, searchEnvTree(nt, e.hostSynTree));
 }
--- Helper for above
-function extractHostSynName
-String ::= f::FlowDef
-{
-  return case f of
-  | hostSynFlowDef(_, at) -> at
-  end;
-}
-
 
 -- Get syns (and "forward") that have flow types specified
 function getSpecifiedSynsForNt

--- a/grammars/silver/definition/flow/env/Occurs.sv
+++ b/grammars/silver/definition/flow/env/Occurs.sv
@@ -10,11 +10,11 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
   local isHost :: Boolean = isExportedBy(top.grammarName, [nt.lookupType.dcl.sourceGrammar], top.compiledGrammars);
   local isSyn :: Boolean = at.lookupAttribute.dcl.isSynthesized;
 
-  -- Rule: non-host synthesized attributes' flow type must be a super set of that for the forward.
+  -- We must be able to identify host-language synthesized attributes from the flow environment
   top.flowDefs = 
-    if !at.lookupAttribute.found || !nt.lookupType.found || isHost || !isSyn then 
+    if !at.lookupAttribute.found || !nt.lookupType.found || !isHost || !isSyn then 
       []
     else
-      [extSynFlowDef(nt.lookupType.fullName, at.lookupAttribute.fullName)];
+      [hostSynFlowDef(nt.lookupType.fullName, at.lookupAttribute.fullName)];
 }
 

--- a/grammars/silver/driver/util/ModuleGraph.sv
+++ b/grammars/silver/driver/util/ModuleGraph.sv
@@ -176,7 +176,7 @@ function completeDependencyClosure
 {
   local n :: [String] = rem(makeSet(flatMap(skipNulls((.moduleNames), _), map(searchEnvTree(_, e), init))), init);
   
-  return if null(n) then init
+  return if null(n) then computeOptionalDeps(init, e)
   else completeDependencyClosure(computeOptionalDeps(n ++ init, e), e);
 }
 

--- a/grammars/silver/extension/treegen/Arbitrary.sv
+++ b/grammars/silver/extension/treegen/Arbitrary.sv
@@ -50,7 +50,7 @@ AGDcl ::= id::QName  env::Decorated Env
   
   local prods :: [DclInfo] = 
     sortBy(prodDclInfoNumChildLte,
-      getProdsForNt(id.lookupType.fullName, env));
+      getKnownProds(id.lookupType.fullName, env));
   
   local num_lowest_arity :: Integer = length(takeWhile2(prodDclInfoNumChildEq, prods));
   

--- a/grammars/silver/extension/treegen/Eq.sv
+++ b/grammars/silver/extension/treegen/Eq.sv
@@ -35,7 +35,7 @@ AGDcl ::= id::QName  env::Decorated Env  fenv::Decorated FlowEnv
   
   local l :: Location = id.location;
   
-  local prods :: [DclInfo] = filter(nonforwardingProd(_, fenv), getProdsForNt(id.lookupType.fullName, env));
+  local prods :: [DclInfo] = filter(nonforwardingProd(_, fenv), getKnownProds(id.lookupType.fullName, env));
 
   local sig :: FunctionSignature =
     functionSignature(

--- a/grammars/silver/extension/treegen/TestFor.sv
+++ b/grammars/silver/extension/treegen/TestFor.sv
@@ -16,7 +16,7 @@ top::AGDcl ::= 'testFor' testSuite::Name ':' n::Name '::' id::QName ',' e::Expr 
 
 
   -- all known productions, including forwarding ones
-  local prods :: [DclInfo] = getProdsForNt(id.lookupType.fullName, top.env);
+  local prods :: [DclInfo] = getKnownProds(id.lookupType.fullName, top.env);
 
   local l :: Location = top.location;
   local generatedName :: String = "checkPropOn" ++ id.name ++ toString(genInt());


### PR DESCRIPTION
Fixes #279 

The flow environment should maintain an authoritative list of host language attributes (those that may have flow type more restricted than forwarding). Previously we assumed that we could check from forwarding production and occurrences to see them all, this assumption proved false in the face of options. After thinking on it a bit, we can check ONLY from forwarding productions, given all privileged attributes. So let's do that.

Also cleans up a lot of old code, comments things, improves quality of error messages.