### PR TITLE
Fixes #259 Java 11 compilation error

### DIFF
--- a/runtime/java/src/common/rawlib/RawXML.java
+++ b/runtime/java/src/common/rawlib/RawXML.java
@@ -411,7 +411,7 @@ public final class RawXML {
 		}
 
 		@Override
-		public Iterator<?> getPrefixes(String namespaceURI) {
+		public Iterator getPrefixes(String namespaceURI) {
 			throw new UnsupportedOperationException();
 		}
 


### PR DESCRIPTION
This tiny change fixes #259 and makes Silver build on Java 11. Not much to it.