### PR TITLE
Add support for matching on annotations

### DIFF
--- a/grammars/silver/extension/patternmatching/Case.sv
+++ b/grammars/silver/extension/patternmatching/Case.sv
@@ -31,8 +31,8 @@ nonterminal AbstractMatchRule with location, headPattern, isVarMatchRule, expand
 synthesized attribute headPattern :: Decorated Pattern;
 -- Whether the head pattern of a match rule is a variable binder or not
 synthesized attribute isVarMatchRule :: Boolean;
--- Turns A(B, C), D into B, C, D in the patterns list.
-synthesized attribute expandHeadPattern :: AbstractMatchRule;
+-- Turns A(B, C), D into B, C, D in the patterns list, with a list of named patterns to include.
+synthesized attribute expandHeadPattern :: (AbstractMatchRule ::= [String]);
 
 -- P , ...
 nonterminal PatternList with location, config, unparse, patternList, env, errors;
@@ -113,13 +113,20 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] failExpr::Expr retType::Type
   {--
    - All constructors? Then do a real primitive match.
    -}
+  local freshCurrName :: String = "__curr_match_" ++ toString(genInt());
+  local freshCurrNameRef :: Expr =
+    baseExpr(qName(top.location, freshCurrName), location=top.location);
   local allConCase :: Expr =
-    matchPrimitive(head(es),
-      typerepTypeExpr(retType, location=top.location),
-      foldPrimPatterns(
-        map(allConCaseTransform(tail(es), failExpr, retType, _),
+    -- Annoyingly, this now needs to be a let in case of annotation patterns.
+    makeLet(top.location,
+      freshCurrName, freshType(), head(es), 
+      matchPrimitive(
+        freshCurrNameRef,
+        typerepTypeExpr(retType, location=top.location),
+        foldPrimPatterns(
+          map(allConCaseTransform(freshCurrNameRef, tail(es), failExpr, retType, _),
           groupMRules(prodRules))),
-      failExpr, location=top.location);
+        failExpr, location=top.location));
   
   {--
    - All variables? Just push a let binding inside each branch.
@@ -197,7 +204,18 @@ top::AbstractMatchRule ::= pl::[Decorated Pattern] cond::Maybe<Expr> e::Expr
   top.isVarMatchRule = null(pl) || head(pl).patternIsVariable;
   -- For this, we safely know that pl is not null:
   top.expandHeadPattern = 
-    matchRule(head(pl).patternSubPatternList ++ tail(pl), cond, e, location=top.location);
+    \ named::[String] ->
+      matchRule(
+        head(pl).patternSubPatternList ++
+        map(
+          \ n::String ->
+            fromMaybe(
+              decorate wildcPattern('_', location=top.location)
+                with { config=head(pl).config; env=head(pl).env; },
+              lookupBy(stringEq, n, head(pl).patternNamedSubPatternList)),
+          named) ++
+        tail(pl),
+        cond, e, location=top.location);
 }
 
 concrete production patternList_one
@@ -208,7 +226,14 @@ top::PatternList ::= p::Pattern
 
   top.patternList = [p];
 }
-concrete production patternList_more
+concrete production patternList_snoc
+top::PatternList ::= ps::PatternList ',' p::Pattern 
+{
+  top.unparse = ps.unparse ++ ", " ++ p.unparse;
+  
+  forwards to appendPatternList(ps, patternList_one(p, location=p.location));
+}
+abstract production patternList_more
 top::PatternList ::= p::Pattern ',' ps1::PatternList
 {
   top.unparse = p.unparse ++ ", " ++ ps1.unparse;
@@ -230,6 +255,18 @@ top::PatternList ::=
 ----------------------------------------------------
 -- Added Functions
 ----------------------------------------------------
+function appendPatternList
+PatternList ::= p1::PatternList p2::PatternList
+{
+  return
+    case p1 of
+    | patternList_more(h, _, t) ->
+      patternList_more(h, ',', appendPatternList(t, p2), location=p1.location)
+    | patternList_one(h) ->
+      patternList_more(h, ',', p2, location=p1.location)
+    | patternList_nil() -> p2
+    end;
+}
 
 function patternListVars
 Name ::= p::Decorated Pattern
@@ -258,6 +295,7 @@ Expr ::= n::Name
  - Takes a set of matchrules that all match against the SAME CONSTRUCTOR and pushes
  - a complex case-expr within a primitive pattern that matches this constructor.
  -
+ - @param currExpr  (The current expression to match against in the overall complex case-expr)
  - @param restExprs  (The remaining expressions to match against in the overall complex case-expr)
  - @param failCase  (The failure expression)
  - @param retType  (The return type of the overall case-expr, and thus this)
@@ -266,7 +304,7 @@ Expr ::= n::Name
  - @return  A primitive pattern matching the constructor, with the overall case-expr pushed down into it
  -}
 function allConCaseTransform
-PrimPattern ::= restExprs::[Expr]  failCase::Expr  retType::Type  mrs::[AbstractMatchRule]
+PrimPattern ::= currExpr::Expr restExprs::[Expr]  failCase::Expr  retType::Type  mrs::[AbstractMatchRule]
 {
   -- TODO: potential source of buggy error messages. We're using head(mrs) as the source of
   -- authority for the length of pattern variables to match against. But each match rule may
@@ -276,17 +314,22 @@ PrimPattern ::= restExprs::[Expr]  failCase::Expr  retType::Type  mrs::[Abstract
 
   local subcase :: Expr =
     caseExpr(
-      map(exprFromName, names) ++ restExprs,
-      map((.expandHeadPattern), mrs),
+      map(exprFromName, names) ++ annoAccesses ++ restExprs,
+      map(\ mr::AbstractMatchRule -> mr.expandHeadPattern(annos), mrs),
       failCase, retType, location=head(mrs).location);
   -- TODO: head(mrs).location is probably not the correct thing to use here?? (generally)
 
+  local annos :: [String] =
+    nubBy(stringEq, map(fst, flatMap((.patternNamedSubPatternList), map((.headPattern), mrs))));
+  local annoAccesses :: [Expr] =
+    map(\ n::String -> access(currExpr, '.', qNameAttrOccur(qName(l, n), location=l), location=l), annos);
+  
   -- Maybe this one is more reasonable? We need to test examples and see what happens...
   local l :: Location = head(mrs).headPattern.location;
 
   return
     case head(mrs).headPattern of
-    | prodAppPattern(qn,_,_,_) -> 
+    | prodAppPattern_named(qn,_,_,_,_,_) -> 
         prodPattern(qn, '(', convStringsToVarBinders(names, l), ')', '->', subcase, location=l)
     | intPattern(it) -> integerPattern(it, '->', subcase, location=l)
     | fltPattern(it) -> floatPattern(it, '->', subcase, location=l)

--- a/grammars/silver/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/extension/patternmatching/PatternTypes.sv
@@ -5,7 +5,7 @@ import silver:extension:list only LSqr_t, RSqr_t;
 {--
  - The forms of syntactic patterns that are permissible in (nested) case expresssions.
  -}
-nonterminal Pattern with location, config, unparse, env, errors, patternIsVariable, patternVariableName, patternSubPatternList, patternSortKey;
+nonterminal Pattern with location, config, unparse, env, errors, patternIsVariable, patternVariableName, patternSubPatternList, patternNamedSubPatternList, patternSortKey;
 
 {--
  - False if it actually matches anything specific, true if it's a variable/wildcard.
@@ -16,9 +16,13 @@ synthesized attribute patternIsVariable :: Boolean;
  -}
 synthesized attribute patternVariableName :: Maybe<String>;
 {--
- - Each child pattern below this one.
+ - Each positional child pattern below this one.
  -}
 synthesized attribute patternSubPatternList :: [Decorated Pattern];
+{--
+ - Each named child pattern below this one.
+ -}
+synthesized attribute patternNamedSubPatternList :: [Pair<String Decorated Pattern>];
 {--
  - The sort (and grouping) key of the pattern.
  - "~var" if patternIsVariable is true. (TODO: actually, we should call it undefined! It's not used.)
@@ -35,8 +39,8 @@ synthesized attribute patternSortKey :: String;
  - The production name may be qualified.
  - TODO: if not qualified filter down to productions on scruntinee type
  -}
-concrete production prodAppPattern
-top::Pattern ::= prod::QName '(' ps::PatternList ')'
+concrete production prodAppPattern_named
+top::Pattern ::= prod::QName '(' ps::PatternList ',' nps::NamedPatternList ')'
 {
   top.unparse = prod.unparse ++ "(" ++ ps.unparse ++ ")";
   top.errors := ps.errors;
@@ -50,8 +54,21 @@ top::Pattern ::= prod::QName '(' ps::PatternList ')'
   top.patternIsVariable = false;
   top.patternVariableName = nothing();
   top.patternSubPatternList = ps.patternList;
+  top.patternNamedSubPatternList = nps.namedPatternList;
   top.patternSortKey = prod.lookupValue.fullName;
-} 
+}
+
+concrete production prodAppPattern
+top::Pattern ::= prod::QName '(' ps::PatternList ')'
+{
+  forwards to prodAppPattern_named(prod, '(', ps, ',', namedPatternList_nil(location=top.location), ')', location=top.location);
+}
+
+concrete production propAppPattern_onlyNamed
+top::Pattern ::= prod::QName '(' nps::NamedPatternList ')'
+{
+  forwards to prodAppPattern_named(prod, '(', patternList_nil(location=top.location), ',', nps, ')', location=top.location);
+}
 
 {--
  - Match anything, and bind nothing.
@@ -115,6 +132,7 @@ top::Pattern ::=
   -- All other patterns should never set these to anything else, so let's default them.
   top.patternIsVariable = false;
   top.patternVariableName = nothing();
+  top.patternNamedSubPatternList = [];
 }
 
 --------------------------------------------------------------------------------
@@ -217,3 +235,51 @@ top::PatternList ::=
 {
   top.asListPattern = nilListPattern('[', ']', location=top.location);
 }
+
+synthesized attribute namedPatternList::[Pair<String Decorated Pattern>];
+
+nonterminal NamedPatternList with location, config, unparse, env, errors, namedPatternList;
+
+concrete production namedPatternList_one
+top::NamedPatternList ::= p::NamedPattern
+{
+  top.unparse = p.unparse;
+  top.errors := p.errors;
+
+  top.namedPatternList = p.namedPatternList;
+}
+concrete production namedPatternList_more
+top::NamedPatternList ::= ps::NamedPatternList ',' p::NamedPattern
+{
+  top.unparse = ps.unparse ++ ", " ++ p.unparse;
+  top.errors := ps.errors ++ p.errors;
+
+  top.namedPatternList = ps.namedPatternList ++ p.namedPatternList;
+}
+
+-- Abstract only to avoid parse conflict
+abstract production namedPatternList_nil
+top::NamedPatternList ::=
+{
+  top.unparse = "";
+  top.errors := [];
+
+  top.namedPatternList = [];
+}
+
+nonterminal NamedPattern with location, config, unparse, env, errors, namedPatternList;
+
+concrete production namedPattern
+top::NamedPattern ::= qn::QName '=' p::Pattern
+{
+  top.unparse = s"${qn.unparse}=${p.unparse}";
+  top.errors := p.errors;
+  
+  top.errors <-
+    if qn.lookupAttribute.found || !qn.lookupAttribute.dcl.isAnnotation
+    then [err(qn.location, s"${qn.name} is not an annotation")]
+    else [];
+  
+  top.namedPatternList = [pair(qn.lookupAttribute.fullName, p)];
+}
+

--- a/grammars/silver/hostEmbedding/Translation.sv
+++ b/grammars/silver/hostEmbedding/Translation.sv
@@ -157,6 +157,7 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
     then just(errorPattern([err(givenLocation, "Expression antiquote is invalid in pattern context")], location=givenLocation))
     else nothing();
   
+  -- Note that we intentionally ignore annotations here
   top.patternTranslation =
     fromMaybe(
       prodAppPattern(

--- a/test/silver_features/anno/Anno.sv
+++ b/test/silver_features/anno/Anno.sv
@@ -112,8 +112,8 @@ top::AnnoNT2 ::= s::String
 global partialApp1 :: (AnnoNT2 ::= String) = annoNT2partialAppProd(_, anno1=5, anno2="6");
 global partialApp2 :: (AnnoNT2 ::= String) = annoNT2partialAppProd(_, anno2="7", anno1=8);
 
-global partialApp1val :: AnnoNT2 = partialApp1("doesn't matter");
-global partialApp2val :: AnnoNT2 = partialApp2("doesn't matter");
+global partialApp1val :: AnnoNT2 = partialApp1("foo");
+global partialApp2val :: AnnoNT2 = partialApp2("bar");
 
 equalityTest ( partialApp1val.anno1, 5, Integer, silver_tests ) ;
 equalityTest ( partialApp1val.anno2, "6", String, silver_tests ) ;
@@ -121,6 +121,11 @@ equalityTest ( partialApp2val.anno2, "7", String, silver_tests ) ;
 equalityTest ( partialApp2val.anno1, 8, Integer, silver_tests ) ;
 
 
-
+equalityTest(
+  case partialApp1val of
+  | annoNT2partialAppProd(a, anno1=b, anno2="6") when a == "foo" -> b
+  | _ -> 42
+  end,
+  5, Integer, silver_tests);
 
 


### PR DESCRIPTION
This adds support for pattern matching on annotations, for example one may now write
```
case e of
| addExpr(a, b, location=l) -> ...
| ...
end
```

This was needed for the term rewriting extension project.  

Cc'ing Ted because he suggested how to do this in #76.  For now I didn't take the step of modifying the primitive match modification to support named VarBinders or something like that, although doing so would avoid needing to introduce extra let expressions and allow for better errors.  