### PR TITLE
Refactor type system implementation to introduce PolyType

### DIFF
--- a/grammars/silver/analysis/typechecking/core/AspectDcl.sv
+++ b/grammars/silver/analysis/typechecking/core/AspectDcl.sv
@@ -7,7 +7,7 @@ top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature bod
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = ns.finalSubst;
 
-  errCheck1 = check(realSig.typerep, namedSig.typerep);
+  errCheck1 = check(realSig.typeScheme.typerep, namedSig.typeScheme.typerep);
   top.errors <-
     if errCheck1.typeerror
     then [err(top.location, "Aspect for '" ++ id.name ++ "' does not have the right signature.\nExpected: "
@@ -34,7 +34,7 @@ top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::P
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = ns.finalSubst;
 
-  errCheck1 = check(realSig.typerep, namedSig.typerep);
+  errCheck1 = check(realSig.typeScheme.typerep, namedSig.typeScheme.typerep);
   top.errors <-
     if errCheck1.typeerror
     then [err(top.location, "Aspect for '" ++ id.name ++ "' does not have the right signature.\nExpected: "

--- a/grammars/silver/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/analysis/typechecking/core/ProductionBody.sv
@@ -196,7 +196,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   errCheck1.downSubst = e.upSubst;
   top.upSubst = errCheck1.upSubst;
 
-  errCheck1 = check(e.typerep, val.lookupValue.typerep);
+  errCheck1 = check(e.typerep, val.lookupValue.typeScheme.typerep);
   top.errors <-
        if errCheck1.typeerror
        then [err(top.location, "Local " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]

--- a/grammars/silver/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/analysis/warnings/flow/Inh.sv
@@ -83,7 +83,7 @@ Boolean ::= sigName::String  e::Decorated Env
   -- Suggested fix: maybe we can directly look at the signature, instead of looking
   -- up the name in the environment?
   
-  return if null(d) then true else head(d).typeScheme.typerep.isDecorable;
+  return if null(d) then true else head(d).typeScheme.isDecorable;
 }
 
 {--
@@ -436,7 +436,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     then
       case e of
       | childReference(lq) ->
-          if lq.lookupValue.typeScheme.typerep.isDecorable
+          if lq.lookupValue.typeScheme.isDecorable
           then
             let inhs :: [String] = 
                   -- N.B. we're filtering out autocopies here
@@ -452,7 +452,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
             end
           else []
       | localReference(lq) ->
-          if lq.lookupValue.typeScheme.typerep.isDecorable
+          if lq.lookupValue.typeScheme.isDecorable
           then
             let inhs :: [String] = 
                   filter(

--- a/grammars/silver/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/analysis/warnings/flow/Inh.sv
@@ -83,7 +83,7 @@ Boolean ::= sigName::String  e::Decorated Env
   -- Suggested fix: maybe we can directly look at the signature, instead of looking
   -- up the name in the environment?
   
-  return if null(d) then true else head(d).typerep.isDecorable;
+  return if null(d) then true else head(d).typeScheme.typerep.isDecorable;
 }
 
 {--
@@ -436,7 +436,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     then
       case e of
       | childReference(lq) ->
-          if lq.lookupValue.typerep.isDecorable
+          if lq.lookupValue.typeScheme.typerep.isDecorable
           then
             let inhs :: [String] = 
                   -- N.B. we're filtering out autocopies here
@@ -452,7 +452,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
             end
           else []
       | localReference(lq) ->
-          if lq.lookupValue.typerep.isDecorable
+          if lq.lookupValue.typeScheme.typerep.isDecorable
           then
             let inhs :: [String] = 
                   filter(

--- a/grammars/silver/analysis/warnings/flow/MissingSynEq.sv
+++ b/grammars/silver/analysis/warnings/flow/MissingSynEq.sv
@@ -26,7 +26,7 @@ aspect production attributionDcl
 top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' nt::QName nttl::BracketedOptTypeExprs ';'
 {
   -- All non-forwarding productions for this nonterminal:
-  local nfprods :: [String] = getNonforwardingProds(nt.lookupType.typerep.typeName, top.flowEnv);
+  local nfprods :: [String] = getNonforwardingProds(nt.lookupType.typeScheme.typerep.typeName, top.flowEnv);
 
   -- The check we're writing in this aspect can find all instances of missing
   -- synthesized equations, but in the interest of improved error messages, we

--- a/grammars/silver/analysis/warnings/flow/MissingSynEq.sv
+++ b/grammars/silver/analysis/warnings/flow/MissingSynEq.sv
@@ -26,7 +26,7 @@ aspect production attributionDcl
 top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' nt::QName nttl::BracketedOptTypeExprs ';'
 {
   -- All non-forwarding productions for this nonterminal:
-  local nfprods :: [String] = getNonforwardingProds(nt.lookupType.typeScheme.typerep.typeName, top.flowEnv);
+  local nfprods :: [String] = getNonforwardingProds(nt.lookupType.typeScheme.typeName, top.flowEnv);
 
   -- The check we're writing in this aspect can find all instances of missing
   -- synthesized equations, but in the interest of improved error messages, we

--- a/grammars/silver/analysis/warnings/flow/OrphanedOccurs.sv
+++ b/grammars/silver/analysis/warnings/flow/OrphanedOccurs.sv
@@ -24,7 +24,7 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
 {
   local isClosedNt :: Boolean =
     case nt.lookupType.dcls of
-    | ntDcl(_, _, _, _, _, closed) :: _ -> closed
+    | ntDcl(_, _, _, _, closed) :: _ -> closed
     | _ -> false -- default, if the lookup fails
     end;
 

--- a/grammars/silver/analysis/warnings/flow/OrphanedProduction.sv
+++ b/grammars/silver/analysis/warnings/flow/OrphanedProduction.sv
@@ -27,7 +27,7 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
 
   local isClosedNt :: Boolean =
     case getTypeDclAll(namedSig.outputElement.typerep.typeName, top.env) of
-    | ntDcl(_, _, _, _, _, closed) :: _ -> closed
+    | ntDcl(_, _, _, _, closed) :: _ -> closed
     | _ -> false -- default, if the lookup fails
     end;
 

--- a/grammars/silver/definition/concrete_syntax/ProductionDcl.sv
+++ b/grammars/silver/definition/concrete_syntax/ProductionDcl.sv
@@ -75,7 +75,7 @@ top::ProductionModifier ::= 'operator' '=' n::QName
   top.productionModifiers := [prodOperator(n.lookupType.fullName)];
 
   top.errors <- n.lookupType.errors ++
-                if !n.lookupType.typerep.isTerminal
+                if !n.lookupType.typeScheme.typerep.isTerminal
                 then [err(n.location, n.unparse ++ " is not a terminal.")]
                 else [];
 }

--- a/grammars/silver/definition/concrete_syntax/ProductionDcl.sv
+++ b/grammars/silver/definition/concrete_syntax/ProductionDcl.sv
@@ -75,7 +75,7 @@ top::ProductionModifier ::= 'operator' '=' n::QName
   top.productionModifiers := [prodOperator(n.lookupType.fullName)];
 
   top.errors <- n.lookupType.errors ++
-                if !n.lookupType.typeScheme.typerep.isTerminal
+                if !n.lookupType.typeScheme.isTerminal
                 then [err(n.location, n.unparse ++ " is not a terminal.")]
                 else [];
 }

--- a/grammars/silver/definition/core/Expr.sv
+++ b/grammars/silver/definition/core/Expr.sv
@@ -77,7 +77,7 @@ top::Expr ::= q::Decorated QName
   
   top.typerep = if q.lookupValue.typeScheme.isDecorable
                 then q.lookupValue.typeScheme.asNtOrDecType
-                else q.lookupValue.typeScheme.typerep;
+                else q.lookupValue.typeScheme.monoType;
 }
 
 abstract production lhsReference
@@ -96,7 +96,7 @@ top::Expr ::= q::Decorated QName
   
   top.typerep = if q.lookupValue.typeScheme.isDecorable
                 then q.lookupValue.typeScheme.asNtOrDecType
-                else q.lookupValue.typeScheme.typerep;
+                else q.lookupValue.typeScheme.monoType;
 }
 
 abstract production forwardReference

--- a/grammars/silver/definition/core/Expr.sv
+++ b/grammars/silver/definition/core/Expr.sv
@@ -75,9 +75,9 @@ top::Expr ::= q::Decorated QName
 {
   top.unparse = q.unparse;
   
-  top.typerep = if q.lookupValue.typerep.isDecorable
-                then ntOrDecType(q.lookupValue.typerep, freshType())
-                else q.lookupValue.typerep;
+  top.typerep = if q.lookupValue.typeScheme.typerep.isDecorable
+                then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
+                else q.lookupValue.typeScheme.typerep;
 }
 
 abstract production lhsReference
@@ -86,7 +86,7 @@ top::Expr ::= q::Decorated QName
   top.unparse = q.unparse;
   
   -- An LHS is *always* a decorable (nonterminal) type.
-  top.typerep = ntOrDecType(q.lookupValue.typerep, freshType());
+  top.typerep = ntOrDecType(q.lookupValue.typeScheme.typerep, freshType());
 }
 
 abstract production localReference
@@ -94,9 +94,9 @@ top::Expr ::= q::Decorated QName
 {
   top.unparse = q.unparse;
   
-  top.typerep = if q.lookupValue.typerep.isDecorable
-                then ntOrDecType(q.lookupValue.typerep, freshType())
-                else q.lookupValue.typerep;
+  top.typerep = if q.lookupValue.typeScheme.typerep.isDecorable
+                then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
+                else q.lookupValue.typeScheme.typerep;
 }
 
 abstract production forwardReference
@@ -105,7 +105,7 @@ top::Expr ::= q::Decorated QName
   top.unparse = q.unparse;
   
   -- An LHS (and thus, forward) is *always* a decorable (nonterminal) type.
-  top.typerep = ntOrDecType(q.lookupValue.typerep, freshType());
+  top.typerep = ntOrDecType(q.lookupValue.typeScheme.typerep, freshType());
 }
 
 -- Note here that production and function *references* are distinguished.
@@ -116,8 +116,7 @@ top::Expr ::= q::Decorated QName
 {
   top.unparse = q.unparse;
 
-  -- TODO: the freshening should probably be the responsibility of the thing in the environment, not here?
-  top.typerep = freshenCompletely(q.lookupValue.typerep);
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 abstract production functionReference
@@ -125,7 +124,7 @@ top::Expr ::= q::Decorated QName
 {
   top.unparse = q.unparse;
 
-  top.typerep = freshenCompletely(q.lookupValue.typerep); -- TODO see above
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 abstract production globalValueReference
@@ -133,7 +132,7 @@ top::Expr ::= q::Decorated QName
 {
   top.unparse = q.unparse;
 
-  top.typerep = freshenCompletely(q.lookupValue.typerep); -- TODO see above
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 concrete production concreteForwardExpr
@@ -252,14 +251,12 @@ top::Expr ::= '(' '.' q::QName ')'
   
   -- Fresh variable for the input type, and we'll come back later and check that it occurs on that type.
   
-  -- Also, freshen the attribute type, because even though there currently should NOT be any type variables
-  -- there, there could be if the code will raise an error.
   local rawInputType :: Type = freshType();
-  top.typerep = functionType(freshenCompletely(q.lookupAttribute.typerep), [rawInputType], []);
+  top.typerep = functionType(q.lookupAttribute.typeScheme.typerep, [rawInputType], []);
   
   top.errors <- q.lookupAttribute.errors;
   
-  top.errors <- if null(q.lookupAttribute.dclBoundVars) then []
+  top.errors <- if null(q.lookupAttribute.typeScheme.boundVars) then []
                 else [err(q.location, "Attribute " ++ q.name ++ " is parameterized, and attribute sections currently do not work with parameterized attributes, yet.")]; -- TODO The type inference system is too weak, currently.
   
   top.errors <- if !q.lookupAttribute.found || q.lookupAttribute.dcl.isSynthesized then []

--- a/grammars/silver/definition/core/Expr.sv
+++ b/grammars/silver/definition/core/Expr.sv
@@ -75,7 +75,7 @@ top::Expr ::= q::Decorated QName
 {
   top.unparse = q.unparse;
   
-  top.typerep = if q.lookupValue.typeScheme.typerep.isDecorable
+  top.typerep = if q.lookupValue.typeScheme.isDecorable
                 then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
                 else q.lookupValue.typeScheme.typerep;
 }
@@ -94,7 +94,7 @@ top::Expr ::= q::Decorated QName
 {
   top.unparse = q.unparse;
   
-  top.typerep = if q.lookupValue.typeScheme.typerep.isDecorable
+  top.typerep = if q.lookupValue.typeScheme.isDecorable
                 then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
                 else q.lookupValue.typeScheme.typerep;
 }

--- a/grammars/silver/definition/core/Expr.sv
+++ b/grammars/silver/definition/core/Expr.sv
@@ -76,7 +76,7 @@ top::Expr ::= q::Decorated QName
   top.unparse = q.unparse;
   
   top.typerep = if q.lookupValue.typeScheme.isDecorable
-                then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
+                then q.lookupValue.typeScheme.asNtOrDecType
                 else q.lookupValue.typeScheme.typerep;
 }
 
@@ -86,7 +86,7 @@ top::Expr ::= q::Decorated QName
   top.unparse = q.unparse;
   
   -- An LHS is *always* a decorable (nonterminal) type.
-  top.typerep = ntOrDecType(q.lookupValue.typeScheme.typerep, freshType());
+  top.typerep = q.lookupValue.typeScheme.asNtOrDecType;
 }
 
 abstract production localReference
@@ -95,7 +95,7 @@ top::Expr ::= q::Decorated QName
   top.unparse = q.unparse;
   
   top.typerep = if q.lookupValue.typeScheme.isDecorable
-                then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
+                then q.lookupValue.typeScheme.asNtOrDecType
                 else q.lookupValue.typeScheme.typerep;
 }
 
@@ -105,7 +105,7 @@ top::Expr ::= q::Decorated QName
   top.unparse = q.unparse;
   
   -- An LHS (and thus, forward) is *always* a decorable (nonterminal) type.
-  top.typerep = ntOrDecType(q.lookupValue.typeScheme.typerep, freshType());
+  top.typerep = q.lookupValue.typeScheme.asNtOrDecType;
 }
 
 -- Note here that production and function *references* are distinguished.

--- a/grammars/silver/definition/core/NonTerminalDcl.sv
+++ b/grammars/silver/definition/core/NonTerminalDcl.sv
@@ -10,11 +10,8 @@ top::AGDcl ::= cl::ClosedOrNot 'nonterminal' id::Name tl::BracketedOptTypeExprs 
   production fName :: String = top.grammarName ++ ":" ++ id.name;
   nm.nonterminalName = fName;
   
-  -- tl.freeVariables is our order list of the bound types for this nonterminal.
-  top.defs := [cl.whichDcl(top.grammarName, id.location, fName, tl.freeVariables, nonterminalType(fName, tl.types))];
-  -- TODO: It's probably reasonable to skip listing
-  -- tl.freeVariables, and the Type. Assuming we have a proper ntDcl.
-  -- And we should consider recording the exact concrete names used... might be nice documentation to use
+  top.defs := [cl.whichDcl(top.grammarName, id.location, fName, length(tl.types))];
+  -- TODO: We should consider recording the exact concrete names used... might be nice documentation to use
   
 
   -- Here we ensure that the type list contains only type *variables*
@@ -39,7 +36,7 @@ top::AGDcl ::= cl::ClosedOrNot 'nonterminal' id::Name tl::BracketedOptTypeExprs 
 -- This feels a bit hackish.
 nonterminal ClosedOrNot with location, whichDcl;
 
-synthesized attribute whichDcl :: (Def ::= String Location String [TyVar] Type);
+synthesized attribute whichDcl :: (Def ::= String Location String Integer);
 
 concrete production openNt
 top::ClosedOrNot ::=

--- a/grammars/silver/definition/core/OccursDcl.sv
+++ b/grammars/silver/definition/core/OccursDcl.sv
@@ -26,7 +26,7 @@ top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::B
   nttl.env = nttl.envBindingTyVars;
   
   local ntTypeScheme::PolyType = nt.lookupType.typeScheme;
-  local atTypeScheme::PolyType = at.lookupType.typeScheme;
+  local atTypeScheme::PolyType = at.lookupAttribute.typeScheme;
   
   -- Make sure we get the number of tyvars correct for the NT
   top.errors <-

--- a/grammars/silver/definition/core/ProductionBody.sv
+++ b/grammars/silver/definition/core/ProductionBody.sv
@@ -282,7 +282,7 @@ top::DefLHS ::= q::Decorated QName
   
   top.errors <-
     if top.typerep.isError then [] else [err(q.location, "Cannot define attributes on " ++ q.name)];
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 }
 
 concrete production concreteDefLHSfwd
@@ -304,7 +304,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define synthesized attribute '" ++ top.defLHSattr.name ++ "' on child '" ++ q.name ++ "'")];
                 
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 }
 
 abstract production lhsDefLHS
@@ -320,7 +320,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define inherited attribute '" ++ top.defLHSattr.name ++ "' on the lhs '" ++ q.name ++ "'")];
 
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 }
 
 abstract production localDefLHS
@@ -336,7 +336,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define synthesized attribute '" ++ top.defLHSattr.name ++ "' on local '" ++ q.name ++ "'")];
 
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 }
 
 abstract production forwardDefLHS
@@ -352,7 +352,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define synthesized attribute '" ++ top.defLHSattr.name ++ "' on forward")];
 
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 }
 
 ----- done with DefLHS

--- a/grammars/silver/definition/core/ProductionBody.sv
+++ b/grammars/silver/definition/core/ProductionBody.sv
@@ -379,7 +379,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
   
   top.errors <-
-    if val.lookupValue.typeScheme.typerep.isError then []
+    if val.lookupValue.typeScheme.isError then []
     else [err(val.location, val.name ++ " cannot be assigned to.")];
 }
 

--- a/grammars/silver/definition/core/ProductionBody.sv
+++ b/grammars/silver/definition/core/ProductionBody.sv
@@ -282,7 +282,7 @@ top::DefLHS ::= q::Decorated QName
   
   top.errors <-
     if top.typerep.isError then [] else [err(q.location, "Cannot define attributes on " ++ q.name)];
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 concrete production concreteDefLHSfwd
@@ -304,7 +304,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define synthesized attribute '" ++ top.defLHSattr.name ++ "' on child '" ++ q.name ++ "'")];
                 
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 abstract production lhsDefLHS
@@ -320,7 +320,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define inherited attribute '" ++ top.defLHSattr.name ++ "' on the lhs '" ++ q.name ++ "'")];
 
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 abstract production localDefLHS
@@ -336,7 +336,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define synthesized attribute '" ++ top.defLHSattr.name ++ "' on local '" ++ q.name ++ "'")];
 
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 abstract production forwardDefLHS
@@ -352,7 +352,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define synthesized attribute '" ++ top.defLHSattr.name ++ "' on forward")];
 
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 ----- done with DefLHS
@@ -379,7 +379,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
   
   top.errors <-
-    if val.lookupValue.typerep.isError then []
+    if val.lookupValue.typeScheme.typerep.isError then []
     else [err(val.location, val.name ++ " cannot be assigned to.")];
 }
 

--- a/grammars/silver/definition/core/QName.sv
+++ b/grammars/silver/definition/core/QName.sv
@@ -59,7 +59,7 @@ top::QName ::= msg::[Message]
   top.lookupAttribute = decorate errorLookup(msg) with {};
 }
 
-nonterminal QNameLookup with fullName, typerep, errors, dcls, dcl, dclBoundVars, found;
+nonterminal QNameLookup with fullName, typeScheme, errors, dcls, dcl, found;
 
 synthesized attribute lookupValue :: Decorated QNameLookup occurs on QName;
 synthesized attribute lookupType :: Decorated QNameLookup occurs on QName;
@@ -76,11 +76,7 @@ top::QNameLookup ::= kindOfLookup::String dcls::[DclInfo] name::String l::Locati
   
   top.fullName = if top.found then top.dcl.fullName else "undeclared:value:" ++ name;
   
-  -- TODO: We could eliminate a lot of explicit calls to 'freshenCompletely' and make this more correct
-  -- if we pushed into 'dcl' a different kind of Type, which recorded quantifiers.
-  -- e.g. QuantifiedType. Then when we asked for .typerep of that, it always freshens.
-  top.typerep = if top.found then top.dcl.typerep else errorType();
-  top.dclBoundVars = if top.found then top.dcl.dclBoundVars else [];
+  top.typeScheme = if top.found then top.dcl.typeScheme else monoType(errorType());
   
   top.errors := 
     (if top.found then []
@@ -96,8 +92,7 @@ top::QNameLookup ::= msg::[Message]
   top.found = true;
   top.dcl = error("dcl demanded from errorLookup");
   top.fullName = "err";
-  top.typerep = errorType();
-  top.dclBoundVars = [];
+  top.typeScheme = monoType(errorType());
   top.errors := msg;
 }
 

--- a/grammars/silver/definition/env/DclInfo.sv
+++ b/grammars/silver/definition/env/DclInfo.sv
@@ -9,7 +9,6 @@ synthesized attribute sourceLocation :: Location;
 synthesized attribute fullName :: String;
 
 -- types
-synthesized attribute typerep :: Type;
 synthesized attribute typeScheme :: PolyType;
 
 -- values

--- a/grammars/silver/definition/env/Defs.sv
+++ b/grammars/silver/definition/env/Defs.sv
@@ -148,14 +148,14 @@ Def ::= sg::String  sl::Location  fn::String  ty::Type
   return valueDef(defaultEnvItem(globalValueDcl(sg,sl,fn,ty)));
 }
 function ntDef
-Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
+Def ::= sg::String  sl::Location  fn::String  arity::Integer
 {
-  return typeDef(defaultEnvItem(ntDcl(sg,sl,fn,bound,ty,false)));
+  return typeDef(defaultEnvItem(ntDcl(sg,sl,fn,arity,false)));
 }
 function closedNtDef
-Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
+Def ::= sg::String  sl::Location  fn::String  arity::Integer
 {
-  return typeDef(defaultEnvItem(ntDcl(sg,sl,fn,bound,ty,true)));
+  return typeDef(defaultEnvItem(ntDcl(sg,sl,fn,arity,true)));
 }
 function termDef
 Def ::= sg::String  sl::Location  fn::String  regex::Regex
@@ -164,9 +164,14 @@ Def ::= sg::String  sl::Location  fn::String  regex::Regex
   return typeValueDef(defaultEnvItem(termDcl(sg,sl,fn,regex)));
 }
 function lexTyVarDef
-Def ::= sg::String  sl::Location  fn::String  ty::Type
+Def ::= sg::String  sl::Location  fn::String  tv::TyVar
 {
-  return typeDef(defaultEnvItem(lexTyVarDcl(sg,sl,fn,ty)));
+  return typeDef(defaultEnvItem(lexTyVarDcl(sg,sl,fn,false,tv)));
+}
+function aspectLexTyVarDef
+Def ::= sg::String  sl::Location  fn::String  tv::TyVar
+{
+  return typeDef(defaultEnvItem(lexTyVarDcl(sg,sl,fn,true,tv)));
 }
 function synDef
 Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type

--- a/grammars/silver/definition/env/Env.sv
+++ b/grammars/silver/definition/env/Env.sv
@@ -264,6 +264,6 @@ NamedSignatureElement ::= nt::Type  anno::DclInfo
   -- Used to compute the local typerep for this nonterminal
   anno.givenNonterminalType = nt;
   
-  return namedSignatureElement(anno.attrOccurring, anno.typerep);
+  return namedSignatureElement(anno.attrOccurring, anno.typeScheme.typerep);
 }
 

--- a/grammars/silver/definition/env/NamedSignature.sv
+++ b/grammars/silver/definition/env/NamedSignature.sv
@@ -7,7 +7,7 @@ grammar silver:definition:env;
  - TODO: we might want to remove the full name of the production from this, and make it just `Signature`?
  - It's not clear if this information really belongs here, or not.
  -}
-nonterminal NamedSignature with fullName, inputElements, outputElement, namedInputElements, typeScheme, inputNames, inputTypes;
+nonterminal NamedSignature with fullName, inputElements, outputElement, namedInputElements, typeScheme, freeVariables, inputNames, inputTypes, typerep;
 
 synthesized attribute inputElements :: [NamedSignatureElement];
 synthesized attribute outputElement :: NamedSignatureElement;
@@ -33,6 +33,8 @@ top::NamedSignature ::= fn::String ie::[NamedSignatureElement] oe::NamedSignatur
   top.inputTypes = map((.typerep), ie); -- Does anything actually use this? TODO: eliminate?
   local typerep::Type = functionType(oe.typerep, top.inputTypes, map((.toNamedArgType), np));
   top.typeScheme = polyType(typerep.freeVariables, typerep);
+  top.freeVariables = typerep.freeVariables;
+  top.typerep = typerep; -- TODO: Only used by unifyNamedSignature.  Would be nice to eliminate, somehow.
 }
 
 {--
@@ -121,9 +123,18 @@ NamedSignatureElement ::= f::(Type ::= Type)  nse::NamedSignatureElement
 function freshenNamedSignature
 NamedSignature ::= ns::NamedSignature
 {
-  local s :: Substitution = zipVarsIntoSubstitution(fvs, ns.typeScheme.boundVars);
+  local s :: Substitution = zipVarsIntoSubstitution(ns.freeVariables, ns.typeScheme.boundVars);
 
   -- Apply the freshening within the signature's types
   return mapNamedSignature(performRenaming(_, s), ns);
+}
+
+function unifyNamedSignature
+Substitution ::= ns1::NamedSignature ns2::NamedSignature
+{
+  local subst :: Substitution = unifyDirectional(ns1.typerep, ns2.typerep);
+  return
+    if !subst.failure then subst
+    else errorSubstitution(ns1.typerep);
 }
 

--- a/grammars/silver/definition/env/Type.sv
+++ b/grammars/silver/definition/env/Type.sv
@@ -1,5 +1,22 @@
 grammar silver:definition:env;
 
+synthesized attribute boundVars :: [TyVar] occurs on PolyType;
+attribute typerep occurs on PolyType;
+
+aspect production monoType
+top::PolyType ::= ty::Type
+{
+  top.boundVars = [];
+  top.typerep = ty;
+}
+
+aspect production polyType
+top::PolyType ::= tvs::[TyVar] ty::Type
+{
+  top.boundVars = freshTyVars(length(tvs));
+  top.typerep = freshenTypeWith(ty, tvs, top.boundVars);
+}
+
 -- Just to clarify:
 -- call prettyType to pretty print the type.
 -- get typeName to find out what nonterminal a NT or DNT is

--- a/grammars/silver/definition/env/Type.sv
+++ b/grammars/silver/definition/env/Type.sv
@@ -1,13 +1,20 @@
 grammar silver:definition:env;
 
+-- Just to clarify:
+-- call prettyType to pretty print the type.
+-- get typeName to find out what nonterminal a NT or DNT is
+synthesized attribute typeName :: String;
+
 synthesized attribute boundVars :: [TyVar] occurs on PolyType;
 attribute typerep occurs on PolyType;
+attribute typeName occurs on PolyType;
 
 aspect production monoType
 top::PolyType ::= ty::Type
 {
   top.boundVars = [];
   top.typerep = ty;
+  top.typeName = ty.typeName;
 }
 
 aspect production polyType
@@ -15,15 +22,10 @@ top::PolyType ::= tvs::[TyVar] ty::Type
 {
   top.boundVars = freshTyVars(length(tvs));
   top.typerep = freshenTypeWith(ty, tvs, top.boundVars);
+  top.typeName = ty.typeName;
 }
 
--- Just to clarify:
--- call prettyType to pretty print the type.
--- get typeName to find out what nonterminal a NT or DNT is
-
 attribute typeName occurs on Type;
-
-synthesized attribute typeName :: String;
 
 aspect default production
 top::Type ::=

--- a/grammars/silver/definition/env/Type.sv
+++ b/grammars/silver/definition/env/Type.sv
@@ -5,23 +5,17 @@ grammar silver:definition:env;
 -- get typeName to find out what nonterminal a NT or DNT is
 synthesized attribute typeName :: String;
 
-synthesized attribute boundVars :: [TyVar] occurs on PolyType;
-attribute typerep occurs on PolyType;
 attribute typeName occurs on PolyType;
 
 aspect production monoType
 top::PolyType ::= ty::Type
 {
-  top.boundVars = [];
-  top.typerep = ty;
   top.typeName = ty.typeName;
 }
 
 aspect production polyType
 top::PolyType ::= tvs::[TyVar] ty::Type
 {
-  top.boundVars = freshTyVars(length(tvs));
-  top.typerep = freshenTypeWith(ty, tvs, top.boundVars);
   top.typeName = ty.typeName;
 }
 

--- a/grammars/silver/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/definition/flow/driver/ProductionGraph.sv
@@ -1,7 +1,7 @@
 grammar silver:definition:flow:driver;
 
 import silver:util only contains, rem;
-import silver:definition:type only isDecorable;
+import silver:definition:type only isDecorable, typerep;
 
 nonterminal ProductionGraph with flowTypes, stitchedGraph, prod, lhsNt, transitiveClosure, edgeMap, suspectEdgeMap, cullSuspect, flowTypeVertexes, prodGraphs;
 

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -58,11 +58,11 @@ top::Expr ::= q::Decorated QName
   -- Note that q should find the actual type written in the signature, and so
   -- isDecorable on that indeed tells us whether it's something autodecorated.
   top.flowDeps :=
-    if q.lookupValue.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
-    then depsForTakingRef(rhsVertexType(q.lookupValue.fullName), q.lookupValue.typerep.typeName, top.flowEnv)
+    if q.lookupValue.typeScheme.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
+    then depsForTakingRef(rhsVertexType(q.lookupValue.fullName), q.lookupValue.typeScheme.typerep.typeName, top.flowEnv)
     else [];
   top.flowVertexInfo = 
-    if q.lookupValue.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
+    if q.lookupValue.typeScheme.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
     then hasVertex(rhsVertexType(q.lookupValue.fullName))
     else noVertex();
 }
@@ -72,7 +72,7 @@ top::Expr ::= q::Decorated QName
   -- Always a decorable type, so just check how it's being used:
   top.flowDeps :=
     if !performSubstitution(top.typerep, top.finalSubst).isDecorable
-    then depsForTakingRef(lhsVertexType, q.lookupValue.typerep.typeName, top.flowEnv)
+    then depsForTakingRef(lhsVertexType, q.lookupValue.typeScheme.typerep.typeName, top.flowEnv)
     else [];
   top.flowVertexInfo = 
     if !performSubstitution(top.typerep, top.finalSubst).isDecorable
@@ -84,12 +84,12 @@ top::Expr ::= q::Decorated QName
 {
   -- Again, q give the actual type written.
   top.flowDeps := [localEqVertex(q.lookupValue.fullName)] ++
-    if q.lookupValue.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
-    then depsForTakingRef(localVertexType(q.lookupValue.fullName), q.lookupValue.typerep.typeName, top.flowEnv)
+    if q.lookupValue.typeScheme.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
+    then depsForTakingRef(localVertexType(q.lookupValue.fullName), q.lookupValue.typeScheme.typerep.typeName, top.flowEnv)
     else [];
     
   top.flowVertexInfo =
-    if q.lookupValue.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
+    if q.lookupValue.typeScheme.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
     then hasVertex(localVertexType(q.lookupValue.fullName))
     else noVertex();
 }
@@ -99,7 +99,7 @@ top::Expr ::= q::Decorated QName
   -- Again, always a decorable type.
   top.flowDeps := [forwardEqVertex()]++
     if !performSubstitution(top.typerep, top.finalSubst).isDecorable
-    then depsForTakingRef(forwardVertexType, q.lookupValue.typerep.typeName, top.flowEnv)
+    then depsForTakingRef(forwardVertexType, q.lookupValue.typeScheme.typerep.typeName, top.flowEnv)
     else [];
     
   top.flowVertexInfo =
@@ -307,7 +307,7 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
   top.flowDeps := 
     case fi of
     | hasVertex(vertex) ->
-        if performSubstitution(q.lookupValue.typerep, top.finalSubst).isDecorated &&
+        if performSubstitution(q.lookupValue.typeScheme.typerep, top.finalSubst).isDecorated &&
            !performSubstitution(top.typerep, top.finalSubst).isDecorated
         then vertex.eqVertex -- we're a `t` emulating `new(t)`
         else fd -- we're passing along our vertex-ness to the outer expression

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -58,11 +58,11 @@ top::Expr ::= q::Decorated QName
   -- Note that q should find the actual type written in the signature, and so
   -- isDecorable on that indeed tells us whether it's something autodecorated.
   top.flowDeps :=
-    if q.lookupValue.typeScheme.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
-    then depsForTakingRef(rhsVertexType(q.lookupValue.fullName), q.lookupValue.typeScheme.typerep.typeName, top.flowEnv)
+    if q.lookupValue.typeScheme.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
+    then depsForTakingRef(rhsVertexType(q.lookupValue.fullName), q.lookupValue.typeScheme.typeName, top.flowEnv)
     else [];
   top.flowVertexInfo = 
-    if q.lookupValue.typeScheme.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
+    if q.lookupValue.typeScheme.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
     then hasVertex(rhsVertexType(q.lookupValue.fullName))
     else noVertex();
 }
@@ -72,7 +72,7 @@ top::Expr ::= q::Decorated QName
   -- Always a decorable type, so just check how it's being used:
   top.flowDeps :=
     if !performSubstitution(top.typerep, top.finalSubst).isDecorable
-    then depsForTakingRef(lhsVertexType, q.lookupValue.typeScheme.typerep.typeName, top.flowEnv)
+    then depsForTakingRef(lhsVertexType, q.lookupValue.typeScheme.typeName, top.flowEnv)
     else [];
   top.flowVertexInfo = 
     if !performSubstitution(top.typerep, top.finalSubst).isDecorable
@@ -84,12 +84,12 @@ top::Expr ::= q::Decorated QName
 {
   -- Again, q give the actual type written.
   top.flowDeps := [localEqVertex(q.lookupValue.fullName)] ++
-    if q.lookupValue.typeScheme.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
-    then depsForTakingRef(localVertexType(q.lookupValue.fullName), q.lookupValue.typeScheme.typerep.typeName, top.flowEnv)
+    if q.lookupValue.typeScheme.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
+    then depsForTakingRef(localVertexType(q.lookupValue.fullName), q.lookupValue.typeScheme.typeName, top.flowEnv)
     else [];
     
   top.flowVertexInfo =
-    if q.lookupValue.typeScheme.typerep.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
+    if q.lookupValue.typeScheme.isDecorable && !performSubstitution(top.typerep, top.finalSubst).isDecorable
     then hasVertex(localVertexType(q.lookupValue.fullName))
     else noVertex();
 }
@@ -99,7 +99,7 @@ top::Expr ::= q::Decorated QName
   -- Again, always a decorable type.
   top.flowDeps := [forwardEqVertex()]++
     if !performSubstitution(top.typerep, top.finalSubst).isDecorable
-    then depsForTakingRef(forwardVertexType, q.lookupValue.typeScheme.typerep.typeName, top.flowEnv)
+    then depsForTakingRef(forwardVertexType, q.lookupValue.typeScheme.typeName, top.flowEnv)
     else [];
     
   top.flowVertexInfo =

--- a/grammars/silver/definition/flow/env/Expr.sv
+++ b/grammars/silver/definition/flow/env/Expr.sv
@@ -307,7 +307,7 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
   top.flowDeps := 
     case fi of
     | hasVertex(vertex) ->
-        if performSubstitution(q.lookupValue.typeScheme.typerep, top.finalSubst).isDecorated &&
+        if performSubstitution(q.lookupValue.typeScheme.monoType, top.finalSubst).isDecorated &&
            !performSubstitution(top.typerep, top.finalSubst).isDecorated
         then vertex.eqVertex -- we're a `t` emulating `new(t)`
         else fd -- we're passing along our vertex-ness to the outer expression

--- a/grammars/silver/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/definition/flow/env/ProductionBody.sv
@@ -93,7 +93,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   -- technically, it's possible to break this if you declare it in one grammar, but define it in another, but
   -- I think we should forbid that syntactically, later on...
   top.flowDefs <-
-    [localEq(top.frame.fullName, val.lookupValue.fullName, val.lookupValue.typeScheme.typerep.typeName, e.flowDeps)];
+    [localEq(top.frame.fullName, val.lookupValue.fullName, val.lookupValue.typeScheme.typeName, e.flowDeps)];
 }
 
 -- FROM COLLECTIONS TODO

--- a/grammars/silver/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/definition/flow/env/ProductionBody.sv
@@ -93,7 +93,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   -- technically, it's possible to break this if you declare it in one grammar, but define it in another, but
   -- I think we should forbid that syntactically, later on...
   top.flowDefs <-
-    [localEq(top.frame.fullName, val.lookupValue.fullName, val.lookupValue.typerep.typeName, e.flowDeps)];
+    [localEq(top.frame.fullName, val.lookupValue.fullName, val.lookupValue.typeScheme.typerep.typeName, e.flowDeps)];
 }
 
 -- FROM COLLECTIONS TODO

--- a/grammars/silver/definition/flow/env/ProductionDcl.sv
+++ b/grammars/silver/definition/flow/env/ProductionDcl.sv
@@ -1,5 +1,6 @@
 grammar silver:definition:flow:env;
 
+import silver:definition:type;
 import silver:modification:defaultattr;
 import silver:definition:flow:driver only ProductionGraph, findProductionGraph;
 import silver:driver:util; -- only for productionFlowGraphs occurrence?

--- a/grammars/silver/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/definition/flow/syntax/FlowSpec.sv
@@ -27,8 +27,7 @@ top::AGDcl ::= 'flowtype' nt::QName '=' specs::FlowSpecs ';'
     then specs.flowDefs
     else [];
 
-  -- This is only ever used for its name, really, so no need to freshen
-  specs.onNt = nt.lookupType.typerep;
+  specs.onNt = nt.lookupType.typeScheme.typerep;
 }
 
 concrete production flowtypeAttrDcl
@@ -262,7 +261,6 @@ top::NtName ::= nt::QName
   myCopy.compiledGrammars = top.compiledGrammars;
   myCopy.flowEnv = top.flowEnv;
   
-  -- This is only ever used for its name, really, so no need to freshen
-  myCopy.onNt = nt.lookupType.typerep;
+  myCopy.onNt = nt.lookupType.typeScheme.typerep;
 }
 

--- a/grammars/silver/definition/type/Legacy.sv
+++ b/grammars/silver/definition/type/Legacy.sv
@@ -1,8 +1,8 @@
 grammar silver:definition:type;
 
 -- DEPRECATED STUFF
-attribute isError, isDecorated, isDecorable, isTerminal occurs on PolyType;
-attribute isError, inputTypes, outputType, namedTypes, isDecorated, isDecorable, isTerminal, decoratedType, unifyInstanceNonterminal, unifyInstanceDecorated occurs on Type;
+attribute isError, isDecorated, isDecorable, isTerminal, arity occurs on PolyType;
+attribute isError, inputTypes, outputType, namedTypes, arity, isDecorated, isDecorable, isTerminal, decoratedType, unifyInstanceNonterminal, unifyInstanceDecorated occurs on Type;
 
 -- Quick check to see if an error message should be suppressed
 synthesized attribute isError :: Boolean;
@@ -11,6 +11,7 @@ synthesized attribute isError :: Boolean;
 synthesized attribute inputTypes :: [Type];
 synthesized attribute outputType :: Type;
 synthesized attribute namedTypes :: [NamedArgType];
+synthesized attribute arity :: Integer;
 
 -- Used by Expr, could possibly be replaced by pattern matching for decoratedType
 -- Also used by 'new()'
@@ -34,6 +35,7 @@ synthesized attribute unifyInstanceDecorated :: Substitution;
 aspect production monoType
 top::PolyType ::= ty::Type
 {
+  top.arity = ty.arity;
   top.isError = ty.isError;
   top.isDecorated = ty.isDecorated;
   top.isDecorable = ty.isDecorable;
@@ -43,6 +45,7 @@ top::PolyType ::= ty::Type
 aspect production polyType
 top::PolyType ::= bound::[TyVar] ty::Type
 {
+  top.arity = ty.arity;
   top.isError = ty.isError;
   top.isDecorated = ty.isDecorated;
   top.isDecorable = ty.isDecorable;
@@ -55,6 +58,7 @@ top::Type ::=
   top.inputTypes = [];
   top.outputType = errorType();
   top.namedTypes = [];
+  top.arity = 0;
   
   top.isDecorated = false;
   top.isDecorable = false;
@@ -137,5 +141,6 @@ top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
   top.inputTypes = params;
   top.outputType = out;
   top.namedTypes = namedParams;
+  top.arity = length(params);
 }
 

--- a/grammars/silver/definition/type/Legacy.sv
+++ b/grammars/silver/definition/type/Legacy.sv
@@ -1,6 +1,7 @@
 grammar silver:definition:type;
 
 -- DEPRECATED STUFF
+attribute isError, isDecorated, isDecorable, isTerminal occurs on PolyType;
 attribute isError, inputTypes, outputType, namedTypes, isDecorated, isDecorable, isTerminal, decoratedType, unifyInstanceNonterminal, unifyInstanceDecorated occurs on Type;
 
 -- Quick check to see if an error message should be suppressed
@@ -29,6 +30,24 @@ synthesized attribute decoratedType :: Type;
 -- Used instead of unify() when we want to just know its decorated or undecorated
 synthesized attribute unifyInstanceNonterminal :: Substitution;
 synthesized attribute unifyInstanceDecorated :: Substitution;
+
+aspect production monoType
+top::PolyType ::= ty::Type
+{
+  top.isError = ty.isError;
+  top.isDecorated = ty.isDecorated;
+  top.isDecorable = ty.isDecorable;
+  top.isTerminal = ty.isTerminal;
+}
+
+aspect production polyType
+top::PolyType ::= bound::[TyVar] ty::Type
+{
+  top.isError = ty.isError;
+  top.isDecorated = ty.isDecorated;
+  top.isDecorable = ty.isDecorable;
+  top.isTerminal = ty.isTerminal;
+}
 
 aspect default production
 top::Type ::=

--- a/grammars/silver/definition/type/Substitutions.sv
+++ b/grammars/silver/definition/type/Substitutions.sv
@@ -328,13 +328,6 @@ Type ::= te::Type tvs::[TyVar] ntvs::[TyVar]
   return performRenaming(te, zipVarsIntoSubstitution(tvs, ntvs));
 }
 
--- This function is an artifact of the fact that we ONLY do generalization at the top level, so we don't have (un)bound variables.
-function freshenCompletely
-Type ::= te::Type
-{
-  return freshenType(te, te.freeVariables);
-}
-
 function errorSubstitution
 Substitution ::= t::Type
 {

--- a/grammars/silver/definition/type/Type.sv
+++ b/grammars/silver/definition/type/Type.sv
@@ -2,18 +2,27 @@ grammar silver:definition:type;
 
 option silver:modification:ffi; -- foreign types
 
+synthesized attribute boundVars :: [TyVar];
+synthesized attribute typerep :: Type;
+
 {--
  - Represents a type, quantified over some type variables.
  -}
-nonterminal PolyType;
+nonterminal PolyType with boundVars, typerep;
 
 abstract production monoType
 top::PolyType ::= ty::Type
-{}
+{
+  top.boundVars = [];
+  top.typerep = ty;
+}
 
 abstract production polyType
 top::PolyType ::= bound::[TyVar] ty::Type
-{}
+{
+  top.boundVars = freshTyVars(length(bound));
+  top.typerep = freshenTypeWith(ty, bound, top.boundVars);
+}
 
 {--
  - Silver Type Representations.

--- a/grammars/silver/definition/type/Type.sv
+++ b/grammars/silver/definition/type/Type.sv
@@ -4,17 +4,19 @@ option silver:modification:ffi; -- foreign types
 
 synthesized attribute boundVars :: [TyVar];
 synthesized attribute typerep :: Type;
+synthesized attribute monoType :: Type; -- Raises on error when we encounter a polyType and didn't expect one
 
 {--
  - Represents a type, quantified over some type variables.
  -}
-nonterminal PolyType with boundVars, typerep;
+nonterminal PolyType with boundVars, typerep, monoType;
 
 abstract production monoType
 top::PolyType ::= ty::Type
 {
   top.boundVars = [];
   top.typerep = ty;
+  top.monoType = ty;
 }
 
 abstract production polyType
@@ -22,6 +24,7 @@ top::PolyType ::= bound::[TyVar] ty::Type
 {
   top.boundVars = freshTyVars(length(bound));
   top.typerep = freshenTypeWith(ty, bound, top.boundVars);
+  top.monoType = error("Expected a mono type but found a poly type!");
 }
 
 {--

--- a/grammars/silver/definition/type/Type.sv
+++ b/grammars/silver/definition/type/Type.sv
@@ -3,6 +3,19 @@ grammar silver:definition:type;
 option silver:modification:ffi; -- foreign types
 
 {--
+ - Represents a type, quantified over some type variables.
+ -}
+nonterminal PolyType;
+
+abstract production monoType
+top::PolyType ::= ty::Type
+{}
+
+abstract production polyType
+top::PolyType ::= bound::[TyVar] ty::Type
+{}
+
+{--
  - Silver Type Representations.
  -}
 nonterminal Type with freeVariables;

--- a/grammars/silver/definition/type/Util.sv
+++ b/grammars/silver/definition/type/Util.sv
@@ -52,7 +52,7 @@ top::PolyType ::= bound::[TyVar] ty::Type
   top.isDecorated = ty.isDecorated;
   top.isDecorable = ty.isDecorable;
   top.isTerminal = ty.isTerminal;
-  top.asNtOrDecType = ntOrDecType(top.typerep, freshType());
+  top.asNtOrDecType = error("Only mono types should be possibly-decorated");
 }
 
 attribute isError, inputTypes, outputType, namedTypes, arity, isDecorated, isDecorable, isTerminal, decoratedType, unifyInstanceNonterminal, unifyInstanceDecorated occurs on Type;

--- a/grammars/silver/definition/type/Util.sv
+++ b/grammars/silver/definition/type/Util.sv
@@ -24,11 +24,14 @@ synthesized attribute isTerminal :: Boolean;
 -- Used by 'new' and type-determination for attributes (NOT on regular nonterminals)
 synthesized attribute decoratedType :: Type;
 
+-- Freshens a nonterminal PolyType into a possibly-decorated nonterminal Type
+synthesized attribute asNtOrDecType :: Type;
+
 -- Used instead of unify() when we want to just know its decorated or undecorated
 synthesized attribute unifyInstanceNonterminal :: Substitution;
 synthesized attribute unifyInstanceDecorated :: Substitution;
 
-attribute isError, isDecorated, isDecorable, isTerminal, arity occurs on PolyType;
+attribute arity, isError, isDecorated, isDecorable, isTerminal, asNtOrDecType occurs on PolyType;
 
 aspect production monoType
 top::PolyType ::= ty::Type
@@ -38,6 +41,7 @@ top::PolyType ::= ty::Type
   top.isDecorated = ty.isDecorated;
   top.isDecorable = ty.isDecorable;
   top.isTerminal = ty.isTerminal;
+  top.asNtOrDecType = ntOrDecType(ty, freshType());
 }
 
 aspect production polyType
@@ -48,6 +52,7 @@ top::PolyType ::= bound::[TyVar] ty::Type
   top.isDecorated = ty.isDecorated;
   top.isDecorable = ty.isDecorable;
   top.isTerminal = ty.isTerminal;
+  top.asNtOrDecType = ntOrDecType(top.typerep, freshType());
 }
 
 attribute isError, inputTypes, outputType, namedTypes, arity, isDecorated, isDecorable, isTerminal, decoratedType, unifyInstanceNonterminal, unifyInstanceDecorated occurs on Type;

--- a/grammars/silver/definition/type/Util.sv
+++ b/grammars/silver/definition/type/Util.sv
@@ -1,9 +1,5 @@
 grammar silver:definition:type;
 
--- DEPRECATED STUFF
-attribute isError, isDecorated, isDecorable, isTerminal, arity occurs on PolyType;
-attribute isError, inputTypes, outputType, namedTypes, arity, isDecorated, isDecorable, isTerminal, decoratedType, unifyInstanceNonterminal, unifyInstanceDecorated occurs on Type;
-
 -- Quick check to see if an error message should be suppressed
 synthesized attribute isError :: Boolean;
 
@@ -32,6 +28,8 @@ synthesized attribute decoratedType :: Type;
 synthesized attribute unifyInstanceNonterminal :: Substitution;
 synthesized attribute unifyInstanceDecorated :: Substitution;
 
+attribute isError, isDecorated, isDecorable, isTerminal, arity occurs on PolyType;
+
 aspect production monoType
 top::PolyType ::= ty::Type
 {
@@ -51,6 +49,8 @@ top::PolyType ::= bound::[TyVar] ty::Type
   top.isDecorable = ty.isDecorable;
   top.isTerminal = ty.isTerminal;
 }
+
+attribute isError, inputTypes, outputType, namedTypes, arity, isDecorated, isDecorable, isTerminal, decoratedType, unifyInstanceNonterminal, unifyInstanceDecorated occurs on Type;
 
 aspect default production
 top::Type ::=

--- a/grammars/silver/definition/type/syntax/AspectDcl.sv
+++ b/grammars/silver/definition/type/syntax/AspectDcl.sv
@@ -9,7 +9,7 @@ function addNewLexicalTyVars_ActuallyVariables
 [Def] ::= gn::String sl::Location l::[String]
 {
   return if null(l) then []
-         else lexTyVarDef(gn, sl, head(l), freshType()) ::
+         else aspectLexTyVarDef(gn, sl, head(l), freshTyVar()) ::
                   addNewLexicalTyVars_ActuallyVariables(gn, sl, tail(l));
 }
 

--- a/grammars/silver/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/definition/type/syntax/TypeExpr.sv
@@ -34,7 +34,7 @@ function addNewLexicalTyVars
 [Def] ::= gn::String sl::Location l::[String]
 {
   return if null(l) then []
-         else lexTyVarDef(gn, sl, head(l), skolemType(freshTyVar())) ::
+         else lexTyVarDef(gn, sl, head(l), freshTyVar()) ::
                   addNewLexicalTyVars(gn, sl, tail(l));
 }
 
@@ -130,13 +130,14 @@ top::TypeExpr ::= q::QNameType tl::BracketedOptTypeExprs
   top.errors := q.lookupType.errors ++ tl.errors;
   top.lexicalTypeVariables = tl.lexicalTypeVariables;
 
-  top.errors <- if length(tl.types) != length(q.lookupType.dclBoundVars)
-                then [err(top.location, q.name ++ " has " ++ toString(length(q.lookupType.dclBoundVars)) ++ " type variables, but there are " ++ toString(length(tl.types)) ++ " supplied here.")]
+  local ts::PolyType = q.lookupType.typeScheme;
+  top.errors <- if length(tl.types) != length(ts.boundVars)
+                then [err(top.location, q.name ++ " has " ++ toString(length(ts.boundVars)) ++ " type variables, but there are " ++ toString(length(tl.types)) ++ " supplied here.")]
                 else [];
 
   -- Not necessarily a nonterminalType, so we should take original type and substitution
   -- e.g. consider `type Blah<a> = Foo<String a>`
-  top.typerep = performRenaming(q.lookupType.typerep, zipVarsAndTypesIntoSubstitution(q.lookupType.dclBoundVars, tl.types));
+  top.typerep = performRenaming(ts.typerep, zipVarsAndTypesIntoSubstitution(ts.boundVars, tl.types));
 }
 
 concrete production typeVariableTypeExpr

--- a/grammars/silver/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/definition/type/syntax/TypeExpr.sv
@@ -148,7 +148,7 @@ top::TypeExpr ::= tv::IdLower_t
   local attribute hack::QNameLookup;
   hack = customLookup("type", getTypeDcl(tv.lexeme, top.env), tv.lexeme, top.location);
   
-  top.typerep = hack.typerep;
+  top.typerep = hack.typeScheme.typerep; -- Is a monoType
   top.errors := hack.errors;
 
   top.lexicalTypeVariables = [tv.lexeme];

--- a/grammars/silver/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/definition/type/syntax/TypeExpr.sv
@@ -148,7 +148,7 @@ top::TypeExpr ::= tv::IdLower_t
   local attribute hack::QNameLookup;
   hack = customLookup("type", getTypeDcl(tv.lexeme, top.env), tv.lexeme, top.location);
   
-  top.typerep = hack.typeScheme.typerep; -- Is a monoType
+  top.typerep = hack.typeScheme.monoType;
   top.errors := hack.errors;
 
   top.lexicalTypeVariables = [tv.lexeme];

--- a/grammars/silver/driver/util/Util.sv
+++ b/grammars/silver/driver/util/Util.sv
@@ -1,5 +1,6 @@
 grammar silver:driver:util;
 
+imports silver:definition:type;
 imports silver:definition:env;
 imports silver:util only contains, rem, makeSet, containsAny;
 

--- a/grammars/silver/extension/auto_ast/AutoAst.sv
+++ b/grammars/silver/extension/auto_ast/AutoAst.sv
@@ -11,8 +11,7 @@ top::ProductionStmt ::= 'abstract' v::QName ';'
 {
   top.unparse = "abstract " ++ v.unparse ++ ";";
 
-  local vty :: Type =
-    freshenCompletely(v.lookupValue.typerep);
+  local vty :: Type = v.lookupValue.typeScheme.typerep;
   
   local hasLoc :: Boolean =
     !null(vty.namedTypes) && head(vty.namedTypes).argName == "location";

--- a/grammars/silver/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/extension/autoattr/DclInfo.sv
@@ -24,8 +24,7 @@ top::DclInfo ::= sg::String sl::Location fn::String tyVar::TyVar
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = varType(tyVar);
-  top.dclBoundVars = [tyVar];
+  top.typeScheme = polyType([tyVar], varType(tyVar));
   top.isSynthesized = true;
   
   top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
@@ -42,8 +41,7 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type empt
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
-  top.dclBoundVars = bound;
+  top.typeScheme = polyType(bound, ty);
   top.isSynthesized = true;
   top.emptyVal = empty;
   top.operation = append;
@@ -66,8 +64,7 @@ top::DclInfo ::= sg::String sl::Location fn::String tyVar::TyVar
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = varType(tyVar);
-  top.dclBoundVars = [tyVar];
+  top.typeScheme = polyType([tyVar], varType(tyVar));
   top.isInherited = true;
   
   top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
@@ -84,8 +81,7 @@ top::DclInfo ::= sg::String sl::Location inh::String syn::String
   top.sourceLocation = sl;
   top.fullName = syn;
 
-  top.typerep = boolType();
-  top.dclBoundVars = [];
+  top.typeScheme = monoType(boolType());
   top.isSynthesized = true;
   
   top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
@@ -102,8 +98,7 @@ top::DclInfo ::= sg::String sl::Location fn::String tyVar::TyVar
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = varType(tyVar);
-  top.dclBoundVars = [tyVar];
+  top.typeScheme = polyType([tyVar], varType(tyVar));
   top.isInherited = true;
   
   top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
@@ -120,8 +115,7 @@ top::DclInfo ::= sg::String sl::Location inh::String synPartial::String syn::Str
   top.sourceLocation = sl;
   top.fullName = synPartial;
 
-  top.typerep = boolType();
-  top.dclBoundVars = [];
+  top.typeScheme = monoType(boolType());
   top.isSynthesized = true;
   
   top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
@@ -138,8 +132,7 @@ top::DclInfo ::= sg::String sl::Location inh::String synPartial::String syn::Str
   top.sourceLocation = sl;
   top.fullName = syn;
 
-  top.typerep = boolType();
-  top.dclBoundVars = [];
+  top.typeScheme = monoType(boolType());
   top.isSynthesized = true;
   
   top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
@@ -156,8 +149,7 @@ top::DclInfo ::= sg::String sl::Location inh::String syn::String bound::[TyVar] 
   top.sourceLocation = sl;
   top.fullName = inh;
 
-  top.typerep = ty;
-  top.dclBoundVars = bound;
+  top.typeScheme = polyType(bound, ty);
   top.isInherited = true;
   
   top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
@@ -174,8 +166,7 @@ top::DclInfo ::= sg::String sl::Location inh::String syn::String bound::[TyVar] 
   top.sourceLocation = sl;
   top.fullName = syn;
 
-  top.typerep = ty;
-  top.dclBoundVars = bound;
+  top.typeScheme = polyType(bound, ty);
   top.isSynthesized = true;
   
   top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);

--- a/grammars/silver/extension/easyterminal/TerminalDcl.sv
+++ b/grammars/silver/extension/easyterminal/TerminalDcl.sv
@@ -55,7 +55,7 @@ top::EasyTerminalRef ::= t::Terminal_t
       [err(t.location, "Found ambiguous possibilities for " ++ t.lexeme ++ "\n" ++ printPossibilities(top.dcls))]
     else [];
   
-  top.typerep = if null(top.dcls) then errorType() else head(top.dcls).typerep;
+  top.typerep = if null(top.dcls) then errorType() else head(top.dcls).typeScheme.typerep;
 }
 
 

--- a/grammars/silver/extension/easyterminal/TerminalDcl.sv
+++ b/grammars/silver/extension/easyterminal/TerminalDcl.sv
@@ -55,7 +55,7 @@ top::EasyTerminalRef ::= t::Terminal_t
       [err(t.location, "Found ambiguous possibilities for " ++ t.lexeme ++ "\n" ++ printPossibilities(top.dcls))]
     else [];
   
-  top.typerep = if null(top.dcls) then errorType() else head(top.dcls).typeScheme.typerep;
+  top.typerep = if null(top.dcls) then errorType() else head(top.dcls).typeScheme.monoType;
 }
 
 

--- a/grammars/silver/extension/implicit_monads/CopperExpr.sv
+++ b/grammars/silver/extension/implicit_monads/CopperExpr.sv
@@ -10,7 +10,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -46,7 +46,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -58,7 +58,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];

--- a/grammars/silver/extension/implicit_monads/CopperExpr.sv
+++ b/grammars/silver/extension/implicit_monads/CopperExpr.sv
@@ -10,7 +10,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typeScheme.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.monoType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -46,7 +46,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typeScheme.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.monoType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -58,7 +58,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typeScheme.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.monoType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];

--- a/grammars/silver/extension/implicit_monads/DclInfo.sv
+++ b/grammars/silver/extension/implicit_monads/DclInfo.sv
@@ -15,9 +15,8 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = polyType(bound, ty);
 
-  top.dclBoundVars = bound;
   top.isSynthesized = true;
   top.isInherited = false;
 }
@@ -37,9 +36,8 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = polyType(bound, ty);
 
-  top.dclBoundVars = bound;
   top.isSynthesized = false;
   top.isInherited = true;
 }
@@ -61,9 +59,8 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = polyType(bound, ty);
 
-  top.dclBoundVars = bound;
   top.isSynthesized = true;
   top.isInherited = false;
 }
@@ -83,9 +80,8 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = polyType(bound, ty);
 
-  top.dclBoundVars = bound;
   top.isSynthesized = false;
   top.isInherited = true;
 }

--- a/grammars/silver/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/extension/implicit_monads/Expr.sv
@@ -49,7 +49,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = if q.lookupValue.typeScheme.typerep.isDecorable
+  top.mtyperep = if q.lookupValue.typeScheme.isDecorable
                  then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
                  else q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
@@ -75,7 +75,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = if q.lookupValue.typeScheme.typerep.isDecorable
+  top.mtyperep = if q.lookupValue.typeScheme.isDecorable
                  then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
                  else q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed

--- a/grammars/silver/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/extension/implicit_monads/Expr.sv
@@ -50,7 +50,7 @@ top::Expr ::= q::Decorated QName
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
   top.mtyperep = if q.lookupValue.typeScheme.isDecorable
-                 then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
+                 then q.lookupValue.typeScheme.asNtOrDecType
                  else q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
@@ -63,7 +63,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = ntOrDecType(q.lookupValue.typeScheme.typerep, freshType());
+  top.mtyperep = q.lookupValue.typeScheme.asNtOrDecType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -76,7 +76,7 @@ top::Expr ::= q::Decorated QName
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
   top.mtyperep = if q.lookupValue.typeScheme.isDecorable
-                 then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
+                 then q.lookupValue.typeScheme.asNtOrDecType
                  else q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
@@ -90,7 +90,7 @@ top::Expr ::= q::Decorated QName
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
   -- An LHS (and thus, forward) is *always* a decorable (nonterminal) type.
-  top.mtyperep = ntOrDecType(q.lookupValue.typeScheme.typerep, freshType());
+  top.mtyperep = q.lookupValue.typeScheme.asNtOrDecType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];

--- a/grammars/silver/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/extension/implicit_monads/Expr.sv
@@ -49,9 +49,9 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = if q.lookupValue.typerep.isDecorable
-                 then ntOrDecType(q.lookupValue.typerep, freshType())
-                 else q.lookupValue.typerep;
+  top.mtyperep = if q.lookupValue.typeScheme.typerep.isDecorable
+                 then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
+                 else q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -63,7 +63,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = ntOrDecType(q.lookupValue.typerep, freshType());
+  top.mtyperep = ntOrDecType(q.lookupValue.typeScheme.typerep, freshType());
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -75,9 +75,9 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = if q.lookupValue.typerep.isDecorable
-                 then ntOrDecType(q.lookupValue.typerep, freshType())
-                 else q.lookupValue.typerep;
+  top.mtyperep = if q.lookupValue.typeScheme.typerep.isDecorable
+                 then ntOrDecType(q.lookupValue.typeScheme.typerep, freshType())
+                 else q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -90,7 +90,7 @@ top::Expr ::= q::Decorated QName
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
   -- An LHS (and thus, forward) is *always* a decorable (nonterminal) type.
-  top.mtyperep = ntOrDecType(q.lookupValue.typerep, freshType());
+  top.mtyperep = ntOrDecType(q.lookupValue.typeScheme.typerep, freshType());
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -102,7 +102,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = freshenCompletely(q.lookupValue.typerep);
+  top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -114,7 +114,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = freshenCompletely(q.lookupValue.typerep);
+  top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -126,7 +126,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = freshenCompletely(q.lookupValue.typerep);
+  top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -481,7 +481,7 @@ top::Expr ::= '(' '.' q::QName ')'
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = functionType(freshenCompletely(q.lookupAttribute.typerep), [freshType()], []);
+  top.mtyperep = functionType(q.lookupAttribute.typeScheme.typerep, [freshType()], []);
   top.monadicNames = [];
   top.monadRewritten = attributeSection('(', '.', q, ')', location=top.location);
 }

--- a/grammars/silver/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/extension/implicit_monads/Expr.sv
@@ -51,7 +51,7 @@ top::Expr ::= q::Decorated QName
   top.mUpSubst = top.mDownSubst;
   top.mtyperep = if q.lookupValue.typeScheme.isDecorable
                  then q.lookupValue.typeScheme.asNtOrDecType
-                 else q.lookupValue.typeScheme.typerep;
+                 else q.lookupValue.typeScheme.monoType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];
@@ -77,7 +77,7 @@ top::Expr ::= q::Decorated QName
   top.mUpSubst = top.mDownSubst;
   top.mtyperep = if q.lookupValue.typeScheme.isDecorable
                  then q.lookupValue.typeScheme.asNtOrDecType
-                 else q.lookupValue.typeScheme.typerep;
+                 else q.lookupValue.typeScheme.monoType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];

--- a/grammars/silver/extension/implicit_monads/Lambda.sv
+++ b/grammars/silver/extension/implicit_monads/Lambda.sv
@@ -24,7 +24,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typeScheme.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.monoType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];

--- a/grammars/silver/extension/implicit_monads/Lambda.sv
+++ b/grammars/silver/extension/implicit_monads/Lambda.sv
@@ -24,7 +24,7 @@ top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];

--- a/grammars/silver/extension/implicit_monads/Let.sv
+++ b/grammars/silver/extension/implicit_monads/Let.sv
@@ -147,7 +147,7 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typeScheme.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.monoType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];

--- a/grammars/silver/extension/implicit_monads/Let.sv
+++ b/grammars/silver/extension/implicit_monads/Let.sv
@@ -147,7 +147,7 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
-  top.mtyperep = q.lookupValue.typerep;
+  top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
                      else [];

--- a/grammars/silver/extension/implicit_monads/PatternTypes.sv
+++ b/grammars/silver/extension/implicit_monads/PatternTypes.sv
@@ -3,6 +3,7 @@ grammar silver:extension:implicit_monads;
 aspect production prodAppPattern
 top::Pattern ::= prod::QName '(' ps::PatternList ')'
 {
+  -- TODO: is this right?  Seems like we should unify with ps pattern types?
   top.patternType = case prod.lookupValue.typeScheme.typerep of
                     | functionType(out, _, _) -> out
                     | t -> t

--- a/grammars/silver/extension/implicit_monads/PatternTypes.sv
+++ b/grammars/silver/extension/implicit_monads/PatternTypes.sv
@@ -5,7 +5,7 @@ top::Pattern ::= prod::QName '(' ps::PatternList ')'
 {
   top.patternType = case prod.lookupValue.typeScheme.typerep of
                     | functionType(out, _, _) -> out
-                    | _ -> prod.lookupValue.typeScheme.typerep
+                    | t -> t
                     end;
 } 
 

--- a/grammars/silver/extension/implicit_monads/PatternTypes.sv
+++ b/grammars/silver/extension/implicit_monads/PatternTypes.sv
@@ -3,9 +3,9 @@ grammar silver:extension:implicit_monads;
 aspect production prodAppPattern
 top::Pattern ::= prod::QName '(' ps::PatternList ')'
 {
-  top.patternType = case prod.lookupValue.typerep of
+  top.patternType = case prod.lookupValue.typeScheme.typerep of
                     | functionType(out, _, _) -> out
-                    | _ -> prod.lookupValue.typerep
+                    | _ -> prod.lookupValue.typeScheme.typerep
                     end;
 } 
 

--- a/grammars/silver/extension/implicit_monads/PrimitiveMatch.sv
+++ b/grammars/silver/extension/implicit_monads/PrimitiveMatch.sv
@@ -320,8 +320,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
 
   top.mtyperep = e.mtyperep;
   -- Turns the existential variables existential
-  local prod_type :: Type =
-    skolemizeProductionType(qn.lookupValue.typerep);
+  local prod_type :: Type = skolemizeProductionType(qn.lookupValue.typeScheme);
   top.patternType = prod_type.outputType;
 
   top.returnify = prodPatternNormal(qn, ns,
@@ -343,8 +342,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   top.monadicNames = e.monadicNames;
 
   top.mtyperep = e.mtyperep;
-  local prod_type :: Type =
-    fullySkolemizeProductionType(qn.lookupValue.typerep); -- that says FULLY. See the comments on that function.
+  local prod_type :: Type = fullySkolemizeProductionType(qn.lookupValue.typeScheme); -- that says FULLY. See the comments on that function.
   top.patternType = prod_type.outputType;
 
   top.returnify = prodPatternGadt(qn, ns,

--- a/grammars/silver/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/extension/patternmatching/PatternTypes.sv
@@ -53,7 +53,7 @@ top::Pattern ::= prod::QName '(' ps::PatternList ',' nps::NamedPatternList ')'
   top.unparse = prod.unparse ++ "(" ++ ps.unparse ++ ")";
   top.errors := ps.errors ++ nps.errors;
 
-  local parms :: Integer = length(prod.lookupValue.typeScheme.typerep.inputTypes);
+  local parms :: Integer = prod.lookupValue.typeScheme.arity;
 
   top.errors <-
     if null(prod.lookupValue.dcls) || length(ps.patternList) == parms then []

--- a/grammars/silver/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/extension/patternmatching/PatternTypes.sv
@@ -53,7 +53,7 @@ top::Pattern ::= prod::QName '(' ps::PatternList ',' nps::NamedPatternList ')'
   top.unparse = prod.unparse ++ "(" ++ ps.unparse ++ ")";
   top.errors := ps.errors ++ nps.errors;
 
-  local parms :: Integer = length(prod.lookupValue.typerep.inputTypes);
+  local parms :: Integer = length(prod.lookupValue.typeScheme.typerep.inputTypes);
 
   top.errors <-
     if null(prod.lookupValue.dcls) || length(ps.patternList) == parms then []

--- a/grammars/silver/extension/rewriting/Expr.sv
+++ b/grammars/silver/extension/rewriting/Expr.sv
@@ -60,7 +60,7 @@ top::Expr ::= q::Decorated QName _ _
     | nothing() ->
       -- The variable is bound in an enclosing let/match
       -- Explicitly undecorate the variable, if appropriate for the final expected type
-      if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
+      if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
       then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
       else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) })
     end;
@@ -71,7 +71,7 @@ top::Expr ::= q::Decorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
-    if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
+    if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
     then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
@@ -81,7 +81,7 @@ top::Expr ::= q::Decorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
-    if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
+    if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
     then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
@@ -91,7 +91,7 @@ top::Expr ::= q::Decorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
-    if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
+    if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
     then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
@@ -101,7 +101,7 @@ top::Expr ::= q::Decorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
-    if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
+    if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
     then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }

--- a/grammars/silver/extension/rewriting/Expr.sv
+++ b/grammars/silver/extension/rewriting/Expr.sv
@@ -60,7 +60,7 @@ top::Expr ::= q::Decorated QName _ _
     | nothing() ->
       -- The variable is bound in an enclosing let/match
       -- Explicitly undecorate the variable, if appropriate for the final expected type
-      if q.lookupValue.typerep.isDecorable && !finalType(top).isDecorated
+      if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
       then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
       else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) })
     end;
@@ -71,7 +71,7 @@ top::Expr ::= q::Decorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
-    if q.lookupValue.typerep.isDecorable && !finalType(top).isDecorated
+    if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
     then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
@@ -81,7 +81,7 @@ top::Expr ::= q::Decorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
-    if q.lookupValue.typerep.isDecorable && !finalType(top).isDecorated
+    if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
     then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
@@ -91,7 +91,7 @@ top::Expr ::= q::Decorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
-    if q.lookupValue.typerep.isDecorable && !finalType(top).isDecorated
+    if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
     then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
@@ -101,7 +101,7 @@ top::Expr ::= q::Decorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
-    if q.lookupValue.typerep.isDecorable && !finalType(top).isDecorated
+    if q.lookupValue.typeScheme.typerep.isDecorable && !finalType(top).isDecorated
     then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }

--- a/grammars/silver/extension/rewriting/Pattern.sv
+++ b/grammars/silver/extension/rewriting/Pattern.sv
@@ -239,16 +239,17 @@ top::Pattern ::= prod::QName '(' ps::PatternList ',' nps::NamedPatternList ')'
     prodCallASTPattern(prod.lookupValue.fullName, ps.transform, nps.transform);
   top.isPolymorphic = ps.isPolymorphic || nps.isPolymorphic;
   
-  local outputFreeVars::[TyVar] = prod.lookupValue.typerep.outputType.freeVariables;
+  local prodType::Type = prod.lookupValue.typeScheme.typerep;
+  local outputFreeVars::[TyVar] = prodType.outputType.freeVariables;
   ps.typesHaveUniversalVars =
     map(
       \ t::Type -> !null(intersectBy(tyVarEqual, outputFreeVars, t.freeVariables)),
-      prod.lookupValue.typerep.inputTypes);
+      prodType.inputTypes);
   nps.namedTypesHaveUniversalVars =
     map(
       \ t::NamedArgType ->
         pair(t.argName, !null(intersectBy(tyVarEqual, outputFreeVars, t.argType.freeVariables))),
-      prod.lookupValue.typerep.namedTypes);
+      prodType.namedTypes);
 } 
 
 aspect production wildcPattern

--- a/grammars/silver/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/extension/rewriting/Rewriting.sv
@@ -93,8 +93,8 @@ top::Expr ::= 'traverse' n::QName '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 {
   top.unparse = s"traverse ${n.name}(${es.unparse}, ${anns.unparse})";
   
-  local numChildren::Integer = length(n.lookupValue.typerep.inputTypes);
-  local annotations::[String] = map((.argName), n.lookupValue.typerep.namedTypes);
+  local numChildren::Integer = length(n.lookupValue.typeScheme.typerep.inputTypes);
+  local annotations::[String] = map((.argName), n.lookupValue.typeScheme.typerep.namedTypes);
   es.appExprTypereps = repeat(nonterminalType("silver:rewrite:Strategy", []), numChildren);
   es.appExprApplied = n.unparse;
   anns.appExprApplied = n.unparse;

--- a/grammars/silver/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/extension/rewriting/Rewriting.sv
@@ -93,7 +93,7 @@ top::Expr ::= 'traverse' n::QName '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 {
   top.unparse = s"traverse ${n.name}(${es.unparse}, ${anns.unparse})";
   
-  local numChildren::Integer = length(n.lookupValue.typeScheme.typerep.inputTypes);
+  local numChildren::Integer = n.lookupValue.typeScheme.arity;
   local annotations::[String] = map((.argName), n.lookupValue.typeScheme.typerep.namedTypes);
   es.appExprTypereps = repeat(nonterminalType("silver:rewrite:Strategy", []), numChildren);
   es.appExprApplied = n.unparse;

--- a/grammars/silver/extension/strategyattr/DclInfo.sv
+++ b/grammars/silver/extension/strategyattr/DclInfo.sv
@@ -33,11 +33,10 @@ top::DclInfo ::=
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep =
+  top.typeScheme = polyType([tyVar],
     if isTotal
     then varType(tyVar)
-    else nonterminalType("core:Maybe", [varType(tyVar)]);
-  top.dclBoundVars = [tyVar];
+    else nonterminalType("core:Maybe", [varType(tyVar)]));
   top.isSynthesized = true;
   top.isStrategy = true;
   

--- a/grammars/silver/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/extension/strategyattr/StrategyExpr.sv
@@ -877,9 +877,11 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   attrDcl.givenNonterminalType = error("Not actually needed"); -- Ugh environment needs refactoring
   local attrTypeScheme::PolyType = attrDcl.typeScheme;
   top.errors :=
-    case attrTypeScheme.typerep, attrTypeScheme.boundVars of
-    | nonterminalType("core:Maybe", [varType(a1)]), [a2] when tyVarEqual(a1, a2) -> []
-    | nonterminalType("core:Maybe", [nonterminalType(nt, _)]), _ ->
+    if !attrDcl.isSynthesized
+    then [err(attr.location, s"Attribute ${attr.name} cannot be used as a partial strategy, because it is not a synthesized attribute")]
+    else case attrTypeScheme.typerep, attrTypeScheme.boundVars of
+    | nonterminalType("core:Maybe", [varType(a1)]), [a2] when tyVarEqual(a1, a2) && attrDcl.isSynthesized -> []
+    | nonterminalType("core:Maybe", [nonterminalType(nt, _)]), _ when attrDcl.isSynthesized ->
       if null(getOccursDcl(attrDcl.fullName, nt, top.env))
       then [wrn(attr.location, s"Attribute ${attr.name} cannot be used as a partial strategy, because it doesn't occur on its own nonterminal type ${nt}")]
       else []
@@ -910,14 +912,16 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   attrDcl.givenNonterminalType = error("Not actually needed"); -- Ugh environment needs refactoring
   local attrTypeScheme::PolyType = attrDcl.typeScheme;
   top.errors :=
-    case attrTypeScheme.typerep, attrTypeScheme.boundVars of
+    if !attrDcl.isSynthesized
+    then [err(attr.location, s"Attribute ${attr.name} cannot be used as a total strategy, because it is not a synthesized attribute")]
+    else case attrTypeScheme.typerep, attrTypeScheme.boundVars of
     | varType(a1), [a2] when tyVarEqual(a1, a2) -> []
     | nonterminalType(nt, _), _ ->
       if null(getOccursDcl(attrDcl.fullName, nt, top.env))
-      then [wrn(attr.location, s"Attribute ${attr.name} cannot be used as total strategy, because it doesn't occur on its own nonterminal type ${nt}")]
+      then [wrn(attr.location, s"Attribute ${attr.name} cannot be used as a total strategy, because it doesn't occur on its own nonterminal type ${nt}")]
       else []
     | errorType(), _ -> []
-    | _, _ -> [err(attr.location, s"Attribute ${attr.name} cannot be used as total strategy")]
+    | _, _ -> [err(attr.location, s"Attribute ${attr.name} cannot be used as a total strategy")]
     end;
   
   propagate liftedStrategies;

--- a/grammars/silver/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/extension/strategyattr/StrategyExpr.sv
@@ -875,8 +875,9 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   -- Lookup for error checking is *not* contextual, since we don't know the frame here
   local attrDcl::DclInfo = case attr of qNameAttrOccur(a) -> a.lookupAttribute.dcl end;
   attrDcl.givenNonterminalType = error("Not actually needed"); -- Ugh environment needs refactoring
+  local attrTypeScheme::PolyType = attrDcl.typeScheme;
   top.errors :=
-    case attrDcl.typerep, attrDcl.dclBoundVars of
+    case attrTypeScheme.typerep, attrTypeScheme.boundVars of
     | nonterminalType("core:Maybe", [varType(a1)]), [a2] when tyVarEqual(a1, a2) -> []
     | nonterminalType("core:Maybe", [nonterminalType(nt, _)]), _ ->
       if null(getOccursDcl(attrDcl.fullName, nt, top.env))
@@ -907,8 +908,9 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   -- Lookup for error checking is *not* contextual, since we don't know the frame here
   local attrDcl::DclInfo = case attr of qNameAttrOccur(a) -> a.lookupAttribute.dcl end;
   attrDcl.givenNonterminalType = error("Not actually needed"); -- Ugh environment needs refactoring
+  local attrTypeScheme::PolyType = attrDcl.typeScheme;
   top.errors :=
-    case attrDcl.typerep, attrDcl.dclBoundVars of
+    case attrTypeScheme.typerep, attrTypeScheme.boundVars of
     | varType(a1), [a2] when tyVarEqual(a1, a2) -> []
     | nonterminalType(nt, _), _ ->
       if null(getOccursDcl(attrDcl.fullName, nt, top.env))
@@ -967,7 +969,7 @@ Boolean ::= env::Decorated Env attrName::String
     case dcls of
     | [] -> false
     | d :: _ ->
-      case decorate d with { givenNonterminalType = error("Not actually needed"); }.typerep of -- Ugh environment needs refactoring
+      case decorate d with { givenNonterminalType = error("Not actually needed"); }.typeScheme.typerep of -- Ugh environment needs refactoring
       | nonterminalType("core:Maybe", _) -> false
       | _ -> true
       end

--- a/grammars/silver/extension/treegen/Arbitrary.sv
+++ b/grammars/silver/extension/treegen/Arbitrary.sv
@@ -22,12 +22,12 @@ top::AGDcl ::= 'derive' 'Arbitrary' 'on' names::QNames ';'
 function prodDclInfoNumChildLte
 Boolean ::= l::DclInfo  r::DclInfo
 {
-  return length(l.typerep.inputTypes) <= length(r.typerep.inputTypes);
+  return length(l.typeScheme.typerep.inputTypes) <= length(r.typeScheme.typerep.inputTypes);
 }
 function prodDclInfoNumChildEq
 Boolean ::= l::DclInfo  r::DclInfo
 {
-  return length(l.typerep.inputTypes) == length(r.typerep.inputTypes);
+  return length(l.typeScheme.typerep.inputTypes) == length(r.typeScheme.typerep.inputTypes);
 }
 
 -- splits where operator becomes false in list
@@ -56,7 +56,7 @@ AGDcl ::= id::QName  env::Decorated Env
   
   local sig :: FunctionSignature =
     functionSignature(
-      functionLHS(typerepTypeExpr(id.lookupType.typerep, location=l), location=l),
+      functionLHS(typerepTypeExpr(id.lookupType.typeScheme.typerep, location=l), location=l),
       '::=',
       productionRHSCons(
         productionRHSElem(name("current__depth", l), '::', typerepTypeExpr(intType(), location=l), location=l),
@@ -83,7 +83,7 @@ AGDcl ::= id::QName  env::Decorated Env
   return
     functionDcl(
       'function',
-      name(getGenArbName(id.lookupType.typerep), l),
+      name(getGenArbName(id.lookupType.typeScheme.typerep), l),
       sig,
       body, location=l);
 {-
@@ -117,7 +117,7 @@ function deriveGenerateOn
 Expr ::= id::DclInfo  l::Location
 {
   local annos :: [Pair<String Expr>] =
-    if null(id.typerep.namedTypes) then
+    if null(id.typeScheme.typerep.namedTypes) then
       []
     else
       -- we just erroneously assume the annotation must be location, for now
@@ -127,7 +127,7 @@ Expr ::= id::DclInfo  l::Location
     mkFullFunctionInvocation(
       l,
       baseExpr(qName(l, id.fullName), location=l),
-      map(callGenArb(_, l), id.typerep.inputTypes),
+      map(callGenArb(_, l), id.typeScheme.typerep.inputTypes),
       annos);
 }
 

--- a/grammars/silver/extension/treegen/Arbitrary.sv
+++ b/grammars/silver/extension/treegen/Arbitrary.sv
@@ -22,12 +22,12 @@ top::AGDcl ::= 'derive' 'Arbitrary' 'on' names::QNames ';'
 function prodDclInfoNumChildLte
 Boolean ::= l::DclInfo  r::DclInfo
 {
-  return length(l.typeScheme.typerep.inputTypes) <= length(r.typeScheme.typerep.inputTypes);
+  return l.typeScheme.arity <= r.typeScheme.arity;
 }
 function prodDclInfoNumChildEq
 Boolean ::= l::DclInfo  r::DclInfo
 {
-  return length(l.typeScheme.typerep.inputTypes) == length(r.typeScheme.typerep.inputTypes);
+  return l.typeScheme.arity == r.typeScheme.arity;
 }
 
 -- splits where operator becomes false in list

--- a/grammars/silver/extension/treegen/Eq.sv
+++ b/grammars/silver/extension/treegen/Eq.sv
@@ -42,9 +42,9 @@ AGDcl ::= id::QName  env::Decorated Env  fenv::Decorated FlowEnv
       functionLHS(typerepTypeExpr(boolType(), location=l), location=l),
       '::=',
       productionRHSCons(
-        productionRHSElem(name("l", l), '::', typerepTypeExpr(id.lookupType.typerep, location=l), location=l),
+        productionRHSElem(name("l", l), '::', typerepTypeExpr(id.lookupType.typeScheme.typerep, location=l), location=l),
         productionRHSCons(
-          productionRHSElem(name("r", l), '::', typerepTypeExpr(id.lookupType.typerep, location=l), location=l),
+          productionRHSElem(name("r", l), '::', typerepTypeExpr(id.lookupType.typeScheme.typerep, location=l), location=l),
           productionRHSNil(location=l), location=l), location=l),
       location=l);
 
@@ -61,7 +61,7 @@ AGDcl ::= id::QName  env::Decorated Env  fenv::Decorated FlowEnv
   return
     functionDcl(
       'function',
-      name(getCheckEqName(id.lookupType.typerep), l),
+      name(getCheckEqName(id.lookupType.typeScheme.typerep), l),
       sig,
       body, location=l);
 }
@@ -87,7 +87,7 @@ PatternList ::= l::[Pattern]
 function generateCheckEqMRuleList
 MatchRule ::= prod::DclInfo  l::Location
 {
-  local children :: [Type] = prod.typerep.inputTypes;
+  local children :: [Type] = prod.typeScheme.typerep.inputTypes;
   
   local lchildren :: [Name] = genIds("l", 0, length(children), l);
   local rchildren :: [Name] = genIds("r", 0, length(children), l);

--- a/grammars/silver/extension/treegen/TestFor.sv
+++ b/grammars/silver/extension/treegen/TestFor.sv
@@ -33,7 +33,7 @@ top::AGDcl ::= 'testFor' testSuite::Name ':' n::Name '::' id::QName ',' e::Expr 
       functionLHS(typerepTypeExpr(boolType(), location=l), location=l),
       '::=',
       productionRHSCons(
-        productionRHSElem(n, '::', typerepTypeExpr(id.lookupType.typerep, location=l), location=l),
+        productionRHSElem(n, '::', typerepTypeExpr(id.lookupType.typeScheme.typerep, location=l), location=l),
         productionRHSNil(location=l), location=l),
       location=l);
   

--- a/grammars/silver/modification/autocopyattr/DclInfo.sv
+++ b/grammars/silver/modification/autocopyattr/DclInfo.sv
@@ -15,8 +15,7 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
-  top.dclBoundVars = bound;
+  top.typeScheme = polyType(bound, ty);
 
   top.isInherited = true;
   top.isAutocopy = true;

--- a/grammars/silver/modification/collection/Collection.sv
+++ b/grammars/silver/modification/collection/Collection.sv
@@ -30,8 +30,7 @@ top::NameOrBOperator ::= e::Expr
   top.errors := e.errors;
   
   local checkOperationType :: TypeCheck =
-    check(freshenCompletely(e.typerep),
-      functionType(top.operatorForType, [top.operatorForType, top.operatorForType], []));
+    check(e.typerep, functionType(top.operatorForType, [top.operatorForType, top.operatorForType], []));
   
   e.downSubst = emptySubst();
   checkOperationType.downSubst = e.upSubst;
@@ -250,7 +249,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   e.downSubst = top.downSubst;
   -- the real type checking is done by the forward, but we must ensure things are tied up nicely
   -- otherwise we don't specialize ntOrDecs in OUR e
-  forward.downSubst = unifyCheck(val.lookupValue.typerep, e.typerep, e.upSubst);
+  forward.downSubst = unifyCheck(val.lookupValue.typeScheme.typerep, e.typerep, e.upSubst);
   
   forwards to localValueDef(val, e, location=top.location);
 }
@@ -262,7 +261,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   e.downSubst = top.downSubst;
   -- the real type checking is done by the forward, but we must ensure things are tied up nicely
   -- otherwise we don't specialize ntOrDecs in OUR e
-  forward.downSubst = unifyCheck(val.lookupValue.typerep, e.typerep, e.upSubst);
+  forward.downSubst = unifyCheck(val.lookupValue.typeScheme.typerep, e.typerep, e.upSubst);
   
   forwards to localValueDef(val, e, location=top.location);
 }

--- a/grammars/silver/modification/collection/Collection.sv
+++ b/grammars/silver/modification/collection/Collection.sv
@@ -249,7 +249,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   e.downSubst = top.downSubst;
   -- the real type checking is done by the forward, but we must ensure things are tied up nicely
   -- otherwise we don't specialize ntOrDecs in OUR e
-  forward.downSubst = unifyCheck(val.lookupValue.typeScheme.typerep, e.typerep, e.upSubst);
+  forward.downSubst = unifyCheck(val.lookupValue.typeScheme.monoType, e.typerep, e.upSubst);
   
   forwards to localValueDef(val, e, location=top.location);
 }
@@ -261,7 +261,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   e.downSubst = top.downSubst;
   -- the real type checking is done by the forward, but we must ensure things are tied up nicely
   -- otherwise we don't specialize ntOrDecs in OUR e
-  forward.downSubst = unifyCheck(val.lookupValue.typeScheme.typerep, e.typerep, e.upSubst);
+  forward.downSubst = unifyCheck(val.lookupValue.typeScheme.monoType, e.typerep, e.upSubst);
   
   forwards to localValueDef(val, e, location=top.location);
 }

--- a/grammars/silver/modification/collection/DclInfo.sv
+++ b/grammars/silver/modification/collection/DclInfo.sv
@@ -31,8 +31,7 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type o::O
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
-  top.dclBoundVars = bound;
+  top.typeScheme = polyType(bound, ty);
   top.isSynthesized = true;
   top.operation = o;
 
@@ -53,8 +52,7 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type o::O
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
-  top.dclBoundVars = bound;
+  top.typeScheme = polyType(bound, ty);
   top.isInherited = true;
   top.operation = o;
 
@@ -76,7 +74,7 @@ top::DclInfo ::= sg::String sl::Location fn::String ty::Type o::Operation
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = monoType(ty);
   top.operation = o;
   
   top.refDispatcher = localReference(_, location=_);

--- a/grammars/silver/modification/copper/ActionCode.sv
+++ b/grammars/silver/modification/copper/ActionCode.sv
@@ -98,7 +98,7 @@ top::ProductionStmt ::= 'if' '(' c::Expr ')' th::ProductionStmt 'else' el::Produ
 function hacklocaldeclarations
 String ::= d::Def
 {
-  return d.dcl.typerep.transType ++ " " ++ makeCopperName(d.dcl.fullName) ++ ";\n";
+  return d.dcl.typeScheme.typerep.transType ++ " " ++ makeCopperName(d.dcl.fullName) ++ ";\n";
 }
 
 function hackTransformLocals

--- a/grammars/silver/modification/copper/ActionCode.sv
+++ b/grammars/silver/modification/copper/ActionCode.sv
@@ -98,7 +98,7 @@ top::ProductionStmt ::= 'if' '(' c::Expr ')' th::ProductionStmt 'else' el::Produ
 function hacklocaldeclarations
 String ::= d::Def
 {
-  return d.dcl.typeScheme.typerep.transType ++ " " ++ makeCopperName(d.dcl.fullName) ++ ";\n";
+  return d.dcl.typeScheme.monoType.transType ++ " " ++ makeCopperName(d.dcl.fullName) ++ ";\n";
 }
 
 function hackTransformLocals

--- a/grammars/silver/modification/copper/DclInfo.sv
+++ b/grammars/silver/modification/copper/DclInfo.sv
@@ -10,7 +10,7 @@ top::DclInfo ::= sg::String sl::Location fn::String ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = monoType(ty);
   
   top.refDispatcher = parserAttributeReference(_, location=_);
   top.defDispatcher = parserAttributeValueDef(_, _, location=_);
@@ -27,8 +27,9 @@ top::DclInfo ::= sg::String sl::Location fn::String
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = terminalIdType(); -- TODO: Still needs work to prevent returning terminals
-                                  -- that are not part of the disambiguation set.
+  -- TODO: Still needs work to prevent returning terminals
+  -- that are not part of the disambiguation set.
+  top.typeScheme = monoType(terminalIdType());
   
   top.refDispatcher = pluckTerminalReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
@@ -48,7 +49,7 @@ top::DclInfo ::= sg::String sl::Location fn::String
   -- If we made lexer classes proper types, it might simplify a lot of code.
   -- We wouldn't need a separate namespace, they could just be in the type namespace.
   -- Currently referencing a lexer class gives a list of its member's TerminalIds.
-  top.typerep = listType(terminalIdType());
+  top.typeScheme = monoType(listType(terminalIdType()));
   top.refDispatcher = lexerClassReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
   top.defLHSDispatcher = errorDefLHS(_, location=_);
@@ -64,7 +65,7 @@ top::DclInfo ::= sg::String sl::Location fn::String ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = monoType(ty);
   
   top.refDispatcher = termAttrValueReference(_, location=_);
   top.defDispatcher = termAttrValueValueDef(_, _, location=_);
@@ -81,7 +82,7 @@ top::DclInfo ::= sg::String sl::Location fn::String ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = monoType(ty);
   
   top.refDispatcher = actionChildReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
@@ -98,7 +99,7 @@ top::DclInfo ::= sg::String sl::Location fn::String ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = monoType(ty);
   
   -- TODO: use specialized ones that give better errors messages!
   top.refDispatcher = parserAttributeReference(_, location=_);

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -22,7 +22,7 @@ top::Expr ::= q::Decorated QName
 
   top.errors := []; -- Should only ever be in scope when valid
 
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 
   top.translation = "((" ++ top.typerep.transType ++ ")((common.Node)RESULTfinal).getChild(" ++ top.frame.className ++ ".i_" ++ q.lookupValue.fullName ++ "))";
   top.lazyTranslation = top.translation; -- never, but okay!
@@ -94,7 +94,7 @@ top::Expr ::= q::Decorated QName
                 then [err(top.location, "References to parser attributes can only be made in action blocks")]
                 else [];
 
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 
   top.translation =
     s"""(${makeCopperName(q.lookupValue.fullName)} == null? (${top.typerep.transType})common.Util.error("Uninitialized parser attribute ${q.name}") : ${makeCopperName(q.lookupValue.fullName)})""";
@@ -110,7 +110,7 @@ top::Expr ::= q::Decorated QName
 
   top.errors := []; -- Should only ever be in scope in action blocks
 
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 
   -- Yeah, it's a big if/then/else block, but these are all very similar and related.
   top.translation =

--- a/grammars/silver/modification/copper/Expr.sv
+++ b/grammars/silver/modification/copper/Expr.sv
@@ -22,7 +22,7 @@ top::Expr ::= q::Decorated QName
 
   top.errors := []; -- Should only ever be in scope when valid
 
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 
   top.translation = "((" ++ top.typerep.transType ++ ")((common.Node)RESULTfinal).getChild(" ++ top.frame.className ++ ".i_" ++ q.lookupValue.fullName ++ "))";
   top.lazyTranslation = top.translation; -- never, but okay!
@@ -94,7 +94,7 @@ top::Expr ::= q::Decorated QName
                 then [err(top.location, "References to parser attributes can only be made in action blocks")]
                 else [];
 
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 
   top.translation =
     s"""(${makeCopperName(q.lookupValue.fullName)} == null? (${top.typerep.transType})common.Util.error("Uninitialized parser attribute ${q.name}") : ${makeCopperName(q.lookupValue.fullName)})""";
@@ -110,7 +110,7 @@ top::Expr ::= q::Decorated QName
 
   top.errors := []; -- Should only ever be in scope in action blocks
 
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 
   -- Yeah, it's a big if/then/else block, but these are all very similar and related.
   top.translation =

--- a/grammars/silver/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/modification/copper/ProductionStmt.sv
@@ -96,7 +96,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   errCheck1.downSubst = e.upSubst;
   top.upSubst = errCheck1.upSubst;
 
-  errCheck1 = check(e.typerep, val.lookupValue.typerep);
+  errCheck1 = check(e.typerep, val.lookupValue.typeScheme.typerep);
   top.errors <-
        if errCheck1.typeerror
        then [err(top.location, "Parser attribute " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
@@ -203,7 +203,7 @@ top::DefLHS ::= q::Decorated QName
 
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
 
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 abstract production termAttrValueValueDef
@@ -233,7 +233,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   errCheck1.downSubst = e.upSubst;
   top.upSubst = errCheck1.upSubst;
 
-  errCheck1 = check(e.typerep, val.lookupValue.typerep);
+  errCheck1 = check(e.typerep, val.lookupValue.typeScheme.typerep);
   top.errors <-
     if errCheck1.typeerror
     then [err(top.location, "Terminal attribute " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]

--- a/grammars/silver/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/modification/copper/ProductionStmt.sv
@@ -96,7 +96,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   errCheck1.downSubst = e.upSubst;
   top.upSubst = errCheck1.upSubst;
 
-  errCheck1 = check(e.typerep, val.lookupValue.typeScheme.typerep);
+  errCheck1 = check(e.typerep, val.lookupValue.typeScheme.monoType);
   top.errors <-
        if errCheck1.typeerror
        then [err(top.location, "Parser attribute " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
@@ -203,7 +203,7 @@ top::DefLHS ::= q::Decorated QName
 
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
 
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 }
 
 abstract production termAttrValueValueDef
@@ -233,7 +233,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   errCheck1.downSubst = e.upSubst;
   top.upSubst = errCheck1.upSubst;
 
-  errCheck1 = check(e.typerep, val.lookupValue.typeScheme.typerep);
+  errCheck1 = check(e.typerep, val.lookupValue.typeScheme.monoType);
   top.errors <-
     if errCheck1.typeerror
     then [err(top.location, "Terminal attribute " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]

--- a/grammars/silver/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/modification/defaultattr/DefaultAttr.sv
@@ -63,7 +63,7 @@ top::DclInfo ::= sg::String sl::Location fn::String ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = monoType(ty);
   
   top.refDispatcher = lhsReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- TODO: be smarter about the error message
@@ -83,7 +83,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define inherited attribute '" ++ top.defLHSattr.name ++ "' on the lhs '" ++ q.name ++ "'")];
   
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 
   top.translation = makeNTClassName(top.frame.lhsNtName) ++ ".defaultSynthesizedAttributes";
 }

--- a/grammars/silver/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/modification/defaultattr/DefaultAttr.sv
@@ -83,7 +83,7 @@ top::DefLHS ::= q::Decorated QName
     if existingProblems || top.found then []
     else [err(q.location, "Cannot define inherited attribute '" ++ top.defLHSattr.name ++ "' on the lhs '" ++ q.name ++ "'")];
   
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 
   top.translation = makeNTClassName(top.frame.lhsNtName) ++ ".defaultSynthesizedAttributes";
 }

--- a/grammars/silver/modification/impide/Env.sv
+++ b/grammars/silver/modification/impide/Env.sv
@@ -12,7 +12,7 @@ top::DclInfo ::= sg::String sl::Location fn::String
   top.sourceLocation = sl;
   top.fullName = fn;
   
-  top.typerep = error("Internal compiler error: font style do not have types");
+  top.typeScheme = error("Internal compiler error: font style do not have types");
 }
 
 --------------------------------------------------------------------------------

--- a/grammars/silver/modification/impide/IdeDecl.sv
+++ b/grammars/silver/modification/impide/IdeDecl.sv
@@ -185,7 +185,7 @@ top::IdeStmt ::= 'builder' builderName::QName ';'
   local expectedType :: Type =
     functionType(t_iomsgs, [t_proj, t_props, t_io], []);
   
-  local tc1 :: TypeCheck = check(freshenCompletely(builderName.lookupValue.typerep), expectedType);
+  local tc1 :: TypeCheck = check(builderName.lookupValue.typeScheme.typerep, expectedType);
   tc1.downSubst = emptySubst();
   tc1.finalSubst = tc1.upSubst;
 
@@ -205,7 +205,7 @@ top::IdeStmt ::= 'postbuilder' postbuilderName::QName ';'
   local expectedType :: Type =
     functionType(t_iomsgs, [t_proj, t_props, t_io], []);
   
-  local tc1 :: TypeCheck = check(freshenCompletely(postbuilderName.lookupValue.typerep), expectedType);
+  local tc1 :: TypeCheck = check(postbuilderName.lookupValue.typeScheme.typerep, expectedType);
   tc1.downSubst = emptySubst();
   tc1.finalSubst = tc1.upSubst;
 
@@ -225,7 +225,7 @@ top::IdeStmt ::= 'exporter' exporterName::QName ';'
   local expectedType :: Type =
     functionType(t_iomsgs, [t_proj, t_props, t_io], []);
   
-  local tc1 :: TypeCheck = check(freshenCompletely(exporterName.lookupValue.typerep), expectedType);
+  local tc1 :: TypeCheck = check(exporterName.lookupValue.typeScheme.typerep, expectedType);
   tc1.downSubst = emptySubst();
   tc1.finalSubst = tc1.upSubst;
 
@@ -245,7 +245,7 @@ top::IdeStmt ::= 'folder' folderName::QName ';'
   local expectedType :: Type =
     functionType(listType(t_loc), [nonterminalType(top.startNTName, [])], []);
   
-  local tc1 :: TypeCheck = check(freshenCompletely(folderName.lookupValue.typerep), expectedType);
+  local tc1 :: TypeCheck = check(folderName.lookupValue.typeScheme.typerep, expectedType);
   tc1.downSubst = emptySubst();
   tc1.finalSubst = tc1.upSubst;
 
@@ -328,7 +328,7 @@ top::StubGenerator ::= 'stub generator' genName::QName ';'
       [listType(nonterminalType("ide:IdeProperty", []))], -- argument type list
       []);
   
-  local tc1 :: TypeCheck = check(freshenCompletely(genName.lookupValue.typerep), stubGenTypeExpected);
+  local tc1 :: TypeCheck = check(genName.lookupValue.typeScheme.typerep, stubGenTypeExpected);
   tc1.downSubst = emptySubst();
   tc1.finalSubst = tc1.upSubst;
 

--- a/grammars/silver/modification/lambda_fn/DclInfo.sv
+++ b/grammars/silver/modification/lambda_fn/DclInfo.sv
@@ -7,7 +7,7 @@ top::DclInfo ::= sg::String sl::Location fn::String ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = monoType(ty);
 
   top.refDispatcher = lambdaParamReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- should be impossible (never in scope at production level?)

--- a/grammars/silver/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/modification/lambda_fn/Lambda.sv
@@ -57,7 +57,7 @@ top::Expr ::= q::Decorated QName
   top.unparse = q.unparse;
   propagate errors;
   
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = q.lookupValue.typeScheme.monoType;
 
   top.upSubst = top.downSubst;
   

--- a/grammars/silver/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/modification/lambda_fn/Lambda.sv
@@ -57,7 +57,7 @@ top::Expr ::= q::Decorated QName
   top.unparse = q.unparse;
   propagate errors;
   
-  top.typerep = q.lookupValue.typerep;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 
   top.upSubst = top.downSubst;
   

--- a/grammars/silver/modification/let_fix/DclInfo.sv
+++ b/grammars/silver/modification/let_fix/DclInfo.sv
@@ -9,7 +9,7 @@ top::DclInfo ::= sg::String sl::Location fn::String ty::Type fi::ExprVertexInfo 
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
+  top.typeScheme = monoType(ty);
 
   top.refDispatcher = lexicalLocalReference(_, fi, fd, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- should be impossible (never in scope at production level?)

--- a/grammars/silver/modification/let_fix/Let.sv
+++ b/grammars/silver/modification/let_fix/Let.sv
@@ -137,8 +137,8 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
   top.typerep = 
     -- isDecorated should return true if it's a ntOrDecType.
     if q.lookupValue.typeScheme.isDecorated
-    then q.lookupValue.typeScheme.asNtOrDecType
-    else q.lookupValue.typeScheme.typerep;
+    then ntOrDecType(q.lookupValue.typeScheme.monoType.decoratedType, freshType())
+    else q.lookupValue.typeScheme.monoType;
 
   top.upSubst = top.downSubst;
 }

--- a/grammars/silver/modification/let_fix/Let.sv
+++ b/grammars/silver/modification/let_fix/Let.sv
@@ -136,7 +136,7 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
   
   top.typerep = 
     -- isDecorated should return true if it's a ntOrDecType.
-    if q.lookupValue.typeScheme.typerep.isDecorated
+    if q.lookupValue.typeScheme.isDecorated
     then ntOrDecType(q.lookupValue.typeScheme.typerep.decoratedType, freshType())
     else q.lookupValue.typeScheme.typerep;
 

--- a/grammars/silver/modification/let_fix/Let.sv
+++ b/grammars/silver/modification/let_fix/Let.sv
@@ -137,7 +137,7 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
   top.typerep = 
     -- isDecorated should return true if it's a ntOrDecType.
     if q.lookupValue.typeScheme.isDecorated
-    then ntOrDecType(q.lookupValue.typeScheme.typerep.decoratedType, freshType())
+    then q.lookupValue.typeScheme.asNtOrDecType
     else q.lookupValue.typeScheme.typerep;
 
   top.upSubst = top.downSubst;

--- a/grammars/silver/modification/let_fix/Let.sv
+++ b/grammars/silver/modification/let_fix/Let.sv
@@ -136,9 +136,9 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
   
   top.typerep = 
     -- isDecorated should return true if it's a ntOrDecType.
-    if q.lookupValue.typerep.isDecorated
-    then ntOrDecType(q.lookupValue.typerep.decoratedType, freshType())
-    else q.lookupValue.typerep;
+    if q.lookupValue.typeScheme.typerep.isDecorated
+    then ntOrDecType(q.lookupValue.typeScheme.typerep.decoratedType, freshType())
+    else q.lookupValue.typeScheme.typerep;
 
   top.upSubst = top.downSubst;
 }

--- a/grammars/silver/modification/let_fix/java/Let.sv
+++ b/grammars/silver/modification/let_fix/java/Let.sv
@@ -71,7 +71,7 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
   -- it could be isDecorated (ntOrDecType) that later gets specialized to undecorated
   -- and therefore we must be careful not to try to undecorate it again!
   local needsUndecorating :: Boolean =
-    performSubstitution(q.lookupValue.typeScheme.typerep, top.finalSubst).isDecorated && !finalType(top).isDecorated;
+    performSubstitution(q.lookupValue.typeScheme.monoType, top.finalSubst).isDecorated && !finalType(top).isDecorated;
   
   top.translation = 
     if needsUndecorating

--- a/grammars/silver/modification/let_fix/java/Let.sv
+++ b/grammars/silver/modification/let_fix/java/Let.sv
@@ -71,7 +71,7 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
   -- it could be isDecorated (ntOrDecType) that later gets specialized to undecorated
   -- and therefore we must be careful not to try to undecorate it again!
   local needsUndecorating :: Boolean =
-    performSubstitution(q.lookupValue.typerep, top.finalSubst).isDecorated && !finalType(top).isDecorated;
+    performSubstitution(q.lookupValue.typeScheme.typerep, top.finalSubst).isDecorated && !finalType(top).isDecorated;
   
   top.translation = 
     if needsUndecorating

--- a/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
@@ -181,8 +181,8 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   top.unparse = qn.unparse ++ "(" ++ ns.unparse ++ ") -> " ++ e.unparse;
   
   local chk :: [Message] =
-    if null(qn.lookupValue.dcls) || ns.varBinderCount == length(prod_type.inputTypes) then []
-    else [err(qn.location, qn.name ++ " has " ++ toString(length(prod_type.inputTypes)) ++ " parameters but " ++ toString(ns.varBinderCount) ++ " patterns were provided")];
+    if null(qn.lookupValue.dcls) || ns.varBinderCount == prod_type.arity then []
+    else [err(qn.location, qn.name ++ " has " ++ toString(prod_type.arity) ++ " parameters but " ++ toString(ns.varBinderCount) ++ " patterns were provided")];
   
   top.errors <- qn.lookupValue.errors;
 
@@ -227,8 +227,8 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   top.unparse = qn.unparse ++ "(" ++ ns.unparse ++ ") -> " ++ e.unparse;
   
   local chk :: [Message] =
-    if null(qn.lookupValue.dcls) || ns.varBinderCount == length(prod_type.inputTypes) then []
-    else [err(qn.location, qn.name ++ " has " ++ toString(length(prod_type.inputTypes)) ++ " parameters but " ++ toString(ns.varBinderCount) ++ " patterns were provided")];
+    if null(qn.lookupValue.dcls) || ns.varBinderCount == prod_type.arity then []
+    else [err(qn.location, qn.name ++ " has " ++ toString(prod_type.arity) ++ " parameters but " ++ toString(ns.varBinderCount) ++ " patterns were provided")];
   
   top.errors <- qn.lookupValue.errors;
 

--- a/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
@@ -157,7 +157,7 @@ top::PrimPattern ::= qn::QName '(' ns::VarBinders ')' '->' e::Expr
   top.unparse = qn.unparse ++ "(" ++ ns.unparse ++ ") -> " ++ e.unparse;
 
   local isGadt :: Boolean =
-    case qn.lookupValue.typerep.outputType of
+    case qn.lookupValue.typeScheme.typerep.outputType of
     -- If the lookup is successful, and it's a production type, and it 
     -- constructs a nonterminal that either:
     --  1. has a non-type-variable parameter (e.g. Expr<Boolean>)
@@ -187,8 +187,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   top.errors <- qn.lookupValue.errors;
 
   -- Turns the existential variables existential
-  local prod_type :: Type =
-    skolemizeProductionType(qn.lookupValue.typerep);
+  local prod_type :: Type = skolemizeProductionType(qn.lookupValue.typeScheme);
   -- Note that we're going to check prod_type against top.scrutineeType shortly.
   -- This is where the type variables become unified.
   
@@ -233,8 +232,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   
   top.errors <- qn.lookupValue.errors;
 
-  local prod_type :: Type =
-    fullySkolemizeProductionType(qn.lookupValue.typerep); -- that says FULLY. See the comments on that function.
+  local prod_type :: Type = fullySkolemizeProductionType(qn.lookupValue.typeScheme); -- that says FULLY. See the comments on that function.
   
   ns.bindingTypes = prod_type.inputTypes;
   ns.bindingIndex = 0;

--- a/grammars/silver/modification/primitivepattern/Types.sv
+++ b/grammars/silver/modification/primitivepattern/Types.sv
@@ -10,17 +10,15 @@ import silver:modification:ffi only foreignType; -- so we cover foreignType with
  - (This is used for *non-gadt* productions.)
  -}
 function skolemizeProductionType
-Type ::= te::Type
+Type ::= te::PolyType
 {
-  local attribute existentialVars :: [TyVar];
-  existentialVars = removeTyVars(te.freeVariables, te.outputType.freeVariables);
+  local existentialVars :: [TyVar] = removeTyVars(te.boundVars, te.typerep.outputType.freeVariables);
   
-  local attribute skolemize :: Substitution;
-  skolemize = composeSubst(
+  local skolemize :: Substitution = composeSubst(
     zipVarsIntoSkolemizedSubstitution(existentialVars, freshTyVars(length(existentialVars))),
-    zipVarsIntoSubstitution(te.outputType.freeVariables, freshTyVars(length(te.outputType.freeVariables))));
+    zipVarsIntoSubstitution(te.typerep.outputType.freeVariables, freshTyVars(length(te.typerep.outputType.freeVariables))));
   
-  return performRenaming(te, skolemize);
+  return performRenaming(te.typerep, skolemize);
 }
 
 {--
@@ -53,12 +51,11 @@ Type ::= te::Type
  - is as good as another, as far as correctness goes, anyway...
  -}
 function fullySkolemizeProductionType
-Type ::= te::Type
+Type ::= te::PolyType
 {
-  local attribute skolemize :: Substitution;
-  skolemize = zipVarsIntoSkolemizedSubstitution(te.freeVariables, freshTyVars(length(te.freeVariables)));
+  local skolemize :: Substitution = zipVarsIntoSkolemizedSubstitution(te.boundVars, freshTyVars(length(te.boundVars)));
   
-  return performRenaming(te, skolemize);
+  return performRenaming(te.typerep, skolemize);
 }
 
 

--- a/grammars/silver/modification/typedecl/TypeDecl.sv
+++ b/grammars/silver/modification/typedecl/TypeDecl.sv
@@ -50,8 +50,7 @@ top::DclInfo ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type
   top.sourceLocation = sl;
   top.fullName = fn;
 
-  top.typerep = ty;
-  top.dclBoundVars = bound;
+  top.typeScheme = polyType(bound, ty);
 }
 
 

--- a/grammars/silver/translation/java/core/Expr.sv
+++ b/grammars/silver/translation/java/core/Expr.sv
@@ -47,7 +47,7 @@ top::Expr ::= q::Decorated QName
     top.frame.className ++ ".i_" ++ q.lookupValue.fullName;
 
   top.translation =
-    if q.lookupValue.typerep.isDecorable
+    if q.lookupValue.typeScheme.typerep.isDecorable
     then if finalType(top).isDecorable
          then s"((${finalType(top).transType})context.childDecorated(${childIDref}).undecorate())"
          else s"((${finalType(top).transType})context.childDecorated(${childIDref}))"
@@ -57,7 +57,7 @@ top::Expr ::= q::Decorated QName
 
   top.lazyTranslation =
     if !top.frame.lazyApplication then top.translation else
-    if q.lookupValue.typerep.isDecorable
+    if q.lookupValue.typeScheme.typerep.isDecorable
     then if finalType(top).isDecorable
          then s"common.Thunk.transformUndecorate(context.childDecoratedLazy(${childIDref}))"
          else s"context.childDecoratedLazy(${childIDref})"
@@ -68,7 +68,7 @@ aspect production localReference
 top::Expr ::= q::Decorated QName
 {
   top.translation =
-    if q.lookupValue.typerep.isDecorable
+    if q.lookupValue.typeScheme.typerep.isDecorable
     then if finalType(top).isDecorable
          then s"((${finalType(top).transType})context.localDecorated(${q.lookupValue.dcl.attrOccursIndex}).undecorate())"
          else s"((${finalType(top).transType})context.localDecorated(${q.lookupValue.dcl.attrOccursIndex}))"
@@ -77,7 +77,7 @@ top::Expr ::= q::Decorated QName
 
   top.lazyTranslation =
     if !top.frame.lazyApplication then top.translation else
-    if q.lookupValue.typerep.isDecorable
+    if q.lookupValue.typeScheme.typerep.isDecorable
     then if finalType(top).isDecorable
          then s"common.Thunk.transformUndecorate(context.localDecoratedLazy(${q.lookupValue.dcl.attrOccursIndex}))"
          else s"context.localDecoratedLazy(${q.lookupValue.dcl.attrOccursIndex})"
@@ -261,7 +261,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
   top.lazyTranslation = 
     case e, top.frame.lazyApplication of
     | childReference(cqn), true -> 
-        if cqn.lookupValue.typerep.isDecorable
+        if cqn.lookupValue.typeScheme.typerep.isDecorable
         then
           s"context.childDecoratedSynthesizedLazy(${top.frame.className}.i_${cqn.lookupValue.fullName}, ${q.dcl.attrOccursIndex})"
         else

--- a/grammars/silver/translation/java/core/Expr.sv
+++ b/grammars/silver/translation/java/core/Expr.sv
@@ -47,7 +47,7 @@ top::Expr ::= q::Decorated QName
     top.frame.className ++ ".i_" ++ q.lookupValue.fullName;
 
   top.translation =
-    if q.lookupValue.typeScheme.typerep.isDecorable
+    if q.lookupValue.typeScheme.isDecorable
     then if finalType(top).isDecorable
          then s"((${finalType(top).transType})context.childDecorated(${childIDref}).undecorate())"
          else s"((${finalType(top).transType})context.childDecorated(${childIDref}))"
@@ -57,7 +57,7 @@ top::Expr ::= q::Decorated QName
 
   top.lazyTranslation =
     if !top.frame.lazyApplication then top.translation else
-    if q.lookupValue.typeScheme.typerep.isDecorable
+    if q.lookupValue.typeScheme.isDecorable
     then if finalType(top).isDecorable
          then s"common.Thunk.transformUndecorate(context.childDecoratedLazy(${childIDref}))"
          else s"context.childDecoratedLazy(${childIDref})"
@@ -68,7 +68,7 @@ aspect production localReference
 top::Expr ::= q::Decorated QName
 {
   top.translation =
-    if q.lookupValue.typeScheme.typerep.isDecorable
+    if q.lookupValue.typeScheme.isDecorable
     then if finalType(top).isDecorable
          then s"((${finalType(top).transType})context.localDecorated(${q.lookupValue.dcl.attrOccursIndex}).undecorate())"
          else s"((${finalType(top).transType})context.localDecorated(${q.lookupValue.dcl.attrOccursIndex}))"
@@ -77,7 +77,7 @@ top::Expr ::= q::Decorated QName
 
   top.lazyTranslation =
     if !top.frame.lazyApplication then top.translation else
-    if q.lookupValue.typeScheme.typerep.isDecorable
+    if q.lookupValue.typeScheme.isDecorable
     then if finalType(top).isDecorable
          then s"common.Thunk.transformUndecorate(context.localDecoratedLazy(${q.lookupValue.dcl.attrOccursIndex}))"
          else s"context.localDecoratedLazy(${q.lookupValue.dcl.attrOccursIndex})"
@@ -261,7 +261,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
   top.lazyTranslation = 
     case e, top.frame.lazyApplication of
     | childReference(cqn), true -> 
-        if cqn.lookupValue.typeScheme.typerep.isDecorable
+        if cqn.lookupValue.typeScheme.isDecorable
         then
           s"context.childDecoratedSynthesizedLazy(${top.frame.className}.i_${cqn.lookupValue.fullName}, ${q.dcl.attrOccursIndex})"
         else

--- a/test/silver_features/Strategy.sv
+++ b/test/silver_features/Strategy.sv
@@ -174,8 +174,13 @@ equalityTest(
 
 -- Negative tests
 inherited attribute badInh<a>::a;
-wrongCode "cannot be used as total strategy" {
+wrongCode "cannot be used as a total strategy" {
   strategy attribute badInhS = badInh;
+}
+
+synthesized attribute badSyn::Boolean;
+wrongCode "cannot be used as a total strategy" {
+  strategy attribute badSynS = badSyn;
 }
 
 warnCode "is not total" {


### PR DESCRIPTION
This does one of the type system refactorings mentioned in #185, introducing `PolyType` to be explicit about what type variables are being quantified over, as a prerequisite to implementing type classes.  Instead of `DclInfo` items having a `typerep`, they now have a `typeScheme` (the common term for these in Hindley-Milner type systems) from which a freshened `typerep` may be accessed.  This eliminates all uses of `freshenCompletely`, as looked-up types are now automatically freshened to the appropriate degree as determined in the environment.  Not having to keep track of this manually wherever a type is used should help keep things more maintainable; this change uncovered a (minor) bug in error checking for strategy attributes.  

I think that this is essentially what @tedinski had in mind, but he can chime in if he wants if I missed something critical here.  