### PR TITLE
Simplify deserialization grammar for (slightly) improved performance

### DIFF
--- a/grammars/silver/extension/astconstruction/Syntax.sv
+++ b/grammars/silver/extension/astconstruction/Syntax.sv
@@ -33,11 +33,14 @@ top::AST_c ::= '$' '{' e::Expr '}'
 }
 
 concrete production varAST_c
-top::AST_c ::= n::Id_t
+top::AST_c ::= n::QName_t
 {
   top.unparse = n.lexeme;
   top.ast = varAST(name(n.lexeme, n.location));
-  top.errors := [];
+  top.errors :=
+    if indexOf(":", n.lexeme) != -1
+    then [err(n.location, "Pattern variable name must be unqualified")]
+    else [];
 }
 
 concrete production wildAST_c


### PR DESCRIPTION
In discussion with Eric today I realized there was no reason `QName` needs to be a nonterminal in the `AST` deserialization grammar, making it a terminal should slightly speed up parsing and simplify the code.  