### PR TITLE
Fix attribute equation in TerminalDescriptor in core

### DIFF
--- a/grammars/core/TerminalDescriptor.sv
+++ b/grammars/core/TerminalDescriptor.sv
@@ -10,7 +10,7 @@ nonterminal TerminalDescriptor with lexeme, lexerClasses, terminalLocation, term
 abstract production terminalDescriptor
 top::TerminalDescriptor ::= lexeme::String lexerClasses::[String] terminalName::String terminalLocation::Location
 {
-  top.lexeme = top.lexeme;
+  top.lexeme = lexeme;
   top.lexerClasses = lexerClasses;
   top.terminalLocation = terminalLocation;
   top.terminalName = terminalName;


### PR DESCRIPTION
Fix attribute equation for top.lexeme in TerminalDescriptor to equal the lexeme passed in instead of itself which does not have a value yet.