### PR TITLE
When clauses for pattern matching

### DIFF
--- a/test/patt/When.sv
+++ b/test/patt/When.sv
@@ -5,9 +5,9 @@ function testVariableMatches
 Integer ::= input::Integer
 {
   return  case input of
-          | a when a > 3 -> 0
-          | b when b < 0 -> 1
-          | c -> 2
+          | vara when vara > 3 -> 0
+          | varb when varb < 0 -> 1
+          | varc -> 2
           end;
 }
 
@@ -40,7 +40,7 @@ Integer ::= nn1::Nonsense nn2::Nonsense
   return  case nn1, nn2 of
           | n3(n1(), i1), n3(_, i2) when i1 == i2 -> 0
           | n3(_, i1), n3(_, i2) when i1 <= i2 -> 1
-          | n2(a, n3(b, i)), _ when i > 5 -> 2
+          | n2(vara, n3(varb, i)), _ when i > 5 -> 2
           | n1(), n1() -> 3
           | n2(_, n1()), n2(_, n1()) -> 4
           | _, _ -> 5
@@ -67,8 +67,8 @@ function testMultipleVars
 Boolean ::= p1::Pair<Integer Integer> p2::Pair<Integer Integer>
 {
   return  case p1, p2 of
-          | pair(a,b), pair(c,d) when a + b == c + d -> true
-          | pair(a,b), pair(c,d) -> false
+          | pair(vara,varb), pair(varc,vard) when vara + varb == varc + vard -> true
+          | pair(vara,varb), pair(varc,vard) -> false
           end;
 }
 

--- a/test/patt/When.sv
+++ b/test/patt/When.sv
@@ -1,0 +1,90 @@
+grammar patt;
+
+
+function testVariableMatches
+Integer ::= input::Integer
+{
+  return  case input of
+          | a when a > 3 -> 0
+          | b when b < 0 -> 1
+          | c -> 2
+          end;
+}
+
+equalityTest ( testVariableMatches(5), 0, Integer, pat_tests ) ;
+equalityTest ( testVariableMatches(-1), 1, Integer, pat_tests ) ;
+equalityTest ( testVariableMatches(2), 2, Integer, pat_tests ) ;
+
+
+nonterminal Nonsense;
+
+abstract production n1
+top::Nonsense ::=
+{}
+
+abstract production n2
+top::Nonsense ::= c1::Nonsense t2::Nonsense
+{}
+
+abstract production n3
+top::Nonsense ::= c1::Nonsense t2::Integer
+{}
+
+abstract production n4
+top::Nonsense ::=
+{}
+
+function testNonterminalMatches
+Integer ::= n1::Nonsense n2::Nonsense
+{
+  return  case n1, n2 of
+          | n3(n1(), i1), n3(_, i2) when i1 == i2 -> 0
+          | n3(_, i1), n3(_, i2) when i1 <= i2 -> 1
+          | n2(a, n3(b, i)), _ when i > 5 -> 2
+          | n1(), n1() -> 3
+          | n2(_, n1()), n2(_, n1()) -> 4
+          | _, _ -> 5
+          end;
+}
+
+equalityTest ( testNonterminalMatches( n3(n1(), 5),   n3(n4(), 5) ),
+               0, Integer, pat_tests ) ;
+equalityTest ( testNonterminalMatches( n3(n4(), 4),   n3(n4(), 5) ),
+               1, Integer, pat_tests ) ;
+equalityTest ( testNonterminalMatches( n3(n1(), 3),   n3(n4(), 5) ),
+               1, Integer, pat_tests ) ;
+equalityTest ( testNonterminalMatches( n2(n4(), n3(n4(), 6)),   n4() ),
+               2, Integer, pat_tests ) ;
+equalityTest ( testNonterminalMatches( n2(n4(),   n3(n4(), 0)), n4() ),
+               5, Integer, pat_tests ) ;
+equalityTest ( testNonterminalMatches( n1(),   n1() ),
+               3, Integer, pat_tests ) ;
+equalityTest ( testNonterminalMatches( n2(n4(), n1()),   n2(n4(), n1()) ),
+               4, Integer, pat_tests ) ;
+
+
+function testMultipleVars
+Boolean ::= p1::Pair<Integer Integer> p2::Pair<Integer Integer>
+{
+  return  case p1, p2 of
+          | pair(a,b), pair(c,d) when a + b == c + d -> true
+          | pair(a,b), pair(c,d) -> false
+          end;
+}
+
+equalityTest ( testMultipleVars(pair(3,4), pair(7,0)), true, Boolean, pat_tests ) ;
+equalityTest ( testMultipleVars(pair(3,4), pair(3,3)), false, Boolean, pat_tests ) ;
+
+
+
+wrongCode "Pattern has overlapping cases" {
+  global whenCrashTest1 :: Integer =
+    case 5 of
+    | a when a > 3 -> 0
+    --the last two are overlapping patterns
+    | b -> b
+    | c -> c
+    end;
+}
+
+

--- a/test/patt/When.sv
+++ b/test/patt/When.sv
@@ -35,9 +35,9 @@ top::Nonsense ::=
 {}
 
 function testNonterminalMatches
-Integer ::= n1::Nonsense n2::Nonsense
+Integer ::= nn1::Nonsense nn2::Nonsense
 {
-  return  case n1, n2 of
+  return  case nn1, nn2 of
           | n3(n1(), i1), n3(_, i2) when i1 == i2 -> 0
           | n3(_, i1), n3(_, i2) when i1 <= i2 -> 1
           | n2(a, n3(b, i)), _ when i > 5 -> 2


### PR DESCRIPTION
This adds `when` clauses to pattern matching with `case`, allowing Boolean conditions to be added to match clauses.  This enables something like the following code to be written:
```
case x of
| bar(_, _) -> 5
| foo(a,b) when a > b -> a - b
| foo(a,b) when b > a -> b - a
| _ -> 0
end
```