### PR TITLE
Fix file testing bug in Silver install script, remove useless code

### DIFF
--- a/support/bin/install-silver-bin
+++ b/support/bin/install-silver-bin
@@ -67,11 +67,6 @@ do
 
     ln -s "$("$READLINK" -f "$SCRIPT")" ~/bin/
 
-    if [ ! $? ]; then
-        echo "Install failed!!"
-        exit 3
-    fi
-
     echo "Created ~/bin/$SCRIPT_NAME"
 
     # Just in case

--- a/support/bin/install-silver-bin
+++ b/support/bin/install-silver-bin
@@ -59,7 +59,8 @@ do
     
     echo "Found $REPO"
 
-    if [ -a ~/bin/$SCRIPT_NAME ]; then
+    if [ -e ~/bin/$SCRIPT_NAME -o -h ~/bin/$SCRIPT_NAME ]; then
+        # -h needed in case the link exists but the targeted file does not
         rm ~/bin/$SCRIPT_NAME
         echo "Removed old(?) ~/bin/$SCRIPT_NAME file."
     fi


### PR DESCRIPTION
In `install-silver-bin` we test for the existence of a link to `silver` and `silver-custom` using the `-a` operator.  I changed this to `-e` since `-a` is deprecated and added `-o -h ~/bin/$SCRIPT_NAME` to also check if this is a link.  If it is a link and points to an existing file, then the `-e` operator is enough.  But if the link exists but its target does not, then we need `-h`.

Since we have `set -eu` at the top of this script, it aborts if a command returns a non-zero return code.  Thus the check for this case after the link command is not needed - thus I removed it.