### PR TITLE
Remove an unsound strategy expression optimization

### DIFF
--- a/grammars/silver/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/extension/strategyattr/StrategyExpr.sv
@@ -41,7 +41,6 @@ partial strategy attribute genericStep =
   | someTraversal(fail()) -> fail(location=top.location, genName=top.genName)
   | oneTraversal(fail()) -> fail(location=top.location, genName=top.genName)
   | prodTraversal(_, ss) when ss.containsFail -> fail(location=top.location, genName=top.genName)
-  | prodTraversal(_, ss) when ss.allId -> id(location=top.location, genName=top.genName)
   | recComb(n, s) when !containsBy(stringEq, n.name, s.freeRecVars) -> s
   | inlined(_, fail()) -> fail(location=top.location, genName=top.genName)
   end;


### PR DESCRIPTION
I just realized while working on the paper that one of the rules for optimizing congruences is actually invalid - while a congruence containing a strategy that always fails will always fail, a strategy containing all identity strategies is not equivalent to identity, as it will still fail when applied to any non-matching production.  Fortunately I don't think this actually made a difference in any of our examples.