### PR TITLE
A fix to file IO, discovered after profiling

### DIFF
--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -354,17 +354,13 @@ public final class Util {
 	 * <p>Avoids demanding a StringCatter.
 	 *
 	 * @param file The filename
-	 * @param content Either a String or {@link StringCatter} object.
+	 * @param content A {@link StringCatter} object.
 	 * @return singleton IO token.
 	 */
 	public static IOToken writeFile(String file, Object content) {
 		try {
-			Writer fout = new FileWriter(file); // already buffered
-			if(content instanceof StringCatter)
-				((StringCatter)content).write(fout);
-			else
-				fout.write(content.toString());
-			fout.flush();
+			Writer fout = new BufferedWriter(new FileWriter(file));
+			((StringCatter)content).write(fout);
 			fout.close();
 			return IOToken.singleton;
 		} catch (Exception e) {
@@ -378,17 +374,13 @@ public final class Util {
 	 * <p>Avoids demanding a StringCatter.
 	 *
 	 * @param file The filename
-	 * @param content Either a String or {@link StringCatter} object.
+	 * @param content A {@link StringCatter} object.
 	 * @return singleton IO token.
 	 */
 	public static IOToken appendFile(String file, Object content) { // TODO: merge with above!
 		try {
-			Writer fout = new FileWriter(file, true); // already buffered
-			if(content instanceof StringCatter)
-				((StringCatter)content).write(fout);
-			else
-				fout.write(content.toString());
-			fout.flush();
+			Writer fout = new BufferedWriter(new FileWriter(file, true));
+			((StringCatter)content).write(fout);
 			fout.close();
 			return IOToken.singleton;
 		} catch (Exception e) {

--- a/support/profile/run.sh
+++ b/support/profile/run.sh
@@ -9,3 +9,13 @@ mkdir -p build
 cd build
 
 java -Xss8M -Xmx3000M -Xrunhprof:heap=sites,cpu=samples -jar ../jars/silver.composed.Default.jar --clean silver:composed:Default
+
+# Heap profile:
+#java -Xss8M -Xmx3000M -Xrunhprof:heap=sites,depth=2 -jar ../jars/silver.composed.Default.jar --clean silver:composed:Default
+
+# Deep CPU stack profile:
+#java -Xss8M -Xmx3000M -Xrunhprof:cpu=samples,depth=12 -jar ../jars/silver.composed.Default.jar --clean silver:composed:Default
+
+# Kinda useless CPU profile
+#java -Xss8M -Xmx3000M -Xrunhprof:cpu=samples,depth=1,interval=1 -jar ../jars/silver.composed.Default.jar --clean silver:composed:Default
+


### PR DESCRIPTION
Oddly enough, this doesn't improve performance in any noticeable way. I suspect we have enough other allocation/GC issues that the time saved on I/O isn't much. But still, this is less egregious behavior.

Turns out that "already buffered" comment is LIES