### PR TITLE
Refactor type checking to use threaded attributes

### DIFF
--- a/grammars/silver/analysis/typechecking/core/AspectDcl.sv
+++ b/grammars/silver/analysis/typechecking/core/AspectDcl.sv
@@ -22,8 +22,7 @@ top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature bod
       end;
 
   ns.downSubst = emptySubst();
-  errCheck1.downSubst = ns.upSubst;
-  body.downSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on ns, errCheck1, body;
   
   ns.finalSubst = errCheck1.upSubst;
 }
@@ -48,8 +47,7 @@ top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::P
       end;
 
   ns.downSubst = emptySubst();
-  errCheck1.downSubst = ns.upSubst;
-  body.downSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on ns, errCheck1, body;
   
   ns.finalSubst = errCheck1.upSubst;
 }
@@ -59,9 +57,7 @@ top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::P
 aspect production aspectProductionSignature
 top::AspectProductionSignature ::= lhs::AspectProductionLHS '::=' rhs::AspectRHS
 {
-  lhs.downSubst = top.downSubst;
-  rhs.downSubst = lhs.upSubst;
-  top.upSubst = rhs.upSubst;
+  propagate downSubst, upSubst;
 }
 
 aspect production aspectProductionLHSFull
@@ -69,8 +65,7 @@ top::AspectProductionLHS ::= id::Name t::Type
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  errCheck1.downSubst = top.downSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, errCheck1, top;
   
   errCheck1 = check(rType, t);
   top.errors <-
@@ -82,15 +77,13 @@ top::AspectProductionLHS ::= id::Name t::Type
 aspect production aspectRHSElemNil
 top::AspectRHS ::= 
 {
-  top.upSubst = top.downSubst;
+  propagate downSubst, upSubst;
 }
 
 aspect production aspectRHSElemCons
 top::AspectRHS ::= h::AspectRHSElem t::AspectRHS
 {
-  h.downSubst = top.downSubst;
-  t.downSubst = h.upSubst;
-  top.upSubst = t.upSubst;
+  propagate downSubst, upSubst;
 }
 
 aspect production aspectRHSElemFull
@@ -98,8 +91,7 @@ top::AspectRHSElem ::= id::Name t::Type
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  errCheck1.downSubst = top.downSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, errCheck1, top;
   
   errCheck1 = check(rType, t);
   top.errors <-
@@ -111,9 +103,7 @@ top::AspectRHSElem ::= id::Name t::Type
 aspect production aspectFunctionSignature
 top::AspectFunctionSignature ::= lhs::AspectFunctionLHS '::=' rhs::AspectRHS 
 {
-  lhs.downSubst = top.downSubst;
-  rhs.downSubst = lhs.upSubst;
-  top.upSubst = rhs.upSubst;
+  propagate downSubst, upSubst;
 }
 
 aspect production functionLHSType
@@ -121,8 +111,7 @@ top::AspectFunctionLHS ::= t::TypeExpr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  errCheck1.downSubst = top.downSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, errCheck1, top;
   
   errCheck1 = check(rType, t.typerep);
   top.errors <-

--- a/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
@@ -75,7 +75,7 @@ top::Expr ::= 'new' '(' e1::Expr ')'
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  thread downSubst, upSubst on top, errCheck1, top;
+  thread downSubst, upSubst on top, e1, errCheck1, top;
   
   errCheck1 = checkDecorated(e1.typerep);
   top.errors <-

--- a/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
@@ -1,28 +1,8 @@
 grammar silver:analysis:typechecking:core;
 
-aspect production lengthFunction
-top::Expr ::= 'length' '(' e::Expr ')'
-{
-  e.downSubst = top.downSubst;
-  forward.downSubst= e.upSubst;
-}
-aspect production stringLength
-top::Expr ::= e::Decorated Expr
-{
-  top.upSubst = top.downSubst;
-}
-aspect production errorLength
-top::Expr ::= e::Decorated Expr
-{
-  top.upSubst = top.downSubst;
-}
-
 aspect production toBooleanFunction
 top::Expr ::= 'toBoolean' '(' e1::Expr ')'
 {
-  e1.downSubst = top.downSubst;
-  top.upSubst = e1.upSubst;
-  
   top.errors <-
     if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
     then []
@@ -32,9 +12,6 @@ top::Expr ::= 'toBoolean' '(' e1::Expr ')'
 aspect production toIntegerFunction
 top::Expr ::= 'toInteger' '(' e1::Expr ')'
 {
-  e1.downSubst = top.downSubst;
-  top.upSubst = e1.upSubst;
-  
   top.errors <-
     if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
     then []
@@ -44,8 +21,6 @@ top::Expr ::= 'toInteger' '(' e1::Expr ')'
 aspect production toFloatFunction
 top::Expr ::= 'toFloat' '(' e1::Expr ')'
 {
-  e1.downSubst = top.downSubst;
-  top.upSubst = e1.upSubst;
   
   top.errors <-
     if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
@@ -56,9 +31,6 @@ top::Expr ::= 'toFloat' '(' e1::Expr ')'
 aspect production toStringFunction
 top::Expr ::= 'toString' '(' e1::Expr ')'
 {
-  e1.downSubst = top.downSubst;
-  top.upSubst = e1.upSubst;
-  
   top.errors <-
     if performSubstitution(e1.typerep, top.finalSubst).instanceConvertible
     then []
@@ -80,8 +52,6 @@ Boolean ::= ty::Type
 aspect production reifyFunctionLiteral
 top::Expr ::= 'reify'
 {
-  top.upSubst = top.downSubst;
-
   top.errors <-
     case performSubstitution(top.typerep, top.finalSubst) of
     | functionType(nonterminalType("core:Either", [stringType(), resultType]), [nonterminalType("core:reflect:AST", [])], []) ->
@@ -99,9 +69,7 @@ top::Expr ::= 'new' '(' e1::Expr ')'
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  errCheck1.downSubst = e1.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, errCheck1, top;
   
   errCheck1 = checkDecorated(e1.typerep);
   top.errors <-
@@ -116,11 +84,7 @@ top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
 
-  es.downSubst = top.downSubst;
-  el.downSubst = es.upSubst;
-  errCheck1.downSubst = el.upSubst;
-  errCheck2.downSubst = errCheck1.upSubst;
-  top.upSubst = errCheck2.upSubst;
+  thread downSubst, upSubst on top, es, el, errCheck1, errCheck2, top;
   
   errCheck1 = check(es.typerep, stringType());
   errCheck2 = check(el.typerep, nonterminalType("core:Location", []));

--- a/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/analysis/typechecking/core/BuiltInFunctions.sv
@@ -1,5 +1,11 @@
 grammar silver:analysis:typechecking:core;
 
+aspect production lengthFunction
+top::Expr ::= 'length' '(' e::Expr ')'
+{
+  propagate upSubst, downSubst;
+}
+
 aspect production toBooleanFunction
 top::Expr ::= 'toBoolean' '(' e1::Expr ')'
 {

--- a/grammars/silver/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/analysis/typechecking/core/Expr.sv
@@ -12,7 +12,7 @@ propagate upSubst, downSubst
 aspect production application
 top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 {
-  propagate upSubst, downSubst;
+  thread downSubst, upSubst on top, e, forward;
 }
 
 aspect production functionApplication

--- a/grammars/silver/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/analysis/typechecking/core/Expr.sv
@@ -2,113 +2,12 @@ grammar silver:analysis:typechecking:core;
 
 attribute upSubst, downSubst, finalSubst occurs on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoExpr, AnnoAppExprs;
 
-aspect production errorExpr
-top::Expr ::= e::[Message]
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production errorReference
-top::Expr ::= msg::[Message]  q::Decorated QName
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production childReference
-top::Expr ::= q::Decorated QName
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production lhsReference
-top::Expr ::= q::Decorated QName
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production localReference
-top::Expr ::= q::Decorated QName
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production productionReference
-top::Expr ::= q::Decorated QName
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production functionReference
-top::Expr ::= q::Decorated QName
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production forwardReference
-top::Expr ::= q::Decorated QName
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production globalValueReference
-top::Expr ::= q::Decorated QName
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production application
-top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
-{
-  e.downSubst = top.downSubst;
-  forward.downSubst = e.upSubst;
-}
-
-aspect production functionApplication
-top::Expr ::= e::Decorated Expr es::AppExprs anns::AnnoAppExprs
-{
-  es.downSubst = top.downSubst;
-  anns.downSubst = es.upSubst;
-  forward.downSubst = anns.upSubst;
-}
-
-aspect production functionInvocation
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production partialApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production errorApplication
-top::Expr ::= e::Decorated Expr es::AppExprs anns::AnnoAppExprs
-{
-  es.downSubst = top.downSubst;
-  anns.downSubst = es.upSubst;
-  top.upSubst = anns.upSubst;
-}
-
-aspect production attributeSection
-top::Expr ::= '(' '.' q::QName ')'
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production access
-top::Expr ::= e::Expr '.' q::QNameAttrOccur
-{
-  e.downSubst = top.downSubst;
-  forward.downSubst = e.upSubst;
-}
-
-aspect production errorAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
-{
-  top.upSubst = top.downSubst;
-}
+propagate upSubst, downSubst
+   on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoExpr, AnnoAppExprs
+   excluding undecoratedAccessHandler, forwardAccess, decoratedAccessHandler,
+     and, or, not, gt, lt, gteq, lteq, eqeq, neq, ifThenElse, plus, minus, multiply, divide, modulus,
+     decorateExprWith, exprInh, presentAppExpr,
+     newFunction, terminalConstructor;
 
 aspect production undecoratedAccessHandler
 top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
@@ -125,15 +24,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     then [err(top.location, "Access of " ++ q.name ++ " from a decorated type.")]
     else [];
   
-  errCheck1.downSubst = top.downSubst;
-  top.upSubst = errCheck1.upSubst;
-}
-
-aspect production accessBouncer
-top::Expr ::= target::(Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) e::Expr  q::Decorated QNameAttrOccur
-{
-  e.downSubst = top.downSubst;
-  forward.downSubst = e.upSubst;
+  thread downSubst, upSubst on top, errCheck1, top;
 }
 
 aspect production forwardAccess
@@ -141,10 +32,8 @@ top::Expr ::= e::Expr '.' 'forward'
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   errCheck1 = checkDecorated(e.typerep);
-  
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
+
+  thread downSubst, upSubst on top, errCheck1, top;
   
   top.errors <-
     if errCheck1.typeerror
@@ -167,50 +56,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     then [err(top.location, "Attribute " ++ q.name ++ " being accessed from an undecorated type.")]
     else [];
   
-  errCheck1.downSubst = top.downSubst;
-  top.upSubst = errCheck1.upSubst;
-}
-
-aspect production synDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
-{
-  top.upSubst = top.downSubst;
-}
-aspect production inhDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
-{
-  top.upSubst = top.downSubst;
-}
-aspect production errorDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
-{
-  top.upSubst = top.downSubst;
-}
-
-
-aspect production terminalAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
-{
-  top.upSubst = top.downSubst;
-}
-aspect production annoAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
-{
-  top.upSubst = top.downSubst;
-}
-
-
-
-aspect production trueConst
-top::Expr ::= 'true'
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production falseConst
-top::Expr ::= 'false'
-{
-  top.upSubst = top.downSubst;
+  thread downSubst, upSubst on top, errCheck1, top;
 }
 
 aspect production and
@@ -219,11 +65,7 @@ top::Expr ::= e1::Expr '&&' e2::Expr
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  errCheck2.downSubst = errCheck1.upSubst;
-  top.upSubst = errCheck2.upSubst;
+  thread downSubst, upSubst on top, errCheck1, errCheck2, top;
   
   errCheck1 = check(e1.typerep, boolType());
   errCheck2 = check(e2.typerep, boolType());
@@ -243,11 +85,7 @@ top::Expr ::= e1::Expr '||' e2::Expr
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  errCheck2.downSubst = errCheck1.upSubst;
-  top.upSubst = errCheck2.upSubst;
+  thread downSubst, upSubst on top, errCheck1, errCheck2, top;
   
   errCheck1 = check(e1.typerep, boolType());
   errCheck2 = check(e2.typerep, boolType());
@@ -265,10 +103,8 @@ aspect production not
 top::Expr ::= '!' e1::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
-
-  e1.downSubst = top.downSubst;
-  errCheck1.downSubst = e1.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  
+  thread downSubst, upSubst on top, errCheck1, top;
   
   errCheck1 = check(e1.typerep, boolType());
   top.errors <-
@@ -282,10 +118,7 @@ top::Expr ::= e1::Expr '>' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -304,10 +137,7 @@ top::Expr ::= e1::Expr '<' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -327,10 +157,7 @@ top::Expr ::= e1::Expr '>=' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -350,10 +177,7 @@ top::Expr ::= e1::Expr '<=' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -373,10 +197,7 @@ top::Expr ::= e1::Expr '==' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -396,10 +217,7 @@ top::Expr ::= e1::Expr '!=' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -420,12 +238,7 @@ top::Expr ::= 'if' e1::Expr 'then' e2::Expr 'else' e3::Expr
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  e3.downSubst = e2.upSubst;
-  errCheck1.downSubst = e3.upSubst;
-  errCheck2.downSubst = errCheck1.upSubst;
-  top.upSubst = errCheck2.upSubst;
+  thread downSubst, upSubst on top, e1, e2, e3, errCheck1, errCheck2, top;
   
   errCheck1 = check(e2.typerep, e3.typerep);
   errCheck2 = check(e1.typerep, boolType());
@@ -439,27 +252,12 @@ top::Expr ::= 'if' e1::Expr 'then' e2::Expr 'else' e3::Expr
        else [];
 }
 
-aspect production intConst
-top::Expr ::= i::Int_t
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production floatConst
-top::Expr ::= f::Float_t
-{
-  top.upSubst = top.downSubst;
-} 
-
 aspect production plus
 top::Expr ::= e1::Expr '+' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -478,10 +276,7 @@ top::Expr ::= e1::Expr '-' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -499,10 +294,7 @@ top::Expr ::= e1::Expr '*' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -520,10 +312,7 @@ top::Expr ::= e1::Expr '/' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -541,10 +330,7 @@ top::Expr ::= e1::Expr '%' e2::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, top;
   
   errCheck1 = check(e1.typerep, e2.typerep);
   top.errors <-
@@ -560,8 +346,6 @@ top::Expr ::= e1::Expr '%' e2::Expr
 aspect production neg
 top::Expr ::= '-' e1::Expr
 {
-  e1.downSubst = top.downSubst;
-  top.upSubst = e1.upSubst;
   
   top.errors <-
        if performSubstitution(e1.typerep, top.finalSubst).instanceNum
@@ -569,58 +353,12 @@ top::Expr ::= '-' e1::Expr
        else [err(top.location, "Operand to unary - must be concrete types Integer or Float.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
-aspect production stringConst
-top::Expr ::= s::String_t
-{
-  top.upSubst = top.downSubst;
-}
-
--- Already merged into silver:definition:core
---aspect production plusPlus
-
-aspect production errorPlusPlus
-top::Expr ::= e1::Decorated Expr e2::Decorated Expr
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production stringPlusPlus
-top::Expr ::= e1::Decorated Expr e2::Decorated Expr
-{
-  top.upSubst = top.downSubst;
-}
-
-
-aspect production exprsEmpty
-top::Exprs ::=
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production exprsSingle
-top::Exprs ::= e::Expr
-{
-  e.downSubst = top.downSubst;
-  top.upSubst = e.upSubst;
-}
-
-aspect production exprsCons
-top::Exprs ::= e1::Expr ',' e2::Exprs
-{
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  top.upSubst = e2.upSubst;
-}
-
 aspect production decorateExprWith
 top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  inh.downSubst = errCheck1.upSubst;
-  top.upSubst = inh.upSubst;
+  thread downSubst, upSubst on top, e, errCheck1, inh, top;
 
   errCheck1 = checkNonterminal(e.typerep);
   top.errors <-
@@ -634,9 +372,7 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e1::Expr ';'
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  errCheck1.downSubst = e1.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, errCheck1, top;
   
   errCheck1 = check(lhs.typerep, e1.typerep);
   top.errors <-
@@ -646,40 +382,12 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e1::Expr ';'
        else [];
 }
 
-aspect production exprInhsEmpty
-top::ExprInhs ::= 
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production exprInhsOne
-top::ExprInhs ::= lhs::ExprInh
-{
-  lhs.downSubst = top.downSubst;
-  top.upSubst = lhs.upSubst;
-}
-
-aspect production exprInhsCons
-top::ExprInhs ::= lhs::ExprInh inh::ExprInhs
-{
-  lhs.downSubst = top.downSubst;
-  inh.downSubst = lhs.upSubst;
-  top.upSubst = inh.upSubst;
-}
-
-aspect production missingAppExpr
-top::AppExpr ::= '_'
-{
-  top.upSubst = top.downSubst;
-}
 aspect production presentAppExpr
 top::AppExpr ::= e::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e, errCheck1, top;
   
   errCheck1 = check(e.typerep, top.appExprTyperep);
   top.errors <-
@@ -688,56 +396,6 @@ top::AppExpr ::= e::Expr
             top.appExprApplied ++ "' expected " ++ errCheck1.rightpp ++
             " but argument is of type " ++ errCheck1.leftpp)];  
 }
-aspect production snocAppExprs
-top::AppExprs ::= es::AppExprs ',' e::AppExpr
-{
-  es.downSubst = top.downSubst;
-  e.downSubst = es.upSubst;
-  top.upSubst = e.upSubst;
-}
-aspect production oneAppExprs
-top::AppExprs ::= e::AppExpr
-{
-  e.downSubst = top.downSubst;
-  top.upSubst = e.upSubst;
-}
-aspect production emptyAppExprs
-top::AppExprs ::=
-{
-  top.upSubst = top.downSubst;
-}
 
-aspect production annoExpr
-top::AnnoExpr ::= qn::QName '=' e::AppExpr
-{
-  e.downSubst = top.downSubst;
-  top.upSubst = e.upSubst;
-}
-aspect production snocAnnoAppExprs
-top::AnnoAppExprs ::= es::AnnoAppExprs ',' e::AnnoExpr
-{
-  es.downSubst = top.downSubst;
-  e.downSubst = es.upSubst;
-  top.upSubst = e.upSubst;
-}
-aspect production oneAnnoAppExprs
-top::AnnoAppExprs ::= e::AnnoExpr
-{
-  e.downSubst = top.downSubst;
-  top.upSubst = e.upSubst;
-}
-aspect production emptyAnnoAppExprs
-top::AnnoAppExprs ::=
-{
-  top.upSubst = top.downSubst;
-}
-
-
-aspect production exprRef
-top::Expr ::= e::Decorated Expr
-{
-  -- See documentation for major restriction on use of exprRef.
-  -- Essentially, the referred expression MUST have already been type checked.
-  top.upSubst = top.downSubst;
-}
-
+-- See documentation for major restriction on use of exprRef.
+-- Essentially, the referred expression MUST have already been type checked.

--- a/grammars/silver/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/analysis/typechecking/core/Expr.sv
@@ -9,6 +9,24 @@ propagate upSubst, downSubst
      decorateExprWith, exprInh, presentAppExpr,
      newFunction, terminalConstructor;
 
+aspect production application
+top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
+{
+  propagate upSubst, downSubst;
+}
+
+aspect production functionApplication
+top::Expr ::= e::Decorated Expr es::AppExprs anns::AnnoAppExprs
+{
+  propagate upSubst, downSubst;
+}
+
+aspect production access
+top::Expr ::= e::Expr '.' q::QNameAttrOccur
+{
+  propagate upSubst, downSubst;
+}
+
 aspect production undecoratedAccessHandler
 top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 {
@@ -25,6 +43,12 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     else [];
   
   thread downSubst, upSubst on top, errCheck1, top;
+}
+
+aspect production accessBouncer
+top::Expr ::= target::(Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) e::Expr  q::Decorated QNameAttrOccur
+{
+  propagate upSubst, downSubst;
 }
 
 aspect production forwardAccess

--- a/grammars/silver/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/analysis/typechecking/core/Expr.sv
@@ -89,7 +89,7 @@ top::Expr ::= e1::Expr '&&' e2::Expr
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
 
-  thread downSubst, upSubst on top, errCheck1, errCheck2, top;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, errCheck2, top;
   
   errCheck1 = check(e1.typerep, boolType());
   errCheck2 = check(e2.typerep, boolType());
@@ -109,7 +109,7 @@ top::Expr ::= e1::Expr '||' e2::Expr
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
 
-  thread downSubst, upSubst on top, errCheck1, errCheck2, top;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, errCheck2, top;
   
   errCheck1 = check(e1.typerep, boolType());
   errCheck2 = check(e2.typerep, boolType());
@@ -128,7 +128,7 @@ top::Expr ::= '!' e1::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   
-  thread downSubst, upSubst on top, errCheck1, top;
+  thread downSubst, upSubst on top, e1, errCheck1, top;
   
   errCheck1 = check(e1.typerep, boolType());
   top.errors <-

--- a/grammars/silver/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/analysis/typechecking/core/ProductionBody.sv
@@ -3,13 +3,15 @@ grammar silver:analysis:typechecking:core;
 import silver:util;
 
 attribute upSubst, downSubst, finalSubst occurs on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr;
+propagate upSubst, downSubst on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr
+  excluding productionStmtAppend, forwardsTo, forwardInh, returnDef, synthesizedAttributeDef, inheritedAttributeDef, localValueDef;
 
 {--
  - These need an initial state only due to aspects (I think? maybe not. Investigate someday.)
  - They otherwise confine their contexts to each individual Stmt.
  -}
 attribute downSubst occurs on ProductionBody, ProductionStmts;
-
+-- downSubst is NOT propagated here - we give ever stmt the same downSubst, rather than threading like usual
 
 aspect production productionBody
 top::ProductionBody ::= '{' stmts::ProductionStmts '}'
@@ -45,47 +47,17 @@ top::ProductionStmt ::= h::ProductionStmt t::ProductionStmt
   -- Of course, this means do not use top.finalSubst here!
 }
 
-aspect production errorProductionStmt
-top::ProductionStmt ::= e::[Message]
-{
-  top.upSubst = top.downSubst;
-}
-
 aspect production forwardsTo
 top::ProductionStmt ::= 'forwards' 'to' e::Expr ';'
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
-
+  thread downSubst, upSubst on top, e, errCheck1, top;
+  
   errCheck1 = check(e.typerep, top.frame.signature.outputElement.typerep);
   top.errors <- if errCheck1.typeerror
                 then [err(e.location, "Forward's expected type is " ++ errCheck1.rightpp ++ ", but the actual type supplied is " ++ errCheck1.leftpp)]
                 else [];
-}
-
-aspect production forwardingWith
-top::ProductionStmt ::= 'forwarding' 'with' '{' inh::ForwardInhs '}' ';'
-{
-  inh.downSubst = top.downSubst;
-  top.upSubst = inh.upSubst;
-}
-
-aspect production forwardInhsOne
-top::ForwardInhs ::= lhs::ForwardInh
-{
-  lhs.downSubst = top.downSubst;
-  top.upSubst = lhs.upSubst;
-}
-
-aspect production forwardInhsCons
-top::ForwardInhs ::= lhs::ForwardInh rhs::ForwardInhs
-{
-  lhs.downSubst = top.downSubst;
-  rhs.downSubst = lhs.upSubst;
-  top.upSubst = rhs.upSubst;
 }
 
 aspect production forwardInh
@@ -93,10 +65,7 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  lhs.downSubst = top.downSubst;
-  e.downSubst = lhs.upSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, lhs, e, errCheck1, top;
   
   errCheck1 = check(lhs.typerep, e.typerep);
   top.errors <- 
@@ -106,26 +75,12 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
        else [];
 }
 
-aspect production forwardLhsExpr
-top::ForwardLHSExpr ::= q::QNameAttrOccur
-{
-  top.upSubst = top.downSubst;
-}
-
-aspect production localAttributeDcl
-top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
-{
-  top.upSubst = top.downSubst;
-}
-
 aspect production returnDef
 top::ProductionStmt ::= 'return' e::Expr ';'
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
-
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  
+  thread downSubst, upSubst on top, e, errCheck1, top;
   
   errCheck1 = check(e.typerep, top.frame.signature.outputElement.typerep);
   top.errors <-
@@ -134,21 +89,12 @@ top::ProductionStmt ::= 'return' e::Expr ';'
        else [];
 }
 
-aspect production errorAttributeDef
-top::ProductionStmt ::= msg::[Message] dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
-{
-  e.downSubst = top.downSubst;
-  top.upSubst = e.upSubst;
-}
-
 aspect production synthesizedAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst; 
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   errCheck1 = check(attr.typerep, e.typerep);
   top.errors <-
@@ -162,9 +108,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst; 
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   errCheck1 = check(attr.typerep, e.typerep);
   top.errors <-
@@ -192,9 +136,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   errCheck1 = check(e.typerep, val.lookupValue.typeScheme.typerep);
   top.errors <-
@@ -202,11 +144,3 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
        then [err(top.location, "Local " ++ val.name ++ " has type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
        else [];
 }
-
-aspect production errorValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
-{
-  e.downSubst = top.downSubst;
-  top.upSubst = e.upSubst;
-}
-

--- a/grammars/silver/analysis/typechecking/core/Project.sv
+++ b/grammars/silver/analysis/typechecking/core/Project.sv
@@ -6,13 +6,8 @@ imports silver:definition:type:syntax;
 imports silver:definition:env;
 imports silver:definition:type;
 
-
-
-{-- The resulting substitution context -}
-synthesized attribute upSubst   :: Substitution;
-
-{-- The initial substitution context -}
-inherited attribute downSubst :: Substitution;
+{-- The initial and resulting substitution contexts -}
+threaded attribute downSubst, upSubst :: Substitution;
 
 {-- The complete, final substitution context -}
 autocopy attribute finalSubst :: Substitution;

--- a/grammars/silver/definition/core/Expr.sv
+++ b/grammars/silver/definition/core/Expr.sv
@@ -288,8 +288,6 @@ concrete production access
 top::Expr ::= e::Expr '.' q::QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
-
-  propagate downSubst, upSubst;
   
   -- We don't include 'q' here because this might be a terminal, where
   -- 'q' shouldn't actually resolve to a name!

--- a/grammars/silver/definition/core/Expr.sv
+++ b/grammars/silver/definition/core/Expr.sv
@@ -688,10 +688,7 @@ top::Expr ::= e1::Expr '++' e2::Expr
   -- Moved from 'analysis:typechecking' because we want to use this stuff here now
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e1.downSubst = top.downSubst;
-  e2.downSubst = e1.upSubst;
-  errCheck1.downSubst = e2.upSubst;
-  forward.downSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e1, e2, errCheck1, forward;
   -- upSubst defined via forward :D
 
   errCheck1 = check(e1.typerep, e2.typerep);

--- a/grammars/silver/definition/core/Expr.sv
+++ b/grammars/silver/definition/core/Expr.sv
@@ -288,6 +288,8 @@ concrete production access
 top::Expr ::= e::Expr '.' q::QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
+
+  propagate downSubst, upSubst;
   
   -- We don't include 'q' here because this might be a terminal, where
   -- 'q' shouldn't actually resolve to a name!

--- a/grammars/silver/extension/auto_ast/AutoAst.sv
+++ b/grammars/silver/extension/auto_ast/AutoAst.sv
@@ -33,8 +33,7 @@ top::ProductionStmt ::= 'abstract' v::QName ';'
   
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   
-  errCheck1.downSubst = top.downSubst;
-  forward.downSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, errCheck1, forward;
 
   errCheck1 = check(vty, inferredType);
   top.errors <-

--- a/grammars/silver/extension/autoattr/Threaded.sv
+++ b/grammars/silver/extension/autoattr/Threaded.sv
@@ -47,6 +47,7 @@ top::ProductionStmt ::= inh::Decorated QName syn::String
           (.elementName),
           filter(
             \ ie::NamedSignatureElement ->
+              ie.typerep.isDecorable &&
               !null(getOccursDcl(inh.lookupAttribute.fullName, ie.typerep.typeName, top.env)) &&
               !null(getOccursDcl(syn, ie.typerep.typeName, top.env)),
             if null(getOccursDcl(syn, top.frame.lhsNtName, top.env)) && !null(top.frame.signature.inputElements)
@@ -76,6 +77,7 @@ top::ProductionStmt ::= inh::String syn::Decorated QName
           (.elementName),
           filter(
             \ ie::NamedSignatureElement ->
+              ie.typerep.isDecorable &&
               !null(getOccursDcl(inh, ie.typerep.typeName, top.env)) &&
               !null(getOccursDcl(syn.lookupAttribute.fullName, ie.typerep.typeName, top.env)),
             top.frame.signature.inputElements)) ++

--- a/grammars/silver/extension/autoattr/Threaded.sv
+++ b/grammars/silver/extension/autoattr/Threaded.sv
@@ -86,7 +86,7 @@ top::ProductionStmt ::= inh::String syn::Decorated QName
 }
 
 concrete production threadDcl_c
-top::ProductionStmt ::= 'thread' inh::QName ',' syn::QName 'on' children::Names ';'
+top::ProductionStmt ::= 'thread' inh::QName ',' syn::QName 'on' children::ChildNameList ';'
 {
   top.unparse = s"thread ${inh.unparse}, ${syn.unparse} on ${children.unparse};";
   forwards to
@@ -156,17 +156,35 @@ top::ProductionStmt ::= inh::String syn::String children::[Name]
 
 synthesized attribute ids :: [Name];
 
-nonterminal Names with unparse, ids;
+nonterminal ChildNameList with location, unparse, ids;
 concrete production idSingle
-top::Names ::= id::Name
+top::ChildNameList ::= id::ChildName
 {
-  top.unparse = id.name;
-  top.ids = [id];
+  top.unparse = id.unparse;
+  top.ids = [id.id];
 }
 
 concrete production idCons
-top::Names ::= id1::Name ',' id2::Names
+top::ChildNameList ::= id1::ChildName ',' id2::ChildNameList
 {
-  top.unparse = id1.name ++ ", " ++ id2.unparse ;
-  top.ids = [id1] ++ id2.ids;
+  top.unparse = id1.unparse ++ ", " ++ id2.unparse;
+  top.ids = id1.id :: id2.ids;
 }
+
+synthesized attribute id :: Name;
+
+nonterminal ChildName with location, unparse, id;
+concrete production idName
+top::ChildName ::= id::Name
+{
+  top.unparse = id.unparse;
+  top.id = id;
+}
+
+concrete production idForward
+top::ChildName ::= 'forward'
+{
+  top.unparse = "forward";
+  top.id = name("forward", top.location);
+}
+

--- a/grammars/silver/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/extension/implicit_monads/Expr.sv
@@ -28,7 +28,7 @@ aspect production errorExpr
 top::Expr ::= e::[Message]
 {
   top.merrors := e;
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = errorType();
   top.monadicNames = [];
   top.monadRewritten = errorExpr(e, location=top.location);
@@ -38,7 +38,7 @@ aspect production errorReference
 top::Expr ::= msg::[Message]  q::Decorated QName
 {
   top.merrors := msg;
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = errorType();
   top.monadicNames = [];
   top.monadRewritten = errorReference(msg, q, location=top.location);
@@ -48,7 +48,7 @@ aspect production childReference
 top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = if q.lookupValue.typeScheme.isDecorable
                  then q.lookupValue.typeScheme.asNtOrDecType
                  else q.lookupValue.typeScheme.monoType;
@@ -62,7 +62,7 @@ aspect production lhsReference
 top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = q.lookupValue.typeScheme.asNtOrDecType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
@@ -74,7 +74,7 @@ aspect production localReference
 top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = if q.lookupValue.typeScheme.isDecorable
                  then q.lookupValue.typeScheme.asNtOrDecType
                  else q.lookupValue.typeScheme.monoType;
@@ -88,7 +88,7 @@ aspect production forwardReference
 top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   -- An LHS (and thus, forward) is *always* a decorable (nonterminal) type.
   top.mtyperep = q.lookupValue.typeScheme.asNtOrDecType;
   top.monadicNames = if top.monadicallyUsed
@@ -101,7 +101,7 @@ aspect production productionReference
 top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
@@ -113,7 +113,7 @@ aspect production functionReference
 top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
@@ -125,7 +125,7 @@ aspect production globalValueReference
 top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = q.lookupValue.typeScheme.typerep;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]
@@ -480,7 +480,7 @@ aspect production attributeSection
 top::Expr ::= '(' '.' q::QName ')'
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = functionType(q.lookupAttribute.typeScheme.typerep, [freshType()], []);
   top.monadicNames = [];
   top.monadRewritten = attributeSection('(', '.', q, ')', location=top.location);
@@ -490,8 +490,7 @@ aspect production forwardAccess
 top::Expr ::= e::Expr '.' 'forward'
 {
   top.merrors := e.errors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
   e.expectedMonad = top.expectedMonad;
   top.mtyperep = e.mtyperep;
   e.monadicallyUsed = false; --this needs to change when we decorate monadic trees
@@ -502,8 +501,7 @@ top::Expr ::= e::Expr '.' 'forward'
 aspect production access
 top::Expr ::= e::Expr '.' q::QNameAttrOccur
 {
-  e.mDownSubst = top.mDownSubst;
-  forward.mDownSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
   e.expectedMonad = top.expectedMonad;
   top.merrors := e.merrors ++ forward.merrors;
   top.merrors <- if q.found
@@ -572,7 +570,7 @@ aspect production errorAccessHandler
 top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 {
   top.mtyperep = errorType();
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.merrors := [];
   top.merrors <- case q.attrDcl of
                  | restrictedSynDcl(_, _, _, _, _) -> []
@@ -813,9 +811,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
     monads, so anything that is a monad gets bound in to have its insides
     decorated.
   -}
-  e.mDownSubst = top.mDownSubst;
-  inh.mDownSubst = e.mUpSubst;
-  top.mUpSubst = inh.mUpSubst;
+  propagate mDownSubst, mUpSubst;
   top.merrors := e.merrors;
   e.expectedMonad = top.expectedMonad;
 
@@ -858,11 +854,12 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
 attribute monadRewritten<ExprInhs>, merrors, mDownSubst, mUpSubst, monadicNames occurs on ExprInhs;
 attribute monadRewritten<ExprInh>, merrors, mDownSubst, mUpSubst, monadicNames occurs on ExprInh;
 
+propagate mDownSubst, mUpSubst on ExprInhs, ExprInh;
+
 aspect production exprInhsEmpty
 top::ExprInhs ::= 
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
 
   top.monadicNames = [];
 
@@ -874,9 +871,6 @@ top::ExprInhs ::= lhs::ExprInh
 {
   top.merrors := lhs.merrors;
 
-  lhs.mDownSubst = top.mDownSubst;
-  top.mUpSubst = lhs.mUpSubst;
-
   top.monadicNames = lhs.monadicNames;
 
   top.monadRewritten = exprInhsOne(lhs.monadRewritten, location=top.location);
@@ -887,10 +881,6 @@ top::ExprInhs ::= lhs::ExprInh inh::ExprInhs
 {
   top.merrors := lhs.merrors ++ inh.merrors;
 
-  lhs.mDownSubst = top.mDownSubst;
-  inh.mDownSubst = lhs.mUpSubst;
-  top.mUpSubst = inh.mUpSubst;
-
   top.monadicNames = lhs.monadicNames ++ inh.monadicNames;
 
   top.monadRewritten = exprInhsCons(lhs.monadRewritten, inh.monadRewritten, location=top.location);
@@ -900,9 +890,6 @@ aspect production exprInh
 top::ExprInh ::= lhs::ExprLHSExpr '=' e::Expr ';'
 {
   top.merrors := e.merrors;
-
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
 
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;
@@ -916,7 +903,7 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e::Expr ';'
 aspect production trueConst
 top::Expr ::= 'true'
 {
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = boolType();
   top.merrors := [];
   top.monadicNames = [];
@@ -926,7 +913,7 @@ top::Expr ::= 'true'
 aspect production falseConst
 top::Expr ::= 'false'
 {
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = boolType();
   top.merrors := [];
   top.monadicNames = [];
@@ -1725,7 +1712,7 @@ aspect production intConst
 top::Expr ::= i::Int_t
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = intType();
   top.monadicNames = [];
   top.monadRewritten = intConst(i, location=top.location);
@@ -1735,7 +1722,7 @@ aspect production floatConst
 top::Expr ::= f::Float_t
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = floatType();
   top.monadicNames = [];
   top.monadRewritten = floatConst(f, location=top.location);
@@ -2138,8 +2125,7 @@ top::Expr ::= '-' e::Expr
 
   e.expectedMonad = top.expectedMonad;
 
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
   top.monadRewritten =
     if isMonad(e.mtyperep)
     then Silver_Expr {
@@ -2155,7 +2141,7 @@ aspect production stringConst
 top::Expr ::= s::String_t
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = stringType();
   top.monadicNames = [];
 
@@ -2366,7 +2352,7 @@ aspect production missingAppExpr
 top::AppExpr ::= '_'
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.monadRewritten = missingAppExpr('_', location=top.location);
   top.realTypes = [];
   top.monadTypesLocations = [];
@@ -2429,14 +2415,12 @@ top::AppExpr ::= e::Expr
   top.monadRewritten = presentAppExpr(e.monadRewritten, location=top.location);
 }
 
+propagate mDownSubst, mUpSubst on AppExprs;
+
 aspect production snocAppExprs
 top::AppExprs ::= es::AppExprs ',' e::AppExpr
 {
   top.merrors := es.merrors ++ e.merrors;
-
-  es.mDownSubst = top.mDownSubst;
-  e.mDownSubst = es.mUpSubst;
-  top.mUpSubst = e.mUpSubst;
 
   es.expectedMonad = top.expectedMonad;
   e.expectedMonad = top.expectedMonad;
@@ -2454,9 +2438,6 @@ top::AppExprs ::= e::AppExpr
 {
   top.merrors := e.merrors;
 
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
-
   e.expectedMonad = top.expectedMonad;
 
   top.realTypes = e.realTypes;
@@ -2471,8 +2452,6 @@ aspect production emptyAppExprs
 top::AppExprs ::=
 {
   top.merrors := [];
-
-  top.mUpSubst = top.mDownSubst;
 
   top.realTypes = [];
 

--- a/grammars/silver/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/extension/implicit_monads/Expr.sv
@@ -1638,7 +1638,8 @@ top::Expr ::= 'if' e1::Expr 'then' e2::Expr 'else' e3::Expr
   ec2.finalSubst = top.finalSubst;
   e1.mDownSubst = top.mDownSubst;
   e2.mDownSubst = e1.mUpSubst;
-  ec1.downSubst = e2.mUpSubst;
+  e3.mDownSubst = e2.mUpSubst;
+  ec1.downSubst = e3.mUpSubst;
   ec2.downSubst = ec1.upSubst;
   top.mUpSubst = ec2.upSubst;
 

--- a/grammars/silver/extension/implicit_monads/Lambda.sv
+++ b/grammars/silver/extension/implicit_monads/Lambda.sv
@@ -4,8 +4,7 @@ aspect production lambdap
 top::Expr ::= params::ProductionRHS e::Expr
 {
   top.merrors := e.merrors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 
@@ -23,7 +22,7 @@ aspect production lambdaParamReference
 top::Expr ::= q::Decorated QName
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = q.lookupValue.typeScheme.monoType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]

--- a/grammars/silver/extension/implicit_monads/Let.sv
+++ b/grammars/silver/extension/implicit_monads/Let.sv
@@ -19,9 +19,7 @@ top::Expr ::= la::AssignExpr  e::Expr
   ne.env = newScopeEnv(la.mdefs, top.env);
   ne.expectedMonad = top.expectedMonad;
 
-  la.mDownSubst = top.mDownSubst;
-  ne.mDownSubst = la.mUpSubst;
-  top.mUpSubst = ne.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 
@@ -81,9 +79,7 @@ top::AssignExpr ::= a1::AssignExpr a2::AssignExpr
 {
   top.merrors := a1.merrors ++ a2.merrors;
 
-  a1.mDownSubst = top.mDownSubst;
-  a2.mDownSubst = a1.mUpSubst;
-  top.mUpSubst = a2.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   a1.expectedMonad = top.expectedMonad;
   a2.expectedMonad = top.expectedMonad;
@@ -146,7 +142,7 @@ aspect production lexicalLocalReference
 top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   top.merrors := [];
-  top.mUpSubst = top.mDownSubst;
+  propagate mDownSubst, mUpSubst;
   top.mtyperep = q.lookupValue.typeScheme.monoType;
   top.monadicNames = if top.monadicallyUsed
                      then [baseExpr(new(q), location=top.location)]

--- a/grammars/silver/extension/implicit_monads/PrimitiveMatch.sv
+++ b/grammars/silver/extension/implicit_monads/PrimitiveMatch.sv
@@ -209,8 +209,7 @@ top::PrimPatterns ::= p::PrimPattern
 {
   top.merrors := p.merrors;
 
-  p.mDownSubst = top.mDownSubst;
-  top.mUpSubst = p.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   p.expectedMonad = top.expectedMonad;
 
@@ -297,9 +296,7 @@ top::PrimPatterns ::= p::PrimPattern vbar::Vbar_kwd ps::PrimPatterns
 aspect production prodPattern
 top::PrimPattern ::= qn::QName '(' ns::VarBinders ')' arr::Arrow_kwd e::Expr
 {
-  e.mDownSubst = top.mDownSubst;
-  e.downSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 
@@ -310,8 +307,7 @@ aspect production prodPatternNormal
 top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
 {
   top.merrors := e.merrors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 
@@ -333,8 +329,7 @@ aspect production prodPatternGadt
 top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
 {
   top.merrors := e.merrors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 
@@ -376,8 +371,7 @@ aspect production floatPattern
 top::PrimPattern ::= f::Float_t arr::Arrow_kwd e::Expr
 {
   top.merrors := e.merrors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 
@@ -396,8 +390,7 @@ aspect production stringPattern
 top::PrimPattern ::= i::String_t arr::Arrow_kwd e::Expr
 {
   top.merrors := e.merrors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 
@@ -416,8 +409,7 @@ aspect production booleanPattern
 top::PrimPattern ::= i::String arr::Arrow_kwd e::Expr
 {
   top.merrors := e.merrors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 
@@ -436,8 +428,7 @@ aspect production nilPattern
 top::PrimPattern ::= e::Expr
 {
   top.merrors := e.merrors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 
@@ -456,8 +447,7 @@ aspect production conslstPattern
 top::PrimPattern ::= h::Name t::Name e::Expr
 {
   top.merrors := e.merrors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
+  propagate mDownSubst, mUpSubst;
 
   e.expectedMonad = top.expectedMonad;
 

--- a/grammars/silver/extension/implicit_monads/Util.sv
+++ b/grammars/silver/extension/implicit_monads/Util.sv
@@ -24,8 +24,10 @@ autocopy attribute expectedMonad::Type;
 synthesized attribute monadRewritten<a>::a;
 synthesized attribute merrors::[Message] with ++;
 synthesized attribute mtyperep::Type;
-autocopy attribute mDownSubst::Substitution;
-synthesized attribute mUpSubst::Substitution;
+
+-- TODO: There's lots of places where we can't automatically propagate these because
+-- the host downSubst/upSubst attributes are mixed in too. 
+threaded attribute mDownSubst, mUpSubst::Substitution;
 
 
 function isMonad

--- a/grammars/silver/extension/monad/AbstractSyntax.sv
+++ b/grammars/silver/extension/monad/AbstractSyntax.sv
@@ -2,9 +2,7 @@
 abstract production bindExpr
 top::Expr ::= n::Name t::TypeExpr e::Expr rest::Expr bindFn::QName
 {
-  {-e.downSubst = top.downSubst;
-  rest.downSubst = e.upSubst;
-  forward.downSubst = rest.upSubst;-}
+  --propagate downSubst, upSubst;
 
   local cont :: Expr =
     lambdap(

--- a/grammars/silver/extension/reflection/BuiltinFunctions.sv
+++ b/grammars/silver/extension/reflection/BuiltinFunctions.sv
@@ -42,11 +42,7 @@ top::Expr ::= 'deserialize' '(' fileName::Expr ',' text::Expr ')'
   local errCheck2::TypeCheck = check(text.typerep, stringType());
   errCheck2.finalSubst = top.finalSubst;
   
-  fileName.downSubst = top.downSubst;
-  text.downSubst = fileName.upSubst;
-  errCheck1.downSubst = text.upSubst;
-  errCheck2.downSubst = errCheck1.upSubst;
-  --top.upSubst = errCheck2.upSubst;
+  thread downSubst, upSubst on top, fileName, text, errCheck1, errCheck2, forward;
   
   local localErrors::[Message] =
     (if errCheck1.typeerror

--- a/grammars/silver/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/extension/rewriting/Rewriting.sv
@@ -44,10 +44,7 @@ top::Expr ::= 'rewriteWith' '(' s::Expr ',' e::Expr ')'
   -- Actual syntax to exactly constrain the types of arbitrary expressions would be useful here.
   top.typerep = nonterminalType("core:Maybe", [e.typerep]);
   
-  s.downSubst = top.downSubst;
-  e.downSubst = s.upSubst;
-  errCheckS.downSubst = e.upSubst;
-  forward.downSubst = errCheckS.upSubst;
+  thread downSubst, upSubst on top, s, e, errCheckS, forward;
   
   forwards to
     Silver_Expr {
@@ -108,9 +105,7 @@ top::Expr ::= 'traverse' n::QName '(' es::AppExprs ',' anns::AnnoAppExprs ')'
     then [err(top.location, "Term rewriting requires import of silver:rewrite")]
     else [];
 
-  es.downSubst = top.downSubst;
-  anns.downSubst = es.upSubst;
-  forward.downSubst = es.downSubst;
+  propagate downSubst, upSubst;
   
   local transform::Strategy =
     traversal(n.lookupValue.fullName, es.traverseTransform, anns.traverseTransform);
@@ -278,9 +273,8 @@ top::Expr ::= 'rule' 'on' ty::TypeExpr 'of' Opt_Vbar_t ml::MRuleList 'end'
   
   -- Can't use an error production here, unfourtunately, due to circular dependency issues.
   top.errors := if !null(localErrors) then localErrors else forward.errors;
-  
-  checkExpr.downSubst = top.downSubst;
-  forward.downSubst = checkExpr.upSubst;
+
+  thread downSubst, upSubst on top, checkExpr, forward;
   
   local finalRuleType::Type =
     freshenType(

--- a/grammars/silver/extension/testing/EqualityTest.sv
+++ b/grammars/silver/extension/testing/EqualityTest.sv
@@ -51,10 +51,7 @@ ag::AGDcl ::= kwd::'equalityTest'
     else [err(value.location, "Type of second expression does not match specified type (3rd argument). Instead they are " ++ errCheck3.leftpp ++ " and " ++ errCheck3.rightpp)];
 
   value.downSubst = emptySubst();
-  expected.downSubst = value.upSubst;
-  errCheck1.downSubst = expected.upSubst;
-  errCheck2.downSubst = errCheck1.upSubst;
-  errCheck3.downSubst = errCheck2.upSubst;
+  thread downSubst, upSubst on value, expected, errCheck1, errCheck2, errCheck3;
   
   value.finalSubst = errCheck3.upSubst;
   expected.finalSubst = errCheck3.upSubst;

--- a/grammars/silver/modification/collection/Collection.sv
+++ b/grammars/silver/modification/collection/Collection.sv
@@ -277,9 +277,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst; 
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   errCheck1 = check(attr.typerep, e.typerep);
   top.errors <-
@@ -296,9 +294,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst; 
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   errCheck1 = check(attr.typerep, e.typerep);
   top.errors <-
@@ -318,9 +314,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst; 
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   errCheck1 = check(attr.typerep, e.typerep);
   top.errors <-
@@ -337,9 +331,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst; 
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   errCheck1 = check(attr.typerep, e.typerep);
   top.errors <-

--- a/grammars/silver/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/modification/copper/ProductionStmt.sv
@@ -30,7 +30,6 @@ top::ProductionStmt ::= 'pluck' e::Expr ';'
     else [];
 
   local tyCk :: TypeCheck = check(e.typerep, terminalIdType());
-  tyCk.downSubst = e.upSubst;
   tyCk.finalSubst = top.finalSubst;
   top.errors <-
     if tyCk.typeerror

--- a/grammars/silver/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/modification/copper/ProductionStmt.sv
@@ -37,12 +37,10 @@ top::ProductionStmt ::= 'pluck' e::Expr ';'
     then [err(top.location, "'pluck' expects one of the terminals it is disambiguating between. Instead it received "++tyCk.leftpp)]
     else [];
 
+  thread downSubst, upSubst on top, e, tyCk, top;
 
   -- TODO: Enforce that the plucked terminal is one of those that are being disambiguated between.
   -- Currently all that is checked is that it is a terminal.
-
-  e.downSubst = top.downSubst;
-  top.upSubst = e.upSubst;
 }
 
 concrete production printStmt
@@ -60,9 +58,7 @@ top::ProductionStmt ::= 'print' e::Expr ';'
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e, errCheck1, top;
   
   errCheck1 = check(e.typerep, stringType());
   top.errors <-
@@ -92,9 +88,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   errCheck1 = check(e.typerep, val.lookupValue.typeScheme.monoType);
   top.errors <-
@@ -118,9 +112,7 @@ top::ProductionStmt ::= 'pushToken' '(' val::QName ',' lexeme::Expr ')' ';'
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  lexeme.downSubst = top.downSubst;
-  errCheck1.downSubst = lexeme.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, lexeme, errCheck1, top;
 
   errCheck1 = check(lexeme.typerep, stringType());
   top.errors <-
@@ -162,9 +154,7 @@ top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt 'else' e
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  condition.downSubst = top.downSubst;
-  errCheck1.downSubst = condition.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, condition, errCheck1, top;
   
   th.downSubst = top.downSubst;
   th.finalSubst = th.upSubst;
@@ -229,9 +219,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   errCheck1 = check(e.typerep, val.lookupValue.typeScheme.monoType);
   top.errors <-

--- a/grammars/silver/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/modification/lambda_fn/Lambda.sv
@@ -29,10 +29,8 @@ top::Expr ::= params::ProductionRHS e::Expr
   propagate errors;
   
   top.typerep = functionType(e.typerep, map((.typerep), params.inputElements), []);
-  
-  e.downSubst = top.downSubst;
-  top.upSubst = e.upSubst;
-  
+
+  propagate downSubst, upSubst;
   propagate flowDeps, flowDefs;
   
   e.env = newScopeEnv(params.lambdaDefs, top.env);
@@ -59,7 +57,7 @@ top::Expr ::= q::Decorated QName
   
   top.typerep = q.lookupValue.typeScheme.monoType;
 
-  top.upSubst = top.downSubst;
+  propagate downSubst, upSubst;
   
   -- TODO?
   propagate flowDeps, flowDefs;

--- a/grammars/silver/modification/let_fix/Let.sv
+++ b/grammars/silver/modification/let_fix/Let.sv
@@ -46,10 +46,8 @@ top::Expr ::= la::AssignExpr  e::Expr
   propagate errors;
   
   top.typerep = e.typerep;
-    
-  la.downSubst = top.downSubst;
-  e.downSubst = la.upSubst;
-  top.upSubst = e.upSubst;
+
+  propagate downSubst, upSubst;
   
   -- Semantics for the moment is these are not mutually recursive,
   -- so la does NOT get new environment, only e. Thus, la.defs can depend on downSubst...
@@ -66,10 +64,8 @@ abstract production appendAssignExpr
 top::AssignExpr ::= a1::AssignExpr a2::AssignExpr
 {
   top.unparse = a1.unparse ++ ", " ++ a2.unparse;
-  
-  a1.downSubst = top.downSubst;
-  a2.downSubst = a1.upSubst;
-  top.upSubst = a2.upSubst;
+
+  propagate downSubst, upSubst;
 }
 
 -- TODO: Well, okay, so this isn't really abstract syntax...
@@ -100,9 +96,7 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
     then [err(id.location, "Value '" ++ id.name ++ "' is already bound.")]
     else [];
 
-  e.downSubst = top.downSubst;
-  errCheck1.downSubst = e.upSubst;
-  top.upSubst = errCheck1.upSubst;
+  thread downSubst, upSubst on top, e, errCheck1, top;
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
@@ -140,6 +134,6 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
     then ntOrDecType(q.lookupValue.typeScheme.monoType.decoratedType, freshType())
     else q.lookupValue.typeScheme.monoType;
 
-  top.upSubst = top.downSubst;
+  propagate downSubst, upSubst;
 }
 

--- a/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/modification/primitivepattern/PrimitiveMatch.sv
@@ -210,10 +210,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
                 else [];
   
   -- Thread NORMALLY! YAY!
-  errCheck1.downSubst = top.downSubst;
-  e.downSubst = errCheck1.upSubst;
-  errCheck2.downSubst = e.upSubst;
-  top.upSubst = errCheck2.upSubst;
+  thread downSubst, upSubst on top, errCheck1, e, errCheck2, top;
   
   e.env = newScopeEnv(ns.defs, top.env);
   
@@ -292,11 +289,8 @@ top::PrimPattern ::= i::Int_t '->' e::Expr
   top.errors <- if errCheck2.typeerror
                 then [err(e.location, "pattern expression should have type " ++ errCheck2.rightpp ++ " instead it has type " ++ errCheck2.leftpp)]
                 else [];
-  
-  errCheck1.downSubst = top.downSubst;
-  e.downSubst = errCheck1.upSubst;
-  errCheck2.downSubst = e.upSubst;
-  top.upSubst = errCheck2.upSubst;
+
+  thread downSubst, upSubst on top, errCheck1, e, errCheck2, top;
 
   top.translation = "if(scrutinee == " ++ i.lexeme ++ ") { return (" ++ performSubstitution(top.returnType, top.finalSubst).transType ++ ")" ++
                          e.translation ++ "; }";
@@ -318,11 +312,8 @@ top::PrimPattern ::= f::Float_t '->' e::Expr
   top.errors <- if errCheck2.typeerror
                 then [err(e.location, "pattern expression should have type " ++ errCheck2.rightpp ++ " instead it has type " ++ errCheck2.leftpp)]
                 else [];
-  
-  errCheck1.downSubst = top.downSubst;
-  e.downSubst = errCheck1.upSubst;
-  errCheck2.downSubst = e.upSubst;
-  top.upSubst = errCheck2.upSubst;
+
+  thread downSubst, upSubst on top, errCheck1, e, errCheck2, top;
 
   top.translation = "if(scrutinee == " ++ f.lexeme ++ ") { return (" ++ performSubstitution(top.returnType, top.finalSubst).transType ++ ")" ++
                          e.translation ++ "; }";
@@ -344,11 +335,8 @@ top::PrimPattern ::= i::String_t '->' e::Expr
   top.errors <- if errCheck2.typeerror
                 then [err(e.location, "pattern expression should have type " ++ errCheck2.rightpp ++ " instead it has type " ++ errCheck2.leftpp)]
                 else [];
-  
-  errCheck1.downSubst = top.downSubst;
-  e.downSubst = errCheck1.upSubst;
-  errCheck2.downSubst = e.upSubst;
-  top.upSubst = errCheck2.upSubst;
+
+  thread downSubst, upSubst on top, errCheck1, e, errCheck2, top;
 
   top.translation = "if(scrutinee.equals(" ++ i.lexeme ++ ")) { return (" ++ performSubstitution(top.returnType, top.finalSubst).transType ++ ")" ++
                          e.translation ++ "; }";
@@ -370,11 +358,8 @@ top::PrimPattern ::= i::String '->' e::Expr
   top.errors <- if errCheck2.typeerror
                 then [err(e.location, "pattern expression should have type " ++ errCheck2.rightpp ++ " instead it has type " ++ errCheck2.leftpp)]
                 else [];
-  
-  errCheck1.downSubst = top.downSubst;
-  e.downSubst = errCheck1.upSubst;
-  errCheck2.downSubst = e.upSubst;
-  top.upSubst = errCheck2.upSubst;
+
+  thread downSubst, upSubst on top, errCheck1, e, errCheck2, top;
 
   top.translation = "if(scrutinee == " ++ i ++ ") { return (" ++ performSubstitution(top.returnType, top.finalSubst).transType ++ ")" ++
                          e.translation ++ "; }";
@@ -396,11 +381,8 @@ top::PrimPattern ::= e::Expr
   top.errors <- if errCheck2.typeerror
                 then [err(e.location, "pattern expression should have type " ++ errCheck2.rightpp ++ " instead it has type " ++ errCheck2.leftpp)]
                 else [];
-  
-  errCheck1.downSubst = top.downSubst;
-  e.downSubst = errCheck1.upSubst;
-  errCheck2.downSubst = e.upSubst;
-  top.upSubst = errCheck2.upSubst;
+
+  thread downSubst, upSubst on top, errCheck1, e, errCheck2, top;
 
   top.translation = "if(scrutinee.nil()) { return (" ++ performSubstitution(top.returnType, top.finalSubst).transType ++ ")" ++
                          e.translation ++ "; }";
@@ -425,11 +407,8 @@ top::PrimPattern ::= h::Name t::Name e::Expr
   top.errors <- if errCheck2.typeerror
                 then [err(e.location, "pattern expression should have type " ++ errCheck2.rightpp ++ " instead it has type " ++ errCheck2.leftpp)]
                 else [];
-  
-  errCheck1.downSubst = top.downSubst;
-  e.downSubst = errCheck1.upSubst;
-  errCheck2.downSubst = e.upSubst;
-  top.upSubst = errCheck2.upSubst;
+
+  thread downSubst, upSubst on top, errCheck1, e, errCheck2, top;
   
   local consdefs :: [Def] =
     [lexicalLocalDef(top.grammarName, top.location, h_fName, elemType, noVertex(), []),


### PR DESCRIPTION
This cuts out a bunch of boilerplate by using threaded attributes for `upSubst`/`downSubst` throughout the typechecking code.  

This is based on feature/polytype, so review this after #385 is merged, I guess?