### PR TITLE
Implement parser attribute aspects

### DIFF
--- a/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
@@ -25,6 +25,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   s.containingGrammar = "host";
   s.univLayout = error("TODO: make this environment not be decorated?"); -- TODO
   s.classTerminals = error("TODO: shouldn't by necessary to normalize"); -- TODO
+  s.parserAttributeAspects = error("TODO: shouldn't by necessary to normalize"); -- TODO
   s.prefixesForTerminals = error("TODO: shouldn't by necessary to normalize"); -- TODO
   
   -- Move productions under their nonterminal, and sort the declarations
@@ -34,6 +35,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   s2.containingGrammar = "host";
   s2.cstNTProds = error("TODO: make this environment not be decorated?"); -- TODO
   s2.classTerminals = directBuildTree(s.classTerminalContribs);
+  s2.parserAttributeAspects = directBuildTree(s.parserAttributeAspectContribs);
   s2.prefixesForTerminals = directBuildTree(terminalPrefixes);
   
   -- This should be on s1, because the s2 transform assumes everything is well formed.

--- a/grammars/silver/modification/copper/ParserAttributes.sv
+++ b/grammars/silver/modification/copper/ParserAttributes.sv
@@ -22,3 +22,25 @@ top::AGDcl ::= 'parser' 'attribute' a::Name '::' te::TypeExpr 'action' acode::Ac
   top.syntaxAst = [syntaxParserAttribute(fName, te.typerep, acode.actionCode)];
 }
 
+concrete production attributeAspectParser
+top::AGDcl ::= 'aspect' 'parser' 'attribute' a::QName 'action' acode::ActionCode_c ';'
+{
+  top.unparse = "aspect parser attribute " ++ a.name ++ " action " ++ acode.unparse ++ " ;" ;
+
+  production attribute fName :: String;
+  fName = a.lookupValue.dcl.fullName;
+
+  top.defs = [];
+
+  top.errors <- if null(a.lookupValue.dcls)
+                then [err(a.location, "Undefined attribute '" ++ a.name ++ "'.")]
+                else [];
+
+  top.errors := acode.errors;
+  
+  acode.frame = actionContext();
+  acode.env = newScopeEnv(acode.defs, top.env);
+  
+  top.syntaxAst = [syntaxParserAttributeAspect(fName, acode.actionCode)];
+}
+

--- a/grammars/silver/modification/copper/Prefix.sv
+++ b/grammars/silver/modification/copper/Prefix.sv
@@ -110,6 +110,8 @@ top::TerminalPrefixItems ::=
   syntax.containingGrammar = error("This shouldn't be needed...");
   syntax.cstEnv = error("This shouldn't be needed...");
   syntax.cstNTProds = error("This shouldn't be needed...");
+  syntax.classTerminals = error("This shouldn't be needed...");
+  syntax.parserAttributeAspects = error("This shouldn't be needed...");
   syntax.prefixesForTerminals = error("This shouldn't be needed...");
   syntax.univLayout = error("This shouldn't be needed...");
 

--- a/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
+++ b/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
@@ -12,11 +12,13 @@ top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Synt
   host.containingGrammar = "host";
   host.cstNTProds = error("TODO: this should only be used by normalize"); -- TODO
   host.classTerminals = directBuildTree(host.classTerminalContribs ++ ext.classTerminalContribs);
+  host.parserAttributeAspects = directBuildTree(host.parserAttributeAspectContribs ++ ext.parserAttributeAspectContribs);
   host.prefixesForTerminals = directBuildTree(terminalPrefixes);
   ext.cstEnv = host.cstEnv;
   ext.containingGrammar = "ext";
   ext.cstNTProds = error("TODO: this should only be used by normalize"); -- TODO
   ext.classTerminals = host.classTerminals;
+  ext.parserAttributeAspects = host.parserAttributeAspects;
   ext.prefixesForTerminals = host.prefixesForTerminals;
   
   local startFound :: [Decorated SyntaxDcl] = searchEnvTree(startnt, host.cstEnv);

--- a/test/copper_features/ParserAttributes.sv
+++ b/test/copper_features/ParserAttributes.sv
@@ -55,6 +55,10 @@ parser attribute knownlist :: [String]  action {
   knownlist = [];
 };
 
+aspect parser attribute knownlist  action {
+  knownlist = "quix" :: knownlist;
+};
+
 -- THE TESTS
 
 equalityTest ( PAparse("!foo foo", "asdf").parseSuccess, true, Boolean, copper_tests ) ;
@@ -70,3 +74,5 @@ equalityTest ( PAparse("!foo !bar foo bar foo", "").parseTree.unknownsused, [], 
 equalityTest ( PAparse("!foo !bar foo foo", "").parseTree.unknownsused, [], [String], copper_tests ) ;
 equalityTest ( PAparse("!foo !bar foo bar foo baz", "").parseTree.unknownsused, ["baz"], [String], copper_tests ) ;
 
+equalityTest ( PAparse("quix", "").parseSuccess, true, Boolean, copper_tests ) ;
+equalityTest ( PAparse("quix", "").parseTree.unknownsused, [], [String], copper_tests ) ;


### PR DESCRIPTION
Fixes #300.  

This seems to work as intended when used with `context` to eliminate keywords from the string extension.  