### PR TITLE
Implement disambiguation classes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ melt.trynode('silver') {
       }
     }
     // If requested, go download the latest Copper jars and use them instead of the archived/provided ones
-    if (params.FETCH_COPPER_JARS) {
+    if (params.FETCH_COPPER_JARS == 'yes') {
       echo "Fetching lastest Copper jars"
       melt.annotate("Fetched Copper jars.")
       sh "./fetch-jars --copper"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,12 @@ melt.trynode('silver') {
         }
       }
     }
+    // If requested, go download the latest Copper jars and use them instead of the archived/provided ones
+    if (params.FETCH_COPPER_JARS) {
+      echo "Fetching lastest Copper jars"
+      melt.annotate("Fetched Copper jars.")
+      sh "./fetch-jars --copper"
+    }
     // Build
     sh "./deep-rebuild"
     // Clean (but leave generated files)

--- a/grammars/core/TerminalId.sv
+++ b/grammars/core/TerminalId.sv
@@ -1,0 +1,7 @@
+grammar core;
+
+function terminalIdEq
+Boolean ::= t1::TerminalId  t2::TerminalId
+{
+  return t1 == t2;
+}

--- a/grammars/silver/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/analysis/typechecking/core/Expr.sv
@@ -296,7 +296,7 @@ top::Expr ::= e1::Expr '>' e2::Expr
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceOrd
        then []
-       else [err(top.location, "Operands to > must be concrete types Integer, Float, or String.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+       else [err(top.location, "Operands to > must be concrete types Integer, Float, String or TerminalId.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 aspect production lt
@@ -318,7 +318,7 @@ top::Expr ::= e1::Expr '<' e2::Expr
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceOrd
        then []
-       else [err(top.location, "Operands to < must be concrete types Integer, Float, or String.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+       else [err(top.location, "Operands to < must be concrete types Integer, Float, String or TerminalId.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 
@@ -341,7 +341,7 @@ top::Expr ::= e1::Expr '>=' e2::Expr
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceOrd
        then []
-       else [err(top.location, "Operands to >= must be concrete types Integer, Float, or String.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+       else [err(top.location, "Operands to >= must be concrete types Integer, Float, String or TerminalId.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 
@@ -364,7 +364,7 @@ top::Expr ::= e1::Expr '<=' e2::Expr
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceOrd
        then []
-       else [err(top.location, "Operands to <= must be concrete types Integer, Float, or String.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+       else [err(top.location, "Operands to <= must be concrete types Integer, Float, String or TerminalId.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 
@@ -387,7 +387,7 @@ top::Expr ::= e1::Expr '==' e2::Expr
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceEq
        then []
-       else [err(top.location, "Operands to == must be concrete types Boolean, Integer, Float, or String.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+       else [err(top.location, "Operands to == must be concrete types Boolean, Integer, Float, String or TerminalId.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 
@@ -410,7 +410,7 @@ top::Expr ::= e1::Expr '!=' e2::Expr
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceEq
        then []
-       else [err(top.location, "Operands to != must be concrete types Boolean, Integer, Float, or String.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+       else [err(top.location, "Operands to != must be concrete types Boolean, Integer, Float, String or TerminalId.  Instead they are of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 

--- a/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
@@ -122,8 +122,8 @@ s"""    <Layout>${univLayout}</Layout>
       ${s2.xmlCopper}
 """ ++
 -- Disambiguation classes
+implode("\n", map((.xmlCopper), s2.disambiguationClasses)) ++
 s"""
-      ${implode("\n", map(snd, s2.disambiguationClasses))}
     </Declarations>
   </Grammar>
 </CopperSpec>""";

--- a/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
@@ -24,6 +24,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   s.cstNTProds = directBuildTree(s.cstProds);
   s.containingGrammar = "host";
   s.univLayout = error("TODO: make this environment not be decorated?"); -- TODO
+  s.classTerminals = error("TODO: shouldn't by necessary to normalize"); -- TODO
   s.prefixesForTerminals = error("TODO: shouldn't by necessary to normalize"); -- TODO
   
   -- Move productions under their nonterminal, and sort the declarations
@@ -32,6 +33,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   s2.cstEnv = directBuildTree(s.cstDcls);
   s2.containingGrammar = "host";
   s2.cstNTProds = error("TODO: make this environment not be decorated?"); -- TODO
+  s2.classTerminals = directBuildTree(s.classTerminalContribs);
   s2.prefixesForTerminals = directBuildTree(terminalPrefixes);
   
   -- This should be on s1, because the s2 transform assumes everything is well formed.

--- a/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
@@ -52,7 +52,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   top.xmlCopper =
 s"""<?xml version="1.0" encoding="UTF-8"?>
 
-<CopperSpec xmlns="http://melt.cs.umn.edu/copper/xmlns">
+<CopperSpec xmlns="http://melt.cs.umn.edu/copper/xmlns/skins/xml/0.9">
   <Parser id="${makeCopperName(parsername)}" isUnitary="true">
     <PP>${parsername}</PP>
     <Grammars><GrammarRef id="${s2.containingGrammar}"/></Grammars>

--- a/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
@@ -119,7 +119,11 @@ s"""    <Layout>${univLayout}</Layout>
         <Type><![CDATA[common.DecoratedNode]]></Type>
         <Code><![CDATA[context = common.TopNode.singleton;]]></Code>
       </ParserAttribute>
-       ${s2.xmlCopper}
+      ${s2.xmlCopper}
+""" ++
+-- Disambiguation classes
+s"""
+      ${implode("\n", map(snd, s2.disambiguationClasses))}
     </Declarations>
   </Grammar>
 </CopperSpec>""";

--- a/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -24,6 +24,7 @@ abstract production nilLexerClassMod
 top::SyntaxLexerClassModifiers ::= 
 {
   top.cstErrors := [];
+  top.xmlCopper = "";
   top.dominatesXML = "";
   top.submitsXML = "";
 }
@@ -87,7 +88,7 @@ top::SyntaxLexerClassModifier ::= acode::String
 
   top.cstErrors := []; -- TODO: Check for duplicate disambiguation for a lexer class
   top.xmlCopper = s"""
-  <DisambiguationFunction id="${makeCopperName(top.className)}" appliesToSubsets="true">
+  <DisambiguationFunction id="disambiguate_${makeCopperName(top.className)}" applicableToSubsets="true">
     <Members>${implode("", map(xmlCopperRef, map(head, trefs)))}</Members>
     <Code><![CDATA[
 ${acode}

--- a/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -91,7 +91,11 @@ top::SyntaxLexerClassModifier ::= acode::String
   <DisambiguationFunction id="disambiguate_${makeCopperName(top.className)}" applicableToSubsets="true">
     <Members>${implode("", map(xmlCopperRef, map(head, trefs)))}</Members>
     <Code><![CDATA[
-common.ConsCell shiftableList = common.Util.bitSetToList(shiftable);
+common.ConsCell tempShiftableList = common.ConsCell.nil;
+for (int i = nextMember(0, shiftable); i >= 0; i = nextMember(i+1, shiftable)) {
+	tempShiftableList = new common.ConsCell(i, tempShiftableList);
+}
+final common.ConsCell shiftableList = tempShiftableList;
 ${acode}
     ]]></Code>
   </DisambiguationFunction>

--- a/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -91,6 +91,7 @@ top::SyntaxLexerClassModifier ::= acode::String
   <DisambiguationFunction id="disambiguate_${makeCopperName(top.className)}" applicableToSubsets="true">
     <Members>${implode("", map(xmlCopperRef, map(head, trefs)))}</Members>
     <Code><![CDATA[
+common.ConsCell shiftableList = common.Util.bitSetToList(shiftable);
 ${acode}
     ]]></Code>
   </DisambiguationFunction>

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -18,6 +18,7 @@ autocopy attribute classTerminals::EnvTree<String>;
 
 synthesized attribute allIgnoreTerminals :: [Decorated SyntaxDcl];
 synthesized attribute allMarkingTerminals :: [Decorated SyntaxDcl];
+synthesized attribute disambiguationClasses :: [Pair<String String>];
 autocopy attribute univLayout :: String;
 synthesized attribute classDomContribs :: String;
 synthesized attribute classSubContribs :: String;
@@ -29,7 +30,7 @@ autocopy attribute prefixesForTerminals :: EnvTree<String>;
 {--
  - An abstract syntax tree for representing concrete syntax.
  -}
-nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allIgnoreTerminals, allMarkingTerminals, classTerminalContribs, classTerminals, univLayout, xmlCopper, containingGrammar, prefixesForTerminals;
+nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, univLayout, xmlCopper, containingGrammar, prefixesForTerminals;
 
 abstract production nilSyntax
 top::Syntax ::=
@@ -40,6 +41,7 @@ top::Syntax ::=
   top.cstNormalize = [];
   top.allIgnoreTerminals = [];
   top.allMarkingTerminals = [];
+  top.disambiguationClasses = [];
   top.classTerminalContribs = [];
   top.xmlCopper = "";
 }
@@ -52,6 +54,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
   top.cstNormalize = s1.cstNormalize ++ s2.cstNormalize;
   top.allIgnoreTerminals = s1.allIgnoreTerminals ++ s2.allIgnoreTerminals;
   top.allMarkingTerminals = s1.allMarkingTerminals ++ s2.allMarkingTerminals;
+  top.disambiguationClasses = s1.disambiguationClasses ++ s2.disambiguationClasses;
   top.classTerminalContribs = s1.classTerminalContribs ++ s2.classTerminalContribs;
   top.xmlCopper = s1.xmlCopper ++ s2.xmlCopper;
 }
@@ -59,7 +62,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, sortKey, allIgnoreTerminals, allMarkingTerminals, classTerminalContribs, classTerminals, univLayout, xmlCopper, classDomContribs, classSubContribs, containingGrammar, prefixesForTerminals;
+nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, sortKey, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, univLayout, xmlCopper, classDomContribs, classSubContribs, containingGrammar, prefixesForTerminals;
 
 synthesized attribute sortKey :: String;
 
@@ -69,6 +72,7 @@ top::SyntaxDcl ::=
   top.cstProds = [];
   top.allIgnoreTerminals = [];
   top.allMarkingTerminals = [];
+  top.disambiguationClasses = [];
   top.classTerminalContribs = [];
   top.classDomContribs = error("Internal compiler error: should only ever be demanded of lexer classes");
   top.classSubContribs = error("Internal compiler error: should only ever be demanded of lexer classes");
@@ -280,10 +284,10 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
   top.classSubContribs = modifiers.submitsXML;
 
   top.cstNormalize = [top];
+  top.disambiguationClasses = modifiers.disambiguationClasses;
 
   top.xmlCopper =
-    "  <TerminalClass id=\"" ++ makeCopperName(n) ++ "\" />\n" ++
-    modifiers.xmlCopper;
+    "  <TerminalClass id=\"" ++ makeCopperName(n) ++ "\" />\n";
 }
 
 {--

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -203,6 +203,8 @@ top::SyntaxDcl ::= ns::NamedSignature  modifiers::SyntaxProductionModifiers
     "    <Precedence>" ++ toString(modifiers.productionPrecedence.fromJust) ++ "</Precedence>\n"
     else "") ++
     "    <Code><![CDATA[\n" ++
+    -- Annoying workaround for if a lambda in an action block needs to capture RESULT when accessing a child.
+    -- Java complains when we capture something that is non-final.
     "final " ++ makeClassName(ns.fullName) ++ " RESULTfinal = new " ++ makeClassName(ns.fullName) ++ "(" ++ fetchChildren(0, ns.inputElements) ++ insertLocationAnnotation(ns) ++ ");\n" ++
     "RESULT = RESULTfinal;\n" ++
       modifiers.acode ++

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -138,7 +138,6 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
     "    <Regex>" ++ regex.xmlCopper ++ "</Regex>\n" ++
     (if modifiers.opPrecedence.isJust || modifiers.opAssociation.isJust then
     "    <Operator>\n" ++
---    "      <Class><OperatorClassRef id=\"main\"/></Class>\n" ++
     "      <Precedence>" ++ toString(fromMaybe(0, modifiers.opPrecedence)) ++ "</Precedence>\n" ++
     "      " ++ convertAssocNXML(modifiers.opAssociation) ++ "\n" ++ -- TODO
     "    </Operator>\n"

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -203,7 +203,8 @@ top::SyntaxDcl ::= ns::NamedSignature  modifiers::SyntaxProductionModifiers
     "    <Precedence>" ++ toString(modifiers.productionPrecedence.fromJust) ++ "</Precedence>\n"
     else "") ++
     "    <Code><![CDATA[\n" ++
-    "RESULT = new " ++ makeClassName(ns.fullName) ++ "(" ++ fetchChildren(0, ns.inputElements) ++ insertLocationAnnotation(ns) ++ ");\n" ++
+    "final " ++ makeClassName(ns.fullName) ++ " RESULTfinal = new " ++ makeClassName(ns.fullName) ++ "(" ++ fetchChildren(0, ns.inputElements) ++ insertLocationAnnotation(ns) ++ ");\n" ++
+    "RESULT = RESULTfinal;\n" ++
       modifiers.acode ++
     "]]></Code>\n" ++
     "    <LHS>" ++ xmlCopperRef(head(lhsRef)) ++ "</LHS>\n" ++

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -18,7 +18,7 @@ autocopy attribute classTerminals::EnvTree<String>;
 
 synthesized attribute allIgnoreTerminals :: [Decorated SyntaxDcl];
 synthesized attribute allMarkingTerminals :: [Decorated SyntaxDcl];
-synthesized attribute disambiguationClasses :: [Pair<String String>];
+synthesized attribute disambiguationClasses :: [Decorated SyntaxDcl];
 autocopy attribute univLayout :: String;
 synthesized attribute classDomContribs :: String;
 synthesized attribute classSubContribs :: String;
@@ -320,7 +320,7 @@ top::SyntaxDcl ::= n::String ty::Type acode::String
  - The acode distinguished between the listed terminals.
  -}
 abstract production syntaxDisambiguationGroup
-top::SyntaxDcl ::= n::String terms::[String] acode::String
+top::SyntaxDcl ::= n::String terms::[String] applicableToSubsets::Boolean acode::String
 {
   top.sortKey = "DDD" ++ n;
   top.cstDcls = [];
@@ -338,7 +338,7 @@ top::SyntaxDcl ::= n::String terms::[String] acode::String
   top.cstNormalize = [top];
 
   top.xmlCopper =
-    "  <DisambiguationFunction id=\"" ++ makeCopperName(n) ++ "\">\n" ++
+    "  <DisambiguationFunction id=\"" ++ makeCopperName(n) ++ "\" applicableToSubsets=\"" ++ toString(applicableToSubsets) ++ "\">\n" ++
     "    <Members>" ++ implode("", map(xmlCopperRef, map(head, trefs))) ++ "</Members>\n" ++
     "    <Code><![CDATA[\n" ++
     acode ++
@@ -368,6 +368,7 @@ String ::= d::Decorated SyntaxDcl
   | syntaxTerminal(n, _, _) -> "<TerminalRef id=\"" ++ makeCopperName(n) ++ "\" grammar=\"" ++ d.containingGrammar ++ "\" />"
   | syntaxNonterminal(n, _) -> "<NonterminalRef id=\"" ++ makeCopperName(n.typeName) ++ "\" grammar=\"" ++ d.containingGrammar ++ "\" />"
   | syntaxProduction(ns, _) -> "<ProductionRef id=\"" ++ makeCopperName(ns.fullName) ++ "\" grammar=\"" ++ d.containingGrammar ++ "\" />"
+  | syntaxDisambiguationGroup(n, _, _, _) -> "<DisambiguationFunctionRef id=\"" ++ makeCopperName(n) ++ "\" grammar=\"" ++ d.containingGrammar ++ "\" />"
   end;
 }
 

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -134,7 +134,7 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
     "    <Regex>" ++ regex.xmlCopper ++ "</Regex>\n" ++
     (if modifiers.opPrecedence.isJust || modifiers.opAssociation.isJust then
     "    <Operator>\n" ++
-    "      <Class>main</Class>\n" ++
+--    "      <Class><OperatorClassRef id=\"main\"/></Class>\n" ++
     "      <Precedence>" ++ toString(fromMaybe(0, modifiers.opPrecedence)) ++ "</Precedence>\n" ++
     "      " ++ convertAssocNXML(modifiers.opAssociation) ++ "\n" ++ -- TODO
     "    </Operator>\n"
@@ -199,7 +199,7 @@ top::SyntaxDcl ::= ns::NamedSignature  modifiers::SyntaxProductionModifiers
   top.xmlCopper =
     "  <Production id=\"" ++ makeCopperName(ns.fullName) ++ "\">\n" ++
     (if modifiers.productionPrecedence.isJust then
-    "    <Class>main</Class>\n" ++
+--    "    <Class><OperatorClassRef id=\"main\"/></Class>\n" ++
     "    <Precedence>" ++ toString(modifiers.productionPrecedence.fromJust) ++ "</Precedence>\n"
     else "") ++
     "    <Code><![CDATA[\n" ++

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -279,7 +279,8 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
   top.cstNormalize = [top];
 
   top.xmlCopper =
-    "  <TerminalClass id=\"" ++ makeCopperName(n) ++ "\" />\n";
+    "  <TerminalClass id=\"" ++ makeCopperName(n) ++ "\" />\n" ++
+    modifiers.xmlCopper;
 }
 
 {--

--- a/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -14,7 +14,7 @@ autocopy attribute terminalName :: String;
 {--
  - Modifiers for terminals.
  -}
-nonterminal SyntaxTerminalModifiers with cstEnv, cstErrors, dominatesXML,
+nonterminal SyntaxTerminalModifiers with cstEnv, cstErrors, classTerminalContribs, dominatesXML,
   submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation,
   marking, terminalName, prettyName;
 
@@ -22,6 +22,7 @@ abstract production consTerminalMod
 top::SyntaxTerminalModifiers ::= h::SyntaxTerminalModifier  t::SyntaxTerminalModifiers
 {
   top.cstErrors := h.cstErrors ++ t.cstErrors;
+  top.classTerminalContribs = h.classTerminalContribs ++ t.classTerminalContribs;
   top.dominatesXML = h.dominatesXML ++ t.dominatesXML;
   top.submitsXML = h.submitsXML ++ t.submitsXML;
   top.lexerclassesXML = h.lexerclassesXML ++ t.lexerclassesXML;
@@ -37,6 +38,7 @@ abstract production nilTerminalMod
 top::SyntaxTerminalModifiers ::= 
 {
   top.cstErrors := [];
+  top.classTerminalContribs = [];
   top.dominatesXML = "";
   top.submitsXML = "";
   top.lexerclassesXML = "";
@@ -53,7 +55,7 @@ top::SyntaxTerminalModifiers ::=
 {--
  - Modifiers for terminals.
  -}
-nonterminal SyntaxTerminalModifier with cstEnv, cstErrors, dominatesXML,
+nonterminal SyntaxTerminalModifier with cstEnv, cstErrors, classTerminalContribs, dominatesXML,
   submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation,
   marking, terminalName, prettyName;
 
@@ -62,6 +64,7 @@ aspect default production
 top::SyntaxTerminalModifier ::=
 {
   top.cstErrors := [];
+  top.classTerminalContribs = [];
   top.dominatesXML = "";
   top.submitsXML = "";
   top.lexerclassesXML = "";
@@ -129,6 +132,7 @@ top::SyntaxTerminalModifier ::= cls::[String]
                      else ["Lexer Class " ++ a.fst ++ " was referenced but " ++
                            "this grammar was not included in this parser. (Referenced from lexer class on terminal " ++ top.terminalName ++")"], 
                    zipWith(pair, cls, clsRefsL)); 
+  top.classTerminalContribs = map(pair(_, top.terminalName), cls);
   -- We "translate away" lexer classes dom/sub, by moving that info to the terminals (here)
   top.dominatesXML = implode("", map((.classDomContribs), clsRefs));
   top.submitsXML = implode("", map((.classSubContribs), clsRefs));

--- a/grammars/silver/definition/core/DclInfo.sv
+++ b/grammars/silver/definition/core/DclInfo.sv
@@ -1,6 +1,7 @@
 grammar silver:definition:core;
 
 import silver:definition:regex;  -- soley for Terms. TODO : fix?
+import silver:modification:copper only terminalIdReference;
 
 {--
  - The production a variable reference should forward to for this type of value
@@ -129,3 +130,8 @@ top::DclInfo ::= sg::String sl::Location ty::Type
   top.defLHSDispatcher = forwardDefLHS(_, location=_);
 }
 
+aspect production termDcl
+top::DclInfo ::= sg::String sl::Location fn::String regex::Regex
+{
+  top.refDispatcher = terminalIdReference(_, location=_);
+}

--- a/grammars/silver/definition/core/Type.sv
+++ b/grammars/silver/definition/core/Type.sv
@@ -66,6 +66,13 @@ top::Type ::=
   top.appendDispatcher = stringPlusPlus(_, _, location=_);
 }
 
+aspect production terminalIdType
+top::Type ::=
+{
+  top.instanceEq = true;
+  top.instanceOrd = true;
+}
+
 aspect production nonterminalType
 top::Type ::= fn::String params::[Type]
 {

--- a/grammars/silver/definition/env/Defs.sv
+++ b/grammars/silver/definition/env/Defs.sv
@@ -71,6 +71,13 @@ top::Def ::= d::EnvItem
   top.dcl = d.dcl;
   top.valueList = [d];
 }
+abstract production typeValueDef
+top::Def ::= d::EnvItem
+{
+  top.dcl = d.dcl;
+  top.typeList = [d];
+  top.valueList = [d];
+}
 abstract production attrDef
 top::Def ::= d::EnvItem
 {
@@ -97,7 +104,6 @@ top::Def ::= d::DclInfo
   top.dcl = d;
   top.occursList = [d];
 }
-
 
 
 function childDef
@@ -143,7 +149,8 @@ Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
 function termDef
 Def ::= sg::String  sl::Location  fn::String  regex::Regex
 {
-  return typeDef(defaultEnvItem(termDcl(sg,sl,fn,regex)));
+  -- Terminals are also in the value namespace as terminal identifiers
+  return typeValueDef(defaultEnvItem(termDcl(sg,sl,fn,regex)));
 }
 function lexTyVarDef
 Def ::= sg::String  sl::Location  fn::String  ty::Type
@@ -217,6 +224,7 @@ Boolean ::= fn::(Boolean ::= EnvItem)  d::Def
   return case d of
   | valueDef(ei) -> fn(ei)
   | typeDef(ei) -> fn(ei)
+  | typeValueDef(ei) -> fn(ei)
   | attrDef(ei) -> fn(ei)
   | prodDclDef(ei) -> fn(ei)
   | _ -> true -- preserve all others for now (legit don't consider occurs, pa)
@@ -228,6 +236,7 @@ Def ::= fn::(EnvItem ::= EnvItem)  d::Def
   return case d of
   | valueDef(ei) -> valueDef(fn(ei))
   | typeDef(ei) -> typeDef(fn(ei))
+  | typeValueDef(ei) -> typeValueDef(fn(ei))
   | attrDef(ei) -> attrDef(fn(ei))
   | prodDclDef(ei) -> prodDclDef(fn(ei))
   | _ -> d -- ditto

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -614,6 +614,13 @@ top::Expr ::= q::Decorated QName
   top.flowDefs = [];
 }
 
+aspect production terminalIdReference
+top::Expr ::= q::Decorated QName
+{
+  top.flowDeps = [];
+  top.flowDefs = [];
+}
+
 aspect production parserAttributeReference
 top::Expr ::= q::Decorated QName
 {

--- a/grammars/silver/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/definition/type/PrettyPrinting.sv
@@ -61,6 +61,12 @@ top::Type ::=
   top.typepp = "String";
 }
 
+aspect production terminalIdType
+top::Type ::=
+{
+  top.typepp = "TerminalId";
+}
+
 aspect production nonterminalType
 top::Type ::= fn::String params::[Type]
 {

--- a/grammars/silver/definition/type/Substitutions.sv
+++ b/grammars/silver/definition/type/Substitutions.sv
@@ -170,6 +170,13 @@ top::Type ::=
   top.flatRenamed = top;
 }
 
+aspect production terminalIdType
+top::Type ::=
+{
+  top.substituted = top;
+  top.flatRenamed = top;
+}
+
 aspect production nonterminalType
 top::Type ::= fn::String params::[Type]
 {

--- a/grammars/silver/definition/type/Type.sv
+++ b/grammars/silver/definition/type/Type.sv
@@ -76,6 +76,8 @@ top::Type ::=
 
 {--
  - Terminal identifier type.
+ - This isn't a foreign type, since we want equality checking.
+ - TODO: Revisit this once we have type classes.
  -}
 abstract production terminalIdType
 top::Type ::=

--- a/grammars/silver/definition/type/Type.sv
+++ b/grammars/silver/definition/type/Type.sv
@@ -75,6 +75,15 @@ top::Type ::=
 }
 
 {--
+ - Terminal identifier type.
+ -}
+abstract production terminalIdType
+top::Type ::=
+{
+  top.freeVariables = [];
+}
+
+{--
  - An (undecorated) nonterminal type.
  - @param fn  The fully qualified name of the nonterminal.
  - @param params  The type parameters for that nonterminal.

--- a/grammars/silver/definition/type/Unification.sv
+++ b/grammars/silver/definition/type/Unification.sv
@@ -78,6 +78,16 @@ top::Type ::=
     end;
 }
 
+aspect production terminalIdType
+top::Type ::=
+{
+  top.unify = 
+    case top.unifyWith of
+    | terminalIdType() -> emptySubst()
+    | _ -> errorSubst("Tried to unify TerminalId with " ++ prettyType(top.unifyWith))
+    end;
+}
+
 aspect production nonterminalType
 top::Type ::= fn::String params::[Type]
 {

--- a/grammars/silver/definition/type/syntax/Terminals.sv
+++ b/grammars/silver/definition/type/syntax/Terminals.sv
@@ -1,9 +1,10 @@
 grammar silver:definition:type:syntax;
 
-terminal Boolean_tkwd    'Boolean'   lexer classes {TYPE,RESERVED};
-terminal Decorated_tkwd  'Decorated' lexer classes {TYPE,RESERVED};
-terminal Float_tkwd      'Float'     lexer classes {TYPE,RESERVED};
-terminal Integer_tkwd    'Integer'   lexer classes {TYPE,RESERVED};
-terminal String_tkwd     'String'    lexer classes {TYPE,RESERVED};
+terminal Boolean_tkwd    'Boolean'    lexer classes {TYPE,RESERVED};
+terminal Decorated_tkwd  'Decorated'  lexer classes {TYPE,RESERVED};
+terminal Float_tkwd      'Float'      lexer classes {TYPE,RESERVED};
+terminal Integer_tkwd    'Integer'    lexer classes {TYPE,RESERVED};
+terminal String_tkwd     'String'     lexer classes {TYPE,RESERVED};
+terminal TerminalId_tkwd 'TerminalId' lexer classes {TYPE,RESERVED};
 
 

--- a/grammars/silver/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/definition/type/syntax/TypeExpr.sv
@@ -105,6 +105,18 @@ top::TypeExpr ::= 'Boolean'
   top.lexicalTypeVariables = [];
 }
 
+concrete production termnalIdTypeExpr
+top::TypeExpr ::= 'TerminalId'
+{
+  top.unparse = "TerminalId";
+
+  top.typerep = terminalIdType();
+
+  top.errors := [];
+
+  top.lexicalTypeVariables = [];
+}
+
 concrete production nominalTypeExpr
 top::TypeExpr ::= q::QNameType tl::BracketedOptTypeExprs
 {

--- a/grammars/silver/modification/copper/DisambiguationGroup.sv
+++ b/grammars/silver/modification/copper/DisambiguationGroup.sv
@@ -16,6 +16,6 @@ top::AGDcl ::= 'disambiguate' terms::TermList acode::ActionCode_c
   
   acode.frame = disambiguationContext();
 
-  top.syntaxAst = [syntaxDisambiguationGroup(fName, terms.termList, acode.actionCode)];
+  top.syntaxAst = [syntaxDisambiguationGroup(fName, terms.termList, false, acode.actionCode)];
 }
 

--- a/grammars/silver/modification/copper/Env.sv
+++ b/grammars/silver/modification/copper/Env.sv
@@ -1,5 +1,7 @@
 grammar silver:modification:copper;
 
+import silver:extension:list;
+
 --------------------------------------------------------------------------------
 -- Defs.sv
 
@@ -127,6 +129,8 @@ top::QName ::= id::Name ':' qn::QName
 
 global i_lexemeVariable :: [Def] =
   [termAttrValueDef("DBGtav", bogusLoc(), "lexeme", stringType())];
+global i_shiftableVariable :: [Def] =
+  [termAttrValueDef("DBGtav", bogusLoc(), "shiftable", listType(terminalIdType()))];
 global i_locVariables :: [Def] = [
   termAttrValueDef("DBGtav", bogusLoc(), "filename", stringType()),
   termAttrValueDef("DBGtav", bogusLoc(), "line", intType()),
@@ -135,4 +139,5 @@ global i_locVariables :: [Def] = [
 global terminalActionVars :: [Def] = i_lexemeVariable ++ i_locVariables;
 global productionActionVars :: [Def] = i_locVariables;
 global disambiguationActionVars :: [Def] = i_lexemeVariable;
+global disambiguationClassActionVars :: [Def] = i_lexemeVariable ++ i_shiftableVariable;
 

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -9,7 +9,7 @@ top::Expr ::= q::Decorated QName
 
   top.typerep = q.lookupValue.typerep;
 
-  top.translation = "((" ++ q.lookupValue.typerep.transType ++ ")((common.Node)RESULT).getChild(" ++ top.frame.className ++ ".i_" ++ q.lookupValue.fullName ++ "))";
+  top.translation = "((" ++ q.lookupValue.typerep.transType ++ ")((common.Node)RESULTfinal).getChild(" ++ top.frame.className ++ ".i_" ++ q.lookupValue.fullName ++ "))";
   top.lazyTranslation = top.translation; -- never, but okay!
 
   top.upSubst = top.downSubst;

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -31,6 +31,25 @@ top::Expr ::= q::Decorated QName
   top.upSubst = top.downSubst;
 }
 
+-- TODO: Distinct from pluckTerminalReference (since this can occur in any action block and
+-- reference any terminal), but maybe it shouldn't be?  Type classes would be nice here.
+abstract production terminalIdReference
+top::Expr ::= q::Decorated QName
+{
+  top.unparse = q.unparse;
+
+  top.errors := if !top.frame.permitActions
+                then [err(top.location, "References to terminal identifiers can only be made in action blocks")]
+                else [];
+
+  top.typerep = terminalIdType();
+
+  top.translation = s"Terminals.${makeCopperName(q.lookupValue.fullName)}.num()";
+  top.lazyTranslation = top.translation; -- never, but okay!
+
+  top.upSubst = top.downSubst;
+}
+
 abstract production parserAttributeReference
 top::Expr ::= q::Decorated QName
 {
@@ -68,4 +87,3 @@ top::Expr ::= q::Decorated QName
 
   top.upSubst = top.downSubst;
 }
-

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -32,7 +32,9 @@ top::Expr ::= q::Decorated QName
 }
 
 -- TODO: Distinct from pluckTerminalReference (since this can occur in any action block and
--- reference any terminal), but maybe it shouldn't be?  Type classes would be nice here.
+-- reference any terminal), but maybe it shouldn't be?  These productions do almost the same
+-- thing.  Also having type classes would let us use a more specific type than generic TerminalId,
+-- and pluckTerminalReference wouldn't need to cheat with a fresh type.
 abstract production terminalIdReference
 top::Expr ::= q::Decorated QName
 {

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -79,6 +79,7 @@ top::Expr ::= q::Decorated QName
   -- Yeah, it's a big if/then/else block, but these are all very similar and related.
   top.translation =
     if q.name == "lexeme" then "new common.StringCatter(lexeme)" else
+    if q.name == "shiftable" then "shiftableList" else
     if q.name == "line" then "virtualLocation.getLine()" else
     if q.name == "column" then "virtualLocation.getColumn()" else
     if q.name == "filename" then "new common.StringCatter(virtualLocation.getFileName())" else

--- a/grammars/silver/modification/copper/LexerClass.sv
+++ b/grammars/silver/modification/copper/LexerClass.sv
@@ -77,3 +77,15 @@ top::LexerClassModifier ::= 'submits' 'to' terms::TermPrecList
   top.errors := terms.errors;
 }
 
+concrete production lexerClassModifierDisambiguate
+top::LexerClassModifier ::= 'disambiguate' acode::ActionCode_c
+{
+  top.unparse = "disambiguate " ++ acode.unparse;
+
+  top.lexerClassModifiers = [lexerClassDisambiguate(acode.actionCode)];
+  top.errors := acode.errors;
+  
+  acode.env = newScopeEnv(acode.defs, top.env);
+  acode.frame = disambiguationContext();
+}
+

--- a/grammars/silver/modification/copper/LexerClass.sv
+++ b/grammars/silver/modification/copper/LexerClass.sv
@@ -85,7 +85,7 @@ top::LexerClassModifier ::= 'disambiguate' acode::ActionCode_c
   top.lexerClassModifiers = [lexerClassDisambiguate(acode.actionCode)];
   top.errors := acode.errors;
   
-  acode.env = newScopeEnv(acode.defs, top.env);
+  acode.env = newScopeEnv(disambiguationActionVars ++ acode.defs, top.env);
   acode.frame = disambiguationContext();
 }
 

--- a/grammars/silver/modification/copper/LexerClass.sv
+++ b/grammars/silver/modification/copper/LexerClass.sv
@@ -85,7 +85,7 @@ top::LexerClassModifier ::= 'disambiguate' acode::ActionCode_c
   top.lexerClassModifiers = [lexerClassDisambiguate(acode.actionCode)];
   top.errors := acode.errors;
   
-  acode.env = newScopeEnv(disambiguationActionVars ++ acode.defs, top.env);
+  acode.env = newScopeEnv(disambiguationClassActionVars ++ acode.defs, top.env);
   acode.frame = disambiguationContext();
 }
 

--- a/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
+++ b/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
@@ -72,6 +72,10 @@ top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Synt
 "    </BridgeProductions>\n" ++
 "    <Declarations>\n" ++
   ext.xmlCopper ++
+-- All disambiguation classes go in the extension grammar for now,
+-- since they reference extension terminals.
+  implode("\n", map(snd, host.disambiguationClasses)) ++
+  implode("\n", map(snd, ext.disambiguationClasses)) ++
 "    </Declarations>\n" ++
 "  </ExtensionGrammar>\n\n" ++
 

--- a/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
+++ b/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
@@ -11,10 +11,12 @@ top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Synt
   host.cstEnv = directBuildTree(host.cstDcls ++ ext.cstDcls);
   host.containingGrammar = "host";
   host.cstNTProds = error("TODO: this should only be used by normalize"); -- TODO
+  host.classTerminals = directBuildTree(host.classTerminalContribs ++ ext.classTerminalContribs);
   host.prefixesForTerminals = directBuildTree(terminalPrefixes);
   ext.cstEnv = host.cstEnv;
   ext.containingGrammar = "ext";
   ext.cstNTProds = error("TODO: this should only be used by normalize"); -- TODO
+  ext.classTerminals = host.classTerminals;
   ext.prefixesForTerminals = host.prefixesForTerminals;
   
   local startFound :: [Decorated SyntaxDcl] = searchEnvTree(startnt, host.cstEnv);

--- a/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
+++ b/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
@@ -34,7 +34,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Synt
   top.xmlCopper = 
 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n" ++
 
-"<CopperSpec xmlns=\"http://melt.cs.umn.edu/copper/xmlns\">\n" ++
+"<CopperSpec xmlns=\"http://melt.cs.umn.edu/copper/xmlns/skins/xml/0.9\">\n" ++
 
 "  <ExtendedParser id=\"" ++ makeCopperName(parsername) ++ "\">\n" ++
 "    <PP>" ++ parsername ++ "</PP>\n" ++

--- a/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
+++ b/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
@@ -70,12 +70,22 @@ top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Synt
 "    <BridgeProductions>\n" ++
   implode("", map(xmlCopperRef, ext.bridgeProductions)) ++
 "    </BridgeProductions>\n" ++
+"    <GlueDisambiguationFunctions>\n" ++
+  -- TODO: Workaround hack since host disambiguation functions are moved
+  -- to the extension grammar.
+  implode("",
+    map(xmlCopperRef,
+      map(
+        \ d::Decorated SyntaxDcl -> decorate new(d) with {containingGrammar = "ext";},
+        host.disambiguationClasses))) ++
+  implode("", map(xmlCopperRef, ext.disambiguationClasses)) ++
+"    </GlueDisambiguationFunctions>\n" ++
 "    <Declarations>\n" ++
   ext.xmlCopper ++
 -- All disambiguation classes go in the extension grammar for now,
 -- since they reference extension terminals.
-  implode("\n", map(snd, host.disambiguationClasses)) ++
-  implode("\n", map(snd, ext.disambiguationClasses)) ++
+  implode("\n", map((.xmlCopper), host.disambiguationClasses)) ++
+  implode("\n", map((.xmlCopper), ext.disambiguationClasses)) ++
 "    </Declarations>\n" ++
 "  </ExtensionGrammar>\n\n" ++
 

--- a/grammars/silver/modification/impide/cstast/Syntax.sv
+++ b/grammars/silver/modification/impide/cstast/Syntax.sv
@@ -58,7 +58,7 @@ top::SyntaxDcl ::= n::String ty::Type acode::String
 }
 
 aspect production syntaxDisambiguationGroup
-top::SyntaxDcl ::= n::String terms::[String] acode::String
+top::SyntaxDcl ::= n::String terms::[String] applicableToSubsets::Boolean acode::String
 {
 }
 

--- a/grammars/silver/modification/primitivepattern/Types.sv
+++ b/grammars/silver/modification/primitivepattern/Types.sv
@@ -144,6 +144,16 @@ top::Type ::=
     end;
 }
 
+aspect production terminalIdType
+top::Type ::=
+{
+  top.refine = 
+    case top.refineWith of
+    | terminalIdType() -> emptySubst()
+    | _ -> errorSubst("Tried to refine TerminalId with " ++ prettyType(top.refineWith))
+    end;
+}
+
 aspect production nonterminalType
 top::Type ::= fn::String params::[Type]
 {

--- a/grammars/silver/translation/java/core/Expr.sv
+++ b/grammars/silver/translation/java/core/Expr.sv
@@ -421,6 +421,7 @@ String ::= e1::Decorated Expr  op::String  e2::Decorated Expr
   | floatType() -> s"(${e1.translation} ${op} (float)${e2.translation})"
   | boolType() -> s"(${e1.translation} ${op} (boolean)${e2.translation})"
   | stringType() -> s"(${e1.translation}.toString().compareTo(${e2.translation}.toString()) ${op} 0)"
+  | terminalIdType() -> s"(${e1.translation} ${op} (int)${e2.translation})"
   | t -> error(s"INTERNAL ERROR: no ${op} trans for type ${prettyType(t)}")
   end;
 }

--- a/grammars/silver/translation/java/type/Type.sv
+++ b/grammars/silver/translation/java/type/Type.sv
@@ -80,6 +80,15 @@ top::Type ::=
   top.transFreshTypeRep = top.transTypeRep;
 }
 
+aspect production terminalIdType
+top::Type ::=
+{
+  top.transType = "Integer";
+  top.transClassType = "Integer";
+  top.transTypeRep = "new common.BaseTypeRep(\"TerminalId\")";
+  top.transFreshTypeRep = top.transTypeRep;
+}
+
 aspect production nonterminalType
 top::Type ::= fn::String params::[Type]
 {

--- a/runtime/.classpath
+++ b/runtime/.classpath
@@ -5,5 +5,6 @@
 	<classpathentry kind="lib" path="imp/main/target/edu.umn.cs.melt.ide-1.0.0.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/Copper"/>
+	<classpathentry kind="src" path="/Copper run-time"/>
 	<classpathentry kind="output" path="imp/main/target/classes"/>
 </classpath>

--- a/runtime/.project
+++ b/runtime/.project
@@ -3,6 +3,7 @@
 	<name>Silver runtime</name>
 	<comment></comment>
 	<projects>
+		<project>Copper run-time</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -727,4 +727,12 @@ public final class Util {
 		File home = new File(jarLocation).getParentFile().getParentFile();
 		return new StringCatter(home.getPath());
 	}
+	
+	public static ConsCell bitSetToList(BitSet b) {
+		ConsCell result = ConsCell.nil;
+        for (int i = b.nextSetBit(0); i >= 0; i = b.nextSetBit(i+1)) {
+        	result = new ConsCell(i, result);
+        }
+        return result;
+	}
 }

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -730,9 +730,9 @@ public final class Util {
 	
 	public static ConsCell bitSetToList(BitSet b) {
 		ConsCell result = ConsCell.nil;
-        for (int i = b.nextSetBit(0); i >= 0; i = b.nextSetBit(i+1)) {
-        	result = new ConsCell(i, result);
-        }
-        return result;
+		for (int i = b.nextSetBit(0); i >= 0; i = b.nextSetBit(i+1)) {
+			result = new ConsCell(i, result);
+		}
+		return result;
 	}
 }

--- a/support/bin/silver
+++ b/support/bin/silver
@@ -29,8 +29,6 @@ if [ ! -f "$SILVER" ]; then
 fi
 
 # Set flags if not overriden in environment
-SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx2500M -Xss10M"}
+SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx3000M -Xss20M"}
 
 java $SVJVM_FLAGS -jar "$SILVER" "$@" && ant
-
-

--- a/support/bin/silver-custom
+++ b/support/bin/silver-custom
@@ -30,6 +30,6 @@ if [ ! -f "$SILVER" ]; then
 fi
 
 # Set flags if not overriden in environment
-SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx2500M -Xss10M"}
+SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx3000M -Xss20M"}
 
 java $SVJVM_FLAGS -jar "$SILVER" "$@" && ant

--- a/test/copper_features/Main.sv
+++ b/test/copper_features/Main.sv
@@ -6,6 +6,7 @@ imports lib:extcore ;
 import copper_features:test_layout;
 import copper_features:mdatests;
 import copper_features:token_pushing;
+import copper_features:disambiguation_class;
 
 mainTestSuite copper_tests ;
 

--- a/test/copper_features/disambiguation_class/DisambiguationClasses.sv
+++ b/test/copper_features/disambiguation_class/DisambiguationClasses.sv
@@ -54,8 +54,12 @@ parser dcparse::DCRoot {
 
 equalityTest ( dcparse("id1 foo abcd", "ASDF").parseSuccess, true, Boolean, copper_tests ) ;
 equalityTest ( dcparse("id2 foo abcd", "ASDF").parseSuccess, true, Boolean, copper_tests ) ;
-equalityTest ( dcparse("id2 bar abcd", "ASDF").parseSuccess, false, Boolean, copper_tests ) ;
+equalityTest ( dcparse("id2 bar abcd", "ASDF").parseSuccess, true, Boolean, copper_tests ) ;
+equalityTest ( dcparse("id3 bar abcd", "ASDF").parseSuccess, false, Boolean, copper_tests ) ;
+equalityTest ( dcparse("id3 baz abcd", "ASDF").parseSuccess, true, Boolean, copper_tests ) ;
 
 equalityTest ( dcparse("id1 foo abcd", "ASDF").parseTree.n, 1, Integer, copper_tests ) ;
 equalityTest ( dcparse("id2 foo abcd", "ASDF").parseTree.n, 2, Integer, copper_tests ) ;
+equalityTest ( dcparse("id2 bar abcd", "ASDF").parseTree.n, 2, Integer, copper_tests ) ;
+equalityTest ( dcparse("id3 baz abcd", "ASDF").parseTree.n, 1, Integer, copper_tests ) ;
 

--- a/test/copper_features/disambiguation_class/DisambiguationClasses.sv
+++ b/test/copper_features/disambiguation_class/DisambiguationClasses.sv
@@ -1,0 +1,61 @@
+imports silver:testing ;
+imports lib:extcore ;
+imports copper_features;
+
+-- Test disambiguation classes.
+-- Use lexeme in groups
+-- Distinguish terminals properly
+
+parser attribute selectedId::TerminalId
+  action { selectedId = Id3; };
+
+lexer class Identifier disambiguate {
+  pluck selectedId;
+};
+
+ignore terminal Space ' ';
+
+terminal SelectId1 'id1';
+terminal SelectId2 'id2';
+terminal SelectId3 'id3';
+
+terminal Id1 /[a-z]*/ lexer classes {Identifier};
+terminal Id2 /[a-z]*/ lexer classes {Identifier};
+terminal Id3 /[a-z]*/ lexer classes {Identifier};
+
+terminal Foo 'foo';
+terminal Bar 'bar';
+terminal Baz 'baz';
+
+synthesized attribute n::Integer;
+nonterminal DCRoot with n;
+concrete production root
+top::DCRoot ::= s::Select b::Body
+{ top.n = b.n; }
+
+nonterminal Select;
+concrete productions top::Select
+| 'id1' {} action { selectedId = Id1; }
+| 'id2' {} action { selectedId = Id2; }
+| 'id3' {} action { selectedId = Id3; }
+
+nonterminal Body with n;
+concrete productions top::Body
+| 'foo' Id1 { top.n = 1; }
+| 'foo' Id2 { top.n = 2; }
+| 'foo' Id3 { top.n = 3; }
+| 'bar' Id1 { top.n = 1; }
+| 'bar' Id2 { top.n = 2; }
+| 'baz' Id1 { top.n = 1; }
+
+parser dcparse::DCRoot {
+  copper_features:disambiguation_class;
+}
+
+equalityTest ( dcparse("id1 foo abcd", "ASDF").parseSuccess, true, Boolean, copper_tests ) ;
+equalityTest ( dcparse("id2 foo abcd", "ASDF").parseSuccess, true, Boolean, copper_tests ) ;
+equalityTest ( dcparse("id2 bar abcd", "ASDF").parseSuccess, false, Boolean, copper_tests ) ;
+
+equalityTest ( dcparse("id1 foo abcd", "ASDF").parseTree.n, 1, Integer, copper_tests ) ;
+equalityTest ( dcparse("id2 foo abcd", "ASDF").parseTree.n, 2, Integer, copper_tests ) ;
+


### PR DESCRIPTION
This implements disambiguation classes essentially as described in #193.  For now I just introduced a new general `TerminalId` type for representing any terminal, instead of trying some hacky approach to simulating type classes.  
I also updated Silver to use the version 0.9 Copper XML schema instead of the default (0.7 I think?) and made a couple of related fixes.  
I think I caught all the MWDA errors, but I might have missed some equations because Silver's flow types are a mess...
The next step is to implement global parser action blocks as discussed, to allow for "collection-attribute"-style initialization of context parser attributes.  