### PR TITLE
Refactor silver:host to export all the default components of Silver

### DIFF
--- a/grammars/silver/composed/Default/Main.sv
+++ b/grammars/silver/composed/Default/Main.sv
@@ -1,47 +1,9 @@
 grammar silver:composed:Default;
 
 import silver:host;
-import silver:translation:java;
-import silver:driver;
-
-import silver:extension:doc;
-import silver:analysis:warnings:flow;
-import silver:analysis:warnings:exporting;
 
 parser svParse::Root {
   silver:host;
-
-  silver:extension:convenience;
-  silver:extension:list;
-  silver:extension:easyterminal;
-  silver:extension:deprecation;
-  silver:extension:testing;
-  silver:extension:auto_ast;
-  silver:extension:templating;
-  silver:extension:patternmatching;
-  silver:extension:treegen;
-  silver:extension:doc;
-  silver:extension:functorattrib;
-  silver:extension:monad;
-  silver:extension:reflection;
-  silver:extension:silverconstruction;
-  silver:extension:astconstruction;
-  silver:extension:constructparser;
---  silver:extension:concreteSyntaxForTrees ;
-
-  silver:modification:let_fix;
-  silver:modification:lambda_fn;
-  silver:modification:collection;
-  silver:modification:primitivepattern;
-  silver:modification:autocopyattr;
-  silver:modification:ffi;
-  silver:modification:typedecl;
-  silver:modification:copper;
-  silver:modification:defaultattr;
-  
-  -- slight hacks, for the moment
-  silver:modification:copper_mda;
-  silver:modification:impide;
 }
 
 function main 

--- a/grammars/silver/composed/extendedorigins/Main.sv
+++ b/grammars/silver/composed/extendedorigins/Main.sv
@@ -1,40 +1,10 @@
 grammar silver:composed:extendedorigins;
 
 import silver:host;
-import silver:translation:java;
-import silver:driver;
-
---import silver:extension:doc;
-import silver:analysis:warnings:flow;
-import silver:analysis:warnings:exporting;
 
 parser svParse::Root {
   silver:host;
-
-  silver:extension:convenience;
-  silver:extension:list;
-  silver:extension:easyterminal;
-  silver:extension:deprecation;
-  silver:extension:testing;
-  silver:extension:auto_ast;
-  silver:extension:templating;
-  silver:extension:patternmatching;
   silver:extension:extendedorigins;
---  silver:extension:concreteSyntaxForTrees ;
-  -- doc?
-
-  silver:modification:let_fix;
-  silver:modification:collection;
-  silver:modification:primitivepattern;
-  silver:modification:autocopyattr;
-  silver:modification:ffi;
-  silver:modification:typedecl;
-  silver:modification:copper;
-  silver:modification:defaultattr;
-  
-  -- slight hacks, for the moment
-  silver:modification:copper_mda;
-  silver:modification:impide;
 }
 
 function main 

--- a/grammars/silver/composed/idetest/Main.sv
+++ b/grammars/silver/composed/idetest/Main.sv
@@ -1,11 +1,6 @@
 grammar silver:composed:idetest;
 
 import silver:host;
-import silver:translation:java;
-import silver:driver;
-
-import silver:analysis:warnings:flow;
-import silver:analysis:warnings:exporting;
 
 -- NOTE: this is needed for the correct generation of IDE, 
 -- even if we just use an empty IDE declaration block.

--- a/grammars/silver/host/Project.sv
+++ b/grammars/silver/host/Project.sv
@@ -1,27 +1,54 @@
 grammar silver:host;
 
--- concrete syntax from these grammars
-exports silver:definition:core;
-exports silver:definition:concrete_syntax;
-exports silver:definition:type:syntax;
-exports silver:definition:regex;
-exports silver:definition:flow:syntax;
+{- Silver is built as an extensible language with a core "host" language and a
+ - number of extensions containing additional features.
+ - However many of these extensions we typically always want to include by
+ - when building extended versions of Silver, and it becomes cumbersome to list
+ - them repeatedly.
+ - Thus we provide this grammar that exports all the components of the
+ - "default" Silver host language in one place.
+ - Note that this list may grow over time.
+ -} 
 
--- symbols
-exports silver:analysis:typechecking:core;
+-- The "core" host language:
+exports silver:host:core;
 
---We wish regex to remain a generic grammar, so we resolve the conflict here!
-import silver:definition:regex;
-import silver:definition:core;
+-- Modifications to Silver = optional features taht are not pure extensions.
+-- These are explicitly annotated as "options" within the core host language
+exports silver:modification:let_fix;
+exports silver:modification:lambda_fn;
+exports silver:modification:collection;
+exports silver:modification:primitivepattern;
+exports silver:modification:autocopyattr;
+exports silver:modification:ffi;
+exports silver:modification:typedecl;
+exports silver:modification:copper;
+exports silver:modification:defaultattr;
+-- slight hacks, for the moment
+exports silver:modification:copper_mda;
+exports silver:modification:impide;
 
--- Regexes end with /. Escape it if you want it.
-disambiguate RegexChar_t, Divide_t
-{
-  pluck Divide_t;
-}
--- For now, preserve existing behavior. Whitespace is allowed in regex, and ignored.
--- Escape it if you want it.
-disambiguate RegexChar_t, WhiteSpace
-{
-  pluck WhiteSpace;
-}
+-- Pure extensions to Silver
+exports silver:extension:doc;
+exports silver:extension:convenience;
+exports silver:extension:list; -- Not really a pure extension, yuck.
+exports silver:extension:easyterminal;
+exports silver:extension:deprecation;
+exports silver:extension:testing;
+exports silver:extension:auto_ast;
+exports silver:extension:templating;
+exports silver:extension:patternmatching;
+exports silver:extension:treegen;
+exports silver:extension:doc;
+exports silver:extension:functorattrib;
+exports silver:extension:monad;
+exports silver:extension:reflection;
+exports silver:extension:silverconstruction;
+exports silver:extension:astconstruction;
+exports silver:extension:constructparser;
+
+-- Other generally useful stuff:
+exports silver:translation:java;
+exports silver:driver;
+exports silver:analysis:warnings:flow;
+exports silver:analysis:warnings:exporting;

--- a/grammars/silver/host/core/Project.sv
+++ b/grammars/silver/host/core/Project.sv
@@ -1,0 +1,34 @@
+grammar silver:host:core;
+
+{-
+ - This file contains exports for the "core" Silver host language, excluding
+ - all extensions.
+ - Note that the "default" host version of Silver specified in silver:host is
+ - still required to build this.
+ -}
+
+-- concrete syntax from these grammars
+exports silver:definition:core;
+exports silver:definition:concrete_syntax;
+exports silver:definition:type:syntax;
+exports silver:definition:regex;
+exports silver:definition:flow:syntax;
+
+-- symbols
+exports silver:analysis:typechecking:core;
+
+--We wish regex to remain a generic grammar, so we resolve the conflict here!
+import silver:definition:regex;
+import silver:definition:core;
+
+-- Regexes end with /. Escape it if you want it.
+disambiguate RegexChar_t, Divide_t
+{
+  pluck Divide_t;
+}
+-- For now, preserve existing behavior. Whitespace is allowed in regex, and ignored.
+-- Escape it if you want it.
+disambiguate RegexChar_t, WhiteSpace
+{
+  pluck WhiteSpace;
+}

--- a/runtime/java/.classpath
+++ b/runtime/java/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="generated_src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="var" path="SILVER_HOME/jars/CopperRuntime.jar"/>
 	<classpathentry kind="var" path="SILVER_HOME/generated/bin"/>

--- a/runtime/java/.project
+++ b/runtime/java/.project
@@ -14,4 +14,11 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<linkedResources>
+		<link>
+			<name>generated_src</name>
+			<type>2</type>
+			<location>/home/krame505/lrk/PL_research/silver/generated/src</location>
+		</link>
+	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
Currently Silver is organized as a minimal "host" language (containing only a the absolute basics) and a collection of extensions and modifications that we always include in our composed Silver parser specs.  This wasn't an issue in the past, but now that we are actually building various extended versions of Silver, having to include the same list of default grammars in a bunch of places is kind of annoying.  

To that end I propose moving the minimal `silver:host` to `silver:host:core`, and make `silver:host` export `silver:host:core` along with all the default stuff.  All of our Silver parser specs then only need to specify `silver:host` along with whatever specific Silver extensions they are using.  

Also a random fix I made to the eclipse project setup for Silver's runtime, to get rid of a bunch of the errors reported due to not being able to find the generated files.  

Please ignore the accidental (now reverted) duplicate commit on develop, I'm blaming that I currently have one eye sewn shut.  