### PR TITLE
Fixing bugs with monadification and pattern matching

### DIFF
--- a/grammars/silver/extension/implicit_monads/Case.sv
+++ b/grammars/silver/extension/implicit_monads/Case.sv
@@ -172,19 +172,8 @@ Expr ::= bindlst::[Pair<Type Pair<Expr String>>] base::Expr loc::Location
   return case bindlst of
          | [] -> base
          | pair(ty,pair(e,n))::rest ->
-           Silver_Expr{ $Expr{monadBind(ty, loc)}
-            ($Expr{e},
-             $Expr{
-               lambdap(
-                 productionRHSCons(productionRHSElem(name(n, loc),
-                                                     '::',
-                                                     typerepTypeExpr(monadInnerType(ty),
-                                                                     location=loc),
-                                                     location=loc),
-                                   productionRHSNil(location=loc),
-                                   location=loc),
-                 buildMonadicBinds(rest, base, loc),
-                 location=loc)})}
+           buildApplication(monadBind(ty, loc),
+                            [e, buildLambda(n, monadInnerType(ty), buildMonadicBinds(rest, base, loc), loc)], loc)
          end;
 }
 

--- a/grammars/silver/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/extension/implicit_monads/Expr.sv
@@ -177,20 +177,9 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   top.merrors <- if null(nes.monadTypesLocations) ||
                    foldr(\x::Pair<Type Integer> b::Boolean -> b && monadsMatch(mty, x.fst, ne.mUpSubst).fst, 
                          true, tail(nes.monadTypesLocations))
-                then []
-                else [err(top.location,
-                      "All monad types used monadically in a function application must match")];
-  --need to check it is compatible with the function return type
-{-  top.merrors <- if isMonad(ety.outputType)
-                then if null(nes.monadTypesLocations)
-                     then []
-                     else if monadsMatch(ety.outputType, mty, ne.mUpSubst).fst
-                          then []
-                          else [err(top.location,
-                                    "Return type of function " ++ e.unparse ++ " is a monad (" ++
-                                    ety.outputType.typepp ++ ") which doesn't " ++
-                                    "match the monads used for arguments (" ++ mty.typepp ++ ")")]
-                else [];-}
+                 then []
+                 else [err(top.location,
+                       "All monad types used monadically in a function application must match")];
 
   local ety :: Type = performSubstitution(ne.mtyperep, top.mUpSubst);
 
@@ -2291,8 +2280,8 @@ top::AppExpr ::= e::Expr
   top.monadicNames = e.monadicNames;
 
   --these have an 'a' at the end of their names because of a bug where local names are not local to their grammars
-  local attribute errCheck1a :: TypeCheck; errCheck1a.finalSubst = top.mUpSubst;
-  local attribute errCheck2a :: TypeCheck; errCheck2a.finalSubst = top.mUpSubst;
+  local attribute errCheck1a::TypeCheck; errCheck1a.finalSubst = top.mUpSubst;
+  local attribute errCheck2a::TypeCheck; errCheck2a.finalSubst = top.mUpSubst;
 
   e.mDownSubst = top.mDownSubst;
   errCheck1a.downSubst = e.mUpSubst;
@@ -2303,9 +2292,10 @@ top::AppExpr ::= e::Expr
   --determine whether it appears that this is supposed to take
   --   advantage of implicit monads based on types matching the
   --   expected and being monads
-  local isMonadic::Boolean = isMonad(e.mtyperep) &&
-                             (!isMonad(top.appExprTyperep) ||
-                              !fst(monadsMatch(e.mtyperep, top.appExprTyperep, top.mDownSubst)));
+  local isMonadic::Boolean =
+           isMonad(e.mtyperep) &&
+           fst(monadsMatch(e.mtyperep, top.expectedMonad, e.mUpSubst)) &&
+          !fst(monadsMatch(e.mtyperep, top.appExprTyperep, e.mUpSubst));
 
   errCheck1a = check(if isDecorated(top.appExprTyperep) then e.mtyperep else dropDecorated(e.mtyperep), top.appExprTyperep);
   errCheck2a = check(monadInnerType(e.mtyperep), top.appExprTyperep);

--- a/grammars/silver/extension/implicit_monads/PrimitiveMatch.sv
+++ b/grammars/silver/extension/implicit_monads/PrimitiveMatch.sv
@@ -26,31 +26,38 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
 aspect production matchPrimitiveReal
 top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
 {
-  top.mtyperep = if isMonad(e.mtyperep) && monadsMatch(e.mtyperep, top.expectedMonad, top.mDownSubst).fst &&
-                    (!isMonad(pr.patternType) || !monadsMatch(pr.patternType, top.expectedMonad, top.mDownSubst).fst)
-                 then if isMonad(f.mtyperep) && monadsMatch(f.mtyperep, top.expectedMonad, top.mDownSubst).fst
-                      then f.mtyperep
-                      else if isMonad(pr.mtyperep) && monadsMatch(pr.mtyperep, top.expectedMonad, top.mDownSubst).fst
-                           then pr.mtyperep
-                           else if isMonad(t.typerep) && monadsMatch(t.typerep, top.expectedMonad, top.mDownSubst).fst
-                                then monadOfType(t.typerep, pr.mtyperep)
-                                else monadOfType(e.mtyperep, pr.mtyperep)
-                 else if isMonad(pr.mtyperep) && monadsMatch(pr.mtyperep, top.expectedMonad, top.mDownSubst).fst
+  --if e is the implicit monad
+  local eIsMonadic::Boolean = isMonad(e.mtyperep) && monadsMatch(e.mtyperep, top.expectedMonad, top.mDownSubst).fst;
+  --if the pattern type is the implicit monad
+  local prPattIsMonadic::Boolean = isMonad(pr.patternType) && monadsMatch(pr.patternType, top.expectedMonad, top.mDownSubst).fst;
+  --the return type of the patterns is the implicit monad
+  local prRetIsMonadic::Boolean = isMonad(pr.mtyperep) && monadsMatch(pr.mtyperep, top.expectedMonad, top.mDownSubst).fst;
+  --the type of f is the implicit monad
+  local fIsMonadic::Boolean = isMonad(f.mtyperep) && monadsMatch(f.mtyperep, top.expectedMonad, top.mDownSubst).fst;
+  --the type t is the implicit monad
+  local tIsMonadic::Boolean = isMonad(t.typerep) && monadsMatch(t.typerep, top.expectedMonad, top.mDownSubst).fst;
+
+  top.mtyperep = if eIsMonadic
+                 then if tIsMonadic
+                      then t.typerep
+                      else monadOfType(t.typerep, top.expectedMonad)
+                 else if prRetIsMonadic
                       then pr.mtyperep
-                      else if isMonad(t.typerep) && monadsMatch(t.typerep, top.expectedMonad, top.mDownSubst).fst
-                           then monadOfType(t.typerep, pr.mtyperep)
-                           else f.mtyperep;
+                      else f.mtyperep;
 
   top.merrors := e.merrors ++ pr.merrors ++ f.merrors;
+  top.merrors <- if prPattIsMonadic
+                 then [err(top.location, "Cannot match on implicit monadic type " ++ prettyType(pr.patternType))]
+                 else [];
 
   --check the type coming up with the type that's supposed to be
   --   coming out
   local attribute errCheck1::TypeCheck; errCheck1.finalSubst = top.finalSubst;
-  errCheck1 = if isMonad(pr.mtyperep) && monadsMatch(pr.mtyperep, top.expectedMonad, top.mDownSubst).fst
-              then if isMonad(f.mtyperep) && monadsMatch(f.mtyperep, top.expectedMonad, top.mDownSubst).fst
+  errCheck1 = if prRetIsMonadic
+              then if fIsMonadic
                    then check(pr.mtyperep, f.mtyperep)
                    else check(monadInnerType(pr.mtyperep), f.mtyperep)
-              else if isMonad(f.mtyperep) && monadsMatch(f.mtyperep, top.expectedMonad, top.mDownSubst).fst
+              else if fIsMonadic
                    then check(pr.mtyperep, monadInnerType(f.mtyperep))
                    else check(pr.mtyperep, f.mtyperep);
 
@@ -64,143 +71,126 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
   pr.expectedMonad = top.expectedMonad;
   f.expectedMonad = top.expectedMonad;
 
-  e.monadicallyUsed = isMonad(e.mtyperep) && monadsMatch(e.mtyperep, top.expectedMonad, top.mDownSubst).fst &&
-                      (!isMonad(pr.patternType) || monadsMatch(pr.patternType, top.expectedMonad, top.mDownSubst).fst);
+  e.monadicallyUsed = eIsMonadic;
   f.monadicallyUsed = false;
   top.monadicNames = e.monadicNames ++ pr.monadicNames ++ f.monadicNames;
 
   local freshname::String = "__sv_bindingInAMatchExpression_" ++ toString(genInt());
-  local eBind::Expr = monadBind(e.mtyperep, top.location);
+  local eBind::Expr = monadBind(top.expectedMonad, top.location);
   local eInnerType::TypeExpr = typerepTypeExpr(monadInnerType(e.mtyperep), location=top.location);
   local binde_lambdaparams::ProductionRHS =
         productionRHSCons(productionRHSElem(name(freshname, top.location), '::',
                                             eInnerType, location=top.location),
                           productionRHSNil(location=top.location), location=top.location);
   local outty::TypeExpr = typerepTypeExpr(top.mtyperep, location=top.location);
+
+  {-We need to make sure that, if we are matching on a decorable type,
+    it is decorated.  We need to check both whether the type is
+    decorable, or, in case that is a variable because we do as little
+    typechecking as possible, whether the pattern type is decorable
+    (and to avoid double-decoration, we check it isn't decorated
+    already).-}
+  local eMTyDecorable::Boolean =
+        if eIsMonadic
+        then performSubstitution(monadInnerType(e.mtyperep), e.mUpSubst).isDecorable ||
+             (!performSubstitution(monadInnerType(e.mtyperep), e.mUpSubst).isDecorated && pr.patternType.isDecorable)
+        else performSubstitution(e.mtyperep, e.mUpSubst).isDecorable ||
+             (!performSubstitution(e.mtyperep, e.mUpSubst).isDecorated && pr.patternType.isDecorable);
+  local decName::Expr =
+        if eMTyDecorable
+        then decorateExprWithEmpty('decorate', baseExpr(qName(top.location, freshname), location=top.location),
+                                   'with', '{', '}', location=top.location)
+        else baseExpr(qName(top.location, freshname), location=top.location);
+  local decE::Expr =
+        if eMTyDecorable
+        then decorateExprWithEmpty('decorate', e.monadRewritten, 'with', '{', '}', location=top.location)
+        else e.monadRewritten;
+
   --bind e, just do the rest
   local justBind_e::Expr =
-    applicationExpr(eBind,
-                    '(',
-                    snocAppExprs(oneAppExprs(presentAppExpr(e.monadRewritten, location=top.location),
-                                             location=top.location),
-                                 ',',
-                                 presentAppExpr(
-                                   lambdap(binde_lambdaparams,
-                                           matchPrimitiveReal(baseExpr(qName(top.location,
-                                                                             freshname),
-                                                                       location=top.location),
+    buildApplication(eBind,
+                     [e.monadRewritten, lambdap(binde_lambdaparams,
+                                           matchPrimitiveReal(decName,
                                                               outty, pr.monadRewritten, f.monadRewritten,
                                                               location=top.location),
-                                           location=top.location),
-                                   location=top.location),
-                                 location=top.location),
-                    ')',
-                    location=top.location);
+                                           location=top.location)],
+                     top.location);
   --bind e, return f based on e's type
   local bind_e_return_f::Expr =
-    applicationExpr(eBind,
-                    '(',
-                    snocAppExprs(oneAppExprs(presentAppExpr(e.monadRewritten, location=top.location),
-                                             location=top.location),
-                                 ',',
-                                 presentAppExpr(
-                                   lambdap(binde_lambdaparams,
-                                           matchPrimitiveReal(baseExpr(qName(top.location,
-                                                                             freshname),
-                                                                       location=top.location),
+    buildApplication(eBind,
+                     [e.monadRewritten, lambdap(binde_lambdaparams,
+                                           matchPrimitiveReal(decName,
                                                               outty, pr.monadRewritten,
-                                                              Silver_Expr {
-                                                                $Expr{monadReturn(e.mtyperep, top.location)}
-                                                                 ($Expr{f})
-                                                              },
+                                                              buildApplication(monadReturn(top.expectedMonad, top.location),
+                                                                               [f.monadRewritten], top.location),
                                                               location=top.location),
-                                           location=top.location),
-                                   location=top.location),
-                                 location=top.location),
-                    ')',
-                    location=top.location);
+                                           location=top.location)],
+                     top.location);
   --bind e, returnify pr based on e's type
   local prReturnify::PrimPatterns = pr.monadRewritten;
-  prReturnify.returnFun = monadReturn(e.mtyperep, top.location);
+  prReturnify.returnFun = monadReturn(top.expectedMonad, top.location);
   prReturnify.grammarName = top.grammarName;
   prReturnify.env = top.env;
   prReturnify.config = top.config;
   local bind_e_returnify_pr::Expr =
-    applicationExpr(eBind,
-                    '(',
-                    snocAppExprs(oneAppExprs(presentAppExpr(e.monadRewritten, location=top.location),
-                                             location=top.location),
-                                 ',',
-                                 presentAppExpr(
-                                   lambdap(binde_lambdaparams,
-                                           matchPrimitiveReal(baseExpr(qName(top.location,
-                                                                             freshname),
-                                                                       location=top.location),
+    buildApplication(eBind,
+                     [e.monadRewritten, lambdap(binde_lambdaparams,
+                                           matchPrimitiveReal(decName,
                                                               outty, prReturnify.returnify,
                                                               f.monadRewritten, location=top.location),
-                                           location=top.location),
-                                   location=top.location),
-                                 location=top.location),
-                    ')',
-                    location=top.location);
+                                           location=top.location)],
+                     top.location);
   --bind e, returnify pr, return f based on e's type
   local bind_e_returnify_pr_return_f::Expr =
-    applicationExpr(eBind,
-                    '(',
-                    snocAppExprs(oneAppExprs(presentAppExpr(e.monadRewritten, location=top.location),
-                                             location=top.location),
-                                 ',',
-                                 presentAppExpr(
-                                   lambdap(binde_lambdaparams,
-                                           matchPrimitiveReal(baseExpr(qName(top.location,
-                                                                             freshname),
-                                                                       location=top.location),
+    buildApplication(eBind,
+                     [e.monadRewritten, lambdap(binde_lambdaparams,
+                                           matchPrimitiveReal(decName,
                                                               outty, prReturnify.returnify,
-                                                              Silver_Expr {
-                                                                $Expr{monadReturn(e.mtyperep, top.location)}
-                                                                 ($Expr{f.monadRewritten})
-                                                              },
+                                                              buildApplication(monadReturn(top.expectedMonad, top.location),
+                                                                 [f.monadRewritten], top.location),
                                                               location=top.location),
-                                           location=top.location),
-                                   location=top.location),
-                                 location=top.location),
-                    ')',
-                    location=top.location);
+                                           location=top.location)],
+                     top.location);
   --return f from pr's return type
   local return_f::Expr =
-    matchPrimitiveReal(e.monadRewritten, outty, pr.monadRewritten,
-                       Silver_Expr {
-                         $Expr{monadReturn(pr.mtyperep, top.location)}($Expr{f.monadRewritten})
-                       },
+    matchPrimitiveReal(decE, outty, pr.monadRewritten,
+                       buildApplication(monadReturn(top.expectedMonad, top.location), [f.monadRewritten], top.location),
                        location=top.location);
   --returnify pr from f's type
   local ret_pr_from_f::PrimPatterns = pr.monadRewritten;
-  ret_pr_from_f.returnFun = monadReturn(f.mtyperep, top.location);
+  ret_pr_from_f.returnFun = monadReturn(top.expectedMonad, top.location);
   ret_pr_from_f.grammarName = top.grammarName;
   ret_pr_from_f.env = top.env;
   ret_pr_from_f.config = top.config;
-  local returnify_pr::Expr = matchPrimitiveReal(e.monadRewritten, outty, ret_pr_from_f.returnify,
+  local returnify_pr::Expr = matchPrimitiveReal(decE, outty, ret_pr_from_f.returnify,
                                                 f.monadRewritten, location=top.location);
   --just use monadRewritten
-  local just_rewrite::Expr = matchPrimitiveReal(e.monadRewritten, outty, pr.monadRewritten,
+  local just_rewrite::Expr = matchPrimitiveReal(decE, outty, pr.monadRewritten,
                                                 f.monadRewritten, location=top.location);
+  --t is monadic and nothing else is, so return over whole thing
+  local return_whole_thing::Expr =
+    buildApplication(monadReturn(top.expectedMonad, top.location),
+                                 [matchPrimitiveReal(decE, outty, pr.monadRewritten,
+                                                     f.monadRewritten, location=top.location)],
+                                 top.location);
   --pick the right rewriting
-  local mRw::Expr    = if isMonad(e.mtyperep) && monadsMatch(e.mtyperep, top.expectedMonad, top.mDownSubst).fst &&
-                          (!isMonad(pr.patternType) || !monadsMatch(pr.patternType, top.expectedMonad, top.mDownSubst).fst)
-                       then if isMonad(pr.mtyperep) && monadsMatch(pr.mtyperep, top.expectedMonad, top.mDownSubst).fst
-                            then if isMonad(f.mtyperep) && monadsMatch(f.mtyperep, top.expectedMonad, top.mDownSubst).fst
+  local mRw::Expr    = if eIsMonadic
+                       then if prRetIsMonadic
+                            then if fIsMonadic
                                  then justBind_e
                                  else bind_e_return_f
-                            else if isMonad(f.mtyperep) && monadsMatch(f.mtyperep, top.expectedMonad, top.mDownSubst).fst
+                            else if fIsMonadic
                                  then bind_e_returnify_pr
                                  else bind_e_returnify_pr_return_f
-                       else if isMonad(pr.mtyperep) && monadsMatch(pr.mtyperep, top.expectedMonad, top.mDownSubst).fst
-                            then if isMonad(f.mtyperep) && monadsMatch(f.mtyperep, top.expectedMonad, top.mDownSubst).fst
+                       else if prRetIsMonadic
+                            then if fIsMonadic
                                  then just_rewrite
                                  else return_f
-                            else if isMonad(f.mtyperep) && monadsMatch(f.mtyperep, top.expectedMonad, top.mDownSubst).fst
+                            else if fIsMonadic
                                  then returnify_pr
-                                 else just_rewrite;
+                                 else if tIsMonadic
+                                      then return_whole_thing
+                                      else just_rewrite;
   top.monadRewritten = mRw;
 }
 


### PR DESCRIPTION
This fixes a couple of bugs I found with monadification over pattern matching.

First, if a `case` expression didn't have anything monadic other than the expression on which it was matching, it wouldn't get a `return` inserted in the body.  For example, in
```
case e of
| 5 -> 6
| _ -> 0
end
```
where `e` is monadic in a monad without a pre-defined failure, we would bind `e` into the pattern matching, but we wouldn't put a `return` anywhere in the rewritten pattern matching, so the bind would be ill-typed and it would fail to compile.

Second, if we matched on nested decorable types, the expression for the inner match would not get decorated.  For example, if our implicit monad is `Either`, we should be able to match on nested `Maybe`s:
```
case e of
| just(just(x)) -> x
| just(nothing()) -> 1
| nothing() -> 0
end
```
The translation to single matching would match on `just(a)`, then match `a` against `just` and `nothing`, but `a` was not getting decorated and thus it would be ill-typed and fail to compile.