### PR TITLE
Bugfix/incorrect matching order

### DIFF
--- a/grammars/silver/extension/patternmatching/Case.sv
+++ b/grammars/silver/extension/patternmatching/Case.sv
@@ -160,7 +160,7 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] failExpr::Expr retType::Type
 function initialSegmentPatternType
 Pair<[AbstractMatchRule] [AbstractMatchRule]> ::= lst::[AbstractMatchRule]
 {
-  return case lst of
+  {-return case lst of
            --this probably shouldn't be called with an empty list, but catch it anyway
          | [] -> pair([], [])
          | [mr] -> pair([mr], [])
@@ -171,7 +171,17 @@ Pair<[AbstractMatchRule] [AbstractMatchRule]> ::= lst::[AbstractMatchRule]
               in pair(mr1::sub.fst, sub.snd) end
            else --the first has a different type of pattern than the second
               pair([mr1], mr2::rest)
-         end;
+         end;-}
+  return if null(lst) --this probably shouldn't be called with an empty list, but catch it anyway
+         then pair([], [])
+         else if null(tail(lst))
+              then pair(lst, [])
+              else if head(lst).isVarMatchRule == head(tail(lst)).isVarMatchRule
+                   then --both have the same type of pattern
+                      let rest::Pair<[AbstractMatchRule] [AbstractMatchRule]> = initialSegmentPatternType(tail(lst))
+                      in pair(head(lst)::rest.fst, rest.snd) end
+                   else --the first has a different type of pattern than the second
+                      pair([head(lst)], tail(lst));
 }
 
 {-

--- a/grammars/silver/extension/patternmatching/Case.sv
+++ b/grammars/silver/extension/patternmatching/Case.sv
@@ -147,17 +147,55 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] failExpr::Expr retType::Type
       -- So don't try that!
   
   {--
-   - Mixed con/var? Partition, and push the vars into the "fail" branch.
-   - Use a let for it, to avoid code duplication!
+    - Mixed con/var? Partition into segments and build nested case expressions
+    - The whole segment partitioning is done in a function rather than grabbing the initial segment
+      and forwarding to do the rest of the segments (another workable option) for efficiency
    -}
-  local freshFailName :: String = "__fail_" ++ toString(genInt());
-  local mixedCase :: Expr =
-    makeLet(top.location,
-      freshFailName, retType, caseExpr(es, varRules, failExpr, retType, location=top.location),
-      caseExpr(es, prodRules, baseExpr(qName(top.location, freshFailName), location=top.location),
-        retType, location=top.location));
+  local mixedCase :: Expr = buildMixedCaseMatches(es, ml, failExpr, retType, top.location);
 }
 
+
+--Get the initial segment of the match rules which all have the same
+--pattern type (constructor or var) and the rest of the rules
+function initialSegmentPatternType
+Pair<[AbstractMatchRule] [AbstractMatchRule]> ::= lst::[AbstractMatchRule]
+{
+  return if null(lst) --this probably shouldn't be called with an empty list, but catch it anyway
+         then pair([], [])
+         else if null(tail(lst))
+              then pair(lst, [])
+              else if head(lst).isVarMatchRule == head(tail(lst)).isVarMatchRule
+                   then --both have the same type of pattern
+                      let rest::Pair<[AbstractMatchRule] [AbstractMatchRule]> = initialSegmentPatternType(tail(lst))
+                      in pair(head(lst)::rest.fst, rest.snd) end
+                   else --the first has a different type of pattern than the second
+                      pair([head(lst)], tail(lst));
+}
+
+{-
+  Build the correct match expression when we are mixing constructor
+  and variable patterns for the first match.  We do this by
+  partitioning the list into segments of only constructor or variable
+  patterns in order, then putting each segment into its own match.
+-}
+function buildMixedCaseMatches
+Expr ::= es::[Expr] ml::[AbstractMatchRule] failExpr::Expr retType::Type loc::Location
+{
+  return if null(ml)
+         then failExpr
+         else let segments::Pair<[AbstractMatchRule] [AbstractMatchRule]> =
+                            initialSegmentPatternType(ml)
+              in
+                caseExpr(es, segments.fst,
+                         buildMixedCaseMatches(es, segments.snd, failExpr, retType, loc),
+                         retType, location=loc)
+              end;
+}
+
+
+
+
+--Match Rules
 concrete production mRuleList_one
 top::MRuleList ::= m::MatchRule
 {

--- a/grammars/silver/extension/patternmatching/Case.sv
+++ b/grammars/silver/extension/patternmatching/Case.sv
@@ -160,16 +160,18 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] failExpr::Expr retType::Type
 function initialSegmentPatternType
 Pair<[AbstractMatchRule] [AbstractMatchRule]> ::= lst::[AbstractMatchRule]
 {
-  return if null(lst) --this probably shouldn't be called with an empty list, but catch it anyway
-         then pair([], [])
-         else if null(tail(lst))
-              then pair(lst, [])
-              else if head(lst).isVarMatchRule == head(tail(lst)).isVarMatchRule
-                   then --both have the same type of pattern
-                      let rest::Pair<[AbstractMatchRule] [AbstractMatchRule]> = initialSegmentPatternType(tail(lst))
-                      in pair(head(lst)::rest.fst, rest.snd) end
-                   else --the first has a different type of pattern than the second
-                      pair([head(lst)], tail(lst));
+  return case lst of
+           --this probably shouldn't be called with an empty list, but catch it anyway
+         | [] -> pair([], [])
+         | [mr] -> pair([mr], [])
+         | mr1::mr2::rest ->
+           if mr1.isVarMatchRule == mr2.isVarMatchRule
+           then --both have the same type of pattern
+              let sub::Pair<[AbstractMatchRule] [AbstractMatchRule]> = initialSegmentPatternType(mr2::rest)
+              in pair(mr1::sub.fst, sub.snd) end
+           else --the first has a different type of pattern than the second
+              pair([mr1], mr2::rest)
+         end;
 }
 
 {-

--- a/test/patt/Basics.sv
+++ b/test/patt/Basics.sv
@@ -48,8 +48,8 @@ equalityTest ( basic3(nothing(), just("w"), nothing()), "w", String, pat_tests )
 equalityTest ( basic3(just("w"), nothing(), nothing()), "w", String, pat_tests ) ;
 equalityTest ( basic3(nothing(), nothing(), just("w")), "w", String, pat_tests ) ;
 
--- TODO: Well, we do left-to-right preferred above all. Haskell preferrs top-to-bottom above all....
-equalityTest ( basic3(just("g"), just("w"), just("h")), "g", String, pat_tests ) ;
+-- test top-to-bottom matching
+equalityTest ( basic3(just("g"), just("w"), just("h")), "w", String, pat_tests ) ;
 
 function basic4 -- using integers
 Integer ::= p::Pair<Integer Maybe<Integer>>
@@ -117,7 +117,7 @@ end;
 }
 
 -- once, this test returned 40, just to clarify what we're testing here.
-equalityTest ( basic7(mytriple(1,just(20),just(300))), 21, Integer, pat_tests ) ;
+equalityTest ( basic7(mytriple(1,just(20),just(300))), 301, Integer, pat_tests ) ;
 equalityTest ( basic7(mytriple(1,nothing(),just(300))), 301, Integer, pat_tests ) ;
 
 function basic8 -- using mixed name/fullnames
@@ -135,4 +135,26 @@ equalityTest ( basic8(pair(1,2)), 1, Integer, pat_tests );
 equalityTest ( basic8(pair(1,3)), 2, Integer, pat_tests );
 equalityTest ( basic8(pair(2,1)), 3, Integer, pat_tests );
 equalityTest ( basic8(pair(3,1)), 4, Integer, pat_tests );
+
+
+-- more testing mixing variable and constructor patterns
+function basic9
+Integer ::= a::Maybe<Integer> b::Maybe<Integer> c::Maybe<Integer>
+{
+return case a, b, c of
+| aa, just(bb), nothing() -> bb
+| just(aa), bb, cc -> aa
+| aa, just(bb), just(cc) -> bb + cc
+| nothing(), bb, cc -> 0
+end;
+}
+
+equalityTest ( basic9(just(1), just(2), just(5)), 1, Integer, pat_tests ) ;
+equalityTest ( basic9(just(1), just(2), nothing()), 2, Integer, pat_tests ) ;
+equalityTest ( basic9(just(1), nothing(), just(5)), 1, Integer, pat_tests ) ;
+equalityTest ( basic9(just(1), nothing(), nothing()), 1, Integer, pat_tests ) ;
+equalityTest ( basic9(nothing(), just(2), just(5)), 7, Integer, pat_tests ) ;
+equalityTest ( basic9(nothing(), just(2), nothing()), 2, Integer, pat_tests ) ;
+equalityTest ( basic9(nothing(), nothing(), just(5)), 0, Integer, pat_tests ) ;
+equalityTest ( basic9(nothing(), nothing(), nothing()), 0, Integer, pat_tests ) ;
 


### PR DESCRIPTION
This fixes #371, that pattern matching was working left-to-right rather than top-to-bottom, as pattern matching works in other programming languages.

Pattern matching was originally compiling cases where the first match mixed both variable and constructor cases by putting all the constructor cases at the beginning, only considering the variable cases when no constructor case matched.  This meant in
```
case left(3), left(4) of
| _, left(_) -> "right"
| left(_), _ -> "wrong"
end
```
the `| left(_), _ -> "wrong"` match rule was pulled to the beginning of the compiled match, with the other rule put at the end because it starts with matching on a variable.

The solution was to follow Section 5.2.6 in [The Implementation of Functional Programming Languages](https://www.microsoft.com/en-us/research/uploads/prod/1987/01/slpj-book-1987-r90.pdf).  This compiles the mixed case by ordered segments of the match rules, with each segment having the same type of pattern (variable or constructor).  The `case` expression above would yield two segments, one with each match rule, with the segments in the same order as the rules occur in the written code.  Since compilation goes by segments of the match rules in order, rather than partitioning all match rules into lists with the same type of pattern, it respects the top-to-bottom order of the written pattern matching.  It builds each segment into its own `case` with the match failure being the `case`s for the rest of the segments.  The above `case` would take a step toward compilation resulting in (taking notational liberties) something like
```
case left(3), left(4) of
| _, left(_) -> "right"
else case left(3), left(4) of
     | left(_), _ -> "wrong"
     end
end
```
which respects the order in which the match rules were written.

One concern brought up in #371 was that fixing this might cause a blow-up in the size of the generated code.  There is some increase in size because it can build quite a few `case` constructs (in most code people write, this will probably be ~2),  but I don't think there is a large blow-up.  It doesn't duplicate any of the RHS expressions.