### PR TITLE
Create flow graphs for all contexts

### DIFF
--- a/grammars/silver/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/analysis/warnings/flow/Inh.sv
@@ -181,7 +181,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.frame.lhsNtName, myFlow)));
@@ -189,7 +189,6 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   top.errors <-
     if dl.found && attr.found
     && (top.config.warnAll || top.config.warnMissingInh)
-    && top.frame.prodFlowGraph.isJust -- Default synthesized equations have no production graph to use
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
       if null(lhsInhExceedsFlowType) then []
       else [wrn(top.location, "Synthesized equation " ++ attr.name ++ " exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
@@ -200,13 +199,13 @@ aspect production inheritedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
   local transitiveDeps :: [FlowVertex] = 
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
   
   -- TODO: if LHS is forward, we have to check that we aren't exceeding flow type!! (BUG)
   
   -- check transitive deps only. Nothing to check for flow types
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
+    if (top.config.warnAll || top.config.warnMissingInh)
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
@@ -219,7 +218,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.frame.lhsNtName, myFlow)));
@@ -227,7 +226,6 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   top.errors <-
     if dl.found && attr.found
     && (top.config.warnAll || top.config.warnMissingInh)
-    && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
       if null(lhsInhExceedsFlowType) then []
       else [wrn(top.location, "Synthesized equation " ++ attr.name ++ " exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
@@ -240,7 +238,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn(attr.attrDcl.fullName, top.frame.lhsNtName, myFlow)));
@@ -248,7 +246,6 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   top.errors <-
     if dl.found && attr.found
     && (top.config.warnAll || top.config.warnMissingInh)
-    && top.frame.prodFlowGraph.isJust
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
       if null(lhsInhExceedsFlowType) then []
       else [wrn(top.location, "Synthesized equation " ++ attr.name ++ " exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
@@ -258,11 +255,11 @@ aspect production inhBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
   
   -- check transitive deps only. Nothing to be done for flow types
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
+    if (top.config.warnAll || top.config.warnMissingInh)
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
@@ -270,11 +267,11 @@ aspect production inhAppendColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
   local transitiveDeps :: [FlowVertex] = 
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
   
   -- check transitive deps only. Nothing to be done for flow types
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
+    if (top.config.warnAll || top.config.warnMissingInh)
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
@@ -287,13 +284,13 @@ top::ProductionStmt ::= 'forwards' 'to' e::Expr ';'
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   local lhsInhExceedsFlowType :: [String] = set:toList(set:difference(lhsInhDeps, inhDepsForSyn("forward", top.frame.lhsNtName, myFlow)));
 
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
+    if (top.config.warnAll || top.config.warnMissingInh)
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
          if null(lhsInhExceedsFlowType) then []
          else [wrn(top.location, "Forward equation exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
@@ -306,7 +303,7 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
 
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
   
   local lhsInhDeps :: set:Set<String> = onlyLhsInh(transitiveDeps);
   -- problem = lhsinh deps - fwd flow type - this inh attribute
@@ -321,7 +318,7 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
         inhDepsForSyn("forward", top.frame.lhsNtName, myFlow))));
 
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
+    if (top.config.warnAll || top.config.warnMissingInh)
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs)) ++
          if null(lhsInhExceedsFlowType) then []
          else [wrn(top.location, "Forward inherited equation exceeds flow type with dependencies on " ++ implode(", ", lhsInhExceedsFlowType))]
@@ -332,11 +329,11 @@ aspect production localValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
   
   -- check transitive deps only. No worries about flow types.
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
+    if (top.config.warnAll || top.config.warnMissingInh)
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
@@ -345,10 +342,10 @@ aspect production returnDef
 top::ProductionStmt ::= 'return' e::Expr ';'
 {
   local transitiveDeps :: [FlowVertex] =
-    expandGraph(e.flowDeps, top.frame.prodFlowGraph.fromJust);
+    expandGraph(e.flowDeps, top.frame.flowGraph);
 
   top.errors <-
-    if (top.config.warnAll || top.config.warnMissingInh) && top.frame.prodFlowGraph.isJust
+    if (top.config.warnAll || top.config.warnMissingInh)
     then checkAllEqDeps(transitiveDeps, top.location, top.frame.fullName, top.frame.lhsNtName, top.flowEnv, top.env, collectAnonOrigin(e.flowDefs))
     else [];
 }
@@ -359,7 +356,7 @@ top::ProductionStmt ::= 'return' e::Expr ';'
 aspect production appendCollectionValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
-  local productionFlowGraph :: ProductionGraph = top.frame.prodFlowGraph.fromJust;
+  local productionFlowGraph :: ProductionGraph = top.frame.flowGraph;
   local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, productionFlowGraph);
   
   local originalEqDeps :: [FlowVertex] = 
@@ -375,7 +372,6 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
     if (top.config.warnAll || top.config.warnMissingInh)
        -- We can ignore functions. We're checking LHS inhs here... functions don't have any!
     && top.frame.hasFullSignature
-    && top.frame.prodFlowGraph.isJust
     then if null(lhsInhExceedsFlowType) then []
          else [wrn(top.location, "Local contribution (" ++ val.name ++ " <-) equation exceeds flow dependencies with: " ++ implode(", ", lhsInhExceedsFlowType))]
     else [];
@@ -543,16 +539,9 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
     | _, _ -> nothing()
     end;
 
-  -- TODO bug: expressions in globals don't have flow graphs. That's a mistake.
-  -- We need to add edges due to flow types and 'flowDefs' from subexpressions
-  -- to accurately raise errors. We need to fix this by ensuring ALL contexts get
-  -- flow graphs built for them.
-
   -- These should be the only ones that can reference our anon sink
   local transitiveDeps :: [FlowVertex] =
-    if top.frame.prodFlowGraph.isJust
-    then expandGraph(top.flowDeps, top.frame.prodFlowGraph.fromJust)
-    else top.flowDeps;
+    expandGraph(top.flowDeps, top.frame.flowGraph);
   
   pr.receivedDeps = transitiveDeps;
 
@@ -623,5 +612,13 @@ Boolean ::= prod::DclInfo  sigName::String  attrName::String  realEnv::Decorated
     ignoreIfAutoCopyOnLhs(prod.namedSignature.outputElement.typerep.typeName, realEnv, attrName); -- not autocopy (and on lhs)
 }
 
+--------------------------------------------------------------------------------
+
+-- TODO: There are a few final places where we need to `checkEqDeps` for the sake of `anonVertex`s
+
+-- global declarations, action blocks (production, terminal, disam, etc)
+
+-- But we don't create flowEnv information for these locations so they can't be checked... oops
+-- (e.g. `checkEqDeps` wants a production fName to look things up about.)
 
 

--- a/grammars/silver/definition/core/BlockContext.sv
+++ b/grammars/silver/definition/core/BlockContext.sv
@@ -73,7 +73,7 @@ aspect default production
 top::BlockContext ::=
 {
   top.lhsNtName = error("LHS NT accessed for non-production");
-  top.sourceGrammar = error("sourceGrammar accessed for non-production/fuction");
+  top.sourceGrammar = error("sourceGrammar accessed for non-production/function");
   top.prodFlowGraph = nothing();
   -- most restrictive possible
   top.permitReturn = false;
@@ -83,6 +83,8 @@ top::BlockContext ::=
   top.lazyApplication = true;
   top.hasPartialSignature = false;
   top.hasFullSignature = false;
+  
+  -- always required: fullName, signature
 }
 
 abstract production functionContext

--- a/grammars/silver/definition/core/BlockContext.sv
+++ b/grammars/silver/definition/core/BlockContext.sv
@@ -131,9 +131,10 @@ top::BlockContext ::= sig::NamedSignature  g::ProductionGraph
 }
 
 abstract production globalExprContext
-top::BlockContext ::=
+top::BlockContext ::= g::ProductionGraph
 {
   top.fullName = "_NULL_"; -- maybe we should actually error?
   top.signature = bogusNamedSignature(); -- TODO: do something about this?
+  top.prodFlowGraph = just(g);
 }
 

--- a/grammars/silver/definition/core/BlockContext.sv
+++ b/grammars/silver/definition/core/BlockContext.sv
@@ -6,7 +6,7 @@ import silver:definition:flow:driver only ProductionGraph;
  - Permissions management information for certain features that can appear in production
  - statements, etc.  i.e. "can forward/return/pluck?"
  -}
-nonterminal BlockContext with permitReturn, permitForward, permitProductionAttributes, permitLocalAttributes, lazyApplication, hasFullSignature, hasPartialSignature, fullName, lhsNtName, signature, sourceGrammar, prodFlowGraph;
+nonterminal BlockContext with permitReturn, permitForward, permitProductionAttributes, permitLocalAttributes, lazyApplication, hasFullSignature, hasPartialSignature, fullName, lhsNtName, signature, sourceGrammar, flowGraph;
 
 
 {-- Are 'return' equations allowed in this context? -}
@@ -55,7 +55,7 @@ synthesized attribute signature :: NamedSignature;
 {--
  - The flow graph for the current context.
  -}
-synthesized attribute prodFlowGraph :: Maybe<ProductionGraph>;
+synthesized attribute flowGraph :: ProductionGraph;
 
 {- fullName on BlockContext:
  - Used to:
@@ -74,7 +74,6 @@ top::BlockContext ::=
 {
   top.lhsNtName = error("LHS NT accessed for non-production");
   top.sourceGrammar = error("sourceGrammar accessed for non-production/function");
-  top.prodFlowGraph = nothing();
   -- most restrictive possible
   top.permitReturn = false;
   top.permitForward = false;
@@ -84,7 +83,7 @@ top::BlockContext ::=
   top.hasPartialSignature = false;
   top.hasFullSignature = false;
   
-  -- always required: fullName, signature
+  -- always required: fullName, signature, flowGraph
 }
 
 abstract production functionContext
@@ -94,7 +93,7 @@ top::BlockContext ::= sig::NamedSignature  g::ProductionGraph
   top.lhsNtName = "::nolhs"; -- unfortunately this is sometimes accessed, and a dummy value works okay
   top.signature = sig;
   top.sourceGrammar = substring(0, lastIndexOf(":", top.fullName), top.fullName); -- hack
-  top.prodFlowGraph = just(g);
+  top.flowGraph = g;
 
   top.permitReturn = true;
   top.hasPartialSignature = true;
@@ -109,7 +108,7 @@ top::BlockContext ::= sig::NamedSignature  g::ProductionGraph
   top.lhsNtName = sig.outputElement.typerep.typeName;
   top.signature = sig;
   top.sourceGrammar = substring(0, lastIndexOf(":", top.fullName), top.fullName); -- hack
-  top.prodFlowGraph = just(g);
+  top.flowGraph = g;
 
   top.permitForward = true;
   top.hasPartialSignature = true;
@@ -137,6 +136,6 @@ top::BlockContext ::= g::ProductionGraph
 {
   top.fullName = "_NULL_"; -- maybe we should actually error?
   top.signature = bogusNamedSignature(); -- TODO: do something about this?
-  top.prodFlowGraph = just(g);
+  top.flowGraph = g;
 }
 

--- a/grammars/silver/definition/core/GlobalDcl.sv
+++ b/grammars/silver/definition/core/GlobalDcl.sv
@@ -1,5 +1,7 @@
 grammar silver:definition:core;
 
+import silver:definition:flow:driver only ProductionGraph, FlowType, constructAnonymousGraph;
+
 concrete production globalValueDclConcrete
 top::AGDcl ::= 'global' id::Name '::' t::TypeExpr '=' e::Expr ';'
 {
@@ -16,5 +18,12 @@ top::AGDcl ::= 'global' id::Name '::' t::TypeExpr '=' e::Expr ';'
     then [err(id.location, "Value '" ++ fName ++ "' is already bound.")]
     else [];
 
-  e.frame = globalExprContext();
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  local myFlowGraph :: ProductionGraph = 
+    constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
+
+  e.frame = globalExprContext(myFlowGraph);
 }

--- a/grammars/silver/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/definition/flow/driver/ProductionGraph.sv
@@ -115,6 +115,26 @@ function computeAllProductionGraphs
     computeAllProductionGraphs(tail(prods), prodTree, flowEnv, realEnv);
 }
 
+
+--------------------------------------------------------------------------------
+-- Below, we have various means of constructing a production graph.
+-- Two types are used as part of inference:
+--  1. `constructProductionGraph` builds a graph for a normal production.
+--  2. `constructPhantomProductionGraph` builds a "phantom graph" to guide inference.
+--
+-- There are more types of "production" graphs, used NOT for inference, but
+-- for error checking behaviors:
+--  1. `constructFunctionGraph` builds a graph for a function.
+--       (the key here: `aspect function` contributions `<-` needs to be handled.)
+--  2. `constructAnonymousGraph` builds a graph for a global expression. (also action blocks)
+--       (key: decorate/patterns create stitch points and things that need to be handled.)
+--  3. `constructDefaultProductionGraph` builds a graph used locally in a default production.
+--       (key: like phantom, LHS is stitch point, to make dependencies clear.)
+--
+-- This latter type should always call `updateGraph` to fill in all edges after construction.
+--------------------------------------------------------------------------------
+
+
 {--
  - Produces a ProductionGraph in some special way. Fixes up implicit equations,
  - figures out stitch points, and so forth.
@@ -211,13 +231,14 @@ ProductionGraph ::= dcl::DclInfo  defs::[FlowDef]  flowEnv::Decorated FlowEnv  r
 function constructFunctionGraph
 ProductionGraph ::= ns::NamedSignature  flowEnv::Decorated FlowEnv  realEnv::Decorated Env  prodEnv::EnvTree<ProductionGraph>  ntEnv::EnvTree<FlowType>
 {
-  local defs :: [FlowDef] = getGraphContribsFor(ns.fullName, flowEnv);
+  local prod :: String = ns.fullName;
+  local nt :: NtName = "::nolhs"; -- the same hack we use elsewhere
+  local defs :: [FlowDef] = getGraphContribsFor(prod, flowEnv);
 
-  -- Normal edges!
   local normalEdges :: [Pair<FlowVertex FlowVertex>] =
     flatMap((.flowEdges), defs);
   
-  -- Basicaly just <- to local collections...
+  -- In functions, this is just `<-` contributions to local collections from aspects.
   local suspectEdges :: [Pair<FlowVertex FlowVertex>] =
     flatMap((.suspectFlowEdges), defs);
     
@@ -227,11 +248,13 @@ ProductionGraph ::= ns::NamedSignature  flowEnv::Decorated FlowEnv  realEnv::Dec
   -- RHS and locals and forward.
   local stitchPoints :: [StitchPoint] =
     rhsStitchPoints(ns.inputElements) ++
-    localStitchPoints(error("functions have no LHS, no forwarding defs"), defs) ++
+    localStitchPoints(error("functions shouldn't have a forwarding equation?"), defs) ++
     patternStitchPoints(realEnv, defs);
 
+  local flowTypeVertexes :: [FlowVertex] = []; -- Not used as part of inference.
+
   local g :: ProductionGraph =
-    productionGraph(ns.fullName, "::nolhs", [], initialGraph, suspectEdges, stitchPoints).transitiveClosure;
+    productionGraph(prod, nt, flowTypeVertexes, initialGraph, suspectEdges, stitchPoints).transitiveClosure;
 
   return updateGraph(g, prodEnv, ntEnv);
 }
@@ -246,27 +269,69 @@ ProductionGraph ::= ns::NamedSignature  flowEnv::Decorated FlowEnv  realEnv::Dec
 function constructAnonymousGraph
 ProductionGraph ::= defs::[FlowDef]  realEnv::Decorated Env  prodEnv::EnvTree<ProductionGraph>  ntEnv::EnvTree<FlowType>
 {
-  -- Normal edges!
+  -- Actually very unclear to me right now if these dummy names matter.
+  -- Presently duplicating what appears in BlockContext
+  local prod :: String = "_NULL_";
+  local nt :: NtName = "::nolhs"; -- the same hack we use elsewhere
+
   local normalEdges :: [Pair<FlowVertex FlowVertex>] =
     flatMap((.flowEdges), defs);
   
   -- suspectEdges should always be empty! (No "aspects" where they could arise.)
-    
+  local suspectEdges :: [Pair<FlowVertex FlowVertex>] = [];
+
   local initialGraph :: g:Graph<FlowVertex> =
     createFlowGraph(normalEdges);
 
   -- There can still be anonEq, but there's no RHS anymore
   local stitchPoints :: [StitchPoint] =
-    localStitchPoints(error("anon/functions have no LHS, no forwarding defs"), defs) ++
+    localStitchPoints(error("global expressions shouldn't have a forwarding equation?"), defs) ++
     patternStitchPoints(realEnv, defs);
 
-  -- Actually very unclear to me right now if these dummy names matter.
-  -- Presently duplicating what appears in BlockContext
+  local flowTypeVertexes :: [FlowVertex] = []; -- Not used as part of inference.
+  
   local g :: ProductionGraph =
-    productionGraph("_NULL_", "::nolhs", [], initialGraph, [], stitchPoints).transitiveClosure;
+    productionGraph(prod, nt, flowTypeVertexes, initialGraph, suspectEdges, stitchPoints).transitiveClosure;
 
   return updateGraph(g, prodEnv, ntEnv);
 }
+
+{--
+ - An graph for checking dependencies in default equations.
+ -
+ - NOTE: Not used as part of inference. Instead, only used as part of error checking.
+ -
+ -}
+function constructDefaultProductionGraph
+ProductionGraph ::= ns::NamedSignature  defs::[FlowDef]  realEnv::Decorated Env  prodEnv::EnvTree<ProductionGraph>  ntEnv::EnvTree<FlowType>
+{
+  local prod :: String = ns.fullName;
+  local nt :: NtName = ns.outputElement.typerep.typeName;
+  
+  local normalEdges :: [Pair<FlowVertex FlowVertex>] =
+    flatMap((.flowEdges), defs);
+  
+  -- suspectEdges should always be empty! (No "aspects" where they could arise.)
+  local suspectEdges :: [Pair<FlowVertex FlowVertex>] = [];
+    
+  local initialGraph :: g:Graph<FlowVertex> =
+    createFlowGraph(normalEdges);
+
+  -- There can still be anonEq, but there's no RHS anymore
+  -- However, we do behave like phantom graphs and create an LHS stitch point!
+  local stitchPoints :: [StitchPoint] =
+    [nonterminalStitchPoint(nt, lhsVertexType)] ++ 
+    localStitchPoints(error("default production shouldn't have a forwarding equation?"), defs) ++
+    patternStitchPoints(realEnv, defs);
+
+  local flowTypeVertexes :: [FlowVertex] = []; -- Not used as part of inference.
+
+  local g :: ProductionGraph =
+    productionGraph(prod, nt, flowTypeVertexes, initialGraph, suspectEdges, stitchPoints).transitiveClosure;
+
+  return updateGraph(g, prodEnv, ntEnv);
+}
+
 
 
 {--

--- a/grammars/silver/extension/testing/EqualityTest.sv
+++ b/grammars/silver/extension/testing/EqualityTest.sv
@@ -8,6 +8,9 @@ import silver:definition:type:syntax;
 import silver:modification:collection;
 import silver:extension:list;
 
+import silver:definition:flow:driver only ProductionGraph, FlowType, constructAnonymousGraph; -- for the "oh no again!" hack below
+import silver:driver:util only RootSpec;
+
 --import silver:analysis:typechecking:core;
 
 import lib:extcore;
@@ -40,14 +43,12 @@ ag::AGDcl ::= kwd::'equalityTest'
     else [err(value.location, "Type of first and second expressions in equalityTest do not match. Instead they are " ++ errCheck1.leftpp ++ " and " ++ errCheck1.rightpp)];
 
   ag.errors <-
-    if !errCheck1.typeerror then []
-    else [err(value.location, "Type of initial expression does not match specified type (3rd argument). Instead they are " ++
-                               errCheck2.leftpp ++ " and " ++ errCheck2.rightpp)];
+    if !errCheck2.typeerror then []
+    else [err(value.location, "Type of initial expression does not match specified type (3rd argument). Instead they are " ++ errCheck2.leftpp ++ " and " ++ errCheck2.rightpp)];
 
   ag.errors <-
-    if !errCheck1.typeerror then []
-    else [err(value.location, "Type of second expression does not match specified type (3rd argument). Instead they are " ++
-                               errCheck3.leftpp ++ " and " ++ errCheck3.rightpp)];
+    if !errCheck3.typeerror then []
+    else [err(value.location, "Type of second expression does not match specified type (3rd argument). Instead they are " ++ errCheck3.leftpp ++ " and " ++ errCheck3.rightpp)];
 
   value.downSubst = emptySubst();
   expected.downSubst = value.upSubst;
@@ -63,8 +64,12 @@ ag::AGDcl ::= kwd::'equalityTest'
 
   -- TODO: one of those type error checks above is redundant
 
-  value.frame = globalExprContext();
-  expected.frame = globalExprContext();
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(ag.grammarName, ag.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(ag.grammarName, ag.compiledGrammars)).productionFlowGraphs;
+
+  value.frame = globalExprContext(constructAnonymousGraph(value.flowDefs, ag.env, myProds, myFlow));
+  expected.frame = globalExprContext(constructAnonymousGraph(expected.flowDefs, ag.env, myProds, myFlow));
   
 
   ag.errors <- forward.errors;

--- a/grammars/silver/extension/testing/EqualityTest.sv
+++ b/grammars/silver/extension/testing/EqualityTest.sv
@@ -9,7 +9,7 @@ import silver:modification:collection;
 import silver:extension:list;
 
 import silver:definition:flow:driver only ProductionGraph, FlowType, constructAnonymousGraph; -- for the "oh no again!" hack below
-import silver:driver:util only RootSpec;
+import silver:driver:util only RootSpec; -- ditto
 
 --import silver:analysis:typechecking:core;
 

--- a/grammars/silver/modification/copper/BlockContext.sv
+++ b/grammars/silver/modification/copper/BlockContext.sv
@@ -25,7 +25,7 @@ top::BlockContext ::= g::ProductionGraph
 {
   top.fullName = "__action__"; -- Used as part of naming locals... maybe we should fix that? TODO
   top.signature = bogusNamedSignature();
-  top.prodFlowGraph = just(g);
+  top.flowGraph = g;
   
   top.lazyApplication = false;
   top.permitActions = true;

--- a/grammars/silver/modification/copper/BlockContext.sv
+++ b/grammars/silver/modification/copper/BlockContext.sv
@@ -1,5 +1,9 @@
 grammar silver:modification:copper;
 
+-- hack for all uses of this stuff in this grammar. note s on imports
+imports silver:definition:flow:driver only ProductionGraph, FlowType, constructAnonymousGraph;
+imports silver:driver:util only RootSpec;
+
 attribute permitActions, permitPluck occurs on BlockContext;
 
 {--
@@ -17,10 +21,11 @@ top::BlockContext ::=
 
 {-- Terminal shift, parser attribute initialization -}
 abstract production actionContext
-top::BlockContext ::=
+top::BlockContext ::= g::ProductionGraph
 {
   top.fullName = "__action__"; -- Used as part of naming locals... maybe we should fix that? TODO
   top.signature = bogusNamedSignature();
+  top.prodFlowGraph = just(g);
   
   top.lazyApplication = false;
   top.permitActions = true;
@@ -31,20 +36,20 @@ top::BlockContext ::=
 
 {-- Disambiguation groups -}
 abstract production disambiguationContext
-top::BlockContext ::=
+top::BlockContext ::= g::ProductionGraph
 {
   top.permitPluck = true;
-  forwards to actionContext();
+  forwards to actionContext(g);
 }
 
 {-- Production reduce actions -}
 abstract production reduceActionContext
-top::BlockContext ::= sig::NamedSignature
+top::BlockContext ::= sig::NamedSignature  g::ProductionGraph
 {
   top.fullName = sig.fullName;
   top.signature = sig; -- TODO: figure out if this is ever used for actions?
   top.className = makeClassName(top.fullName); -- child references in production actions use it
 
-  forwards to actionContext();
+  forwards to actionContext(g);
 }
 

--- a/grammars/silver/modification/copper/DisambiguationGroup.sv
+++ b/grammars/silver/modification/copper/DisambiguationGroup.sv
@@ -14,7 +14,14 @@ top::AGDcl ::= 'disambiguate' terms::TermList acode::ActionCode_c
   -- Give the group a name, deterministically, based on line number
   production fName :: String = top.grammarName ++ ":__disam" ++ toString(top.location.line);
   
-  acode.frame = disambiguationContext();
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  local myFlowGraph :: ProductionGraph = 
+    constructAnonymousGraph(acode.flowDefs, top.env, myProds, myFlow);
+
+  acode.frame = disambiguationContext(myFlowGraph);
 
   top.syntaxAst = [syntaxDisambiguationGroup(fName, terms.termList, false, acode.actionCode)];
 }

--- a/grammars/silver/modification/copper/LexerClass.sv
+++ b/grammars/silver/modification/copper/LexerClass.sv
@@ -85,7 +85,14 @@ top::LexerClassModifier ::= 'disambiguate' acode::ActionCode_c
   top.lexerClassModifiers = [lexerClassDisambiguate(acode.actionCode)];
   top.errors := acode.errors;
   
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  local myFlowGraph :: ProductionGraph = 
+    constructAnonymousGraph(acode.flowDefs, top.env, myProds, myFlow);
+
   acode.env = newScopeEnv(disambiguationClassActionVars ++ acode.defs, top.env);
-  acode.frame = disambiguationContext();
+  acode.frame = disambiguationContext(myFlowGraph);
 }
 

--- a/grammars/silver/modification/copper/ParserAttributes.sv
+++ b/grammars/silver/modification/copper/ParserAttributes.sv
@@ -16,7 +16,14 @@ top::AGDcl ::= 'parser' 'attribute' a::Name '::' te::TypeExpr 'action' acode::Ac
 
   top.errors := te.errors ++ acode.errors;
   
-  acode.frame = actionContext();
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  local myFlowGraph :: ProductionGraph = 
+    constructAnonymousGraph(acode.flowDefs, top.env, myProds, myFlow);
+
+  acode.frame = actionContext(myFlowGraph);
   acode.env = newScopeEnv(acode.defs, top.env);
   
   top.syntaxAst = [syntaxParserAttribute(fName, te.typerep, acode.actionCode)];
@@ -38,7 +45,14 @@ top::AGDcl ::= 'aspect' 'parser' 'attribute' a::QName 'action' acode::ActionCode
 
   top.errors := acode.errors;
   
-  acode.frame = actionContext();
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  local myFlowGraph :: ProductionGraph = 
+    constructAnonymousGraph(acode.flowDefs, top.env, myProds, myFlow);
+
+  acode.frame = actionContext(myFlowGraph);
   acode.env = newScopeEnv(acode.defs, top.env);
   
   top.syntaxAst = [syntaxParserAttributeAspect(fName, acode.actionCode)];

--- a/grammars/silver/modification/copper/TerminalDcl.sv
+++ b/grammars/silver/modification/copper/TerminalDcl.sv
@@ -63,7 +63,14 @@ top::TerminalModifier ::= 'action' acode::ActionCode_c
 
   top.terminalModifiers = [termAction(acode.actionCode)];
 
-  acode.frame = actionContext();
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  local myFlowGraph :: ProductionGraph = 
+    constructAnonymousGraph(acode.flowDefs, top.env, myProds, myFlow);
+
+  acode.frame = actionContext(myFlowGraph);
   acode.env = newScopeEnv(terminalActionVars ++ acode.defs, top.env);
   
   top.errors := acode.errors;

--- a/grammars/silver/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/modification/defaultattr/DefaultAttr.sv
@@ -7,6 +7,8 @@ import silver:definition:type:syntax;
 --import silver:analysis:typechecking:core;
 import silver:translation:java;
 
+import silver:definition:flow:driver only ProductionGraph, FlowType, constructDefaultProductionGraph; -- for the "oh no again!" hack below
+import silver:driver:util only RootSpec; -- ditto
 
 terminal Default_kwd 'default' lexer classes {KEYWORD, RESERVED};
 
@@ -31,8 +33,16 @@ top::AGDcl ::= 'aspect' 'default' 'production'
   local sigDefs :: [Def] =
     addNewLexicalTyVars_ActuallyVariables(top.grammarName, top.location, te.lexicalTypeVariables);
 
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  local myFlowGraph :: ProductionGraph = 
+    constructDefaultProductionGraph(namedSig, body.flowDefs, top.env, myProds, myFlow);
+
+
   body.env = newScopeEnv(fakedDefs ++ sigDefs, top.env);
-  body.frame = defaultAspectContext(namedSig);
+  body.frame = defaultAspectContext(namedSig, myFlowGraph);
 
   body.downSubst = emptySubst();
 
@@ -79,10 +89,11 @@ top::DefLHS ::= q::Decorated QName
 }
 
 abstract production defaultAspectContext
-top::BlockContext ::= sig::NamedSignature  -- okay, sorta has a sig?
+top::BlockContext ::= sig::NamedSignature  g::ProductionGraph
 {
   top.fullName = sig.fullName;
   top.lhsNtName = sig.outputElement.typerep.typeName;
   top.signature = sig;
+  top.prodFlowGraph = just(g);
 }
 

--- a/grammars/silver/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/modification/defaultattr/DefaultAttr.sv
@@ -94,6 +94,6 @@ top::BlockContext ::= sig::NamedSignature  g::ProductionGraph
   top.fullName = sig.fullName;
   top.lhsNtName = sig.outputElement.typerep.typeName;
   top.signature = sig;
-  top.prodFlowGraph = just(g);
+  top.flowGraph = g;
 }
 

--- a/grammars/silver/translation/java/core/BlockContext.sv
+++ b/grammars/silver/translation/java/core/BlockContext.sv
@@ -43,7 +43,7 @@ top::BlockContext ::= sig::NamedSignature  _
 }
 
 aspect production globalExprContext
-top::BlockContext ::=
+top::BlockContext ::= _
 {
 }
 


### PR DESCRIPTION
This change creates flow graphs for all contexts, not just productions (and functions, which had been fixed previously.) So global expressions, action blocks, and default productions now all have flow graphs.

This implicitly fixes #218, as default productions now have a flow graph and get checked.

This was motivated by #200, and supposed to have closed it, but I'll be editing that issue to make it clear there's still a little bit more work to do yet...

The code in this change further motivates working on #162, as anyone who looks at the diff will see...