### PR TITLE
Various enhancements related to lexer classes

### DIFF
--- a/grammars/core/List.sv
+++ b/grammars/core/List.sv
@@ -390,6 +390,19 @@ function unionsBy
   return nubBy(eq, concat(ss));
 }
 
+function powerSet
+[[a]] ::= xs::[a]
+{
+  return
+    case xs of
+    | h :: t ->
+      let rest::[[a]] = powerSet(t)
+      in rest ++ map(cons(h, _), rest)
+      end
+    | [] -> [[]]
+    end;
+}
+
 
 -- Boolean list operations
 function all

--- a/grammars/core/TerminalId.sv
+++ b/grammars/core/TerminalId.sv
@@ -5,15 +5,17 @@ Boolean ::= t1::TerminalId  t2::TerminalId
 {
   return t1 == t2;
 }
+
+function terminalIdLte
+Boolean ::= t1::TerminalId  t2::TerminalId
+{
+  return t1 <= t2;
+}
  
 function terminalSetEq
 Boolean ::= ts1::[TerminalId] ts2::[TerminalId]
 {
   return
     length(ts1) == length(ts2) &&
-    all(
-      zipWith(
-        terminalIdEq,
-        map(sortBy(terminalIdEq, _), ts1),
-        map(sortBy(terminalIdEq, _), ts2)));
+    all(zipWith(terminalIdEq, sortBy(terminalIdLte, ts1), sortBy(terminalIdLte, ts2)));
 }

--- a/grammars/core/TerminalId.sv
+++ b/grammars/core/TerminalId.sv
@@ -5,3 +5,15 @@ Boolean ::= t1::TerminalId  t2::TerminalId
 {
   return t1 == t2;
 }
+ 
+function terminalSetEq
+Boolean ::= ts1::[TerminalId] ts2::[TerminalId]
+{
+  return
+    length(ts1) == length(ts2) &&
+    all(
+      zipWith(
+        terminalIdEq,
+        map(sortBy(terminalIdEq, _), ts1),
+        map(sortBy(terminalIdEq, _), ts2)));
+}

--- a/grammars/core/TerminalId.sv
+++ b/grammars/core/TerminalId.sv
@@ -11,11 +11,18 @@ Boolean ::= t1::TerminalId  t2::TerminalId
 {
   return t1 <= t2;
 }
- 
+
 function terminalSetEq
 Boolean ::= ts1::[TerminalId] ts2::[TerminalId]
 {
   return
     length(ts1) == length(ts2) &&
     all(zipWith(terminalIdEq, sortBy(terminalIdLte, ts1), sortBy(terminalIdLte, ts2)));
+}
+
+function terminalSubset
+Boolean ::= ts1::[TerminalId] ts2::[TerminalId]
+{
+  -- Probably more efficient than sorting if ts1 is small?
+  return all(map(containsBy(terminalIdEq, _, ts2), ts1));
 }

--- a/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
@@ -7,6 +7,8 @@ imports silver:definition:env;
 imports silver:translation:java:core only makeIdName, makeClassName, makeNTClassName;
 imports silver:translation:java:type only transType;
 
+import silver:util:raw:graph as g;
+
 {--
  - Encapsulates transformations and analysis of Syntax
  -}
@@ -25,6 +27,13 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   s.containingGrammar = "host";
   s.univLayout = error("TODO: make this environment not be decorated?"); -- TODO
   s.classTerminals = error("TODO: shouldn't by necessary to normalize"); -- TODO
+  s.superClasses =
+    directBuildTree(
+      g:toList(
+        g:transitiveClosure(
+          g:add(
+            s.superClassContribs,
+            g:empty(compareString)))));
   s.parserAttributeAspects = error("TODO: shouldn't by necessary to normalize"); -- TODO
   s.prefixesForTerminals = error("TODO: shouldn't by necessary to normalize"); -- TODO
   
@@ -35,6 +44,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   s2.containingGrammar = "host";
   s2.cstNTProds = error("TODO: make this environment not be decorated?"); -- TODO
   s2.classTerminals = directBuildTree(s.classTerminalContribs);
+  s2.superClasses = s.superClasses;
   s2.parserAttributeAspects = directBuildTree(s.parserAttributeAspectContribs);
   s2.prefixesForTerminals = directBuildTree(terminalPrefixes);
   

--- a/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
@@ -79,6 +79,8 @@ s"""    <ClassAuxiliaryCode><Code><![CDATA[
           public List<common.Terminal> getTokens() {
             return tokenList; // The way we reset this iterator when parsing again is to create a new list, so this is defacto immutable
           }
+          
+${s2.lexerClassRefDcls}
         ]]></Code></ClassAuxiliaryCode>
 """ ++
 -- If not otherwise specified. We always specify.

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -15,6 +15,8 @@ synthesized attribute cstNormalize :: [SyntaxDcl];
 -- Compute and allow lookup of all terminals in a lexer class
 synthesized attribute classTerminalContribs::[Pair<String String>];
 autocopy attribute classTerminals::EnvTree<String>;
+synthesized attribute superClassContribs::[Pair<String String>];
+autocopy attribute superClasses::EnvTree<String>;
 
 -- Parser attribute action code aspects
 synthesized attribute parserAttributeAspectContribs::[Pair<String String>];
@@ -35,7 +37,7 @@ autocopy attribute prefixesForTerminals :: EnvTree<String>;
 {--
  - An abstract syntax tree for representing concrete syntax.
  -}
-nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, containingGrammar, prefixesForTerminals;
+nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, containingGrammar, prefixesForTerminals;
 
 abstract production nilSyntax
 top::Syntax ::=
@@ -48,6 +50,7 @@ top::Syntax ::=
   top.allMarkingTerminals = [];
   top.disambiguationClasses = [];
   top.classTerminalContribs = [];
+  top.superClassContribs = [];
   top.parserAttributeAspectContribs = [];
   top.lexerClassRefDcls = "";
   top.xmlCopper = "";
@@ -63,6 +66,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
   top.allMarkingTerminals = s1.allMarkingTerminals ++ s2.allMarkingTerminals;
   top.disambiguationClasses = s1.disambiguationClasses ++ s2.disambiguationClasses;
   top.classTerminalContribs = s1.classTerminalContribs ++ s2.classTerminalContribs;
+  top.superClassContribs = s1.superClassContribs ++ s2.superClassContribs;
   top.parserAttributeAspectContribs = s1.parserAttributeAspectContribs ++ s2.parserAttributeAspectContribs;
   top.lexerClassRefDcls = s1.lexerClassRefDcls ++ s2.lexerClassRefDcls;
   top.xmlCopper = s1.xmlCopper ++ s2.xmlCopper;
@@ -71,7 +75,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, sortKey, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, classDomContribs, classSubContribs, containingGrammar, prefixesForTerminals;
+nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, sortKey, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, classDomContribs, classSubContribs, containingGrammar, prefixesForTerminals;
 
 synthesized attribute sortKey :: String;
 
@@ -83,6 +87,7 @@ top::SyntaxDcl ::=
   top.allMarkingTerminals = [];
   top.disambiguationClasses = [];
   top.classTerminalContribs = [];
+  top.superClassContribs = [];
   top.parserAttributeAspectContribs = [];
   top.classDomContribs = error("Internal compiler error: should only ever be demanded of lexer classes");
   top.classSubContribs = error("Internal compiler error: should only ever be demanded of lexer classes");
@@ -255,7 +260,7 @@ String ::= ns::Decorated NamedSignature
 
 
 function lookupStrings
-[[Decorated SyntaxDcl]] ::= t::[String] e::EnvTree<Decorated SyntaxDcl>
+[[a]] ::= t::[String] e::EnvTree<a>
 {
   return map(searchEnvTree(_, e), t);
 }
@@ -294,6 +299,7 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
   top.classSubContribs = modifiers.submitsXML;
 
   top.cstNormalize = [top];
+  top.superClassContribs = modifiers.superClassContribs;
   top.disambiguationClasses = modifiers.disambiguationClasses;
 
   production terms :: [String] = searchEnvTree(n, top.classTerminals);

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -621,6 +621,13 @@ top::Expr ::= q::Decorated QName
   top.flowDefs = [];
 }
 
+aspect production lexerClassReference
+top::Expr ::= q::Decorated QName
+{
+  top.flowDeps = [];
+  top.flowDefs = [];
+}
+
 aspect production parserAttributeReference
 top::Expr ::= q::Decorated QName
 {

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -601,7 +601,7 @@ top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
 -- These are all errors, basically.
 
 aspect production failureTerminalIdExpr
-top::Expr ::= 'failure'
+top::Expr ::= 'disambiguationFailure'
 {
   top.flowDeps = [];
   top.flowDefs = [];

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -600,6 +600,13 @@ top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
 
 -- These are all errors, basically.
 
+aspect production failureTerminalIdExpr
+top::Expr ::= 'failure'
+{
+  top.flowDeps = [];
+  top.flowDefs = [];
+}
+
 aspect production actionChildReference
 top::Expr ::= q::Decorated QName
 {

--- a/grammars/silver/modification/copper/DclInfo.sv
+++ b/grammars/silver/modification/copper/DclInfo.sv
@@ -45,9 +45,13 @@ top::DclInfo ::= sg::String sl::Location fn::String
   top.sourceLocation = sl;
   top.fullName = fn;
   
-  -- If we made lexer classes types, it might simplify a lot of code.
+  -- If we made lexer classes proper types, it might simplify a lot of code.
   -- We wouldn't need a separate namespace, they could just be in the type namespace.
-  top.typerep = error("Internal compiler error: lexer classes do not have types");
+  -- Currently referencing a lexer class gives a list of its member's TerminalIds.
+  top.typerep = listType(terminalIdType());
+  top.refDispatcher = lexerClassReference(_, location=_);
+  top.defDispatcher = errorValueDef(_, _, location=_);
+  top.defLHSDispatcher = errorDefLHS(_, location=_);
 }
 
 {--

--- a/grammars/silver/modification/copper/Env.sv
+++ b/grammars/silver/modification/copper/Env.sv
@@ -1,7 +1,5 @@
 grammar silver:modification:copper;
 
-import silver:extension:list;
-
 --------------------------------------------------------------------------------
 -- Defs.sv
 
@@ -30,6 +28,7 @@ top::Def ::= d::EnvItem
 {
   top.dcl = d.dcl;
   top.lexerClassList = [d];
+  top.valueList = [d];
 }
 
 -- TODO: we don't do any renaming of lexer classes BUG

--- a/grammars/silver/modification/copper/Env.sv
+++ b/grammars/silver/modification/copper/Env.sv
@@ -130,6 +130,8 @@ global i_lexemeVariable :: [Def] =
   [termAttrValueDef("DBGtav", bogusLoc(), "lexeme", stringType())];
 global i_shiftableVariable :: [Def] =
   [termAttrValueDef("DBGtav", bogusLoc(), "shiftable", listType(terminalIdType()))];
+global i_failureVariable :: [Def] =
+  [termAttrValueDef("DBGtav", bogusLoc(), "failure", terminalIdType())];
 global i_locVariables :: [Def] = [
   termAttrValueDef("DBGtav", bogusLoc(), "filename", stringType()),
   termAttrValueDef("DBGtav", bogusLoc(), "line", intType()),
@@ -137,6 +139,6 @@ global i_locVariables :: [Def] = [
 
 global terminalActionVars :: [Def] = i_lexemeVariable ++ i_locVariables;
 global productionActionVars :: [Def] = i_locVariables;
-global disambiguationActionVars :: [Def] = i_lexemeVariable;
-global disambiguationClassActionVars :: [Def] = i_lexemeVariable ++ i_shiftableVariable;
+global disambiguationActionVars :: [Def] = i_lexemeVariable ++ i_failureVariable;
+global disambiguationClassActionVars :: [Def] = i_lexemeVariable ++ i_shiftableVariable ++ i_failureVariable;
 

--- a/grammars/silver/modification/copper/Env.sv
+++ b/grammars/silver/modification/copper/Env.sv
@@ -130,8 +130,6 @@ global i_lexemeVariable :: [Def] =
   [termAttrValueDef("DBGtav", bogusLoc(), "lexeme", stringType())];
 global i_shiftableVariable :: [Def] =
   [termAttrValueDef("DBGtav", bogusLoc(), "shiftable", listType(terminalIdType()))];
-global i_failureVariable :: [Def] =
-  [termAttrValueDef("DBGtav", bogusLoc(), "failure", terminalIdType())];
 global i_locVariables :: [Def] = [
   termAttrValueDef("DBGtav", bogusLoc(), "filename", stringType()),
   termAttrValueDef("DBGtav", bogusLoc(), "line", intType()),
@@ -139,6 +137,6 @@ global i_locVariables :: [Def] = [
 
 global terminalActionVars :: [Def] = i_lexemeVariable ++ i_locVariables;
 global productionActionVars :: [Def] = i_locVariables;
-global disambiguationActionVars :: [Def] = i_lexemeVariable ++ i_failureVariable;
-global disambiguationClassActionVars :: [Def] = i_lexemeVariable ++ i_shiftableVariable ++ i_failureVariable;
+global disambiguationActionVars :: [Def] = i_lexemeVariable;
+global disambiguationClassActionVars :: [Def] = i_lexemeVariable ++ i_shiftableVariable;
 

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -9,7 +9,7 @@ top::Expr ::= 'disambiguationFailure'
   top.errors := [];
   top.typerep = terminalIdType();
 
-  top.translation = "-1";
+  top.translation = "(-1)";
   top.lazyTranslation = top.translation;
 
   top.upSubst = top.downSubst;

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -1,5 +1,20 @@
 grammar silver:modification:copper;
 
+terminal Failure_t 'failure' lexer classes {KEYWORD, RESERVED};
+
+concrete production failureTerminalIdExpr
+top::Expr ::= 'failure'
+{
+  top.unparse = "failure";
+  top.errors := [];
+  top.typerep = terminalIdType();
+
+  top.translation = "-1";
+  top.lazyTranslation = top.translation;
+
+  top.upSubst = top.downSubst;
+}
+
 abstract production actionChildReference
 top::Expr ::= q::Decorated QName
 {
@@ -22,8 +37,7 @@ top::Expr ::= q::Decorated QName
 
   top.errors := []; -- Should only be referenceable from a context where its valid.
 
-  -- We... don't actually have a type we can use here TODO. Maybe we could cheat with a skolem type?
-  -- Or maybe these should just be TerminalId, see below.
+  -- TODO: It would be nice to have a more specific type here, see comment below.
   top.typerep = terminalIdType();
   
   top.translation = makeCopperName(q.lookupValue.fullName); -- Value right here?
@@ -102,7 +116,6 @@ top::Expr ::= q::Decorated QName
   top.translation =
     if q.name == "lexeme" then "new common.StringCatter(lexeme)" else
     if q.name == "shiftable" then "shiftableList" else
-    if q.name == "failure" then "-1" else
     if q.name == "line" then "virtualLocation.getLine()" else
     if q.name == "column" then "virtualLocation.getColumn()" else
     if q.name == "filename" then "new common.StringCatter(virtualLocation.getFileName())" else

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -100,6 +100,7 @@ top::Expr ::= q::Decorated QName
   top.translation =
     if q.name == "lexeme" then "new common.StringCatter(lexeme)" else
     if q.name == "shiftable" then "shiftableList" else
+    if q.name == "failure" then "-1" else
     if q.name == "line" then "virtualLocation.getLine()" else
     if q.name == "column" then "virtualLocation.getColumn()" else
     if q.name == "filename" then "new common.StringCatter(virtualLocation.getFileName())" else

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -53,6 +53,22 @@ top::Expr ::= q::Decorated QName
   top.upSubst = top.downSubst;
 }
 
+abstract production lexerClassReference
+top::Expr ::= q::Decorated QName
+{
+  top.unparse = q.unparse;
+
+  top.errors := []; -- Should only be referenceable from a context where its valid.
+
+  -- TODO: This should be a more specific type with type classes
+  top.typerep = listType(terminalIdType());
+  
+  top.translation = makeCopperName(q.lookupValue.fullName);
+  top.lazyTranslation = top.translation; -- never, but okay!
+  
+  top.upSubst = top.downSubst;
+}
+
 abstract production parserAttributeReference
 top::Expr ::= q::Decorated QName
 {

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -1,11 +1,11 @@
 grammar silver:modification:copper;
 
-terminal Failure_t 'failure' lexer classes {KEYWORD, RESERVED};
+terminal DisambiguationFailure_t 'disambiguationFailure' lexer classes {KEYWORD, RESERVED};
 
 concrete production failureTerminalIdExpr
-top::Expr ::= 'failure'
+top::Expr ::= 'disambiguationFailure'
 {
-  top.unparse = "failure";
+  top.unparse = "disambiguationFailure";
   top.errors := [];
   top.typerep = terminalIdType();
 

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -58,7 +58,9 @@ top::Expr ::= q::Decorated QName
 {
   top.unparse = q.unparse;
 
-  top.errors := []; -- Should only be referenceable from a context where its valid.
+  top.errors := if !top.frame.permitActions
+                then [err(top.location, "References to lexer class members can only be made in action blocks")]
+                else [];
 
   -- TODO: This should be a more specific type with type classes
   top.typerep = listType(terminalIdType());

--- a/grammars/silver/modification/copper/LexerClass.sv
+++ b/grammars/silver/modification/copper/LexerClass.sv
@@ -52,7 +52,7 @@ top::LexerClassModifiers ::= tm::LexerClassModifier
   top.errors := tm.errors; 
 }
 concrete production lexerClassModifiersCons
-top::LexerClassModifiers ::= h::LexerClassModifier  t::LexerClassModifiers
+top::LexerClassModifiers ::= h::LexerClassModifier ',' t::LexerClassModifiers
 {
   top.unparse = h.unparse ++ " " ++ t.unparse;
 
@@ -61,7 +61,7 @@ top::LexerClassModifiers ::= h::LexerClassModifier  t::LexerClassModifiers
 }
 
 concrete production lexerClassModifierExtends
-top::LexerClassModifier ::= 'extends' cls::ClassList
+top::LexerClassModifier ::= 'extends' cls::LexerClasses
 {
   top.unparse = "extends " ++ cls.unparse;
 
@@ -70,7 +70,7 @@ top::LexerClassModifier ::= 'extends' cls::ClassList
 }
 
 concrete production lexerClassModifierDominates
-top::LexerClassModifier ::= 'dominates' terms::TermPrecList
+top::LexerClassModifier ::= 'dominates' terms::TermPrecs
 {
   top.unparse = "dominates " ++ terms.unparse;
 
@@ -79,7 +79,7 @@ top::LexerClassModifier ::= 'dominates' terms::TermPrecList
 }
 
 concrete production lexerClassModifierSubmitsTo
-top::LexerClassModifier ::= 'submits' 'to' terms::TermPrecList
+top::LexerClassModifier ::= 'submits' 'to' terms::TermPrecs
 {
   top.unparse = "submits to " ++ terms.unparse;
 

--- a/grammars/silver/modification/copper/LexerClass.sv
+++ b/grammars/silver/modification/copper/LexerClass.sv
@@ -1,7 +1,8 @@
 grammar silver:modification:copper;
 
-terminal Lexer_kwd 'lexer' lexer classes {KEYWORD};
-terminal Class_kwd 'class' lexer classes {KEYWORD};
+terminal Lexer_kwd   'lexer'   lexer classes {KEYWORD};
+terminal Class_kwd   'class'   lexer classes {KEYWORD};
+terminal Extends_kwd 'extends' lexer classes {KEYWORD};
 
 concrete production lexerClassDclEmpty
 top::AGDcl ::= 'lexer' 'class' id::Name ';'
@@ -57,6 +58,15 @@ top::LexerClassModifiers ::= h::LexerClassModifier  t::LexerClassModifiers
 
   top.lexerClassModifiers = h.lexerClassModifiers ++ t.lexerClassModifiers;
   top.errors := h.errors ++ t.errors;
+}
+
+concrete production lexerClassModifierExtends
+top::LexerClassModifier ::= 'extends' cls::ClassList
+{
+  top.unparse = "extends " ++ cls.unparse;
+
+  top.lexerClassModifiers = [lexerClassExtends(cls.lexerClasses)];
+  top.errors := cls.errors;
 }
 
 concrete production lexerClassModifierDominates

--- a/grammars/silver/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/modification/copper/ProductionStmt.sv
@@ -21,7 +21,7 @@ top::ProductionStmt ::= 'pluck' e::Expr ';'
   -- Cast to integer is required, because that's secretly the real type of the
   -- result, but our type system only calls it an Object at the moment.
   -- Perhaps this problem can be resolved by using a proper type in this situation.
-  top.translation = "return (Integer)" ++ e.translation ++ ";\n";
+  top.translation = "return (Integer)(" ++ e.translation ++ ");\n";
 
   top.errors := (if !top.frame.permitPluck
                then [err(top.location, "'pluck' allowed only in disambiguation-group parser actions.")]

--- a/grammars/silver/modification/copper/Project.sv
+++ b/grammars/silver/modification/copper/Project.sv
@@ -7,6 +7,8 @@ imports silver:definition:concrete_syntax:ast;
 imports silver:definition:type;
 imports silver:definition:type:syntax;
 
+imports silver:extension:list;
+
 --imports silver:analysis:typechecking:core;
 
 imports silver:translation:java:core;

--- a/grammars/silver/modification/copper/TermList.sv
+++ b/grammars/silver/modification/copper/TermList.sv
@@ -5,7 +5,8 @@ grammar silver:modification:copper;
 -- specifically with refernce how abstract / concrete is deliniated.
 -- if TermPrecList has its structure refactored, so should TermList.
 
-nonterminal TermList with config, grammarName, unparse, location, termList, defs, errors, env;
+synthesized attribute qnames :: [QName];
+nonterminal TermList with config, grammarName, unparse, location, qnames, termList, defs, errors, env;
 
 synthesized attribute termList :: [String];
 
@@ -29,6 +30,8 @@ top::TermList ::= h::QName t::TermList
              then h.unparse
              else h.unparse ++ ", " ++ t.unparse;
 
+  top.qnames = h :: t.qnames;
+
   production fName::String = h.lookupType.dcl.fullName;
 
   top.termList = [fName] ++ t.termList ;
@@ -51,8 +54,9 @@ top::TermList ::= h::QName t::TermList
 abstract production termListNull
 top::TermList ::=
 {
+  top.unparse = "";
+  top.qnames = [];
   top.termList = [];
   top.defs = [];
-  top.unparse = "";
   top.errors := [];
 }

--- a/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
+++ b/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
@@ -1,5 +1,6 @@
 grammar silver:modification:copper_mda;
 
+import silver:util:raw:graph as g;
 
 abstract production cstCopperMdaRoot
 top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Syntax  terminalPrefixes::[Pair<String String>]
@@ -12,12 +13,20 @@ top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Synt
   host.containingGrammar = "host";
   host.cstNTProds = error("TODO: this should only be used by normalize"); -- TODO
   host.classTerminals = directBuildTree(host.classTerminalContribs ++ ext.classTerminalContribs);
+  host.superClasses =
+    directBuildTree(
+      g:toList(
+        g:transitiveClosure(
+          g:add(
+            host.superClassContribs ++ ext.superClassContribs,
+            g:empty(compareString)))));
   host.parserAttributeAspects = directBuildTree(host.parserAttributeAspectContribs ++ ext.parserAttributeAspectContribs);
   host.prefixesForTerminals = directBuildTree(terminalPrefixes);
   ext.cstEnv = host.cstEnv;
   ext.containingGrammar = "ext";
   ext.cstNTProds = error("TODO: this should only be used by normalize"); -- TODO
   ext.classTerminals = host.classTerminals;
+  ext.superClasses = host.superClasses;
   ext.parserAttributeAspects = host.parserAttributeAspects;
   ext.prefixesForTerminals = host.prefixesForTerminals;
   

--- a/test/copper_features/DisambiguationGroups.sv
+++ b/test/copper_features/DisambiguationGroups.sv
@@ -7,21 +7,22 @@ nonterminal DGRoot with dgFoo;
 synthesized attribute dgFoo :: Boolean;
 
 terminal Foo_t 'foo';
+terminal Bar_t 'bar';
 terminal Id /[a-z]*/;
 
 concrete production rt
 r::DGRoot ::= Id {r.dgFoo = false;}
 concrete production rt2
 r::DGRoot ::= Foo_t {r.dgFoo = true;}
+concrete production rt3
+r::DGRoot ::= Bar_t {r.dgFoo = false;}
 
 disambiguate Foo_t, Id {
---  print (if containsBy(stringEq, lexeme, ["foo", "bar"])
---         then "Fooiong"
---         else "IDing");
+  pluck Foo_t;
+}
 
-  pluck if containsBy(stringEq, lexeme, ["foo", "bar"])
-        then Foo_t
-        else Id;
+disambiguate Bar_t, Id {
+  pluck failure;
 }
 
 parser dgparse::DGRoot {
@@ -29,12 +30,12 @@ parser dgparse::DGRoot {
 }
 
 equalityTest ( dgparse("foo", "ASDF").parseSuccess, true, Boolean, copper_tests ) ;
+equalityTest ( dgparse("bar", "ASDF").parseSuccess, false, Boolean, copper_tests ) ;
 equalityTest ( dgparse("!#@$%", "ASDF").parseSuccess, false, Boolean, copper_tests ) ;
 equalityTest ( dgparse("Foo", "ASDF").parseSuccess, false, Boolean, copper_tests ) ;
 
 
 equalityTest ( dgparse("foo", "ASDF").parseTree.dgFoo, true, Boolean, copper_tests ) ;
-equalityTest ( dgparse("bar", "ASDF").parseTree.dgFoo, false, Boolean, copper_tests ) ;
 equalityTest ( dgparse("fo", "ASDF").parseTree.dgFoo, false, Boolean, copper_tests ) ;
 equalityTest ( dgparse("br", "ASDF").parseTree.dgFoo, false, Boolean, copper_tests ) ;
 equalityTest ( dgparse("foobar", "ASDF").parseTree.dgFoo, false, Boolean, copper_tests ) ;

--- a/test/copper_features/DisambiguationGroups.sv
+++ b/test/copper_features/DisambiguationGroups.sv
@@ -22,7 +22,7 @@ disambiguate Foo_t, Id {
 }
 
 disambiguate Bar_t, Id {
-  pluck failure;
+  pluck disambiguationFailure;
 }
 
 parser dgparse::DGRoot {

--- a/test/copper_features/Main.sv
+++ b/test/copper_features/Main.sv
@@ -7,6 +7,7 @@ import copper_features:test_layout;
 import copper_features:mdatests;
 import copper_features:token_pushing;
 import copper_features:disambiguation_class;
+import copper_features:lexer_class;
 
 mainTestSuite copper_tests ;
 

--- a/test/copper_features/lexer_class/LexerClass.sv
+++ b/test/copper_features/lexer_class/LexerClass.sv
@@ -21,14 +21,6 @@ terminal FooId /foo[a-zA-Z]*/ lexer classes CKeyword;
 
 parser attribute aIds::[TerminalId]
   action {aIds = AKeyword;};
-  
-function terminalSetEq
-Boolean ::= ts1::[TerminalId] ts2::[TerminalId]
-{
-  return
-    length(ts1) == length(ts2) &&
-    all(zipWith(terminalIdEq, map(sortBy(terminalIdEq, _),  ts1), map(sortBy(terminalIdEq, _),  ts2)));
-}
 
 -- The easiest way to test this and get data out of an action block is pushToken, ugh.
 terminal Res /true|false/;

--- a/test/copper_features/lexer_class/LexerClass.sv
+++ b/test/copper_features/lexer_class/LexerClass.sv
@@ -1,0 +1,62 @@
+grammar copper_features:lexer_class;
+
+imports silver:testing ;
+imports lib:extcore ;
+imports copper_features;
+
+terminal Id /[a-zA-Z]+/;
+
+lexer class Keyword dominates Id;
+
+lexer class AKeyword extends Keyword;
+lexer class BKeyword extends AKeyword;
+lexer class CKeyword submits to BKeyword extends AKeyword;
+
+terminal Foo 'foo' lexer classes {BKeyword};
+terminal FooId /foo[a-zA-Z]*/ lexer classes {CKeyword};
+
+parser attribute aIds::[TerminalId]
+  action {aIds = AKeyword;};
+
+-- The easiest way to test this and get data out of an action block is pushToken, ugh.
+terminal Res /true|false/;
+terminal GetA 'getA'
+  lexer classes {Keyword},
+  action {
+    pushToken(Res, toString(
+      containsBy(terminalIdEq, Foo, AKeyword) && 
+      containsBy(terminalIdEq, FooId, AKeyword) && 
+      !containsBy(terminalIdEq, Id, AKeyword) &&
+      containsBy(terminalIdEq, Foo, BKeyword) && 
+      !containsBy(terminalIdEq, FooId, BKeyword) && 
+      !containsBy(terminalIdEq, Id, BKeyword) &&
+      !containsBy(terminalIdEq, Foo, CKeyword) && 
+      containsBy(terminalIdEq, FooId, CKeyword) && 
+      !containsBy(terminalIdEq, Id, CKeyword)));
+  };
+
+synthesized attribute result::String;
+nonterminal Root with result;
+
+concrete productions top::Root
+| Id { top.result = "Id"; }
+| Foo { top.result = "Foo"; }
+| FooId { top.result = "FooId"; }
+| GetA res::Res { top.result = res.lexeme; }
+
+parser parse :: Root {
+  copper_features:lexer_class;
+}
+
+
+equalityTest ( parse("bar", "").parseSuccess, true, Boolean, copper_tests );
+equalityTest ( parse("bar", "").parseTree.result, "Id", String, copper_tests );
+
+equalityTest ( parse("foo", "").parseSuccess, true, Boolean, copper_tests );
+equalityTest ( parse("foo", "").parseTree.result, "Foo", String, copper_tests );
+
+equalityTest ( parse("fooxyz", "").parseSuccess, true, Boolean, copper_tests );
+equalityTest ( parse("fooxyz", "").parseTree.result, "FooId", String, copper_tests );
+
+equalityTest ( parse("getA", "").parseSuccess, true, Boolean, copper_tests );
+equalityTest ( parse("getA", "").parseTree.result, "true", String, copper_tests );

--- a/test/copper_features/lexer_class/LexerClass.sv
+++ b/test/copper_features/lexer_class/LexerClass.sv
@@ -6,14 +6,14 @@ imports copper_features;
 
 terminal Id /[a-zA-Z]+/;
 
-lexer class Keyword dominates Id;
+lexer class Keyword dominates {Id};
 
 lexer class AKeyword extends Keyword;
 lexer class BKeyword extends AKeyword;
-lexer class CKeyword submits to BKeyword extends AKeyword;
+lexer class CKeyword submits to BKeyword, extends AKeyword;
 
 terminal Foo 'foo' lexer classes {BKeyword};
-terminal FooId /foo[a-zA-Z]*/ lexer classes {CKeyword};
+terminal FooId /foo[a-zA-Z]*/ lexer classes CKeyword;
 
 parser attribute aIds::[TerminalId]
   action {aIds = AKeyword;};


### PR DESCRIPTION
This provides a number of enhancements and cleanup related to lexer classes and disambiguation functions.  Much if this is required for https://github.com/melt-umn/ableC/pull/158.  I'm including Ted but no need to respond.

* Allow the name of a lexer class to be used as an expression inside action blocks that evaluates to a list of its members.  This is especially useful for disambiguation classes.
* Allow for disambiguation functions and classes to explicitly fail by returning the value `disambiguationFailure`.  For some ambiguities, the least confusing option may be to explicitly fail with a readable syntax error and require the use of transparent prefixes for all terminals.
* Allow lexer classes to extend other lexer classes.  When dealing with disambiguation, it is often the case that a terminal being in one lexer class means that it should also be in another lexer class.  For example, see [the `Global` disambiguation class in ableC](https://github.com/melt-umn/ableC/blob/feature/lexerClasses/grammars/edu.umn.cs.melt.ableC/concretesyntax/LexerHack.sv).  `Global` terminals are a particular subset of `Scoped` terminals, and requiring extension writers to additionally specify the `Scoped` lexer class for every `Global` terminal is redundant.  Specifying that `Global` extends `Scoped` means that every terminal specifying `Global` will implicitly be added to the `Scoped` lexer class.  A lexer class can extend any number of "super" lexer classes, and a cycle in the lexer class hierarchy just means that classes in the cycle will have the same members.
* When writing `prefer ... over ...;` in a parser spec, we have been only generating a disambiguation function for the ambiguity that includes all the mentioned terminals.  In practice there are usually several ambiguities, some including only a subset of the terminals on the right, and writing a `prefer` clause for each is tedious (previously these ambiguities weren't showing up as frequently in ableC, due to our liberal use of lexical precedence.)  For now I changed this to generate a disambiguation function for each non-empty member of the power set of the terminals on the right, which I believe was the originally intended behavior.
* Change lexer class and terminal modifier syntax to be consistent (#299).  Commas are now required between lexer class modifiers, and braces are optional when only one id is given in `submits to`/`dominates` clauses for both terminals and lexer classes.  Surprisingly, these syntax changes didn't really break any existing code.  

A few things left for future work:
* In Silver we work with sets of terminals as lists of `TerminalId`s.  A more efficient implementation would be to support java `BitSet`s used by Copper as a native type in Silver.  This would also let us avoid building huge Silver list objects containing the members of every lexer class at parser initialization time.  Probably OK to defer this because the performance hit hasn't been noticeable.
* Generating a disambiguation function for every subset of terminals in a `prefer` clause results in us emitting an exponentially-large number of disambiguation functions.  This isn't too much of a problem for now with less than 5 or so terminals in a lexical ambiguity, but a more elegant solution is needed here.  Subset disambiguation functions that we added to Copper for disambiguation classes are *almost* a solution here, but there are a couple of show-stoppers:
  1. A `prefer` clause should take precedence over disambiguation classes applicable to the same set of terminals.  Regular disambiguation functions take precedence over subset-applicable ones, while subset disambiguation functions are required to be disjoint.
  2. `prefer` clauses should only apply for ambiguities involving the preferred terminal.  Generating a subset disambiguation function for all the terminals would also override the disambiguation behavior for ambiguities only involving terminals on the right side of the `prefer` clause.

  A potential solution to both of these issues would be to generalize subset disambiguation functions, so that all disambiguation functions would simply be specified by a set of "required" terminals and a set of "optional" terminals.  A disambiguation function with a larger required set would take precedence over a function with a smaller required set, and disambiguation functions with required sets of the same size would be required to be disjoint.  I'll open a Copper issue about this when I get a chance.

Fixes #299.