### PR TITLE
Implement additional types of automatic attributes

### DIFF
--- a/grammars/silver/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/extension/autoattr/DclInfo.sv
@@ -95,12 +95,66 @@ top::DclInfo ::= sg::String sl::Location inh::String syn::String
   top.propagateDispatcher = propagateEqualitySyn(inh, _, location=_);
 }
 
+abstract production unificationInhDcl
+top::DclInfo ::= sg::String sl::Location fn::String tyVar::TyVar
+{
+  top.sourceGrammar = sg;
+  top.sourceLocation = sl;
+  top.fullName = fn;
+
+  top.typerep = varType(tyVar);
+  top.dclBoundVars = [tyVar];
+  top.isInherited = true;
+  
+  top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _); -- TODO: should probably be an error handler! access inh from undecorated?
+  top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_); -- Allow normal inh equations
+  top.attributionDispatcher = unificationInhAttributionDcl(_, _, _, _, location=_); -- Same as functor, except decorated
+  top.propagateDispatcher = propagateEqualityInh(_, location=_);
+}
+
+abstract production unificationSynPartialDcl
+top::DclInfo ::= sg::String sl::Location inh::String synPartial::String syn::String
+{
+  top.sourceGrammar = sg;
+  top.sourceLocation = sl;
+  top.fullName = synPartial;
+
+  top.typerep = boolType();
+  top.dclBoundVars = [];
+  top.isSynthesized = true;
+  
+  top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
+  top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
+  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
+  top.propagateDispatcher = propagateUnificationSynPartial(inh, _, syn, location=_);
+}
+
+abstract production unificationSynDcl
+top::DclInfo ::= sg::String sl::Location inh::String synPartial::String syn::String
+{
+  top.sourceGrammar = sg;
+  top.sourceLocation = sl;
+  top.fullName = syn;
+
+  top.typerep = boolType();
+  top.dclBoundVars = [];
+  top.isSynthesized = true;
+  
+  top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
+  top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
+  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
+  top.propagateDispatcher = propagateUnificationSyn(inh, synPartial, _, location=_);
+}
+
 abstract production threadedInhDcl
 top::DclInfo ::= sg::String sl::Location inh::String syn::String bound::[TyVar] ty::Type
 {
   top.sourceGrammar = sg;
   top.sourceLocation = sl;
-  top.fullName = syn;
+  top.fullName = inh;
 
   top.typerep = ty;
   top.dclBoundVars = bound;

--- a/grammars/silver/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/extension/autoattr/DclInfo.sv
@@ -11,6 +11,12 @@ top::DclInfo ::=
   top.emptyVal = error("Internal compiler error: must be defined for all monoid attribute declarations");
 }
 
+aspect production inhDcl
+top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type
+{
+  top.propagateDispatcher = propagateInh(_, location=_);
+}
+
 abstract production functorDcl
 top::DclInfo ::= sg::String sl::Location fn::String tyVar::TyVar
 {
@@ -87,4 +93,40 @@ top::DclInfo ::= sg::String sl::Location inh::String syn::String
   top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
   top.propagateDispatcher = propagateEqualitySyn(inh, _, location=_);
+}
+
+abstract production threadedInhDcl
+top::DclInfo ::= sg::String sl::Location inh::String syn::String bound::[TyVar] ty::Type
+{
+  top.sourceGrammar = sg;
+  top.sourceLocation = sl;
+  top.fullName = syn;
+
+  top.typerep = ty;
+  top.dclBoundVars = bound;
+  top.isInherited = true;
+  
+  top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _);
+  top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_); -- Allow normal inh equations
+  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
+  top.propagateDispatcher = propagateThreadedInh(_, syn, location=_);
+}
+
+abstract production threadedSynDcl
+top::DclInfo ::= sg::String sl::Location inh::String syn::String bound::[TyVar] ty::Type
+{
+  top.sourceGrammar = sg;
+  top.sourceLocation = sl;
+  top.fullName = syn;
+
+  top.typerep = ty;
+  top.dclBoundVars = bound;
+  top.isSynthesized = true;
+  
+  top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
+  top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
+  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
+  top.propagateDispatcher = propagateThreadedSyn(inh, _, location=_);
 }

--- a/grammars/silver/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/extension/autoattr/DclInfo.sv
@@ -52,3 +52,39 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type empt
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
   top.propagateDispatcher = propagateMonoid(_, location=_);
 }
+
+abstract production equalityInhDcl
+top::DclInfo ::= sg::String sl::Location fn::String tyVar::TyVar
+{
+  top.sourceGrammar = sg;
+  top.sourceLocation = sl;
+  top.fullName = fn;
+
+  top.typerep = varType(tyVar);
+  top.dclBoundVars = [tyVar];
+  top.isInherited = true;
+  
+  top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _); -- TODO: should probably be an error handler! access inh from undecorated?
+  top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_); -- Allow normal inh equations
+  top.attributionDispatcher = functorAttributionDcl(_, _, _, _, location=_); -- Same as functor
+  top.propagateDispatcher = propagateEqualityInh(_, location=_);
+}
+
+abstract production equalitySynDcl
+top::DclInfo ::= sg::String sl::Location inh::String syn::String
+{
+  top.sourceGrammar = sg;
+  top.sourceLocation = sl;
+  top.fullName = syn;
+
+  top.typerep = boolType();
+  top.dclBoundVars = [];
+  top.isSynthesized = true;
+  
+  top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
+  top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
+  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
+  top.propagateDispatcher = propagateEqualitySyn(inh, _, location=_);
+}

--- a/grammars/silver/extension/autoattr/Equality.sv
+++ b/grammars/silver/extension/autoattr/Equality.sv
@@ -58,6 +58,12 @@ top::ProductionStmt ::= attr::Decorated QName
                       repeat(wildcPattern('_', location=top.location), numChildren - (ie.fst + 1)) ),
                     ')',
                     location=top.location)} -> a
+              | a ->
+                error(
+                  "Attribute " ++ $Expr{stringConst(terminal(String_t, s"\"${attr.name}\"", top.location), location=top.location)} ++
+                  " demanded on child " ++ $Expr{stringConst(terminal(String_t, s"\"${ie.snd.elementName}\"", top.location), location=top.location)} ++
+                  " of production " ++ $Expr{stringConst(terminal(String_t, s"\"${top.frame.signature.fullName}\"", top.location), location=top.location)} ++
+                  " when given value " ++ core:hackUnparse(a) ++ " does not match.")
               end;
           },
         filter(
@@ -75,7 +81,6 @@ top::ProductionStmt ::= inh::String syn::Decorated QName
 {
   top.unparse = s"propagate ${syn.unparse};";
   
-  local numChildren::Integer = length(top.frame.signature.inputElements);
   forwards to
     Silver_ProductionStmt {
       $name{top.frame.signature.outputElement.elementName}.$QName{new(syn)} =

--- a/grammars/silver/extension/autoattr/Equality.sv
+++ b/grammars/silver/extension/autoattr/Equality.sv
@@ -1,0 +1,108 @@
+grammar silver:extension:autoattr;
+
+concrete production equalityAttributeDcl
+top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
+{
+  top.unparse = s"equality attribute ${inh.unparse}, ${syn.unparse};";
+  top.moduleNames := [];
+
+  production attribute inhFName :: String;
+  inhFName = top.grammarName ++ ":" ++ inh.name;
+  production attribute synFName :: String;
+  synFName = top.grammarName ++ ":" ++ syn.name;
+  
+  top.errors <-
+    if length(getAttrDclAll(inhFName, top.env)) > 1
+    then [err(inh.location, "Attribute '" ++ inhFName ++ "' is already bound.")]
+    else [];
+  top.errors <-
+    if length(getAttrDclAll(synFName, top.env)) > 1
+    then [err(syn.location, "Attribute '" ++ synFName ++ "' is already bound.")]
+    else [];
+  
+  forwards to
+    defsAGDcl(
+      [attrDef(defaultEnvItem(equalityInhDcl(top.grammarName, inh.location, inhFName, freshTyVar()))),
+       attrDef(defaultEnvItem(equalitySynDcl(top.grammarName, syn.location, inhFName, synFName)))],
+      location=top.location);
+}
+
+{--
+ - Propagate a equality inherited attribute on the enclosing production
+ - @param attr  The name of the attribute to propagate
+ -}
+abstract production propagateEqualityInh
+top::ProductionStmt ::= attr::Decorated QName
+{
+  top.unparse = s"propagate ${attr.unparse};";
+  
+  local numChildren::Integer = length(top.frame.signature.inputElements);
+  forwards to
+    foldr(
+      productionStmtAppend(_, _, location=top.location),
+      errorProductionStmt([], location=top.location), -- No emptyProductionStmt?
+      map(
+        \ ie::Pair<Integer NamedSignatureElement> ->
+          Silver_ProductionStmt {
+            $name{ie.snd.elementName}.$QName{new(attr)} =
+              case $name{top.frame.signature.outputElement.elementName}.$QName{new(attr)} of
+              | $Pattern{
+                  prodAppPattern(
+                    qName(top.location, top.frame.signature.fullName),
+                    '(',
+                    foldr(
+                      patternList_more(_, ',', _, location=top.location),
+                      patternList_nil(location=top.location),
+                      repeat(wildcPattern('_', location=top.location), ie.fst) ++
+                      Silver_Pattern { a } ::
+                      repeat(wildcPattern('_', location=top.location), numChildren - (ie.fst + 1)) ),
+                    ')',
+                    location=top.location)} -> a
+              end;
+          },
+        filter(
+          \ ie::Pair<Integer NamedSignatureElement> ->
+            !null(getOccursDcl(attr.lookupAttribute.dcl.fullName, ie.snd.typerep.typeName, top.env)),
+          zipWith(pair, range(0, numChildren), top.frame.signature.inputElements))));
+}
+
+{--
+ - Propagate a equality synthesized attribute on the enclosing production
+ - @param attr  The name of the attribute to propagate
+ -}
+abstract production propagateEqualitySyn
+top::ProductionStmt ::= inh::String syn::Decorated QName
+{
+  top.unparse = s"propagate ${syn.unparse};";
+  
+  local numChildren::Integer = length(top.frame.signature.inputElements);
+  forwards to
+    Silver_ProductionStmt {
+      $name{top.frame.signature.outputElement.elementName}.$QName{new(syn)} =
+        case $name{top.frame.signature.outputElement.elementName}.$name{inh} of
+        | $Pattern{
+            prodAppPattern(
+              qName(top.location, top.frame.signature.fullName),
+              '(',
+              foldr(
+                patternList_more(_, ',', _, location=top.location),
+                patternList_nil(location=top.location),
+                map(
+                  \ ie::NamedSignatureElement -> Silver_Pattern { $name{ie.elementName ++ "2"} },
+                  top.frame.signature.inputElements)),
+              ')',
+              location=top.location)} ->
+          $Expr{
+            foldr(
+              and(_, '&&', _, location=top.location),
+              trueConst('true', location=top.location),
+              map(
+                \ ie::NamedSignatureElement ->
+                  if null(getOccursDcl(syn.lookupAttribute.dcl.fullName, ie.typerep.typeName, top.env))
+                  then Silver_Expr { $name{ie.elementName} == $name{ie.elementName ++ "2"} }
+                  else Silver_Expr { $name{ie.elementName}.$QName{new(syn)} },
+                top.frame.signature.inputElements))}
+        | _ -> false
+        end;
+    };
+}

--- a/grammars/silver/extension/autoattr/Functor.sv
+++ b/grammars/silver/extension/autoattr/Functor.sv
@@ -4,6 +4,7 @@ concrete production functorAttributeDcl
 top::AGDcl ::= 'functor' 'attribute' a::Name ';'
 {
   top.unparse = "functor attribute " ++ a.unparse ++ ";";
+  top.moduleNames := [];
 
   production attribute fName :: String;
   fName = top.grammarName ++ ":" ++ a.name;
@@ -23,6 +24,8 @@ abstract production functorAttributionDcl
 top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
+  top.moduleNames := [];
+  
   forwards to
     defaultAttributionDcl(
       at,

--- a/grammars/silver/extension/autoattr/Inherited.sv
+++ b/grammars/silver/extension/autoattr/Inherited.sv
@@ -1,0 +1,32 @@
+grammar silver:extension:autoattr;
+
+abstract production propagateInh
+top::ProductionStmt ::= attr::Decorated QName
+{
+  top.unparse = s"propagate ${attr.unparse};";
+  
+  local attrFullName::String = attr.lookupAttribute.dcl.fullName;
+  local inputsWithAttr::[NamedSignatureElement] =
+    filter(
+      \ input::NamedSignatureElement ->
+        input.typerep.isDecorable &&
+        !null(getOccursDcl(attrFullName, input.typerep.typeName, top.env)),
+      top.frame.signature.inputElements);
+  forwards to
+    foldr(
+      productionStmtAppend(_, _, location=top.location),
+      errorProductionStmt([], location=top.location), -- No emptyProductionStmt?
+      map(
+        \ ie::NamedSignatureElement ->
+          attributeDef(
+            concreteDefLHS(qName(top.location, ie.elementName), location=top.location), '.',
+            qNameAttrOccur(new(attr), location=top.location),
+            '=',
+            access(
+              baseExpr(qName(top.location, top.frame.signature.outputElement.elementName), location=top.location), '.',
+              qNameAttrOccur(new(attr), location=top.location),
+              location=top.location),
+            ';',
+            location=top.location),
+        inputsWithAttr));
+}

--- a/grammars/silver/extension/autoattr/Project.sv
+++ b/grammars/silver/extension/autoattr/Project.sv
@@ -5,5 +5,8 @@ imports silver:definition:env;
 imports silver:definition:type;
 imports silver:definition:type:syntax;
 imports silver:modification:collection;
+imports silver:modification:let_fix;
+imports silver:extension:patternmatching;
+imports silver:metatranslation;
 
 exports silver:extension:autoattr:convenience;

--- a/grammars/silver/extension/autoattr/Terminals.sv
+++ b/grammars/silver/extension/autoattr/Terminals.sv
@@ -4,8 +4,8 @@ terminal Propagate_kwd 'propagate' lexer classes {KEYWORD,RESERVED};
 terminal Excluding_kwd 'excluding' lexer classes {KEYWORD};
 terminal Thread_kwd    'thread'    lexer classes {KEYWORD,RESERVED};
 
-terminal Functor_kwd     'functor'     lexer classes {KEYWORD,RESERVED};
-terminal Monoid_kwd      'monoid'      lexer classes {KEYWORD,RESERVED};
-terminal Equality_kwd    'equality'    lexer classes {KEYWORD,RESERVED};
-terminal Unification_kwd 'unification' lexer classes {KEYWORD,RESERVED};
-terminal Threaded_kwd    'threaded'    lexer classes {KEYWORD,RESERVED};
+terminal Functor_kwd     'functor'     lexer classes {KEYWORD};
+terminal Monoid_kwd      'monoid'      lexer classes {KEYWORD};
+terminal Equality_kwd    'equality'    lexer classes {KEYWORD};
+terminal Unification_kwd 'unification' lexer classes {KEYWORD};
+terminal Threaded_kwd    'threaded'    lexer classes {KEYWORD};

--- a/grammars/silver/extension/autoattr/Terminals.sv
+++ b/grammars/silver/extension/autoattr/Terminals.sv
@@ -2,7 +2,9 @@ grammar silver:extension:autoattr;
 
 terminal Propagate_kwd 'propagate' lexer classes {KEYWORD,RESERVED};
 terminal Excluding_kwd 'excluding' lexer classes {KEYWORD};
+terminal Thread_kwd    'thread'    lexer classes {KEYWORD,RESERVED};
 
 terminal Functor_kwd   'functor'  lexer classes {KEYWORD,RESERVED};
 terminal Monoid_kwd    'monoid'   lexer classes {KEYWORD,RESERVED};
 terminal Equality_kwd  'equality' lexer classes {KEYWORD,RESERVED};
+terminal Threaded_kwd  'threaded' lexer classes {KEYWORD,RESERVED};

--- a/grammars/silver/extension/autoattr/Terminals.sv
+++ b/grammars/silver/extension/autoattr/Terminals.sv
@@ -4,7 +4,8 @@ terminal Propagate_kwd 'propagate' lexer classes {KEYWORD,RESERVED};
 terminal Excluding_kwd 'excluding' lexer classes {KEYWORD};
 terminal Thread_kwd    'thread'    lexer classes {KEYWORD,RESERVED};
 
-terminal Functor_kwd   'functor'  lexer classes {KEYWORD,RESERVED};
-terminal Monoid_kwd    'monoid'   lexer classes {KEYWORD,RESERVED};
-terminal Equality_kwd  'equality' lexer classes {KEYWORD,RESERVED};
-terminal Threaded_kwd  'threaded' lexer classes {KEYWORD,RESERVED};
+terminal Functor_kwd     'functor'     lexer classes {KEYWORD,RESERVED};
+terminal Monoid_kwd      'monoid'      lexer classes {KEYWORD,RESERVED};
+terminal Equality_kwd    'equality'    lexer classes {KEYWORD,RESERVED};
+terminal Unification_kwd 'unification' lexer classes {KEYWORD,RESERVED};
+terminal Threaded_kwd    'threaded'    lexer classes {KEYWORD,RESERVED};

--- a/grammars/silver/extension/autoattr/Terminals.sv
+++ b/grammars/silver/extension/autoattr/Terminals.sv
@@ -3,5 +3,6 @@ grammar silver:extension:autoattr;
 terminal Propagate_kwd 'propagate' lexer classes {KEYWORD,RESERVED};
 terminal Excluding_kwd 'excluding' lexer classes {KEYWORD};
 
-terminal Functor_kwd   'functor' lexer classes {KEYWORD,RESERVED};
-terminal Monoid_kwd    'monoid'  lexer classes {KEYWORD,RESERVED};
+terminal Functor_kwd   'functor'  lexer classes {KEYWORD,RESERVED};
+terminal Monoid_kwd    'monoid'   lexer classes {KEYWORD,RESERVED};
+terminal Equality_kwd  'equality' lexer classes {KEYWORD,RESERVED};

--- a/grammars/silver/extension/autoattr/Threaded.sv
+++ b/grammars/silver/extension/autoattr/Threaded.sv
@@ -3,7 +3,7 @@ grammar silver:extension:autoattr;
 concrete production threadedAttributeDcl
 top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
-  top.unparse = s"threaded attribute ${inh.unparse}, ${syn.unparse};";
+  top.unparse = s"threaded attribute ${inh.unparse}, ${syn.unparse} ${tl.unparse} :: ${te.unparse};";
   top.moduleNames := [];
 
   production attribute inhFName :: String;

--- a/grammars/silver/extension/autoattr/Threaded.sv
+++ b/grammars/silver/extension/autoattr/Threaded.sv
@@ -1,0 +1,155 @@
+grammar silver:extension:autoattr;
+
+concrete production threadedAttributeDcl
+top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+{
+  top.unparse = s"threaded attribute ${inh.unparse}, ${syn.unparse};";
+  top.moduleNames := [];
+
+  production attribute inhFName :: String;
+  inhFName = top.grammarName ++ ":" ++ inh.name;
+  production attribute synFName :: String;
+  synFName = top.grammarName ++ ":" ++ syn.name;
+  
+  tl.initialEnv = top.env;
+  tl.env = tl.envBindingTyVars;
+  te.env = tl.envBindingTyVars;
+  
+  top.errors <-
+    if length(getAttrDclAll(inhFName, top.env)) > 1
+    then [err(inh.location, "Attribute '" ++ inhFName ++ "' is already bound.")]
+    else [];
+  top.errors <-
+    if length(getAttrDclAll(synFName, top.env)) > 1
+    then [err(syn.location, "Attribute '" ++ synFName ++ "' is already bound.")]
+    else [];
+  
+  forwards to
+    defsAGDcl(
+      [attrDef(defaultEnvItem(threadedInhDcl(top.grammarName, inh.location, inhFName, synFName, tl.freeVariables, te.typerep))),
+       attrDef(defaultEnvItem(threadedSynDcl(top.grammarName, syn.location, inhFName, synFName, tl.freeVariables, te.typerep)))],
+      location=top.location);
+}
+
+abstract production propagateThreadedInh
+top::ProductionStmt ::= inh::Decorated QName syn::String
+{
+  top.unparse = s"propagate ${inh.unparse};";
+  
+  local lhsName::String = top.frame.signature.outputElement.elementName;
+  forwards to
+    threadInhDcl(
+      inh.name, syn,
+      map(
+        name(_, top.location),
+        lhsName ::
+        filter(
+          \ n::String -> !null(getOccursDcl(inh.name, n, top.env)) && !null(getOccursDcl(syn, n, top.env)),
+          map((.elementName), top.frame.signature.inputElements)) ++
+        [if !null(getValueDcl("forward", top.env)) then "forward" else lhsName]),
+      location=top.location);
+}
+
+abstract production propagateThreadedSyn
+top::ProductionStmt ::= inh::String syn::Decorated QName
+{
+  top.unparse = s"propagate ${syn.unparse};";
+  
+  local lhsName::String = top.frame.signature.outputElement.elementName;
+  forwards to
+    threadSynDcl(
+      inh, syn.name,
+      map(
+        name(_, top.location),
+        filter(
+          \ n::String -> !null(getOccursDcl(inh, n, top.env)) && !null(getOccursDcl(syn.name, n, top.env)),
+          map((.elementName), top.frame.signature.inputElements)) ++
+        [if !null(getValueDcl("forward", top.env)) then "forward" else lhsName]),
+      location=top.location);
+}
+
+concrete production threadDcl_c
+top::ProductionStmt ::= 'thread' inh::QName ',' syn::QName 'on' children::Names ';'
+{
+  top.unparse = s"thread ${inh.unparse}, ${syn.unparse} on ${children.unparse};";
+  forwards to
+    productionStmtAppend(
+      threadInhDcl(inh.name, syn.name, children.ids, location=top.location),
+      threadInhDcl(inh.name, syn.name, children.ids, location=top.location),
+      location=top.location);
+}
+
+abstract production threadInhDcl
+top::ProductionStmt ::= inh::String syn::String children::[Name]
+{
+  top.unparse = s"thread ${inh}, ${syn} on ${implode(", ", map((.unparse), children))};";
+  
+  local lhsName::String = top.frame.signature.outputElement.elementName;
+  forwards to
+    foldr(
+      productionStmtAppend(_, _, location=top.location),
+      errorProductionStmt([], location=top.location), -- No emptyProductionStmt?
+      zipWith(
+        \ c1::Name c2::Name ->
+          if c1.name != lhsName
+          then
+            attributeDef(
+              concreteDefLHS(qNameId(c1, location=top.location), location=top.location),
+              '.',
+              qNameAttrOccur(qName(top.location, inh), location=top.location),
+              '=',
+              access(
+                baseExpr(qNameId(c2, location=top.location), location=top.location), '.',
+                qNameAttrOccur(qName(top.location, if c2.name == lhsName then inh else syn), location=top.location),
+                location=top.location),
+              ';',
+              location=top.location)
+          else errorProductionStmt([], location=top.location),
+        tail(children), children));
+}
+
+abstract production threadSynDcl
+top::ProductionStmt ::= inh::String syn::String children::[Name]
+{
+  top.unparse = s"thread ${inh}, ${syn} on ${implode(", ", map((.unparse), children))};";
+  
+  local lhsName::String = top.frame.signature.outputElement.elementName;
+  forwards to
+    foldr(
+      productionStmtAppend(_, _, location=top.location),
+      errorProductionStmt([], location=top.location), -- No emptyProductionStmt?
+      zipWith(
+        \ c1::Name c2::Name ->
+          if c1.name == lhsName
+          then
+            attributeDef(
+              concreteDefLHS(qNameId(c1, location=top.location), location=top.location),
+              '.',
+              qNameAttrOccur(qName(top.location, inh), location=top.location),
+              '=',
+              access(
+                baseExpr(qNameId(c2, location=top.location), location=top.location), '.',
+                qNameAttrOccur(qName(top.location, if c2.name == lhsName then inh else syn), location=top.location),
+                location=top.location),
+              ';',
+              location=top.location)
+          else errorProductionStmt([], location=top.location),
+        tail(children), children));
+}
+
+synthesized attribute ids :: [Name];
+
+nonterminal Names with unparse, ids;
+concrete production idSingle
+top::Names ::= id::Name
+{
+  top.unparse = id.name;
+  top.ids = [id];
+}
+
+concrete production idCons
+top::Names ::= id1::Name ',' id2::Names
+{
+  top.unparse = id1.name ++ ", " ++ id2.unparse ;
+  top.ids = [id1] ++ id2.ids;
+}

--- a/grammars/silver/extension/autoattr/Threaded.sv
+++ b/grammars/silver/extension/autoattr/Threaded.sv
@@ -43,9 +43,13 @@ top::ProductionStmt ::= inh::Decorated QName syn::String
       map(
         name(_, top.location),
         lhsName ::
-        filter(
-          \ n::String -> !null(getOccursDcl(inh.name, n, top.env)) && !null(getOccursDcl(syn, n, top.env)),
-          map((.elementName), top.frame.signature.inputElements)) ++
+        map(
+          (.elementName),
+          filter(
+            \ ie::NamedSignatureElement ->
+              !null(getOccursDcl(inh.lookupAttribute.fullName, ie.typerep.typeName, top.env)) &&
+              !null(getOccursDcl(syn, ie.typerep.typeName, top.env)),
+            top.frame.signature.inputElements)) ++
         [if !null(getValueDcl("forward", top.env)) then "forward" else lhsName]),
       location=top.location);
 }
@@ -61,9 +65,14 @@ top::ProductionStmt ::= inh::String syn::Decorated QName
       inh, syn.name,
       map(
         name(_, top.location),
-        filter(
-          \ n::String -> !null(getOccursDcl(inh, n, top.env)) && !null(getOccursDcl(syn.name, n, top.env)),
-          map((.elementName), top.frame.signature.inputElements)) ++
+        lhsName ::
+        map(
+          (.elementName),
+          filter(
+            \ ie::NamedSignatureElement ->
+              !null(getOccursDcl(inh, ie.typerep.typeName, top.env)) &&
+              !null(getOccursDcl(syn.lookupAttribute.fullName, ie.typerep.typeName, top.env)),
+            top.frame.signature.inputElements)) ++
         [if !null(getValueDcl("forward", top.env)) then "forward" else lhsName]),
       location=top.location);
 }
@@ -75,7 +84,7 @@ top::ProductionStmt ::= 'thread' inh::QName ',' syn::QName 'on' children::Names 
   forwards to
     productionStmtAppend(
       threadInhDcl(inh.name, syn.name, children.ids, location=top.location),
-      threadInhDcl(inh.name, syn.name, children.ids, location=top.location),
+      threadSynDcl(inh.name, syn.name, children.ids, location=top.location),
       location=top.location);
 }
 
@@ -125,7 +134,7 @@ top::ProductionStmt ::= inh::String syn::String children::[Name]
             attributeDef(
               concreteDefLHS(qNameId(c1, location=top.location), location=top.location),
               '.',
-              qNameAttrOccur(qName(top.location, inh), location=top.location),
+              qNameAttrOccur(qName(top.location, syn), location=top.location),
               '=',
               access(
                 baseExpr(qNameId(c2, location=top.location), location=top.location), '.',

--- a/grammars/silver/extension/autoattr/Unification.sv
+++ b/grammars/silver/extension/autoattr/Unification.sv
@@ -1,0 +1,109 @@
+grammar silver:extension:autoattr;
+
+concrete production unificationAttributeDcl
+top::AGDcl ::= 'unification' 'attribute' inh::Name ',' synPartial::Name  ',' syn::Name ';'
+{
+  top.unparse = s"unification attribute ${inh.unparse}, ${synPartial.unparse}, ${syn.unparse};";
+  top.moduleNames := [];
+
+  production attribute inhFName :: String;
+  inhFName = top.grammarName ++ ":" ++ inh.name;
+  production attribute synPartialFName :: String;
+  synPartialFName = top.grammarName ++ ":" ++ synPartial.name;
+  production attribute synFName :: String;
+  synFName = top.grammarName ++ ":" ++ syn.name;
+  
+  top.errors <-
+    if length(getAttrDclAll(inhFName, top.env)) > 1
+    then [err(inh.location, "Attribute '" ++ inhFName ++ "' is already bound.")]
+    else [];
+  top.errors <-
+    if length(getAttrDclAll(synPartialFName, top.env)) > 1
+    then [err(syn.location, "Attribute '" ++ synPartialFName ++ "' is already bound.")]
+    else [];
+  top.errors <-
+    if length(getAttrDclAll(synFName, top.env)) > 1
+    then [err(syn.location, "Attribute '" ++ synFName ++ "' is already bound.")]
+    else [];
+  
+  forwards to
+    defsAGDcl(
+      [attrDef(defaultEnvItem(unificationInhDcl(top.grammarName, inh.location, inhFName, freshTyVar()))),
+       attrDef(defaultEnvItem(unificationSynPartialDcl(top.grammarName, syn.location, inhFName, synPartialFName, synFName))),
+       attrDef(defaultEnvItem(unificationSynDcl(top.grammarName, syn.location, inhFName, synPartialFName, synFName)))],
+      location=top.location);
+}
+
+abstract production unificationInhAttributionDcl
+top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+{
+  top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
+  top.moduleNames := [];
+  
+  forwards to
+    defaultAttributionDcl(
+      at,
+      if length(attl.types) > 0
+      then attl
+      else
+        botlSome(
+          '<',
+          typeListSingle(
+            refTypeExpr(
+              'Decorated',
+              nominalTypeExpr(nt.qNameType, nttl, location=top.location),
+              location=top.location),
+            location=top.location),
+          '>', location=top.location),
+      nt, nttl,
+      location=top.location);
+}
+
+abstract production propagateUnificationSynPartial
+top::ProductionStmt ::= inh::String synPartial::Decorated QName syn::String
+{
+  top.unparse = s"propagate ${synPartial.unparse};";
+  
+  forwards to
+    Silver_ProductionStmt {
+      $name{top.frame.signature.outputElement.elementName}.$QName{new(synPartial)} =
+        case $name{top.frame.signature.outputElement.elementName}.$name{inh} of
+        | $Pattern{
+            prodAppPattern(
+              qName(top.location, top.frame.signature.fullName),
+              '(',
+              foldr(
+                patternList_more(_, ',', _, location=top.location),
+                patternList_nil(location=top.location),
+                map(
+                  \ ie::NamedSignatureElement -> Silver_Pattern { $name{ie.elementName ++ "2"} },
+                  top.frame.signature.inputElements)),
+              ')',
+              location=top.location)} ->
+          $Expr{
+            foldr(
+              and(_, '&&', _, location=top.location),
+              trueConst('true', location=top.location),
+              map(
+                \ ie::NamedSignatureElement ->
+                  if null(getOccursDcl(syn, ie.typerep.typeName, top.env))
+                  then Silver_Expr { $name{ie.elementName} == $name{ie.elementName ++ "2"} }
+                  else Silver_Expr { $name{ie.elementName}.$qName{syn} },
+                top.frame.signature.inputElements))}
+        | _ -> false
+        end;
+    };
+}
+
+abstract production propagateUnificationSyn
+top::ProductionStmt ::= inh::String synPartial::String syn::Decorated QName
+{
+  top.unparse = s"propagate ${syn.unparse};";
+  
+  forwards to
+    Silver_ProductionStmt {
+      $name{top.frame.signature.outputElement.elementName}.$QName{new(syn)} =
+        $name{top.frame.signature.outputElement.elementName}.$qName{synPartial} ||
+        $name{top.frame.signature.outputElement.elementName}.$qName{inh}.$qName{synPartial};
+    };
+}

--- a/grammars/silver/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/extension/autoattr/convenience/Convenience.sv
@@ -30,3 +30,17 @@ top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::T
       makeOccursDclsHelp($1.location, qNameWithTL(qNameId(a, location=a.location), botlNone(location=top.location)), qs.qnames),
       location=top.location);
 }
+
+concrete production equalityAttributeDclMultiple
+top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name 'occurs' 'on' qs::QNames ';'
+{
+  top.unparse = "equality attribute " ++ inh.unparse ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
+  forwards to
+    appendAGDcl(
+      equalityAttributeDcl($1, $2, inh, $4, syn, $9, location=top.location),
+      appendAGDcl(
+        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(inh, location=inh.location), botlNone(location=top.location)), qs.qnames),
+        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
+        location=top.location),
+      location=top.location);
+}

--- a/grammars/silver/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/extension/autoattr/convenience/Convenience.sv
@@ -44,3 +44,34 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name 'occurs' 'on' qs::
         location=top.location),
       location=top.location);
 }
+
+concrete production unificationAttributeDclMultiple
+top::AGDcl ::= 'unification' 'attribute' inh::Name ',' synPartial::Name ',' syn::Name 'occurs' 'on' qs::QNames ';'
+{
+  top.unparse = "equality attribute " ++ inh.unparse ++ ", " ++ synPartial.name ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
+  forwards to
+    appendAGDcl(
+      unificationAttributeDcl($1, $2, inh, $4, syn, $6, synPartial, $11, location=top.location),
+      appendAGDcl(
+        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(inh, location=inh.location), botlNone(location=top.location)), qs.qnames),
+        appendAGDcl(
+          makeOccursDclsHelp($1.location, qNameWithTL(qNameId(inh, location=inh.location), botlNone(location=top.location)), qs.qnames),
+          makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
+          location=top.location),
+        location=top.location),
+      location=top.location);
+}
+
+concrete production threadedAttributeDclMultiple
+top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTypeExprs '::' te::TypeExpr 'occurs' 'on' qs::QNames ';'
+{
+  top.unparse = "threaded attribute " ++ inh.unparse ++ ", " ++ syn.name ++ tl.unparse ++ " :: " ++ te.unparse ++ " occurs on " ++ qs.unparse ++ ";";
+  forwards to
+    appendAGDcl(
+      threadedAttributeDcl($1, $2, inh, $4, syn, tl, $7, te, $12, location=top.location),
+      appendAGDcl(
+        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(inh, location=inh.location), botlNone(location=top.location)), qs.qnames),
+        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
+        location=top.location),
+      location=top.location);
+}

--- a/grammars/silver/extension/convenience/Lists.sv
+++ b/grammars/silver/extension/convenience/Lists.sv
@@ -110,7 +110,7 @@ top::Names ::= id1::Name ',' id2::Names
 function qualifyNames
 [QName] ::= i::[Name]
 {
-  return if null(i) then [] else [qNameId(head(i))] ++ qualifyNames(tail(i));
+  return if null(i) then [] else qNameId(head(i), location=head(i).location) :: qualifyNames(tail(i));
 }
 
 -}

--- a/grammars/silver/modification/collection/java/Collection.sv
+++ b/grammars/silver/modification/collection/java/Collection.sv
@@ -36,53 +36,50 @@ import silver:definition:type:syntax;
       not local collections.
 -}
 
-synthesized attribute frontTrans :: String;
-synthesized attribute midTrans :: String;
-synthesized attribute endTrans :: String;
+inherited attribute leftOpTranslation::String occurs on Operation;
+inherited attribute rightOpTranslation::String occurs on Operation;
 
-attribute frontTrans, midTrans, endTrans occurs on Operation;
+attribute translation occurs on Operation;
 
 aspect production functionOperation
-top::Operation ::= s::String
+top::Operation ::= e::Expr eTrans::String isRef::Boolean isFunction::Boolean
 {
-  top.frontTrans = "" ++ makeClassName(s) ++".invoke(";
-  top.midTrans = ", ";
-  top.endTrans = ")";
-}
-aspect production productionOperation
-top::Operation ::= s::String
-{
-  top.frontTrans = "new " ++ makeClassName(s) ++"(";
-  top.midTrans = ", ";
-  top.endTrans = ")";
+  top.translation =
+    if isRef
+    then s"${eTrans}.invoke(new Object[]{${top.leftOpTranslation}, ${top.rightOpTranslation}}, null)"
+    else if isFunction
+    then s"${eTrans}.invoke(${top.leftOpTranslation}, ${top.rightOpTranslation})"
+    else s"new ${eTrans}(${top.leftOpTranslation}, ${top.rightOpTranslation})";
 }
 aspect production plusPlusOperationString
 top::Operation ::= 
 {
-  top.frontTrans = "new common.StringCatter(";
-  top.midTrans = ", ";
-  top.endTrans = ")";
+  top.translation = s"new common.StringCatter(${top.leftOpTranslation}, ${top.rightOpTranslation})";
 }
 aspect production plusPlusOperationList
 top::Operation ::= 
 {
-  top.frontTrans = "common.AppendCell.append(";
-  top.midTrans = ", ";
-  top.endTrans = ")";
+  top.translation = s"common.AppendCell.append(${top.leftOpTranslation}, ${top.rightOpTranslation})";
 }
 aspect production borOperation
 top::Operation ::= 
 {
-  top.frontTrans = "(";
-  top.midTrans = " || ";
-  top.endTrans = ")";
+  top.translation = s"(${top.leftOpTranslation} || ${top.rightOpTranslation})";
 }
 aspect production bandOperation
 top::Operation ::= 
 {
-  top.frontTrans = "(";
-  top.midTrans = " && ";
-  top.endTrans = ")";
+  top.translation = s"(${top.leftOpTranslation} && ${top.rightOpTranslation})";
+}
+aspect production addOperation
+top::Operation ::= 
+{
+  top.translation = s"(${top.leftOpTranslation} + ${top.rightOpTranslation})";
+}
+aspect production mulOperation
+top::Operation ::= 
+{
+  top.translation = s"(${top.leftOpTranslation} * ${top.rightOpTranslation})";
 }
 
 --- Declarations ---------------------------------------------------------------
@@ -90,9 +87,6 @@ top::Operation ::=
 aspect production collectionAttributeDclProd
 top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr 'with' q::NameOrBOperator ';'
 {
-  local attribute o :: Operation;
-  o = q.operation;
-
   local attribute ugh_dcl_hack :: DclInfo;
   ugh_dcl_hack = head(getValueDclAll(fName, top.env)); -- TODO
 
@@ -102,12 +96,16 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr 'with
   
   -- So we'll create the collection attribute object here, and not worry.
 
+  local o :: Operation = q.operation;
+  o.leftOpTranslation = "result";
+  o.rightOpTranslation = s"(${te.typerep.transType})this.getPieces().get(i).eval(context)";
+
   top.setupInh <-
         "\t\t" ++ top.frame.className ++ ".localAttributes[" ++ ugh_dcl_hack.attrOccursIndex ++ "] = new common.CollectionAttribute(){\n" ++ 
         "\t\t\tpublic Object eval(common.DecoratedNode context) {\n" ++ 
         "\t\t\t\t" ++ te.typerep.transType ++ " result = (" ++ te.typerep.transType ++ ")this.getBase().eval(context);\n" ++ 
         "\t\t\t\tfor(int i = 0; i < this.getPieces().size(); i++){\n" ++ 
-        "\t\t\t\t\tresult = " ++ o.frontTrans ++ "result" ++ o.midTrans ++ "(" ++ te.typerep.transType ++ ")this.getPieces().get(i).eval(context)" ++ o.endTrans ++ ";\n" ++ 
+        "\t\t\t\t\tresult = " ++ o.translation ++ ";\n" ++ 
         "\t\t\t\t}\n" ++ 
         "\t\t\t\treturn result;\n" ++ 
         "\t\t\t}\n" ++ 
@@ -120,8 +118,9 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
   local attribute className :: String;
   className = "CA" ++ a.name;
 
-  local attribute o :: Operation;
-  o = q.operation;
+  local o :: Operation = q.operation;
+  o.leftOpTranslation = "result";
+  o.rightOpTranslation = s"(${te.typerep.transType})this.getPieces().get(i).eval(context)";
 
   top.genFiles := [pair(className ++ ".java",
                 
@@ -136,7 +135,7 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
 "\tpublic Object eval(common.DecoratedNode context) {\n" ++ 
 "\t\t" ++ te.typerep.transType ++ " result = (" ++ te.typerep.transType ++ ")this.getBase().eval(context);\n" ++ 
 "\t\tfor(int i = 0; i < this.getPieces().size(); i++){\n" ++ 
-"\t\t\tresult = " ++ o.frontTrans ++ "result" ++ o.midTrans ++ "(" ++ te.typerep.transType ++ ")this.getPieces().get(i).eval(context)" ++ o.endTrans ++ ";\n" ++ 
+"\t\t\tresult = " ++ o.translation ++ ";\n" ++ 
 "\t\t}\n" ++ 
 "\t\treturn result;\n" ++ 
 "\t}\n\n" ++ 
@@ -150,8 +149,9 @@ top::AGDcl ::= 'inherited' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te
   local attribute className :: String;
   className = "CA" ++ a.name;
 
-  local attribute o :: Operation;
-  o = q.operation;
+  local o :: Operation = q.operation;
+  o.leftOpTranslation = "result";
+  o.rightOpTranslation = s"(${te.typerep.transType})this.getPieces().get(i).eval(context)";
 
   top.genFiles := [pair(className ++ ".java",
                 
@@ -166,7 +166,7 @@ top::AGDcl ::= 'inherited' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te
 "\tpublic Object eval(common.DecoratedNode context) {\n" ++ 
 "\t\t" ++ te.typerep.transType ++ " result = (" ++ te.typerep.transType ++ ")this.getBase().eval(context);\n" ++ 
 "\t\tfor(int i = 0; i < this.getPieces().size(); i++){\n" ++ 
-"\t\t\tresult = " ++ o.frontTrans ++ "result" ++ o.midTrans ++ "(" ++ te.typerep.transType ++ ")this.getPieces().get(i).eval(context)" ++ o.endTrans ++ ";\n" ++ 
+"\t\t\tresult = " ++ o.translation ++ ";\n" ++ 
 "\t\t}\n" ++ 
 "\t\treturn result;\n" ++ 
 "\t}\n\n" ++ 

--- a/test/silver_features/EqualityAttr.sv
+++ b/test/silver_features/EqualityAttr.sv
@@ -1,0 +1,37 @@
+grammar silver_features;
+
+equality attribute isEqualTo, isEqual;
+
+nonterminal EqExpr with isEqualTo, isEqual;
+
+abstract production addEqExpr
+top::EqExpr ::= e1::EqExpr e2::EqExpr
+{
+  propagate isEqualTo, isEqual;
+}
+
+abstract production intEqExpr
+top::EqExpr ::= i::Integer
+{
+  propagate isEqualTo, isEqual;
+}
+
+abstract production appEqExpr
+top::EqExpr ::= n::String e::EqExpr
+{
+  propagate isEqualTo, isEqual;
+}
+
+global ee1::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("abc", intEqExpr(5)));
+global ee2::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("c", intEqExpr(5)));
+global ee3::EqExpr = addEqExpr(appEqExpr("c", intEqExpr(5)), intEqExpr(42));
+
+equalityTest(decorate ee1 with {isEqualTo = ee1;}.isEqual, true, Boolean, silver_tests);
+equalityTest(decorate ee1 with {isEqualTo = ee2;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee1 with {isEqualTo = ee3;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee2 with {isEqualTo = ee1;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee2 with {isEqualTo = ee2;}.isEqual, true, Boolean, silver_tests);
+equalityTest(decorate ee2 with {isEqualTo = ee3;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee3 with {isEqualTo = ee1;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee3 with {isEqualTo = ee2;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee3 with {isEqualTo = ee3;}.isEqual, true, Boolean, silver_tests);


### PR DESCRIPTION
This implements several new kinds of automatic attributes that may be propagated:
* Ordinary inherited attributes may now be propagated, with the behavior of autocopy.  I believe this fixes #280.  
* Threaded attributes, e.g. `threaded attribute subsIn, subsOut :: Substitution;` "thread" a pair of synthesized and inherited attributes through a tree.  New syntax is introduced to allow more fine-grained control of this; for example writing
```
abstract production add
top::Expr ::= a::Expr b::Expr
{
  local tCheck  = ...;
  thread subsIn, subsOut on top, a, b, tCheck, top;
}
```
would generate the equations
```
a.subsIn = top.subsIn;
b.subsIn = a.subsOut;
tCheck.subsIn = b.subsOut;
top.subsOut = tCheck.subsOut;
```
Propagating threaded attributes on a production would simply thread the attributes on all children on which they occur.

* Equality attributes, e.g. `equality attribute isEqualTo, isEqual;` for checking equality between trees.  For example
```
equality attribute isEqualTo, isEqual;
nonterminal Term with isEqualTo, isEqual;
abstract production var
top::Term ::= n::String
{}
abstract production app
top::Term ::= a::Term b::Term
{}
abstract production var
top::Term ::= n::String a::Term
{}
propagate isEqualTo, isEqual on Term;
```
would translate to
```
inherited attribute isEqualTo<a>::a;
synthesized attribute isEqual::Boolean;
nonterminal Term with isEqualTo, isEqual;
abstract production var
top::Term ::= n::String
{
  top.isEqual =
    case top.isEqualTo of
    | var(n1) -> n == n1
    | _ -> false
    end;
}
abstract production app
top::Term ::= a::Term b::Term
{
  a.isEqualTo =
    case top.isEqualTo of
    | app(a1, b1) -> a1
    end;
  b.isEqualTo =
    case top.isEqualTo of
    | app(a1, b1) -> b1
    end;
  top.isEqual =
    case top.isEqualTo of
    | app(a1, b1) -> a.isEqual && b.isEqual
    | _ -> false
    end;
}
abstract production abs
top::Term ::= n::String a::Term
{
  a.isEqualTo =
    case top.isEqualTo of
    | abs(n1, a1) -> a1
    end;
  top.isEqual =
    case top.isEqualTo of
    | abs(n1, a1) -> n == n1 && a.isEqual
    | _ -> false
    end;
}
```
* Unification attributes, for equality checks when certain productions have special behavior (e.g. type variables.)  These are similar to equality attributes, except that each tree is provided to the other as a decorated reference, and the Boolean synthesized attribute is split into a "partial" attribute (true if there is equality in one direction, this may be overridden) and a "total" attribute (true if there is equality in both directions.)  See https://github.com/melt-umn/meta-ocaml-lite/blob/feature/autoattr/grammars/edu.umn.cs.melt.metaocaml/abstractsyntax/Type.sv for an example.

This shouldn't be merged until #375 and #333 have been merged.

The next step here is to use these new types of attributes in the Silver compiler, however we should hold off on introducing a circular dependency with this branch until the preceding pull requests have been merged as well.