### PR TITLE
Bug fix to lexical precedence relations involving subclasses

### DIFF
--- a/grammars/silver/composed/Default/Main.sv
+++ b/grammars/silver/composed/Default/Main.sv
@@ -1,47 +1,9 @@
 grammar silver:composed:Default;
 
 import silver:host;
-import silver:translation:java;
-import silver:driver;
-
-import silver:extension:doc;
-import silver:analysis:warnings:flow;
-import silver:analysis:warnings:exporting;
 
 parser svParse::Root {
   silver:host;
-
-  silver:extension:convenience;
-  silver:extension:list;
-  silver:extension:easyterminal;
-  silver:extension:deprecation;
-  silver:extension:testing;
-  silver:extension:auto_ast;
-  silver:extension:templating;
-  silver:extension:patternmatching;
-  silver:extension:treegen;
-  silver:extension:doc;
-  silver:extension:functorattrib;
-  silver:extension:monad;
-  silver:extension:reflection;
-  silver:extension:silverconstruction;
-  silver:extension:astconstruction;
-  silver:extension:constructparser;
---  silver:extension:concreteSyntaxForTrees ;
-
-  silver:modification:let_fix;
-  silver:modification:lambda_fn;
-  silver:modification:collection;
-  silver:modification:primitivepattern;
-  silver:modification:autocopyattr;
-  silver:modification:ffi;
-  silver:modification:typedecl;
-  silver:modification:copper;
-  silver:modification:defaultattr;
-  
-  -- slight hacks, for the moment
-  silver:modification:copper_mda;
-  silver:modification:impide;
 }
 
 function main 

--- a/grammars/silver/composed/extendedorigins/Main.sv
+++ b/grammars/silver/composed/extendedorigins/Main.sv
@@ -1,40 +1,10 @@
 grammar silver:composed:extendedorigins;
 
 import silver:host;
-import silver:translation:java;
-import silver:driver;
-
---import silver:extension:doc;
-import silver:analysis:warnings:flow;
-import silver:analysis:warnings:exporting;
 
 parser svParse::Root {
   silver:host;
-
-  silver:extension:convenience;
-  silver:extension:list;
-  silver:extension:easyterminal;
-  silver:extension:deprecation;
-  silver:extension:testing;
-  silver:extension:auto_ast;
-  silver:extension:templating;
-  silver:extension:patternmatching;
   silver:extension:extendedorigins;
---  silver:extension:concreteSyntaxForTrees ;
-  -- doc?
-
-  silver:modification:let_fix;
-  silver:modification:collection;
-  silver:modification:primitivepattern;
-  silver:modification:autocopyattr;
-  silver:modification:ffi;
-  silver:modification:typedecl;
-  silver:modification:copper;
-  silver:modification:defaultattr;
-  
-  -- slight hacks, for the moment
-  silver:modification:copper_mda;
-  silver:modification:impide;
 }
 
 function main 

--- a/grammars/silver/composed/idetest/Main.sv
+++ b/grammars/silver/composed/idetest/Main.sv
@@ -1,11 +1,6 @@
 grammar silver:composed:idetest;
 
 import silver:host;
-import silver:translation:java;
-import silver:driver;
-
-import silver:analysis:warnings:flow;
-import silver:analysis:warnings:exporting;
 
 -- NOTE: this is needed for the correct generation of IDE, 
 -- even if we just use an empty IDE declaration block.

--- a/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
@@ -34,6 +34,13 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
           g:add(
             s.superClassContribs,
             g:empty(compareString)))));
+  s.subClasses =
+    directBuildTree(
+      g:toList(
+        g:transitiveClosure(
+          g:add(
+            map(\ p::Pair<String String> -> pair(p.snd, p.fst), s.superClassContribs),
+            g:empty(compareString)))));
   s.parserAttributeAspects = error("TODO: shouldn't by necessary to normalize"); -- TODO
   s.prefixesForTerminals = error("TODO: shouldn't by necessary to normalize"); -- TODO
   
@@ -45,6 +52,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   s2.cstNTProds = error("TODO: make this environment not be decorated?"); -- TODO
   s2.classTerminals = directBuildTree(s.classTerminalContribs);
   s2.superClasses = s.superClasses;
+  s2.subClasses = s.subClasses;
   s2.parserAttributeAspects = directBuildTree(s.parserAttributeAspectContribs);
   s2.prefixesForTerminals = directBuildTree(terminalPrefixes);
   

--- a/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -9,7 +9,7 @@ autocopy attribute className :: String;
 {--
  - Modifiers for lexer classes.
  -}
-nonterminal SyntaxLexerClassModifiers with cstEnv, cstErrors, className, classTerminals, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, containingGrammar;
+nonterminal SyntaxLexerClassModifiers with cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, containingGrammar;
 
 abstract production consLexerClassMod
 top::SyntaxLexerClassModifiers ::= h::SyntaxLexerClassModifier  t::SyntaxLexerClassModifiers
@@ -36,7 +36,7 @@ top::SyntaxLexerClassModifiers ::=
 {--
  - Modifiers for lexer classes.
  -}
-nonterminal SyntaxLexerClassModifier with cstEnv, cstErrors, className, classTerminals, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, containingGrammar;
+nonterminal SyntaxLexerClassModifier with cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, containingGrammar;
 
 {- We default ALL attributes, so we can focus only on those that are interesting in each case... -}
 aspect default production
@@ -71,7 +71,8 @@ top::SyntaxLexerClassModifier ::= super::[String]
 abstract production lexerClassSubmits
 top::SyntaxLexerClassModifier ::= sub::[String]
 {
-  production subRefs :: [[Decorated SyntaxDcl]] = lookupStrings(sub, top.cstEnv);
+  production allSubs :: [String] = unionsBy(stringEq, sub :: lookupStrings(sub, top.subClasses));
+  production subRefs :: [[Decorated SyntaxDcl]] = lookupStrings(allSubs, top.cstEnv);
 
   top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
                      if !null(a.snd) then []
@@ -86,7 +87,8 @@ top::SyntaxLexerClassModifier ::= sub::[String]
 abstract production lexerClassDominates
 top::SyntaxLexerClassModifier ::= dom::[String]
 {
-  production domRefs :: [[Decorated SyntaxDcl]] = lookupStrings(dom, top.cstEnv);
+  production allDoms :: [String] = unionsBy(stringEq, dom :: lookupStrings(dom, top.subClasses));
+  production domRefs :: [[Decorated SyntaxDcl]] = lookupStrings(allDoms, top.cstEnv);
 
   top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
                      if !null(a.snd) then []

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -17,6 +17,7 @@ synthesized attribute classTerminalContribs::[Pair<String String>];
 autocopy attribute classTerminals::EnvTree<String>;
 synthesized attribute superClassContribs::[Pair<String String>];
 autocopy attribute superClasses::EnvTree<String>;
+autocopy attribute subClasses::EnvTree<String>;
 
 -- Parser attribute action code aspects
 synthesized attribute parserAttributeAspectContribs::[Pair<String String>];
@@ -37,7 +38,7 @@ autocopy attribute prefixesForTerminals :: EnvTree<String>;
 {--
  - An abstract syntax tree for representing concrete syntax.
  -}
-nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, containingGrammar, prefixesForTerminals;
+nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, containingGrammar, prefixesForTerminals;
 
 abstract production nilSyntax
 top::Syntax ::=
@@ -75,7 +76,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, sortKey, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, classDomContribs, classSubContribs, containingGrammar, prefixesForTerminals;
+nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, sortKey, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, classDomContribs, classSubContribs, containingGrammar, prefixesForTerminals;
 
 synthesized attribute sortKey :: String;
 

--- a/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -14,7 +14,7 @@ autocopy attribute terminalName :: String;
 {--
  - Modifiers for terminals.
  -}
-nonterminal SyntaxTerminalModifiers with cstEnv, cstErrors, classTerminalContribs, superClasses, dominatesXML,
+nonterminal SyntaxTerminalModifiers with cstEnv, cstErrors, classTerminalContribs, superClasses, subClasses, dominatesXML,
   submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation,
   marking, terminalName, prettyName;
 
@@ -55,7 +55,7 @@ top::SyntaxTerminalModifiers ::=
 {--
  - Modifiers for terminals.
  -}
-nonterminal SyntaxTerminalModifier with cstEnv, cstErrors, classTerminalContribs, superClasses, dominatesXML,
+nonterminal SyntaxTerminalModifier with cstEnv, cstErrors, classTerminalContribs, superClasses, subClasses, dominatesXML,
   submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation,
   marking, terminalName, prettyName;
 
@@ -145,7 +145,8 @@ top::SyntaxTerminalModifier ::= cls::[String]
 abstract production termSubmits
 top::SyntaxTerminalModifier ::= sub::[String]
 {
-  production subRefs :: [[Decorated SyntaxDcl]] = lookupStrings(sub, top.cstEnv);
+  production allSubs :: [String] = unionsBy(stringEq, sub :: lookupStrings(sub, top.subClasses));
+  production subRefs :: [[Decorated SyntaxDcl]] = lookupStrings(allSubs, top.cstEnv);
 
   top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
                      if !null(a.snd) then []
@@ -160,7 +161,8 @@ top::SyntaxTerminalModifier ::= sub::[String]
 abstract production termDominates
 top::SyntaxTerminalModifier ::= dom::[String]
 {
-  production domRefs :: [[Decorated SyntaxDcl]] = lookupStrings(dom, top.cstEnv);
+  production allDoms :: [String] = unionsBy(stringEq, dom :: lookupStrings(dom, top.subClasses));
+  production domRefs :: [[Decorated SyntaxDcl]] = lookupStrings(allDoms, top.cstEnv);
 
   top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
                      if !null(a.snd) then []

--- a/grammars/silver/host/Project.sv
+++ b/grammars/silver/host/Project.sv
@@ -1,27 +1,54 @@
 grammar silver:host;
 
--- concrete syntax from these grammars
-exports silver:definition:core;
-exports silver:definition:concrete_syntax;
-exports silver:definition:type:syntax;
-exports silver:definition:regex;
-exports silver:definition:flow:syntax;
+{- Silver is built as an extensible language with a core "host" language and a
+ - number of extensions containing additional features.
+ - However many of these extensions we typically always want to include by
+ - when building extended versions of Silver, and it becomes cumbersome to list
+ - them repeatedly.
+ - Thus we provide this grammar that exports all the components of the
+ - "default" Silver host language in one place.
+ - Note that this list may grow over time.
+ -} 
 
--- symbols
-exports silver:analysis:typechecking:core;
+-- The "core" host language:
+exports silver:host:core;
 
---We wish regex to remain a generic grammar, so we resolve the conflict here!
-import silver:definition:regex;
-import silver:definition:core;
+-- Modifications to Silver = optional features taht are not pure extensions.
+-- These are explicitly annotated as "options" within the core host language
+exports silver:modification:let_fix;
+exports silver:modification:lambda_fn;
+exports silver:modification:collection;
+exports silver:modification:primitivepattern;
+exports silver:modification:autocopyattr;
+exports silver:modification:ffi;
+exports silver:modification:typedecl;
+exports silver:modification:copper;
+exports silver:modification:defaultattr;
+-- slight hacks, for the moment
+exports silver:modification:copper_mda;
+exports silver:modification:impide;
 
--- Regexes end with /. Escape it if you want it.
-disambiguate RegexChar_t, Divide_t
-{
-  pluck Divide_t;
-}
--- For now, preserve existing behavior. Whitespace is allowed in regex, and ignored.
--- Escape it if you want it.
-disambiguate RegexChar_t, WhiteSpace
-{
-  pluck WhiteSpace;
-}
+-- Pure extensions to Silver
+exports silver:extension:doc;
+exports silver:extension:convenience;
+exports silver:extension:list; -- Not really a pure extension, yuck.
+exports silver:extension:easyterminal;
+exports silver:extension:deprecation;
+exports silver:extension:testing;
+exports silver:extension:auto_ast;
+exports silver:extension:templating;
+exports silver:extension:patternmatching;
+exports silver:extension:treegen;
+exports silver:extension:doc;
+exports silver:extension:functorattrib;
+exports silver:extension:monad;
+exports silver:extension:reflection;
+exports silver:extension:silverconstruction;
+exports silver:extension:astconstruction;
+exports silver:extension:constructparser;
+
+-- Other generally useful stuff:
+exports silver:translation:java;
+exports silver:driver;
+exports silver:analysis:warnings:flow;
+exports silver:analysis:warnings:exporting;

--- a/grammars/silver/host/core/Project.sv
+++ b/grammars/silver/host/core/Project.sv
@@ -1,0 +1,34 @@
+grammar silver:host:core;
+
+{-
+ - This file contains exports for the "core" Silver host language, excluding
+ - all extensions.
+ - Note that the "default" host version of Silver specified in silver:host is
+ - still required to build this.
+ -}
+
+-- concrete syntax from these grammars
+exports silver:definition:core;
+exports silver:definition:concrete_syntax;
+exports silver:definition:type:syntax;
+exports silver:definition:regex;
+exports silver:definition:flow:syntax;
+
+-- symbols
+exports silver:analysis:typechecking:core;
+
+--We wish regex to remain a generic grammar, so we resolve the conflict here!
+import silver:definition:regex;
+import silver:definition:core;
+
+-- Regexes end with /. Escape it if you want it.
+disambiguate RegexChar_t, Divide_t
+{
+  pluck Divide_t;
+}
+-- For now, preserve existing behavior. Whitespace is allowed in regex, and ignored.
+-- Escape it if you want it.
+disambiguate RegexChar_t, WhiteSpace
+{
+  pluck WhiteSpace;
+}

--- a/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
+++ b/grammars/silver/modification/copper_mda/SyntaxMdaRoot.sv
@@ -20,6 +20,15 @@ top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Synt
           g:add(
             host.superClassContribs ++ ext.superClassContribs,
             g:empty(compareString)))));
+  host.subClasses =
+    directBuildTree(
+      g:toList(
+        g:transitiveClosure(
+          g:add(
+            map(
+              \ p::Pair<String String> -> pair(p.snd, p.fst),
+              host.superClassContribs ++ ext.superClassContribs),
+            g:empty(compareString)))));
   host.parserAttributeAspects = directBuildTree(host.parserAttributeAspectContribs ++ ext.parserAttributeAspectContribs);
   host.prefixesForTerminals = directBuildTree(terminalPrefixes);
   ext.cstEnv = host.cstEnv;
@@ -27,6 +36,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Synt
   ext.cstNTProds = error("TODO: this should only be used by normalize"); -- TODO
   ext.classTerminals = host.classTerminals;
   ext.superClasses = host.superClasses;
+  ext.subClasses = host.subClasses;
   ext.parserAttributeAspects = host.parserAttributeAspects;
   ext.prefixesForTerminals = host.prefixesForTerminals;
   

--- a/runtime/java/.classpath
+++ b/runtime/java/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="generated_src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="var" path="SILVER_HOME/jars/CopperRuntime.jar"/>
 	<classpathentry kind="var" path="SILVER_HOME/generated/bin"/>

--- a/runtime/java/.project
+++ b/runtime/java/.project
@@ -14,4 +14,11 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<linkedResources>
+		<link>
+			<name>generated_src</name>
+			<type>2</type>
+			<location>/home/krame505/lrk/PL_research/silver/generated/src</location>
+		</link>
+	</linkedResources>
 </projectDescription>

--- a/test/copper_features/lexer_class/LexerClass.sv
+++ b/test/copper_features/lexer_class/LexerClass.sv
@@ -4,9 +4,10 @@ imports silver:testing ;
 imports lib:extcore ;
 imports copper_features;
 
-terminal Id /[a-zA-Z]+/;
+lexer class Identifier;
+lexer class Identifier2 extends Identifier;
 
-lexer class Keyword dominates {Id};
+lexer class Keyword dominates {Identifier};
 
 lexer class AKeyword extends Keyword;
 lexer class BKeyword extends AKeyword;
@@ -15,6 +16,8 @@ lexer class CKeyword submits to BKeyword, extends AKeyword;
 lexer class C1 extends C3;
 lexer class C2 extends C1;
 lexer class C3 extends C2;
+
+terminal Id /[a-zA-Z]+/ lexer classes Identifier2;
 
 terminal Foo 'foo' lexer classes {BKeyword, C2};
 terminal FooId /foo[a-zA-Z]*/ lexer classes CKeyword;


### PR DESCRIPTION
This fixes a bug with the implementation of lexer class `extends`.  In addition to terminals in a subclass automatically becoming members on a superclass, lexical precedence relations defined for other terminals/lexer classes on the superclass should also apply to subclasses.  