### PR TITLE
Implement silver extension providing nicer syntax for constructing AST trees

### DIFF
--- a/grammars/silver/composed/Default/Main.sv
+++ b/grammars/silver/composed/Default/Main.sv
@@ -25,6 +25,7 @@ parser svParse::Root {
   silver:extension:monad;
   silver:extension:reflection;
   silver:extension:silverconstruction;
+  silver:extension:astconstruction;
   silver:extension:constructparser;
 --  silver:extension:concreteSyntaxForTrees ;
 

--- a/grammars/silver/extension/astconstruction/Syntax.sv
+++ b/grammars/silver/extension/astconstruction/Syntax.sv
@@ -1,0 +1,31 @@
+grammar silver:extension:astconstruction;
+
+imports silver:langutil:pp;
+
+imports silver:definition:core;
+imports silver:definition:env;
+imports silver:definition:type:syntax;
+imports silver:extension:list;
+
+exports silver:reflect:concretesyntax;
+
+concrete production silverExprLiteral
+top::Expr ::= 'AST' '{' ast::AST_c '}'
+{
+  top.unparse = s"AST {${ast.unparse}}";
+  forwards to translate(top.location, reflect(ast.ast));
+}
+
+concrete production escapeAST_c
+top::AST_c ::= '$' '{' e::Expr '}'
+{
+  top.unparse = s"$${${e.unparse}}";
+  top.ast = escapeAST(e);
+  top.errors := [];
+}
+
+abstract production escapeAST
+top::AST ::= e::Expr
+{
+  forwards to error("forward shouldn't be needed here");
+}

--- a/grammars/silver/extension/astconstruction/Terminals.sv
+++ b/grammars/silver/extension/astconstruction/Terminals.sv
@@ -1,0 +1,22 @@
+grammar silver:extension:astconstruction;
+
+import silver:definition:regex;
+
+marking terminal AST_t 'AST' lexer classes {KEYWORD};
+
+temp_imp_ide_font font_escape color(160, 32, 240) bold italic;
+lexer class Escape font=font_escape;
+
+terminal EscapeAST_t '$' lexer classes {Escape};
+
+disambiguate AST_t, IdUpper_t {
+  pluck AST_t;
+}
+
+disambiguate silver:definition:core:WhiteSpace, silver:reflect:concretesyntax:WhiteSpace {
+  pluck silver:definition:core:WhiteSpace;
+}
+
+disambiguate RegexChar_t, silver:definition:core:WhiteSpace, silver:reflect:concretesyntax:WhiteSpace {
+  pluck silver:definition:core:WhiteSpace;
+}

--- a/grammars/silver/extension/astconstruction/Translation.sv
+++ b/grammars/silver/extension/astconstruction/Translation.sv
@@ -1,0 +1,11 @@
+grammar silver:extension:astconstruction;
+
+imports silver:reflect;
+imports silver:hostEmbedding;
+
+aspect production nonterminalAST
+top::AST ::= prodName::String children::ASTs annotations::NamedASTs
+{
+  directEscapeProductions <-
+    ["silver:extension:astconstruction:escapeAST"];
+}

--- a/grammars/silver/reflect/concretesyntax/ConcreteSyntax.sv
+++ b/grammars/silver/reflect/concretesyntax/ConcreteSyntax.sv
@@ -23,32 +23,37 @@ terminal String_t  /[\"]([^\r\n\"\\]|[\\][\"]|[\\][\\]|[\\]b|[\\]n|[\\]r|[\\]f|[
 
 ignore terminal WhiteSpace /[\r\n\t\ ]+/;
 
-nonterminal AST_c with ast<AST>, errors, location;
+nonterminal AST_c with unparse, ast<AST>, errors, location;
 
 concrete productions top::AST_c
 | prodName::QName_c '(' children::ASTs_c ',' annotations::NamedASTs_c ')'
   {
+    top.unparse = s"${prodName.ast}(${children.unparse}, ${annotations.unparse})";
     top.ast =
       nonterminalAST(prodName.ast, foldr(consAST, nilAST(), children.ast), foldr(consNamedAST, nilNamedAST(), annotations.ast));
     top.errors := children.errors ++ annotations.errors;
   }
 | prodName::QName_c '(' children::ASTs_c ')'
   {
+    top.unparse = s"${prodName.ast}(${children.unparse})";
     top.ast = nonterminalAST(prodName.ast, foldr(consAST, nilAST(), children.ast), nilNamedAST());
     top.errors := children.errors;
   }
 | prodName::QName_c '(' annotations::NamedASTs_c ')'
   {
+    top.unparse = s"${prodName.ast}(${annotations.unparse})";
     top.ast = nonterminalAST(prodName.ast, nilAST(), foldr(consNamedAST, nilNamedAST(), annotations.ast));
     top.errors := annotations.errors;
   }
 | prodName::QName_c '(' ')'
   {
+    top.unparse = s"${prodName.ast}()";
     top.ast = nonterminalAST(prodName.ast, nilAST(), nilNamedAST());
     top.errors := [];
   }
 | 'terminal' '(' terminalName::QName_c ',' lexeme::String_t ',' location::AST_c ')'
   {
+    top.unparse = s"terminal(${terminalName.ast}, ${lexeme.lexeme}, ${location.unparse})";
     local locReifyRes::Either<String Location> = reify(location.ast);
     top.ast =
       terminalAST(
@@ -63,73 +68,85 @@ concrete productions top::AST_c
   }
 | '[' vals::ASTs_c ']'
   {
+    top.unparse = s"[${vals.unparse}]";
     top.ast = listAST(foldr(consAST, nilAST(), vals.ast));
     top.errors := vals.errors;
   }
 | '[' ']'
   {
+    top.unparse = "[]";
     top.ast = listAST(nilAST());
     top.errors := [];
   }
 | s::String_t
   {
+    top.unparse = s.lexeme;
     top.ast = stringAST(unescapeString(substring(1, length(s.lexeme) - 1, s.lexeme)));
     top.errors := [];
   }
 | i::Int_t
   {
+    top.unparse = i.lexeme;
     top.ast = integerAST(toInteger(i.lexeme));
     top.errors := [];
   }
 | f::Float_t
   {
+    top.unparse = f.lexeme;
     top.ast = floatAST(toFloat(f.lexeme));
     top.errors := [];
   }
 | 'true'
   {
+    top.unparse = "true";
     top.ast = booleanAST(true);
     top.errors := [];
   }
 | 'false'
   {
+    top.unparse = "false";
     top.ast = booleanAST(false);
     top.errors := [];
   }
 
-nonterminal ASTs_c with ast<[AST]>, errors;
+nonterminal ASTs_c with unparse, ast<[AST]>, errors;
 
 concrete productions top::ASTs_c
 | t::ASTs_c ',' h::AST_c
   {
+    top.unparse = s"${t.unparse}, ${h.unparse}";
     top.ast = t.ast ++ [h.ast];
     top.errors := h.errors ++ t.errors;
   }
 | h::AST_c
   {
+    top.unparse = h.unparse;
     top.ast = [h.ast];
     top.errors := [];
   }
 
-nonterminal NamedASTs_c with ast<[NamedAST]>, errors;
+nonterminal NamedASTs_c with unparse, ast<[NamedAST]>, errors;
 
 concrete productions top::NamedASTs_c
 | t::NamedASTs_c ',' h::NamedAST_c
   {
+    top.unparse = s"${t.unparse}, ${h.unparse}";
     top.ast = t.ast ++ [h.ast];
     top.errors := h.errors ++ t.errors;
   }
 | h::NamedAST_c
   {
+    top.unparse = h.unparse;
     top.ast = [h.ast];
     top.errors := [];
   }
 
-nonterminal NamedAST_c with ast<NamedAST>, errors, location;
+nonterminal NamedAST_c with unparse, ast<NamedAST>, errors, location;
 
 concrete productions top::NamedAST_c
 | n::QName_c '=' v::AST_c
   {
+    top.unparse = s"${n.ast} = ${v.unparse}";
     top.ast = namedAST(n.ast, v.ast);
     top.errors := v.errors;
   }


### PR DESCRIPTION
This re-uses the reflection library's `AST` deserialization grammar to provide another "tree literal" convenience extension for the `AST` type, analogous to the silver-ableC and silverconstruction extensions.  
These changes are taken from the feature/astTerm branch, for which we are deferring further work until later.  