### PR TITLE
Add support for patterns using language-specific syntax

### DIFF
--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -756,6 +756,12 @@ top::PrimPattern ::= i::Int_t '->' e::Expr
   top.flowDeps = e.flowDeps;
   top.flowDefs = e.flowDefs;
 }
+aspect production floatPattern
+top::PrimPattern ::= f::Float_t '->' e::Expr
+{
+  top.flowDeps = e.flowDeps;
+  top.flowDefs = e.flowDefs;
+}
 aspect production stringPattern
 top::PrimPattern ::= i::String_t '->' e::Expr
 {

--- a/grammars/silver/extension/astconstruction/Syntax.sv
+++ b/grammars/silver/extension/astconstruction/Syntax.sv
@@ -17,6 +17,13 @@ top::Expr ::= 'AST' '{' ast::AST_c '}'
   forwards to translate(top.location, reflect(ast.ast));
 }
 
+concrete production silverPatternLiteral
+top::Pattern ::= 'AST' '{' ast::AST_c '}'
+{
+  top.unparse = s"AST {${ast.unparse}}";
+  forwards to translatePattern(top.location, reflect(ast.ast));
+}
+
 concrete production escapeAST_c
 top::AST_c ::= '$' '{' e::Expr '}'
 {
@@ -26,17 +33,17 @@ top::AST_c ::= '$' '{' e::Expr '}'
 }
 
 concrete production varAST_c
-top::AST_c ::= '$' n::Name
+top::AST_c ::= n::Id_t
 {
-  top.unparse = s"$${${n.unparse}}";
-  top.ast = varAST(n);
+  top.unparse = n.lexeme;
+  top.ast = varAST(name(n.lexeme, n.location));
   top.errors := [];
 }
 
 concrete production wildAST_c
-top::AST_c ::= '$' '_'
+top::AST_c ::= '_'
 {
-  top.unparse = s"$$_";
+  top.unparse = "_";
   top.ast = wildAST();
   top.errors := [];
 }
@@ -60,11 +67,11 @@ top::AST ::= n::Name
 {
   top.translation =
     errorExpr(
-      [err(top.givenLocation, "$<name> should only occur inside AST { } pattern")],
+      [err(top.givenLocation, "Variable patterns should only occur inside AST { } pattern")],
       location=top.givenLocation);
   top.patternTranslation =
     errorPattern(
-      [err(top.givenLocation, "$<name> should only occur inside AST { } pattern")],
+      [err(top.givenLocation, "Variable patterns should only occur inside AST { } pattern")],
       location=top.givenLocation);
   forwards to error("forward shouldn't be needed here");
 }
@@ -74,11 +81,11 @@ top::AST ::=
 {
   top.translation =
     errorExpr(
-      [err(top.givenLocation, "$_ should only occur inside AST { } pattern")],
+      [err(top.givenLocation, "_ should only occur inside AST { } pattern")],
       location=top.givenLocation);
   top.patternTranslation =
     errorPattern(
-      [err(top.givenLocation, "$_ should only occur inside AST { } pattern")],
+      [err(top.givenLocation, "_ should only occur inside AST { } pattern")],
       location=top.givenLocation);
   forwards to error("forward shouldn't be needed here");
 }

--- a/grammars/silver/extension/astconstruction/Syntax.sv
+++ b/grammars/silver/extension/astconstruction/Syntax.sv
@@ -6,6 +6,7 @@ imports silver:definition:core;
 imports silver:definition:env;
 imports silver:definition:type:syntax;
 imports silver:extension:list;
+imports silver:extension:patternmatching;
 
 exports silver:reflect:concretesyntax;
 
@@ -24,8 +25,60 @@ top::AST_c ::= '$' '{' e::Expr '}'
   top.errors := [];
 }
 
+concrete production varAST_c
+top::AST_c ::= '$' n::Name
+{
+  top.unparse = s"$${${n.unparse}}";
+  top.ast = varAST(n);
+  top.errors := [];
+}
+
+concrete production wildAST_c
+top::AST_c ::= '$' '_'
+{
+  top.unparse = s"$$_";
+  top.ast = wildAST();
+  top.errors := [];
+}
+
 abstract production escapeAST
 top::AST ::= e::Expr
 {
+  top.translation =
+    errorExpr(
+      [err(top.givenLocation, "${} should only occur inside AST { } expression")],
+      location=top.givenLocation);
+  top.patternTranslation =
+    errorPattern(
+      [err(top.givenLocation, "${} should only occur inside AST { } expression")],
+      location=top.givenLocation);
+  forwards to error("forward shouldn't be needed here");
+}
+
+abstract production varAST
+top::AST ::= n::Name
+{
+  top.translation =
+    errorExpr(
+      [err(top.givenLocation, "$<name> should only occur inside AST { } pattern")],
+      location=top.givenLocation);
+  top.patternTranslation =
+    errorPattern(
+      [err(top.givenLocation, "$<name> should only occur inside AST { } pattern")],
+      location=top.givenLocation);
+  forwards to error("forward shouldn't be needed here");
+}
+
+abstract production wildAST
+top::AST ::=
+{
+  top.translation =
+    errorExpr(
+      [err(top.givenLocation, "$_ should only occur inside AST { } pattern")],
+      location=top.givenLocation);
+  top.patternTranslation =
+    errorPattern(
+      [err(top.givenLocation, "$_ should only occur inside AST { } pattern")],
+      location=top.givenLocation);
   forwards to error("forward shouldn't be needed here");
 }

--- a/grammars/silver/extension/astconstruction/Translation.sv
+++ b/grammars/silver/extension/astconstruction/Translation.sv
@@ -8,4 +8,8 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
 {
   directEscapeProductions <-
     ["silver:extension:astconstruction:escapeAST"];
+  varPatternProductions <-
+    ["silver:extension:astconstruction:varAST"];
+  wildPatternProductions <-
+    ["silver:extension:astconstruction:wildAST"];
 }

--- a/grammars/silver/extension/patternmatching/Case.sv
+++ b/grammars/silver/extension/patternmatching/Case.sv
@@ -272,6 +272,7 @@ PrimPattern ::= restExprs::[Expr]  failCase::Expr  retType::Type  mrs::[Abstract
     | prodAppPattern(qn,_,_,_) -> 
         prodPattern(qn, '(', convStringsToVarBinders(names, l), ')', '->', subcase, location=l)
     | intPattern(it) -> integerPattern(it, '->', subcase, location=l)
+    | fltPattern(it) -> floatPattern(it, '->', subcase, location=l)
     | strPattern(it) -> stringPattern(it, '->', subcase, location=l)
     | truePattern(_) -> booleanPattern("true", '->', subcase, location=l)
     | falsePattern(_) -> booleanPattern("false", '->', subcase, location=l)

--- a/grammars/silver/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/extension/patternmatching/PatternTypes.sv
@@ -94,6 +94,21 @@ top::Pattern ::= v::Name
   top.patternSortKey = "~var";
 }
 
+{--
+ - For other extensions to pattern matching.  Basically acts like a wildcard.
+ -}
+abstract production errorPattern
+top::Pattern ::= msg::[Message]
+{
+  top.unparse = s"{-${messagesToString(msg)}-}";
+  top.errors := msg;
+
+  top.patternIsVariable = true;
+  top.patternVariableName = nothing();
+  top.patternSubPatternList = [];
+  top.patternSortKey = "error";
+}
+
 aspect default production
 top::Pattern ::=
 {

--- a/grammars/silver/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/extension/patternmatching/PatternTypes.sv
@@ -116,6 +116,16 @@ top::Pattern ::= num::Int_t
   top.patternSortKey = num.lexeme;
 }
 
+concrete production fltPattern
+top::Pattern ::= num::Float_t
+{
+  top.unparse = num.lexeme;
+  top.errors := [];
+  
+  top.patternSubPatternList = [];
+  top.patternSortKey = num.lexeme;
+}
+
 concrete production strPattern
 top::Pattern ::= str::String_t
 {

--- a/grammars/silver/hostEmbedding/Translation.sv
+++ b/grammars/silver/hostEmbedding/Translation.sv
@@ -17,6 +17,13 @@ Expr ::= loc::Location ast::AST
   return ast.translation;
 }
 
+function translatePattern
+Pattern ::= loc::Location ast::AST
+{
+  ast.givenLocation = loc;
+  return ast.patternTranslation;
+}
+
 synthesized attribute translation<a>::a;
 synthesized attribute patternTranslation<a>::a;
 synthesized attribute foundLocation::Maybe<Location>;
@@ -131,7 +138,7 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
   production attribute wildPatternProductions::[String] with ++;
   wildPatternProductions := [];
   patternEscapeTranslation <-
-    if containsBy(stringEq, prodName, varPatternProductions)
+    if containsBy(stringEq, prodName, wildPatternProductions)
     then
       case children of
       | nilAST() -> just(wildcPattern('_', location=givenLocation))

--- a/test/silver_features/Convenience.sv
+++ b/test/silver_features/Convenience.sv
@@ -1,7 +1,7 @@
 
 nonterminal ConcreteProductions with fst<ATerm>;
 
-terminal ATerm //;
+terminal ATerm '';
 
 -- Just make sure the syntax is as expected.
 


### PR DESCRIPTION
Using extensions such as silver-ableC, we can nicely construct trees using expressions that embed the syntax of another language.  However, pattern matching on such trees is still annoying.  We can create extensions that use language-specific syntax to specify patterns in a similar way to those that create expressions, by just computing another translation on `AST`.  

This was a quick test of the idea, I added new pattern syntax for the `AST` type itself, and used that to simplify some of the annoying patterns in silver-ableC.  
I also added patterns for matching `Float`s as it seems Silver was lacking those for some reason?  

One slight issue is that we don't have a way of matching on terminals at the moment, so currently attempting to do so just results in a wildcard pattern instead.  I'm not sure of the best way to deal with this case, besides adding support for terminal patterns, I guess.  Shouldn't really be an issue if we use this for languages with abstract syntax (like ableC), but for a language like Silver unexpected behavior might occur if we try to match using a pattern containing identifier terminals.