### PR TITLE
Make lexer classes play nice with renaming in imports (fix #339)

### DIFF
--- a/grammars/silver/definition/env/Defs.sv
+++ b/grammars/silver/definition/env/Defs.sv
@@ -45,7 +45,13 @@ top::Defs ::= e1::Def e2::Defs
 
 --------------------------------------------------------------------------------
 
-closed nonterminal Def with typeList, valueList, attrList, prodOccursList, occursList, prodDclList, dcl;
+-- Transformations on lists of Def
+inherited attribute filterFn::(Boolean ::= EnvItem);
+synthesized attribute filterDef::Boolean;
+inherited attribute mapFn::(EnvItem ::= EnvItem);
+synthesized attribute mapDef::Def;
+
+closed nonterminal Def with typeList, valueList, attrList, prodOccursList, occursList, prodDclList, dcl, filterFn, filterDef, mapFn, mapDef;
 
 aspect default production
 top::Def ::=
@@ -58,18 +64,25 @@ top::Def ::=
   top.occursList = [];
   
   top.prodDclList = [];
+  
+  top.filterDef = true; -- preserve all others for now (legit don't consider occurs, pa)
+  top.mapDef = top; -- ditto
 }
 abstract production typeDef
 top::Def ::= d::EnvItem
 {
   top.dcl = d.dcl;
   top.typeList = [d];
+  top.filterDef = top.filterFn(d);
+  top.mapDef = typeDef(top.mapFn(d));
 }
 abstract production valueDef
 top::Def ::= d::EnvItem
 {
   top.dcl = d.dcl;
   top.valueList = [d];
+  top.filterDef = top.filterFn(d);
+  top.mapDef = valueDef(top.mapFn(d));
 }
 abstract production typeValueDef
 top::Def ::= d::EnvItem
@@ -77,12 +90,16 @@ top::Def ::= d::EnvItem
   top.dcl = d.dcl;
   top.typeList = [d];
   top.valueList = [d];
+  top.filterDef = top.filterFn(d);
+  top.mapDef = typeValueDef(top.mapFn(d));
 }
 abstract production attrDef
 top::Def ::= d::EnvItem
 {
   top.dcl = d.dcl;
   top.attrList = [d];
+  top.filterDef = top.filterFn(d);
+  top.mapDef = attrDef(top.mapFn(d));
 }
 abstract production prodDclDef
 top::Def ::= d::EnvItem
@@ -91,6 +108,8 @@ top::Def ::= d::EnvItem
   top.valueList = [d];
   -- unlike normal valueDef, also affect production lookups:
   top.prodDclList = [d.dcl];
+  top.filterDef = top.filterFn(d);
+  top.mapDef = prodDclDef(top.mapFn(d));
 }
 abstract production paDef
 top::Def ::= d::DclInfo
@@ -221,25 +240,13 @@ Def ::= d::Def  s::Substitution
 function filterDefOnEnvItem
 Boolean ::= fn::(Boolean ::= EnvItem)  d::Def
 {
-  return case d of
-  | valueDef(ei) -> fn(ei)
-  | typeDef(ei) -> fn(ei)
-  | typeValueDef(ei) -> fn(ei)
-  | attrDef(ei) -> fn(ei)
-  | prodDclDef(ei) -> fn(ei)
-  | _ -> true -- preserve all others for now (legit don't consider occurs, pa)
-  end;
+  d.filterFn = fn;
+  return d.filterDef;
 }
 function mapDefOnEnvItem
 Def ::= fn::(EnvItem ::= EnvItem)  d::Def
 {
-  return case d of
-  | valueDef(ei) -> valueDef(fn(ei))
-  | typeDef(ei) -> typeDef(fn(ei))
-  | typeValueDef(ei) -> typeValueDef(fn(ei))
-  | attrDef(ei) -> attrDef(fn(ei))
-  | prodDclDef(ei) -> prodDclDef(fn(ei))
-  | _ -> d -- ditto
-  end;
+  d.mapFn = fn;
+  return d.mapDef;
 }
 

--- a/grammars/silver/definition/env/Defs.sv
+++ b/grammars/silver/definition/env/Defs.sv
@@ -46,6 +46,8 @@ top::Defs ::= e1::Def e2::Defs
 --------------------------------------------------------------------------------
 
 -- Transformations on lists of Def
+-- This is to support computing the defs introduced by qualified imports
+-- (import foo only bar, import foo as bar, import foo with bar as baz)
 inherited attribute filterFn::(Boolean ::= EnvItem);
 synthesized attribute filterDef::Boolean;
 inherited attribute mapFn::(EnvItem ::= EnvItem);
@@ -65,7 +67,7 @@ top::Def ::=
   
   top.prodDclList = [];
   
-  top.filterDef = true; -- preserve all others for now (legit don't consider occurs, pa)
+  top.filterDef = true; -- We don't do any renaming for production attribute or occurs defs
   top.mapDef = top; -- ditto
 }
 abstract production typeDef

--- a/grammars/silver/modification/copper/Env.sv
+++ b/grammars/silver/modification/copper/Env.sv
@@ -29,9 +29,9 @@ top::Def ::= d::EnvItem
   top.dcl = d.dcl;
   top.lexerClassList = [d];
   top.valueList = [d];
+  top.filterDef = top.filterFn(d);
+  top.mapDef = lxrClsDef(top.mapFn(d));
 }
-
--- TODO: we don't do any renaming of lexer classes BUG
 
 function parserAttrDef
 Def ::= sg::String sl::Location fn::String ty::Type

--- a/tutorials/simple/src/simple/extensions/do_while/DoWhile.sv
+++ b/tutorials/simple/src/simple/extensions/do_while/DoWhile.sv
@@ -12,7 +12,7 @@ imports simple:concretesyntax as cst;
 imports simple:abstractsyntax;
 imports simple:extensions:repeat_until;
 
-terminal Do 'do' lexer classes { KEYWORDS };
+terminal Do 'do' lexer classes { cst:KEYWORDS };
 
 concrete productions s::cst:StmtMatched
  | 'do' body::cst:Stmt 'while' '(' cond::cst:Expr ')' ';'

--- a/tutorials/simple/src/simple/extensions/repeat_until/RepeatUntil.sv
+++ b/tutorials/simple/src/simple/extensions/repeat_until/RepeatUntil.sv
@@ -4,8 +4,8 @@ imports silver:langutil;
 imports simple:concretesyntax as cst;
 imports simple:abstractsyntax;
 
-terminal Repeat 'repeat' lexer classes { KEYWORDS };
-terminal Until  'until'  lexer classes { KEYWORDS };
+terminal Repeat 'repeat' lexer classes { cst:KEYWORDS };
+terminal Until  'until'  lexer classes { cst:KEYWORDS };
 
 concrete productions s::cst:StmtMatched
  | 'repeat' body::cst:Stmts 'until' cond::cst:Expr ';'


### PR DESCRIPTION
This fixes the bug where qualifications on import had no effect on lexer classes, requiring ugly workarounds when combining host languages (see https://github.com/melt-umn/Oberon0/blob/develop/grammars/edu.umn.cs.melt.exts.silver.Oberon0/concretesyntax/Terminals.sv#L6)