### PR TITLE
Make prefix separators less brittle

### DIFF
--- a/grammars/silver/definition/concrete_syntax/ParserSpec.sv
+++ b/grammars/silver/definition/concrete_syntax/ParserSpec.sv
@@ -42,8 +42,5 @@ top::ParserSpec ::= sl::Location  sg::String  fn::String  snt::String  grams::[S
     moduleExportedDefs(sl, top.compiledGrammars, computeDependencies(grams, top.compiledGrammars), grams, []);
 
   top.cstAst = cstRoot(fn, snt, foldr(consSyntax, nilSyntax(), addedDcls ++ med.syntaxAst), terminalPrefixes);
-  
-  local decomposedTerminalPrefixes :: Pair<[String] [String]> =
-    unzipPairs(terminalPrefixes);
 }
 

--- a/grammars/silver/definition/concrete_syntax/TerminalDcl.sv
+++ b/grammars/silver/definition/concrete_syntax/TerminalDcl.sv
@@ -101,7 +101,7 @@ top::TerminalKeywordModifier ::=
 
 
 nonterminal TerminalModifiers with config, location, unparse, terminalModifiers, errors, env, grammarName, compiledGrammars, flowEnv;
-nonterminal TerminalModifier with config, location, unparse, terminalModifiers, errors, env, grammarName, compiledGrammars, flowEnv;
+closed nonterminal TerminalModifier with config, location, unparse, terminalModifiers, errors, env, grammarName, compiledGrammars, flowEnv;
 
 synthesized attribute terminalModifiers :: [SyntaxTerminalModifier];
 

--- a/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/CstAst.sv
@@ -42,7 +42,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
             map(\ p::Pair<String String> -> pair(p.snd, p.fst), s.superClassContribs),
             g:empty(compareString)))));
   s.parserAttributeAspects = error("TODO: shouldn't by necessary to normalize"); -- TODO
-  s.prefixesForTerminals = error("TODO: shouldn't by necessary to normalize"); -- TODO
+  s.prefixesForTerminals = directBuildTree(terminalPrefixes);
   
   -- Move productions under their nonterminal, and sort the declarations
   production s2 :: Syntax =
@@ -54,7 +54,7 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   s2.superClasses = s.superClasses;
   s2.subClasses = s.subClasses;
   s2.parserAttributeAspects = directBuildTree(s.parserAttributeAspectContribs);
-  s2.prefixesForTerminals = directBuildTree(terminalPrefixes);
+  s2.prefixesForTerminals = s.prefixesForTerminals;
   
   -- This should be on s1, because the s2 transform assumes everything is well formed.
   -- In particular, it drops productions it can't find an NT for.

--- a/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/Syntax.sv
@@ -76,7 +76,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, sortKey, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, classDomContribs, classSubContribs, prefixSeperator, containingGrammar, prefixesForTerminals;
+nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allIgnoreTerminals, allMarkingTerminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, univLayout, lexerClassRefDcls, xmlCopper, classDomContribs, classSubContribs, prefixSeperator, containingGrammar, prefixesForTerminals;
 
 synthesized attribute sortKey :: String;
 
@@ -105,6 +105,7 @@ top::SyntaxDcl ::=
 abstract production syntaxNonterminal
 top::SyntaxDcl ::= t::Type subdcls::Syntax --modifiers::SyntaxNonterminalModifiers
 {
+  top.fullName = t.typeName;
   top.sortKey = "EEE" ++ t.typeName;
   top.cstDcls = [pair(t.typeName, top)] ++ subdcls.cstDcls;
   top.cstErrors := if length(searchEnvTree(t.typeName, top.cstEnv)) == 1 then []
@@ -133,6 +134,7 @@ top::SyntaxDcl ::= t::Type subdcls::Syntax --modifiers::SyntaxNonterminalModifie
 abstract production syntaxTerminal
 top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
 {
+  top.fullName = n;
   top.sortKey = "CCC" ++ n;
   top.cstDcls = [pair(n, top)];
   top.cstErrors := modifiers.cstErrors;
@@ -153,10 +155,6 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
     else ["Multiple prefixes for terminal " ++ n];
   
   top.prefixSeperator = modifiers.prefixSeperator;
-  top.cstErrors <-
-    if !null(pfx) && !top.prefixSeperator.isJust
-    then ["Terminal " ++ n ++ " does not define a prefix separator, and must use a terminal to define a prefix."] 
-    else [];
   
   top.cstNormalize =
     case modifiers.prefixSeperatorToApply of
@@ -208,6 +206,7 @@ String ::= opassoc::Maybe<String>
 abstract production syntaxProduction
 top::SyntaxDcl ::= ns::NamedSignature  modifiers::SyntaxProductionModifiers
 {
+  top.fullName = ns.fullName;
   top.sortKey = "FFF" ++ ns.fullName;
   top.cstDcls = [pair(ns.fullName, top)];
   modifiers.productionName = ns.fullName;
@@ -304,6 +303,7 @@ function checkRHS
 abstract production syntaxLexerClass
 top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
 {
+  top.fullName = n;
   top.sortKey = "AAA" ++ n;
   top.cstDcls = [pair(n, top)];
   top.cstErrors := modifiers.cstErrors ++
@@ -341,6 +341,7 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
 abstract production syntaxParserAttribute
 top::SyntaxDcl ::= n::String ty::Type acode::String
 {
+  top.fullName = n;
   top.sortKey = "BBB" ++ n;
   top.cstDcls = [pair(n, top)];
   top.cstErrors := if length(searchEnvTree(n, top.cstEnv)) == 1 then []
@@ -368,6 +369,7 @@ top::SyntaxDcl ::= n::String ty::Type acode::String
 abstract production syntaxParserAttributeAspect
 top::SyntaxDcl ::= n::String acode::String
 {
+  top.fullName = n;
   top.sortKey = "BBB" ++ n;
   top.cstDcls = [];
   top.cstErrors :=
@@ -387,6 +389,7 @@ top::SyntaxDcl ::= n::String acode::String
 abstract production syntaxDisambiguationGroup
 top::SyntaxDcl ::= n::String terms::[String] applicableToSubsets::Boolean acode::String
 {
+  top.fullName = n;
   top.sortKey = "DDD" ++ n;
   top.cstDcls = [];
 

--- a/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -8,6 +8,8 @@ synthesized attribute marking :: Boolean;
 synthesized attribute acode :: String;
 synthesized attribute opPrecedence :: Maybe<Integer>;
 synthesized attribute opAssociation :: Maybe<String>; -- TODO type?
+synthesized attribute prefixSeperator :: Maybe<String>;
+synthesized attribute prefixSeperatorToApply :: Maybe<String>;
 synthesized attribute prettyName :: Maybe<String>;
 autocopy attribute terminalName :: String;
 
@@ -15,7 +17,7 @@ autocopy attribute terminalName :: String;
  - Modifiers for terminals.
  -}
 nonterminal SyntaxTerminalModifiers with cstEnv, cstErrors, classTerminalContribs, superClasses, subClasses, dominatesXML,
-  submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation,
+  submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, prefixSeperator, prefixSeperatorToApply,
   marking, terminalName, prettyName;
 
 abstract production consTerminalMod
@@ -31,7 +33,14 @@ top::SyntaxTerminalModifiers ::= h::SyntaxTerminalModifier  t::SyntaxTerminalMod
   top.acode = h.acode ++ t.acode;
   top.opPrecedence = orElse(h.opPrecedence, t.opPrecedence);
   top.opAssociation = orElse(h.opAssociation, t.opAssociation);
+  top.prefixSeperator = orElse(h.prefixSeperator, t.prefixSeperator);
+  top.prefixSeperatorToApply = orElse(h.prefixSeperatorToApply, t.prefixSeperatorToApply);
   top.prettyName = orElse(h.prettyName, t.prettyName);
+  
+  top.cstErrors <-
+    if h.prefixSeperator.isJust && t.prefixSeperator.isJust
+    then ["Multiple prefix separators for terminal " ++ top.terminalName]
+    else [];
 }
 
 abstract production nilTerminalMod
@@ -47,6 +56,8 @@ top::SyntaxTerminalModifiers ::=
   top.acode = "";
   top.opPrecedence = nothing();
   top.opAssociation = nothing();
+  top.prefixSeperator = nothing();
+  top.prefixSeperatorToApply = nothing();
   top.prettyName = nothing();
 }
 
@@ -55,8 +66,8 @@ top::SyntaxTerminalModifiers ::=
 {--
  - Modifiers for terminals.
  -}
-nonterminal SyntaxTerminalModifier with cstEnv, cstErrors, classTerminalContribs, superClasses, subClasses, dominatesXML,
-  submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation,
+closed nonterminal SyntaxTerminalModifier with cstEnv, cstErrors, classTerminalContribs, superClasses, subClasses, dominatesXML,
+  submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, prefixSeperator, prefixSeperatorToApply,
   marking, terminalName, prettyName;
 
 {- We default ALL attributes, so we can focus only on those that are interesting in each case... -}
@@ -73,6 +84,8 @@ top::SyntaxTerminalModifier ::=
   top.acode = "";
   top.opPrecedence = nothing();
   top.opAssociation = nothing();
+  top.prefixSeperator = nothing();
+  top.prefixSeperatorToApply = nothing();
   top.prettyName = nothing();
 }
 
@@ -125,19 +138,26 @@ abstract production termClasses
 top::SyntaxTerminalModifier ::= cls::[String]
 {
   production allCls :: [String] = unionsBy(stringEq, cls :: lookupStrings(cls, top.superClasses));
-  local clsRefsL :: [[Decorated SyntaxDcl]] = lookupStrings(allCls, top.cstEnv);
-  production clsRefs :: [Decorated SyntaxDcl] = map(head, clsRefsL);
+  local allClsRefsL :: [[Decorated SyntaxDcl]] = lookupStrings(allCls, top.cstEnv);
+  production allClsRefs :: [Decorated SyntaxDcl] = map(head, allClsRefsL);
 
   top.cstErrors := flatMap(\ a::Pair<String [Decorated SyntaxDcl]> ->
                      if !null(a.snd) then []
                      else ["Lexer Class " ++ a.fst ++ " was referenced but " ++
                            "this grammar was not included in this parser. (Referenced from lexer class on terminal " ++ top.terminalName ++ ")"],
-                   zipWith(pair, allCls, clsRefsL)); 
+                   zipWith(pair, allCls, allClsRefsL)); 
   top.classTerminalContribs = map(pair(_, top.terminalName), allCls);
   -- We "translate away" lexer classes dom/sub, by moving that info to the terminals (here)
-  top.dominatesXML = implode("", map((.classDomContribs), clsRefs));
-  top.submitsXML = implode("", map((.classSubContribs), clsRefs));
-  top.lexerclassesXML = implode("", map(xmlCopperRef, clsRefs));
+  top.dominatesXML = implode("", map((.classDomContribs), allClsRefs));
+  top.submitsXML = implode("", map((.classSubContribs), allClsRefs));
+  top.lexerclassesXML = implode("", map(xmlCopperRef, allClsRefs));
+  
+  local termSeps :: [Maybe<String>] = map((.prefixSeperator), allClsRefs);
+  top.prefixSeperator = foldr(orElse, nothing(), termSeps);
+  top.cstErrors <-
+    if length(catMaybes(termSeps)) > 1
+    then ["Multiple prefix separators for terminal " ++ top.terminalName]
+    else [];
 }
 {--
  - The submits list for the terminal. Either lexer classes or terminals.
@@ -178,5 +198,36 @@ abstract production termAction
 top::SyntaxTerminalModifier ::= acode::String
 {
   top.acode = acode;
+}
+{--
+ - The prefix separator to use for the terminal.
+ - Doesn't seem super useful, but support this on terminals too for consistency
+ -}
+abstract production termPrefixSeperator
+top::SyntaxTerminalModifier ::= sep::String
+{
+  top.prefixSeperator = just(sep);
+}
+{--
+ - The terminals prefixed by this terminal, for which to use their separator.
+ -}
+abstract production termUsePrefixSeperatorFor
+top::SyntaxTerminalModifier ::= terms::[String]
+{
+  production termRefs :: [Decorated SyntaxDcl] = map(head, lookupStrings(terms, top.cstEnv));
+  local distinctSepTermRefs :: [Decorated SyntaxDcl] =
+    nubBy(
+      \ s1::Decorated SyntaxDcl s2::Decorated SyntaxDcl ->
+        case s1.prefixSeperator, s2.prefixSeperator of
+        | just(ps1), just(ps2) -> ps1 == ps2
+        | _, _ -> false
+        end,
+      termRefs);
+  top.cstErrors :=
+    if length(distinctSepTermRefs) > 1
+    then ["Terminals " ++ implode(", ", map(\ s::Decorated SyntaxDcl -> case s of syntaxTerminal(n, _, _) -> n end, distinctSepTermRefs)) ++
+          " have different prefix separators, so their prefixes must be specified seperately"]
+    else [];
+  top.prefixSeperatorToApply = head(termRefs).prefixSeperator;
 }
 

--- a/grammars/silver/definition/core/Terminals.sv
+++ b/grammars/silver/definition/core/Terminals.sv
@@ -6,17 +6,18 @@ temp_imp_ide_font font_keyword color(123, 0, 82) bold; -- Good: same as java
 temp_imp_ide_font font_modword color(41,95,148) bold; -- maybe good? Unusual but looks good
 temp_imp_ide_font font_type color(41,95,148); -- type coloring
 
+lexer class Silver prefix separator ":";
 
-lexer class IDENTIFIER;
+lexer class IDENTIFIER extends Silver;
 lexer class RESERVED dominates IDENTIFIER;
 
-lexer class COMMENT font = font_comments;
-lexer class LITERAL font = font_literal;
-lexer class KEYWORD font = font_keyword;
-lexer class MODSTMT font = font_modword;
-lexer class SPECOP  font = font_keyword;
-lexer class BUILTIN font = font_keyword;
-lexer class TYPE    font = font_type;
+lexer class COMMENT extends Silver, font = font_comments;
+lexer class LITERAL extends Silver, font = font_literal;
+lexer class KEYWORD extends Silver, font = font_keyword;
+lexer class MODSTMT extends Silver, font = font_modword;
+lexer class SPECOP  extends Silver, font = font_keyword;
+lexer class BUILTIN extends Silver, font = font_keyword;
+lexer class TYPE    extends Silver, font = font_type;
 
 terminal As_kwd       'as'      lexer classes {MODSTMT,RESERVED};
 terminal Exports_kwd  'exports' lexer classes {MODSTMT};

--- a/grammars/silver/extension/doc/core/Terminals.sv
+++ b/grammars/silver/extension/doc/core/Terminals.sv
@@ -4,9 +4,9 @@ temp_imp_ide_font font_doc color(82, 100, 166) italic; -- TODO?
 temp_imp_ide_font font_doc_kwd color(82, 100, 166) italic bold; -- TODO?
 temp_imp_ide_font font_doc_id color(82, 100, 166); -- TODO?
 
-lexer class DOC font = font_doc;
-lexer class DOC_KWD font = font_doc_kwd;
-lexer class DOC_ID font = font_doc_id;
+lexer class DOC extends Silver, font = font_doc;
+lexer class DOC_KWD extends Silver, font = font_doc_kwd;
+lexer class DOC_ID extends Silver, font = font_doc_id;
 
 -- For comments on AGDcls
 terminal CommentOpen_t '{@comment' lexer classes {DOC_KWD};

--- a/grammars/silver/host/Project.sv
+++ b/grammars/silver/host/Project.sv
@@ -1,7 +1,7 @@
 grammar silver:host;
 
 {- Silver is built as an extensible language with a core "host" language and a
- - number of extensions containing additional features.
+ - number of extensions and modifications containing additional features.
  - However many of these extensions we typically always want to include by
  - when building extended versions of Silver, and it becomes cumbersome to list
  - them repeatedly.
@@ -13,7 +13,7 @@ grammar silver:host;
 -- The "core" host language:
 exports silver:host:core;
 
--- Modifications to Silver = optional features taht are not pure extensions.
+-- Modifications to Silver = optional features that are not pure extensions.
 -- These are explicitly annotated as "options" within the core host language
 exports silver:modification:let_fix;
 exports silver:modification:lambda_fn;

--- a/grammars/silver/host/core/Project.sv
+++ b/grammars/silver/host/core/Project.sv
@@ -2,7 +2,7 @@ grammar silver:host:core;
 
 {-
  - This file contains exports for the "core" Silver host language, excluding
- - all extensions.
+ - all extensions and modifications.
  - Note that the "default" host version of Silver specified in silver:host is
  - still required to build this.
  -}

--- a/grammars/silver/modification/copper/BuildProcess.sv
+++ b/grammars/silver/modification/copper/BuildProcess.sv
@@ -107,7 +107,7 @@ top::DriverAction ::= spec::ParserSpec  cg::EnvTree<Decorated RootSpec>  silverG
   local join :: IO = if ex.iovalue then oldSpec.io else ex.io;
 
   local err :: IO = 
-    print("CST Errors while Generating Parser " ++ spec.fullName ++ ":\n" ++
+    print("CST errors while generating parser " ++ spec.fullName ++ ":\n" ++
       implode("\n", specCst.cstErrors) ++ "\n", join);
 
   local doUTD :: IO =
@@ -115,7 +115,7 @@ top::DriverAction ::= spec::ParserSpec  cg::EnvTree<Decorated RootSpec>  silverG
   
   local doWR :: IO =
     writeFile(file, newSpec,
-      print("Generating Parser " ++ spec.fullName ++ ".\n",
+      print("Generating parser " ++ spec.fullName ++ ".\n",
         -- hack to ensure directory exists (for --dont-translate)
         mkdir(dir, join).io));
 

--- a/grammars/silver/modification/copper/DclInfo.sv
+++ b/grammars/silver/modification/copper/DclInfo.sv
@@ -105,15 +105,3 @@ top::DclInfo ::= sg::String sl::Location fn::String ty::Type
   top.defDispatcher = parserAttributeValueDef(_, _, location=_);
   top.defLHSDispatcher = parserAttributeDefLHS(_, location=_);
 }
-
--- TODO: This sort of thing probably ought to be done on the CstAst and not be a part of the Silver environment pretending to be a value.
-abstract production prefixSeparatorDcl
-top::DclInfo ::= sg::String sl::Location sep::String
-{
-  top.sourceGrammar = sg;
-  top.sourceLocation = sl;
-  top.fullName = "_prefix_seperator";
-
-  top.typerep = error("_prefix_seperator does not have a type");
-}
-

--- a/grammars/silver/modification/copper/Env.sv
+++ b/grammars/silver/modification/copper/Env.sv
@@ -69,12 +69,6 @@ Def ::= sg::String sl::Location fn::String ty::Type
   return valueDef(defaultEnvItem(parserLocalDcl(sg,sl,fn,ty)));
 }
 
-function prefixSeparatorDef
-Def ::= sg::String sl::Location s::String
-{
-  return valueDef(defaultEnvItem(prefixSeparatorDcl(sg, sl, s)));
-}
-
 --------------------------------------------------------------------------------
 -- Env.sv
 

--- a/grammars/silver/modification/copper/LexerClass.sv
+++ b/grammars/silver/modification/copper/LexerClass.sv
@@ -31,7 +31,7 @@ top::AGDcl ::= 'lexer' 'class' id::Name modifiers::LexerClassModifiers ';'
 }
 
 nonterminal LexerClassModifiers with config, location, unparse, lexerClassModifiers, errors, env, grammarName, compiledGrammars, flowEnv;
-nonterminal LexerClassModifier with config, location, unparse, lexerClassModifiers, errors, env, grammarName, compiledGrammars, flowEnv;
+closed nonterminal LexerClassModifier with config, location, unparse, lexerClassModifiers, errors, env, grammarName, compiledGrammars, flowEnv;
 
 synthesized attribute lexerClassModifiers :: [SyntaxLexerClassModifier];
 
@@ -105,4 +105,3 @@ top::LexerClassModifier ::= 'disambiguate' acode::ActionCode_c
   acode.env = newScopeEnv(disambiguationClassActionVars ++ acode.defs, top.env);
   acode.frame = disambiguationContext(myFlowGraph);
 }
-

--- a/grammars/silver/modification/copper/ParserDcl.sv
+++ b/grammars/silver/modification/copper/ParserDcl.sv
@@ -19,10 +19,7 @@ top::AGDcl ::= 'parser' n::Name '::' t::TypeExpr '{' m::ParserComponents '}'
   -- Only bug is that you can aspect it, but it's pointless to do so, you can't affect anything.
   top.defs = [funDef(top.grammarName, n.location, namedSig)];
   
-  -- TODO: I think it's inappropriate that we don't bubble up these declarations to the top level.
-  -- However, this necessitates a re-design of how we do 'prefix separators' which are a def we
-  -- need to be scoped to this parser only, not to be overheard by other parsers in this grammar.
-  
+  -- TODO: These declarations should probably bubble up to the top level instead of being decorated here
   production liftedAGDcls :: AGDcl = m.liftedAGDcls;
   liftedAGDcls.config = top.config;
   liftedAGDcls.grammarName = top.grammarName;

--- a/grammars/silver/modification/copper/Prefix.sv
+++ b/grammars/silver/modification/copper/Prefix.sv
@@ -129,9 +129,7 @@ top::TerminalPrefixItems ::=
       consTerminalPrefixItem(_, ',', _, location=top.location),
       nilTerminalPrefixItem(location=top.location),
       map(\ sd::Decorated SyntaxDcl ->
-        qNameTerminalPrefixItem(
-          qName(top.location, case sd of syntaxTerminal(n, _, _) -> n end),
-          location=top.location),
+        qNameTerminalPrefixItem(qName(top.location, sd.fullName), location=top.location),
         syntax.allMarkingTerminals));
 }
 

--- a/grammars/silver/modification/copper/Prefix.sv
+++ b/grammars/silver/modification/copper/Prefix.sv
@@ -204,7 +204,7 @@ top::LexerClassModifier ::= 'prefix' 'separator' s::String_t
 {
   top.unparse = s"prefix separator ${s.lexeme}";
 
-  top.lexerClassModifiers = [lexerClassPrefixSeperator(substring(1, length(s.lexeme) - 1 , s.lexeme))];
+  top.lexerClassModifiers = [lexerClassPrefixSeperator(substring(1, length(s.lexeme) - 1, s.lexeme))];
   top.errors := [];
 }
 
@@ -215,7 +215,7 @@ top::TerminalModifier ::= 'prefix' 'separator' s::String_t
 {
   top.unparse = s"prefix separator ${s.lexeme}";
 
-  top.terminalModifiers = [termPrefixSeperator(substring(1, length(s.lexeme) - 1 , s.lexeme))];
+  top.terminalModifiers = [termPrefixSeperator(substring(1, length(s.lexeme) - 1, s.lexeme))];
   top.errors := [];
 }
 -}

--- a/grammars/silver/modification/copper_mda/BuildProcess.sv
+++ b/grammars/silver/modification/copper_mda/BuildProcess.sv
@@ -41,7 +41,7 @@ top::DriverAction ::= grams::EnvTree<Decorated RootSpec>  spec::MdaSpec  silverg
   local copperFile :: String = dir ++ parserName ++ ".copper";
   
   local err :: IO = 
-    print("CST Errors while Testing MDA " ++ spec.fullName ++ ":\n" ++
+    print("CST errors while testing MDA " ++ spec.fullName ++ ":\n" ++
       foldr(\ a::String b::String -> 
         a ++ "\n" ++ b, "", ast.cstErrors) ++
       "\n", top.ioIn);

--- a/grammars/silver/modification/impide/cstast/CstAst.sv
+++ b/grammars/silver/modification/impide/cstast/CstAst.sv
@@ -21,4 +21,3 @@ top::SyntaxRoot ::= parsername::String  startnt::String  s::Syntax  terminalPref
   top.fontList = s2.fontList;
   top.classFontList = s2.classFontList;
 }
-

--- a/grammars/silver/modification/impide/cstast/TerminalModifiers.sv
+++ b/grammars/silver/modification/impide/cstast/TerminalModifiers.sv
@@ -39,7 +39,7 @@ top::SyntaxTerminalModifier ::=
 aspect production termClasses
 top::SyntaxTerminalModifier ::= cls::[String]
 {
-  top.fontAttrFromClass = dumbExtractFont(clsRefs);
+  top.fontAttrFromClass = dumbExtractFont(allClsRefs);
   
 }
 function dumbExtractFont

--- a/test/copper_features/mdatests/Test.sv
+++ b/test/copper_features/mdatests/Test.sv
@@ -14,8 +14,12 @@ copper_mda test(doParse) {
 
 parser shouldSucceed :: Root {
   copper_features:mdatests:host;
-  copper_features:mdatests:ext prefix copper_features:mdatests:ext:C with '1:'; -- Explicitly give token name
-  copper_features:mdatests:ext2 prefix with '2:'; -- Prefix marking terminals
+  
+  -- Explicitly give token name, use terminal literal as separator
+  copper_features:mdatests:ext prefix copper_features:mdatests:ext:C with '1:';
+  
+  -- Prefix marking terminals, use prefix separator
+  copper_features:mdatests:ext2 prefix with "2";
 
   prefer copper_features:mdatests:ext:C over copper_features:mdatests:ext2:C;
 }

--- a/test/copper_features/mdatests/ext/Ext.sv
+++ b/test/copper_features/mdatests/ext/Ext.sv
@@ -2,7 +2,7 @@ grammar copper_features:mdatests:ext;
 
 import copper_features:mdatests:host;
 
-marking terminal C 'c';
+marking terminal C 'c' lexer classes ColonSep;
 
 terminal D 'd';
 

--- a/test/copper_features/mdatests/ext2/Ext.sv
+++ b/test/copper_features/mdatests/ext2/Ext.sv
@@ -4,7 +4,7 @@ import copper_features:mdatests:host;
 
 -- SAME token as :ext
 
-marking terminal C 'c';
+marking terminal C 'c' lexer classes ColonSep;
 
 terminal E 'e'; -- prefix
 

--- a/test/copper_features/mdatests/host/Host.sv
+++ b/test/copper_features/mdatests/host/Host.sv
@@ -4,6 +4,8 @@ parser doParse :: Root {
   copper_features:mdatests:host;
 }
 
+lexer class ColonSep prefix separator ":";
+
 terminal A 'a';
 terminal B 'b';
 

--- a/test/csterrors/missingSeparator/Artifact.sv
+++ b/test/csterrors/missingSeparator/Artifact.sv
@@ -1,0 +1,8 @@
+grammar missingSeparator;
+
+imports test:nonterm_b;
+
+-- Mangle_t does not have a prefix seperator
+parser extendedParser :: B {
+  test:nonterm_b prefix Mangle_t with "foo";
+}

--- a/test/csterrors/multipleSeparators/Artifact.sv
+++ b/test/csterrors/multipleSeparators/Artifact.sv
@@ -1,0 +1,15 @@
+grammar multipleSeparators;
+
+imports test:nonterm_b;
+
+lexer class Sep1 prefix separator ":";
+lexer class Sep2 prefix separator "$";
+
+marking terminal A_t 'A' lexer classes Sep1;
+marking terminal B_t 'B' lexer classes Sep2;
+
+-- A_t and B_t have different prefix seperators, and prefixes must be specified separately
+parser extendedParser :: B {
+  test:nonterm_b;
+  multipleSeparators prefix with "foo";
+}

--- a/test/csterrors/silver-compile
+++ b/test/csterrors/silver-compile
@@ -24,6 +24,8 @@ silver $ARGS terminalDominate | grep "B_t" > /dev/null || ((count++))
 silver $ARGS terminalLexer | grep "lexer_b:B" > /dev/null || ((count++))
 silver $ARGS lexerSubmit | grep "B_t" > /dev/null || ((count++))
 silver $ARGS lexerDominate | grep "B_t" > /dev/null || ((count++))
+silver $ARGS missingSeparator | grep "test:nonterm_b:Mangle_t" > /dev/null || ((count++))
+silver $ARGS multipleSeparators | grep "multipleSeparators:B_t, multipleSeparators:A_t" > /dev/null || ((count++))
 
 
 rm -f build.xml


### PR DESCRIPTION
Fixes #148.

This moves prefix separators from being a standalone global definition (that can only appear once) to being specified on lexer classes.  This means that the prefix separator is now a property of individual terminals, such that terminals with different prefix separators may be included in the same parser, and specifying string prefixes will automatically choose the appropriate separator.  Note that this means it is no longer makes sense to allow the prefix separator to be globally overridden in a parser specification (resolves #85); in such an (unusual) case users may still specify a regex or single-quoted literal to define a prefix that includes the desired separator, if any.

This change is particularly helpful in dealing with the composition of multiple host languages (e.g. silver-ableC), as included extensions to ableC that require transparent prefixes should use ableC's prefix separator and not Silver's.  More possibilities also exist: for example an extension that defines a DSL mimicking another language may wish to use prefix separators that mimic the syntax of that language, or a host language might choose different prefix separators for keywords and operators.  However the most common case (as with ableC) is that a host language wishes to use the same prefix separators for all terminals in its lexer classes; this may be achieved elegantly through the use of a common lexer superclass:
```
lexer class AbleC  prefix separator "::";

lexer class Comment extends AbleC;
lexer class Identifier extends AbleC;
lexer class Keyword extends AbleC;
...
```
A default prefix separator of ":" for Silver was also added in a similar fashion.  

One annoying implementation detail is that the creation of new terminals to serve as prefixes can't be moved entirely into the CstAst code, as Java class providing the Silver representation of the terminals must still be generated.  Thus writing `foo prefix Foo_t with "bar";` in a parser spec must still declare the prefix terminal, even though we don't know `Foo_t`'s prefix separator until we build the CstAst.  
This problem is solved by introducing an (abstract) terminal modifier for the generated prefix terminal, specifying which terminals are being prefixed.  During CstAst normalization, the regex of any (prefix) terminals with this modifier are updated to append the prefix separator for the prefixed terminals.  This does mean that all terminals in each prefix specification must have the same prefix separator as a single terminal is generated for each prefix specification (to avoid lexical ambiguities between prefix terminals.)  The only major consequence of this restriction is that when prefixing a grammar that exports multiple marking terminals with different prefix sepererators, the terminals being prefixed must be listed explicitly for every terminal in a prefix specification for each prefix separator (example: https://github.com/melt-umn/ableC-sample-projects/blob/feature/prefixSeperator/using_transparent_prefixes/alternate_separator/CompilerSpec.sv#L26.)