### PR TITLE
Fix some issues with `pluck` in disambiguation functions and groups

### DIFF
--- a/grammars/silver/modification/copper/DclInfo.sv
+++ b/grammars/silver/modification/copper/DclInfo.sv
@@ -27,7 +27,8 @@ top::DclInfo ::= sg::String sl::Location fn::String
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = freshType(); -- no appropriate type to use...
+  top.typerep = terminalIdType(); -- TODO: Still needs work to prevent returning terminals
+                                  -- that are not part of the disambiguation set.
   
   top.refDispatcher = pluckTerminalReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -24,7 +24,7 @@ top::Expr ::= q::Decorated QName
 
   -- We... don't actually have a type we can use here TODO. Maybe we could cheat with a skolem type?
   -- Or maybe these should just be TerminalId, see below.
-  top.typerep = freshType();
+  top.typerep = terminalIdType();
   
   top.translation = makeCopperName(q.lookupValue.fullName); -- Value right here?
   top.lazyTranslation = top.translation; -- never, but okay!

--- a/grammars/silver/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/modification/copper/ProductionStmt.sv
@@ -28,7 +28,15 @@ top::ProductionStmt ::= 'pluck' e::Expr ';'
                else [])
                ++ e.errors;
 
-  -- TODO: figure out wtf is going on with type here! (needs to be a terminal, plus one of the ones in the disgroup)
+  local tyCk :: TypeCheck = check(e.typerep, terminalIdType());
+  tyCk.downSubst = e.upSubst;
+  top.errors <- if tyCk.typeerror
+    then [err(top.location, "'pluck' expects one of the terminals it is disambiguating between. Instead it received "++tyCk.leftpp)]
+    else [];
+
+
+  -- TODO: Enforce that the plucked terminal is one of those that are being disambiguated between.
+  -- Currently all that is checked is that it is a terminal.
 
   e.downSubst = top.downSubst;
   top.upSubst = e.upSubst;


### PR DESCRIPTION
Fixes #305 , fixes #306 , fixes the "easy" part of #304 .