### PR TITLE
Add --mwda flag to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ Silver and Copper are distributed under the GNU Lesser General Public
 License.  See the files COPYING and COPYING.LESSER for details of
 these licenses.  More information can be found at
 http://www.gnu.org/licenses/.
+

--- a/grammars/silver/compiler/analysis/warnings/flow/MissingSynEq.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/MissingSynEq.sv
@@ -38,7 +38,7 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
 
   top.errors <-
     if nt.lookupType.found && at.lookupAttribute.found
-    && (top.config.warnAll || top.config.warnMissingSyn)
+    && (top.config.warnAll || top.config.warnMissingSyn || top.config.runMwda)
     -- We only care about synthesized attributes:
     && at.lookupAttribute.dcl.isSynthesized
     -- This error message won't be redundant:
@@ -46,7 +46,7 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
     -- And we can ignore any attribute that has a default equation:
     && null(lookupDef(nt.lookupType.fullName, at.lookupAttribute.fullName, top.flowEnv))
     -- Otherwise, examine them all:
-    then flatMap(raiseMissingProds(top.location, at.lookupAttribute.fullName, _, top.flowEnv), nfprods)
+    then flatMap(raiseMissingProds(top.location, at.lookupAttribute.fullName, _, top.flowEnv, top.config.runMwda), nfprods)
     else [];
 }
 
@@ -61,14 +61,14 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
  - @returns      An error message from the attribute occurrence's perspective, if any
  -}
 function raiseMissingProds
-[Message] ::= l::Location  attr::String  prod::String  e::Decorated FlowEnv
+[Message] ::= l::Location  attr::String  prod::String  e::Decorated FlowEnv runMwda::Boolean
 {
   -- Because the location is of the attribute occurrence, deliberately use the attribute's shortname
   local shortName :: String = substring(lastIndexOf(":", attr) + 1, length(attr), attr);
 
   return case lookupSyn(prod, attr, e) of
   | _ :: _ -> [] -- equation exists
-  | [] -> [wrn(l, "attribute "  ++ shortName ++ " missing equation for production " ++ prod)]
+  | [] -> [mwdaWrn(l, "attribute "  ++ shortName ++ " missing equation for production " ++ prod, runMwda)]
   end;
 
 }
@@ -89,11 +89,11 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
 
   top.errors <-
     if null(body.errors ++ ns.errors)
-    && (top.config.warnAll || top.config.warnMissingSyn)
+    && (top.config.warnAll || top.config.warnMissingSyn || top.config.runMwda)
     -- Forwarding productions do no have missing synthesized equations:
     && null(body.uniqueSignificantExpression)
     -- Otherwise, examine them all:
-    then flatMap(raiseMissingAttrs(top.location, fName, _, top.flowEnv), attrs)
+    then flatMap(raiseMissingAttrs(top.location, fName, _, top.flowEnv, top.config.runMwda), attrs)
     else [];
 }
 
@@ -108,7 +108,7 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
  - @returns      An error message from the production's perspective, if any
  -}
 function raiseMissingAttrs
-[Message] ::= l::Location  prod::String  attr::DclInfo  e::Decorated FlowEnv
+[Message] ::= l::Location  prod::String  attr::DclInfo  e::Decorated FlowEnv runMwda::Boolean
 {
   -- Because the location is of the production, deliberately use the production's shortname
   local shortName :: String = substring(lastIndexOf(":", prod) + 1, length(prod), prod);
@@ -123,7 +123,7 @@ function raiseMissingAttrs
     end;
  
   return if lacks_default_equation && missing_explicit_equation
-  then [wrn(l, "production " ++ shortName ++ " lacks synthesized equation for " ++ attr.attrOccurring)]
+  then [mwdaWrn(l, "production " ++ shortName ++ " lacks synthesized equation for " ++ attr.attrOccurring, runMwda)]
   else [];
 }
 

--- a/grammars/silver/compiler/analysis/warnings/flow/MwdaFlag.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/MwdaFlag.sv
@@ -1,0 +1,31 @@
+grammar silver:compiler:analysis:warnings:flow;
+
+synthesized attribute runMwda :: Boolean occurs on CmdArgs;
+
+aspect production endCmdArgs
+top::CmdArgs ::= l::[String]
+{
+  top.runMwda = false;
+}
+abstract production mwdaFlag
+top::CmdArgs ::= rest::CmdArgs
+{
+  top.runMwda = true;
+  forwards to rest;
+}
+
+aspect function parseArgs
+Either<String  Decorated CmdArgs> ::= args::[String]
+{
+  flags <- [pair("--mwda", flag(mwdaFlag))];
+  flagdescs <- ["\t--mwda  : report MWDA violations as errors"];
+}
+
+abstract production mwdaWrn
+top::Message ::= l::Location m::String runMwda::Boolean
+{
+  forwards to
+    if runMwda
+    then err(l, m)
+    else wrn(l, m);
+}

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
@@ -30,15 +30,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur e::
   -- Orphaned equation check
   top.errors <-
     if dl.found && attr.found
-    && (top.config.warnAll || top.config.warnEqdef)
+    && (top.config.warnAll || top.config.warnEqdef || top.config.runMwda)
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [wrn(top.location, "Orphaned equation: " ++ attr.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
+    then [mwdaWrn(top.location, "Orphaned equation: " ++ attr.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName, top.config.runMwda)]
     else [];
   
   -- Duplicate equation check
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [wrn(top.location, "Duplicate equation for " ++ attr.name ++ " in production " ++ top.frame.fullName)]
+    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name ++ " in production " ++ top.frame.fullName, top.config.runMwda)]
     else [];
 }
 
@@ -55,15 +55,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
   top.errors <-
     if dl.found && attr.found
-    && (top.config.warnAll || top.config.warnEqdef)
+    && (top.config.warnAll || top.config.warnEqdef || top.config.runMwda)
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [wrn(top.location, "Orphaned equation: " ++ attr.name ++ " on " ++ dl.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
+    then [mwdaWrn(top.location, "Orphaned equation: " ++ attr.name ++ " on " ++ dl.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName, top.config.runMwda)]
     -- Now, check for duplicate equations!
     else [];
     
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [wrn(top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName)]
+    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName, top.config.runMwda)]
     else [];
 }
 
@@ -81,15 +81,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   -- Orphaned equation check
   top.errors <-
     if dl.found && attr.found
-    && (top.config.warnAll || top.config.warnEqdef)
+    && (top.config.warnAll || top.config.warnEqdef || top.config.runMwda)
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [wrn(top.location, "Orphaned equation: " ++ attr.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
+    then [mwdaWrn(top.location, "Orphaned equation: " ++ attr.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName, top.config.runMwda)]
     else [];
   
   -- Duplicate equation check
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [wrn(top.location, "Duplicate equation for " ++ attr.name ++ " in production " ++ top.frame.fullName)]
+    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name ++ " in production " ++ top.frame.fullName, top.config.runMwda)]
     else [];
 }
 aspect production inhBaseColAttributeDef
@@ -105,15 +105,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
   top.errors <-
     if dl.found && attr.found
-    && (top.config.warnAll || top.config.warnEqdef)
+    && (top.config.warnAll || top.config.warnEqdef || top.config.runMwda)
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [wrn(top.location, "Orphaned equation: " ++ attr.name ++ " on " ++ dl.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
+    then [mwdaWrn(top.location, "Orphaned equation: " ++ attr.name ++ " on " ++ dl.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName, top.config.runMwda)]
     -- Now, check for duplicate equations!
     else [];
     
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [wrn(top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName)]
+    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName, top.config.runMwda)]
     else [];
 }
 

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedOccurs.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedOccurs.sv
@@ -30,9 +30,9 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
 
   top.errors <-
     if nt.lookupType.found && at.lookupAttribute.found
-    && (top.config.warnAll || top.config.warnOrphaned)
+    && (top.config.warnAll || top.config.warnOrphaned || top.config.runMwda)
     && !isExportedBy(top.grammarName, [nt.lookupType.dcl.sourceGrammar, at.lookupAttribute.dcl.sourceGrammar], top.compiledGrammars)
-    then [wrn(top.location, "Orphaned occurs declaration: " ++ at.lookupAttribute.fullName ++ " on " ++ nt.lookupType.fullName)]
+    then [mwdaWrn(top.location, "Orphaned occurs declaration: " ++ at.lookupAttribute.fullName ++ " on " ++ nt.lookupType.fullName, top.config.runMwda)]
          -- If this is a non-closed NT, or not a synthesized attribute, then we're done.
     else [];
   
@@ -41,7 +41,7 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
     -- For closed nt, either we're exported by only the nt, OR there MUST be a default!
     else if !isExportedBy(top.grammarName, [nt.lookupType.dcl.sourceGrammar], top.compiledGrammars)
          && null(lookupDef(nt.lookupType.fullName, at.lookupAttribute.fullName, top.flowEnv))
-         then [wrn(top.location, at.lookupAttribute.fullName ++ " cannot occur on " ++ nt.lookupType.fullName ++ " because that nonterminal is closed, and this attribute does not have a default equation.")]
+         then [mwdaWrn(top.location, at.lookupAttribute.fullName ++ " cannot occur on " ++ nt.lookupType.fullName ++ " because that nonterminal is closed, and this attribute does not have a default equation.", top.config.runMwda)]
          else [];
 }
 

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedProduction.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedProduction.sv
@@ -33,14 +33,14 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
 
   top.errors <-
     if null(body.errors ++ ns.errors)
-    && (top.config.warnAll || top.config.warnFwd)
+    && (top.config.warnAll || top.config.warnFwd || top.config.runMwda)
     -- If this production does not forward
     && null(body.uniqueSignificantExpression)
     -- AND this is not a closed nonterminal
     && !isClosedNt
     -- AND this production is not exported by the nonterminal definition grammar... even including options
     && !isExportedBy(top.grammarName, [ntDefGram], top.compiledGrammars)
-    then [wrn(top.location, "Orphaned production: " ++ id.name ++ " on " ++ namedSig.outputElement.typerep.typeName)]
+    then [mwdaWrn(top.location, "Orphaned production: " ++ id.name ++ " on " ++ namedSig.outputElement.typerep.typeName, top.config.runMwda)]
     else [];
 }
 


### PR DESCRIPTION
Resolves #396 
My approach is to introduce a new --mwda flag into the command-line options and wire the resulting boolean (whether the flag is given or not) into everywhere the `wrn` for the MWDA analysis was produced. The flag is then used to enable the production of these messages (the same as if the `--warn-all` flag were used) and the value is also used to determine whether to produce a `wrn` or an `err`. The reason for this is that it causes `--warn-all` to still produce all MWDA warnings as just warnings (which can then be made errors using `--warn-error`).

Once this is merged we'll need to change the Makefiles in all the ableC extensions to use `--mwda` rather than `--warn-all --warn-error` to run MWDA analysis. Once that's done I am aware of one place in Silver (line 130 of silver/compiler/definition/core/BuiltInFunctions.sv) where we have a deprecation warning that is commented out because of its interference with the MWDA analysis.