### PR TITLE
Improve type errors on functions with incorrect number of arguments

### DIFF
--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -199,22 +199,18 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   anns.remainingFuncAnnotations = t.namedTypes;
   anns.funcAnnotations = anns.remainingFuncAnnotations;
   
+  top.errors <- 
+    if !t.isApplicable
+    then []
+    else if length(t.inputTypes) > es.appExprSize
+    then [err(top.location, "Too few arguments provided to function '" ++ e.unparse ++ "'")]
+    else if length(t.inputTypes) < es.appExprSize
+    then [err(top.location, "Too many arguments provided to function '" ++ e.unparse ++ "'")]
+    else [];
+
   -- TODO: You know, since the rule is we can't access .typerep without "first" supplying
   -- .downSubst, perhaps we should just... report .typerep after substitution in the first place!
-  local applied :: Expr = t.applicationDispatcher(e, es, anns, top.location);
-  
-  top.errors <- 
-    case applied of
-    | errorApplication(_, _, _) -> []
-    | _ ->
-      if length(t.inputTypes) > es.appExprSize
-      then [err(top.location, "Too few arguments provided to function '" ++ e.unparse ++ "'")]
-      else if length(t.inputTypes) < es.appExprSize
-      then [err(top.location, "Too many arguments provided to function '" ++ e.unparse ++ "'")]
-      else []
-    end;
-
-  forwards to applied;
+  forwards to t.applicationDispatcher(e, es, anns, top.location);
 }
 
 concrete production applicationAnno

--- a/grammars/silver/compiler/definition/core/Type.sv
+++ b/grammars/silver/compiler/definition/core/Type.sv
@@ -15,17 +15,13 @@ synthesized attribute instanceOrd :: Boolean;
 synthesized attribute instanceNum :: Boolean;
 synthesized attribute instanceConvertible :: Boolean;
 
-synthesized attribute isApplicable :: Boolean;
-
 attribute applicationDispatcher, accessHandler, lengthDispatcher, appendDispatcher,
-          instanceEq, instanceOrd, instanceNum, instanceConvertible, isApplicable
-          occurs on Type;
+          instanceEq, instanceOrd, instanceNum, instanceConvertible occurs on Type;
 
 aspect default production
 top::Type ::=
 {
   top.applicationDispatcher = errorApplication(_, _, _, location=_);
-  top.isApplicable = false;
   top.accessHandler = errorAccessHandler(_, _, location=_);
   top.instanceEq = false;
   top.instanceOrd = false;
@@ -49,7 +45,6 @@ aspect production appType
 top::Type ::= c::Type a::Type
 {
   top.applicationDispatcher = c.applicationDispatcher;
-  top.isApplicable = c.isApplicable;
   top.accessHandler = c.accessHandler;
   top.instanceEq = c.instanceEq;
   top.instanceOrd = c.instanceOrd;
@@ -122,8 +117,6 @@ top::Type ::= te::Type
 aspect production functionType
 top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
 {
-  -- TODO: We don't seem to use this. Perhaps we should remove it?
   top.applicationDispatcher = functionApplication(_, _, _, location=_);
-  top.isApplicable = true;
 }
 

--- a/grammars/silver/compiler/definition/core/Type.sv
+++ b/grammars/silver/compiler/definition/core/Type.sv
@@ -15,13 +15,17 @@ synthesized attribute instanceOrd :: Boolean;
 synthesized attribute instanceNum :: Boolean;
 synthesized attribute instanceConvertible :: Boolean;
 
+synthesized attribute isApplicable :: Boolean;
+
 attribute applicationDispatcher, accessHandler, lengthDispatcher, appendDispatcher,
-          instanceEq, instanceOrd, instanceNum, instanceConvertible occurs on Type;
+          instanceEq, instanceOrd, instanceNum, instanceConvertible, isApplicable
+          occurs on Type;
 
 aspect default production
 top::Type ::=
 {
   top.applicationDispatcher = errorApplication(_, _, _, location=_);
+  top.isApplicable = false;
   top.accessHandler = errorAccessHandler(_, _, location=_);
   top.instanceEq = false;
   top.instanceOrd = false;
@@ -45,6 +49,7 @@ aspect production appType
 top::Type ::= c::Type a::Type
 {
   top.applicationDispatcher = c.applicationDispatcher;
+  top.isApplicable = c.isApplicable;
   top.accessHandler = c.accessHandler;
   top.instanceEq = c.instanceEq;
   top.instanceOrd = c.instanceOrd;
@@ -119,5 +124,6 @@ top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
 {
   -- TODO: We don't seem to use this. Perhaps we should remove it?
   top.applicationDispatcher = functionApplication(_, _, _, location=_);
+  top.isApplicable = true;
 }
 

--- a/grammars/silver/compiler/definition/type/Util.sv
+++ b/grammars/silver/compiler/definition/type/Util.sv
@@ -3,6 +3,9 @@ grammar silver:compiler:definition:type;
 -- Quick check to see if an error message should be suppressed
 synthesized attribute isError :: Boolean;
 
+-- Check for whether the type can be applied
+synthesized attribute isApplicable :: Boolean;
+
 synthesized attribute inputTypes :: [Type];
 synthesized attribute outputType :: Type;
 synthesized attribute namedTypes :: [NamedArgType];
@@ -67,7 +70,7 @@ top::PolyType ::= bound::[TyVar] contexts::[Context] ty::Type
   top.asNtOrDecType = error("Only mono types should be possibly-decorated");
 }
 
-attribute isError, inputTypes, outputType, namedTypes, arity, baseType, argTypes, isDecorated, isDecorable, isTerminal, decoratedType, unifyInstanceNonterminal, unifyInstanceDecorated occurs on Type;
+attribute isError, inputTypes, outputType, namedTypes, arity, baseType, argTypes, isDecorated, isDecorable, isTerminal, decoratedType, unifyInstanceNonterminal, unifyInstanceDecorated, isApplicable occurs on Type;
 
 aspect default production
 top::Type ::=
@@ -83,6 +86,7 @@ top::Type ::=
   top.isDecorable = false;
   top.isTerminal = false;
   top.isError = false;
+  top.isApplicable = false;
   
   top.decoratedType = errorType();
   
@@ -107,6 +111,7 @@ top::Type ::= c::Type a::Type
   top.argTypes = c.argTypes ++ [a];
   top.isDecorable = c.isDecorable;
   top.unifyInstanceNonterminal = c.unifyInstanceNonterminal;
+  top.isApplicable = c.isApplicable;
 }
 
 
@@ -173,5 +178,6 @@ top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
   top.outputType = out;
   top.namedTypes = namedParams;
   top.arity = length(params);
+  top.isApplicable = true;
 }
 


### PR DESCRIPTION
Resolve #33 (I think, still can't replicate the "too many arguments" errors when the function is not found).

My approach to matching types to arguments from left-to-right, rather than right-to-left, is to construct a list of types that matches the number of provided arguments; if too many arguments are provided we add `errorType()` to the front (which because the argument types are reversed places the `errorType()` on the arguments at the end which makes sense since we really can't type-check them) and if there are too few arguments we drop elements from the front of the list of types (which correspond to arguments that should be given at the end). This also requires that we handle the checking for whether the number of expected arguments matches the number of provided arguments in `snocAppExprs` since we will provide the `AppExprs` child a list of types that is equal to the number of arguments it has listed, so the checking in `oneAppExprs` will no longer detect that there are too few or too many children.