### PR TITLE
Cleanup builtins and reduce poor error messages

### DIFF
--- a/grammars/core/List.sv
+++ b/grammars/core/List.sv
@@ -315,7 +315,7 @@ function sortByHelp -- do not use
   back_half = sortByHelp(lte, drop(middle, lst), upTo - middle);
 
   local attribute middle :: Integer;
-  middle = toInt(toFloat(upTo) / 2.0);
+  middle = toInteger(toFloat(upTo) / 2.0);
 }
 function mergeBy -- do not use
 [a] ::= lte::(Boolean ::= a a) l1::[a] l2::[a]

--- a/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
@@ -24,9 +24,9 @@ top::Expr ::= 'toBoolean' '(' e1::Expr ')'
   top.upSubst = e1.upSubst;
   
   top.errors <-
-       if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
-       then []
-       else [err(top.location, "Operand to toBoolean must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+    if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
+    then []
+    else [err(top.location, "Operand to toBoolean must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 aspect production toIntegerFunction
@@ -36,9 +36,9 @@ top::Expr ::= 'toInteger' '(' e1::Expr ')'
   top.upSubst = e1.upSubst;
   
   top.errors <-
-       if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
-       then []
-       else [err(top.location, "Operand to toInteger must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+    if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
+    then []
+    else [err(top.location, "Operand to toInteger must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 aspect production toFloatFunction
@@ -48,9 +48,9 @@ top::Expr ::= 'toFloat' '(' e1::Expr ')'
   top.upSubst = e1.upSubst;
   
   top.errors <-
-       if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
-       then []
-       else [err(top.location, "Operand to toFloat must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+    if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
+    then []
+    else [err(top.location, "Operand to toFloat must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 aspect production toStringFunction
@@ -60,9 +60,9 @@ top::Expr ::= 'toString' '(' e1::Expr ')'
   top.upSubst = e1.upSubst;
   
   top.errors <-
-       if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
-       then []
-       else [err(top.location, "Operand to toString must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
+    if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
+    then []
+    else [err(top.location, "Operand to toString must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
 aspect production reifyFunctionLiteral
@@ -82,9 +82,9 @@ top::Expr ::= 'new' '(' e1::Expr ')'
   
   errCheck1 = checkDecorated(e1.typerep);
   top.errors <-
-       if errCheck1.typeerror
-       then [err(top.location, "Operand to new must be a decorated nonterminal.  Instead it is of type " ++ errCheck1.leftpp)]
-       else [];
+    if errCheck1.typeerror
+    then [err(top.location, "Operand to new must be a decorated nonterminal.  Instead it is of type " ++ errCheck1.leftpp)]
+    else [];
 }
 
 aspect production terminalConstructor
@@ -102,17 +102,18 @@ top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
   errCheck1 = check(es.typerep, stringType());
   errCheck2 = check(el.typerep, nonterminalType("core:Location", []));
   top.errors <-
-       if errCheck1.typeerror
-       then [err(es.location, "Second operand to 'terminal(type,lexeme,location)' must be a String, instead it is " ++ errCheck1.leftpp)]
-       else [];
+    if errCheck1.typeerror
+    then [err(es.location, "Second operand to 'terminal(type,lexeme,location)' must be a String, instead it is " ++ errCheck1.leftpp)]
+    else [];
+
   top.errors <-
-       if errCheck2.typeerror
-       then [err(el.location, "Third operand to 'terminal(type,lexeme,location)' must be a Location, instead it is " ++ errCheck2.leftpp)]
-       else [];
+    if errCheck2.typeerror
+    then [err(el.location, "Third operand to 'terminal(type,lexeme,location)' must be a Location, instead it is " ++ errCheck2.leftpp)]
+    else [];
   
   top.errors <-
-        if (t.typerep.isTerminal) 
-        then []
-        else [err(t.location, "First operand to 'terminal(type,lexeme,location)' must be a Terminal, instead it is " ++ prettyType(t.typerep))];
+    if t.typerep.isTerminal || t.typerep.isError
+    then []
+    else [err(t.location, "First operand to 'terminal(type,lexeme,location)' must be a Terminal type, instead it is " ++ prettyType(t.typerep))];
 }
 

--- a/grammars/silver/analysis/typechecking/core/Checking.sv
+++ b/grammars/silver/analysis/typechecking/core/Checking.sv
@@ -13,39 +13,42 @@ abstract production check
 top::TypeCheck ::= l::Type r::Type
 {
   top.upSubst = unifyCheck(l, r, top.downSubst);
-  
+
   top.typeerror = top.upSubst.failure;
-  
-  local attribute finleft :: Type;
-  finleft = performSubstitution(l, top.finalSubst);
-  
-  local attribute finright :: Type;
-  finright = performSubstitution(r, top.finalSubst);
-  
-  local attribute fv :: [TyVar];
-  fv = setUnionTyVars(finleft.freeVariables, finright.freeVariables);
-  
+
+  local finleft :: Type = performSubstitution(l, top.finalSubst);
+
+  local finright :: Type = performSubstitution(r, top.finalSubst);
+
+  local fv :: [TyVar] = setUnionTyVars(finleft.freeVariables, finright.freeVariables);
+
   top.leftpp = prettyTypeWith(finleft, fv);
-  top.rightpp = prettyTypeWith(finright, fv); 
+  top.rightpp = prettyTypeWith(finright, fv);
 }
 
 abstract production checkNonterminal
 top::TypeCheck ::= l::Type
 {
-  top.upSubst = composeSubst(ignoreFailure(top.downSubst), performSubstitution(l, top.downSubst).unifyInstanceNonterminal);
-  
-  top.typeerror = top.upSubst.failure;
-  
+  local refined :: Type =
+    performSubstitution(l, top.downSubst);
+
+  top.upSubst = composeSubst(ignoreFailure(top.downSubst), refined.unifyInstanceNonterminal);
+
+  top.typeerror = top.upSubst.failure && !refined.isError;
+
   top.leftpp = prettyType(performSubstitution(l, top.finalSubst));
   top.rightpp = "a nonterminal";
 }
 abstract production checkDecorated
 top::TypeCheck ::= l::Type
 {
-  top.upSubst = composeSubst(ignoreFailure(top.downSubst), performSubstitution(l, top.downSubst).unifyInstanceDecorated);
-  
-  top.typeerror = top.upSubst.failure;
-  
+  local refined :: Type =
+    performSubstitution(l, top.downSubst);
+
+  top.upSubst = composeSubst(ignoreFailure(top.downSubst), refined.unifyInstanceDecorated);
+
+  top.typeerror = top.upSubst.failure && !refined.isError;
+
   top.leftpp = prettyType(performSubstitution(l, top.finalSubst));
   top.rightpp = "a decorated nonterminal";
 }

--- a/grammars/silver/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/analysis/typechecking/core/Expr.sv
@@ -575,23 +575,8 @@ top::Expr ::= s::String_t
   top.upSubst = top.downSubst;
 }
 
-aspect production plusPlus
-top::Expr ::= e1::Expr '++' e2::Expr
-{
-  production attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
-
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  forward.downSubst = errCheck1.upSubst;
-  -- upSubst defined via forward :D
-  
-  errCheck1 = check(e1.typerep, e2.typerep);
-  top.errors <-
-       if errCheck1.typeerror
-       then [err(top.location, "Operands to ++ must be the same type. Instead they are " ++ errCheck1.leftpp ++ " and " ++ errCheck1.rightpp)]
-       else [];
-}
+-- Already merged into silver:definition:core
+--aspect production plusPlus
 
 aspect production errorPlusPlus
 top::Expr ::= e1::Decorated Expr e2::Decorated Expr

--- a/grammars/silver/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/analysis/typechecking/core/ProductionBody.sv
@@ -199,7 +199,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   errCheck1 = check(e.typerep, val.lookupValue.typerep);
   top.errors <-
        if errCheck1.typeerror
-       then [err(top.location, "Value " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
+       then [err(top.location, "Local " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
        else [];
 }
 

--- a/grammars/silver/definition/concrete_syntax/ProductionDcl.sv
+++ b/grammars/silver/definition/concrete_syntax/ProductionDcl.sv
@@ -71,7 +71,7 @@ top::ProductionModifier ::= 'precedence' '=' i::Int_t
 {
   top.unparse = "precedence = " ++ i.lexeme;
 
-  top.productionModifiers = [prodPrecedence(toInt(i.lexeme))];
+  top.productionModifiers = [prodPrecedence(toInteger(i.lexeme))];
   top.errors := [];
 }
 

--- a/grammars/silver/definition/concrete_syntax/TerminalDcl.sv
+++ b/grammars/silver/definition/concrete_syntax/TerminalDcl.sv
@@ -152,7 +152,7 @@ top::TerminalModifier ::= 'precedence' '=' i::Int_t
 {
   top.unparse = "precedence = " ++ i.lexeme;
 
-  top.terminalModifiers = [termPrecedence(toInt(i.lexeme))];
+  top.terminalModifiers = [termPrecedence(toInteger(i.lexeme))];
   top.errors := [];
 }
 

--- a/grammars/silver/definition/core/BuiltInFunctions.sv
+++ b/grammars/silver/definition/core/BuiltInFunctions.sv
@@ -1,15 +1,11 @@
 grammar silver:definition:core;
 
---import silver:analysis:typechecking:core;
-
 concrete production lengthFunction
 top::Expr ::= 'length' '(' e::Expr ')'
 {
   top.unparse = "length(" ++ e.unparse ++ ")";
 
-  top.typerep = intType();
-  
-  top.errors := e.errors ++ forward.errors;
+  top.typerep = intType(); -- is this necessary? for flowtype reasons?
 
   forwards to performSubstitution(e.typerep, e.upSubst).lengthDispatcher(e, top.location);
 }
@@ -21,7 +17,13 @@ top::Expr ::= e::Decorated Expr
 
   top.typerep = intType();
 
-  top.errors := [err(e.location, "Operand to length is not compatible. It is of type " ++ prettyType(performSubstitution(e.typerep, top.finalSubst)))];
+  local resolved :: Type =
+    performSubstitution(e.typerep, top.finalSubst);
+
+  top.errors :=
+    e.errors ++
+    if resolved.isError then [] -- suppress additional error message
+    else [err(e.location, "Operand to length is not compatible. It is of type " ++ prettyType(resolved))];
 }
 
 abstract production stringLength
@@ -31,15 +33,7 @@ top::Expr ::= e::Decorated Expr
 
   top.typerep = intType();
 
-  top.errors := [];
-}
-
--- Legacy, TODO: deprecate this eventually
-concrete production toIntFunction
-top::Expr ::= 'toInt' '(' e::Expr ')'
-{
-  top.unparse = "toInt(" ++ e.unparse ++ ")";
-  forwards to toIntegerFunction('toInteger', '(', e, ')', location=top.location);
+  top.errors := e.errors;
 }
 
 concrete production toIntegerFunction
@@ -97,6 +91,11 @@ top::Expr ::= 'new' '(' e::Expr ')'
   top.typerep = performSubstitution(e.typerep, top.upSubst).decoratedType;
 }
 
+{--
+ - The standard terminal constructor. This is *abstract* because 3-arg
+ - syntax is ambiguous without type-based disambiguation with a legacy syntax.
+ - See below in this file.
+ -}
 abstract production terminalConstructor
 top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
 {
@@ -106,61 +105,89 @@ top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
   top.typerep = t.typerep;
 }
 
--- OLD DEPRECATED VERSIONS
 
+--------------------------------------------------------------------------------
+-- Deprecated variants of built-in functions
+
+
+concrete production toIntFunction
+top::Expr ::= 'toInt' '(' e::Expr ')'
+{
+  top.unparse = "toInt(" ++ e.unparse ++ ")";
+
+  -- TODO: Please uncomment this soon. I'm only leaving it because
+  -- Jenkins builds things with `--warn-error` as part of MWDA.
+  -- We really need to add a `--mwda` flag or something, so new warnings
+  -- can be introduced safely.
+  --top.errors <- [wrn($1.location, "'toInt' is deprecated syntax, please use 'toInteger' instead.")];
+
+  forwards to toIntegerFunction('toInteger', '(', e, ')', location=top.location);
+}
+
+{--
+ - Three-argument `terminal` is either:
+ - `terminal(type,lexeme,location)` or a legacy syntax of
+ - `terminal(type,lexeme,inherited_terminal)`.
+ -
+ - We should remove the "inherited terminal" variant, eventually.
+ -}
 concrete production terminalConstructorTemporaryDispatcher
 top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
 {
   top.unparse = "terminal(" ++ t.unparse ++ ", " ++ es.unparse ++ ", " ++ el.unparse ++ ")";
-  -- This is a temporary compatibility hack. It's really nasty. Remove as soon as possible. TODO
-  
-  -- We're being stupidly simple here.
+
+  -- A hack, so we can get `typerep`. Should be always fine, since explicitly stated
+  -- types won't actually use `downSubst`.
   el.downSubst = emptySubst();
-  
+
   forwards to
     if el.typerep.isTerminal
     then terminalFunctionInherited($1, $2, t, $4, es, $6, el, $8, location=top.location)
     else terminalConstructor($1, $2, t, $4, es, $6, el, $8, location=top.location);
 }
 
-
 concrete production terminalFunction
 top::Expr ::= 'terminal' '(' t::TypeExpr ',' e::Expr ')'
 {
-  -- let's temporarily not say anything about this one...
+  -- So, *maybe* this is deprecated? But let's not complain for now, because
+  -- it's too widely used.
+
   --top.errors <- [wrn(t.location, "terminal(type,lexeme) is deprecated. Use terminal(type,lexeme,location) instead.")];
-  forwards to terminalConstructor($1, $2, t, $4, e, ',',
-    mkStrFunctionInvocation($6.location, "core:loc", [
-      stringConst(terminal(String_t, "\"??\""), location=$6.location),
-      intConst(terminal(Int_t, "-1"), location=$6.location),
-      intConst(terminal(Int_t, "-1"), location=$6.location),
-      intConst(terminal(Int_t, "-1"), location=$6.location),
-      intConst(terminal(Int_t, "-1"), location=$6.location),
-      intConst(terminal(Int_t, "-1"), location=$6.location),
-      intConst(terminal(Int_t, "-1"), location=$6.location)
-    ]), $6, location=top.location);
+
+  local bogus :: Expr =
+    mkStrFunctionInvocation($6.location, "core:bogusLoc", []);
+
+  forwards to terminalConstructor($1, $2, t, $4, e, ',', bogus, $6, location=top.location);
 }
 
 concrete production terminalFunctionLineCol
 top::Expr ::= 'terminal' '(' t::TypeExpr ',' e1::Expr ',' e2::Expr ',' e3::Expr ')'
 {
-  top.errors <- [wrn(t.location, "terminal(type,lexeme,line,column) is deprecated. Use terminal(type,lexeme,location) instead.")];
+  top.errors <-
+    [wrn(t.location, "terminal(type,lexeme,line,column) is deprecated. Use terminal(type,lexeme,location) instead.")];
+
+  local bogus :: Expr =
+    intConst(terminal(Int_t, "-1"), location=$10.location);
+
   forwards to terminalConstructor($1, $2, t, $4, e1, $6,
     mkStrFunctionInvocation($10.location, "core:loc", [
       stringConst(terminal(String_t, "\"??\""), location=$10.location),
-      e2,
-      e3,
-      intConst(terminal(Int_t, "-1"), location=$10.location),
-      intConst(terminal(Int_t, "-1"), location=$10.location),
-      intConst(terminal(Int_t, "-1"), location=$10.location),
-      intConst(terminal(Int_t, "-1"), location=$10.location)
+      e2, e3, bogus, bogus, bogus, bogus
     ]), $10, location=top.location);
 }
 
+{--
+ - Legacy syntax should be removed, eventually.
+ -}
 abstract production terminalFunctionInherited
 top::Expr ::= 'terminal' '(' t::TypeExpr ',' e1::Expr ',' e2::Expr ')'
 {
-  top.errors <- [wrn(t.location, "terminal(type,lexeme,terminal) is deprecated. Please just add '.location' on the terminal to use terminal(type,lexeme,location)")];
-  forwards to terminalConstructor($1, $2, t, $4, e1, $6, access(e2, '.', qNameAttrOccur(qName(forward.location, "location"), location=top.location), location=top.location), $8, location=top.location);
+  top.errors <-
+    [wrn(t.location, "terminal(type,lexeme,terminal) is deprecated. Please just add '.location' on the terminal to use terminal(type,lexeme,location)")];
+
+  local loc_access :: Expr =
+    access(e2, '.', qNameAttrOccur(qName($8.location, "location"), location=top.location), location=top.location);
+
+  forwards to terminalConstructor($1, $2, t, $4, e1, $6, loc_access, $8, location=top.location);
 }
 

--- a/grammars/silver/definition/core/Expr.sv
+++ b/grammars/silver/definition/core/Expr.sv
@@ -721,11 +721,27 @@ top::Expr ::= e1::Expr '++' e2::Expr
 {
   top.unparse = e1.unparse ++ " ++ " ++ e2.unparse;
 
-  top.typerep = performSubstitution(e1.typerep, errCheck1.upSubst); -- TODO: a bit silly we depend on errCheck, which isn't here...
-
   top.errors := e1.errors ++ e2.errors ++ forward.errors;
+  top.typerep = if errCheck1.typeerror then errorType() else result_type;
 
-  forwards to top.typerep.appendDispatcher(e1, e2, top.location);
+  local result_type :: Type = performSubstitution(e1.typerep, errCheck1.upSubst);
+
+  -- Moved from 'analysis:typechecking' because we want to use this stuff here now
+  local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
+
+  e1.downSubst = top.downSubst;
+  e2.downSubst = e1.upSubst;
+  errCheck1.downSubst = e2.upSubst;
+  forward.downSubst = errCheck1.upSubst;
+  -- upSubst defined via forward :D
+
+  errCheck1 = check(e1.typerep, e2.typerep);
+
+  forwards to
+    -- if the types disagree, forward to an error production instead.
+    if errCheck1.typeerror
+    then errorExpr([err(top.location, "Operands to ++ must be the same concatenable type. Instead they are " ++ errCheck1.leftpp ++ " and " ++ errCheck1.rightpp)], location=top.location)
+    else top.typerep.appendDispatcher(e1, e2, top.location);
 }
 
 abstract production stringPlusPlus
@@ -742,8 +758,11 @@ top::Expr ::= e1::Decorated Expr e2::Decorated Expr
 {
   top.unparse = e1.unparse ++ " ++ " ++ e2.unparse;
 
-  -- TODO perhaps suppress this error is isError
-  top.errors := [err(e1.location, prettyType(performSubstitution(e1.typerep, e1.upSubst)) ++ " is not a concatenable type.")];
+  local result_type :: Type = performSubstitution(e1.typerep, top.downSubst);
+
+  top.errors :=
+    if result_type.isError then []
+    else [err(e1.location, prettyType(result_type) ++ " is not a concatenable type.")];
   top.typerep = errorType();
 }
 

--- a/grammars/silver/definition/core/Type.sv
+++ b/grammars/silver/definition/core/Type.sv
@@ -31,6 +31,16 @@ top::Type ::=
   top.appendDispatcher = errorPlusPlus(_, _, location=_);
 }
 
+aspect production errorType
+top::Type ::=
+{
+  -- Allow these, to suppress raising additional unnecessary errors.
+  top.instanceEq = true;
+  top.instanceOrd = true;
+  top.instanceNum = true;
+  top.instanceConvertible = true;
+}
+
 aspect production intType
 top::Type ::=
 {

--- a/grammars/silver/extension/convenience/Children.sv
+++ b/grammars/silver/extension/convenience/Children.sv
@@ -15,7 +15,7 @@ top::Expr ::= '$' e::Int_t
       if top.frame.signature.outputElement.elementName == "__SV_BOGUS_ELEM" -- TODO hack!
       then nothing()
       else
-        findChild(toInt(e.lexeme), 
+        findChild(toInteger(e.lexeme),
           [top.frame.signature.outputElement.elementName] ++ top.frame.signature.inputNames));
 
   forwards to baseExpr(qName(top.location, ref), location=top.location);

--- a/grammars/silver/extension/list/List.sv
+++ b/grammars/silver/extension/list/List.sv
@@ -78,10 +78,14 @@ top::Expr ::= e1::Decorated Expr e2::Decorated Expr
 {
   forwards to mkStrFunctionInvocationDecorated(e1.location, "core:append", [e1,e2]);
 }
+
 abstract production listLengthBouncer
 top::Expr ::= e::Decorated Expr
 {
-  top.errors <- e.errors;
+  -- Because `e` will get wrapped in `exprRef`, it's errors will not appear in the
+  -- forward tree.
+  top.errors := forward.errors ++ e.errors;
+
   forwards to mkStrFunctionInvocationDecorated(e.location, "core:listLength", [e]);
 }
 

--- a/grammars/silver/extension/list/Type.sv
+++ b/grammars/silver/extension/list/Type.sv
@@ -8,11 +8,12 @@ top::Type ::= el::Type
   top.flatRenamed = listType(el.flatRenamed);
   top.typepp = "[" ++ el.typepp ++ "]";
 
-  top.unify = case top.unifyWith of
-               listType(fel) -> unify(el,fel)
-             | decoratedType(nonterminalType("core:List", ftes)) -> unify(el, head(ftes))
-             | _ -> errorSubst("Tried to unify list with " ++ prettyType(top.unifyWith))
-              end;
+  top.unify =
+    case top.unifyWith of
+    | listType(fel) -> unify(el,fel)
+    | decoratedType(nonterminalType("core:List", ftes)) -> unify(el, head(ftes))
+    | _ -> errorSubst("Tried to unify list with " ++ prettyType(top.unifyWith))
+    end;
   
   -- Suppress its "nonterminal"ness
   top.isDecorable = false;

--- a/grammars/silver/json/Json.sv
+++ b/grammars/silver/json/Json.sv
@@ -60,8 +60,8 @@ Json ::= i::Integer
 abstract production jsonFloat
 top::Json ::= float::Float
 {
-  top.jsonString = if float == toFloat(toInt(float))
-                   then toString(toInt(float))
+  top.jsonString = if float == toFloat(toInteger(float))
+                   then toString(toInteger(float))
                    else toString(float);
 }
 

--- a/grammars/silver/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/modification/copper/ProductionStmt.sv
@@ -86,7 +86,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   errCheck1 = check(e.typerep, val.lookupValue.typerep);
   top.errors <-
        if errCheck1.typeerror
-       then [err(top.location, "Value " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
+       then [err(top.location, "Parser attribute " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
        else [];
 }
 
@@ -216,7 +216,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   errCheck1 = check(e.typerep, val.lookupValue.typerep);
   top.errors <-
     if errCheck1.typeerror
-    then [err(top.location, "Value " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
+    then [err(top.location, "Terminal attribute " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
     else [];
 }
 

--- a/grammars/silver/modification/impide/FontDecl.sv
+++ b/grammars/silver/modification/impide/FontDecl.sv
@@ -20,7 +20,7 @@ top::AGDcl ::= 'temp_imp_ide_font' id::Name 'color' '(' r::Int_t ',' g::Int_t ',
 
   top.syntaxAst = [syntaxFont(
                    fName, 
-                   font(makeColor(toInt(r.lexeme),toInt(g.lexeme),toInt(b.lexeme)), 
+                   font(makeColor(toInteger(r.lexeme),toInteger(g.lexeme),toInteger(b.lexeme)), 
                         fontStyles.isBold, 
                         fontStyles.isItalic)
 		  )];

--- a/grammars/silver/reflect/concretesyntax/ConcreteSyntax.sv
+++ b/grammars/silver/reflect/concretesyntax/ConcreteSyntax.sv
@@ -78,7 +78,7 @@ concrete productions top::AST_c
   }
 | i::Int_t
   {
-    top.ast = integerAST(toInt(i.lexeme));
+    top.ast = integerAST(toInteger(i.lexeme));
     top.errors := [];
   }
 | f::Float_t

--- a/grammars/silver/translation/java/core/BuiltInFunctions.sv
+++ b/grammars/silver/translation/java/core/BuiltInFunctions.sv
@@ -36,7 +36,7 @@ top::Expr ::= 'toInteger' '(' e::Expr ')'
                     | intType() -> e.translation
                     | floatType() -> s"Integer.valueOf(((Float)${e.translation}).intValue())"
                     | stringType() -> s"Integer.valueOf(${e.translation}.toString())"
-                    | t -> error("INTERNAL ERROR: no toInt translation for type " ++ prettyType(t))
+                    | t -> error("INTERNAL ERROR: no toInteger translation for type " ++ prettyType(t))
                     end;
 
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);

--- a/grammars/silver/util/fixedmap/FixedMap.sv
+++ b/grammars/silver/util/fixedmap/FixedMap.sv
@@ -106,7 +106,7 @@ Map<b> ::= collected::[[Pair<String b>]] upTo::Integer
   right_list = drop(middle,collected);
  
   local attribute middle :: Integer;
-  middle = toInt(toFloat(upTo) / 2.0);
+  middle = toInteger(toFloat(upTo) / 2.0);
 }
 
 function getSnd

--- a/runtime/java/README.md
+++ b/runtime/java/README.md
@@ -1,11 +1,21 @@
 
 To edit the Silver runtime from an Eclipse IDE,
 
-1. Run a successful `./deep-rebuild` at project root.
-   This is necessary to build generate translations for Silver standard library
+1. Run a successful `./deep-rebuild` at Silver project root.
+   This is necessary to generate translations for the Silver standard library
    and other things referenced by the runtime.
-2. Add `silver/runtime/java` as a project to your Eclipse workspace.
-3. `Window -> Preferences` and `Java -> Build Path -> Classpath Variables`
-   Then set `SILVER_HOME` to where you have checked out Silver.
-   (e.g. `/home/tedinski/repos/silver`)
+   (Failure to do this, or later having run clean, will result in errors related
+   to not finding classes from `core` and `lib`.)
+
+2. In Eclipse, `File -> Import`, `General -> Existing Projects into Workspace`.
+   Give it the path to `silver/runtime/java`.
+
+3. Go to `Window -> Preferences` (NOTE: **WINDOW** preferences, other
+   ways to get to preferences may not show this option! Confusingly.)
+   and navigate to `Java -> Build Path -> Classpath Variables`.
+   Then create a new `SILVER_HOME` variable, set to where you have checked out
+   Silver. (e.g. `/home/tedinski/repos/silver`)
+
+   (The purpose of this is to ensure the eclipse project configuration that's
+   checked into version control does not need to change from person to person.)
 

--- a/test/silver_features/Main.sv
+++ b/test/silver_features/Main.sv
@@ -12,8 +12,8 @@ mainTestSuite silver_tests;
 -- Some basic aspects of arithmetic
 
 -- Truncates, not rounds
-equalityTest( toInt(0.1), 0, Integer, silver_tests );
-equalityTest( toInt(0.99), 0, Integer, silver_tests );
+equalityTest( toInteger(0.1), 0, Integer, silver_tests );
+equalityTest( toInteger(0.99), 0, Integer, silver_tests );
 equalityTest( 1 / 3, 0, Integer, silver_tests );
 equalityTest( 4 / 3, 1, Integer, silver_tests );
 
@@ -34,7 +34,7 @@ equalityTest( "abc" != "ABC", true, Boolean, silver_tests );
 
 -- Casting floats and ints should compile correctly to objects, not primitives
 -- (previously mostly worked due to autoboxing, but exposed when doing immediate equality checks with the cast on the left-hand side)
-equalityTest( toInt(0.0) == 0, true, Boolean, silver_tests );
+equalityTest( toInteger(0.0) == 0, true, Boolean, silver_tests );
 equalityTest( toFloat(0) == 0.0, true, Boolean, silver_tests );
 
 -- Basic oddball tests, just to have called the functions.

--- a/test/silver_features/Reflection.sv
+++ b/test/silver_features/Reflection.sv
@@ -212,7 +212,11 @@ equalityTest(
 terminal Foo_t 'foo';
 terminal Bar_t /bar[0-9]+/;
 
-global terminalTestValue::Pair<[Foo_t] Maybe<Bar_t>> = pair(['foo', 'foo'], just(terminal(Bar_t, "bar42", loc("a", 1, 2, 3, 4, 5, 6))));
+-- make this test independent of how `'foo'` translates
+global terminal_foo_value :: Foo_t =
+  terminal(Foo_t, "foo", loc("??", -1, -1, -1, -1, -1, -1));
+
+global terminalTestValue::Pair<[Foo_t] Maybe<Bar_t>> = pair([terminal_foo_value, terminal_foo_value], just(terminal(Bar_t, "bar42", loc("a", 1, 2, 3, 4, 5, 6))));
 global terminalSerializeRes::Either<String String> = reflect(terminalTestValue).serialize;
 global terminalDeserializeRes::Either<String AST> = deserializeAST(lessHackyUnparse(terminalTestValue), case terminalSerializeRes of left(msg) -> msg | right(a) -> a end);
 global terminalReifyRes::Either<String Pair<[Foo_t] Maybe<Bar_t>>> = reify(case terminalDeserializeRes of left(msg) -> integerAST(37) | right(a) -> a end);

--- a/tutorials/dc/ConcreteSyntax.sv
+++ b/tutorials/dc/ConcreteSyntax.sv
@@ -84,7 +84,7 @@ concrete production integerConstant_c
 ic::Factor_c ::= i::IntLit_t
 {
  ic.pp = i.lexeme ;
- ic.ast_Expr = integerConstant(toInt(i.lexeme));
+ ic.ast_Expr = integerConstant(toInteger(i.lexeme));
 }
 
 


### PR DESCRIPTION
Fixes #242 

I started out just cleaning up what I found in built-in functions, but then ended up with a messy patch that also significantly reduces the amount of error messages we get. My test bit of bad code went from:

```
ASDF.sv:2:28: error: Operands to ++ must be the same type. Instead they are [Integer] and Integer
ASDF.sv:2:28: error: Argument 2 of function 'core:append' expected [Integer] but argument is of type Integer
ASDF.sv:2:28: error: Operands to ++ must be the same type. Instead they are [Integer] and Integer
ASDF.sv:2:28: error: Argument 2 of function 'core:append' expected [Integer] but argument is of type Integer
ASDF.sv:4:29: error: Operand to new must be a decorated nonterminal.  Instead it is of type <err>
ASDF.sv:4:33: error: Undeclared value 'asdkjfs'.
ASDF.sv:6:31: error: First operand to 'terminal(type,lexeme,location)' must be a Terminal, instead it is <err>
ASDF.sv:6:31: error: Undeclared type 'ASDFASDASDF'.
ASDF.sv:8:22: error: Integer is not a concatenable type.
```

to:

```
ASDF.sv:2:28: error: Operands to ++ must be the same concatenable type. Instead they are [Integer] and Integer
ASDF.sv:4:33: error: Undeclared value 'asdkjfs'.
ASDF.sv:6:31: error: Undeclared type 'ASDFASDASDF'.
ASDF.sv:8:22: error: Integer is not a concatenable type.
```

