### PR TITLE
Add deprecation warning for toInt

### DIFF
--- a/grammars/silver/compiler/definition/core/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/definition/core/BuiltInFunctions.sv
@@ -123,11 +123,7 @@ top::Expr ::= 'toInt' '(' e::Expr ')'
 {
   top.unparse = "toInt(" ++ e.unparse ++ ")";
 
-  -- TODO: Please uncomment this soon. I'm only leaving it because
-  -- Jenkins builds things with `--warn-error` as part of MWDA.
-  -- We really need to add a `--mwda` flag or something, so new warnings
-  -- can be introduced safely.
-  --top.errors <- [wrn($1.location, "'toInt' is deprecated syntax, please use 'toInteger' instead.")];
+  top.errors <- [wrn($1.location, "'toInt' is deprecated syntax, please use 'toInteger' instead.")];
 
   forwards to toIntegerFunction('toInteger', '(', e, ')', location=top.location);
 }


### PR DESCRIPTION
Since we added the `--mwda` flag we can now generate warnings for deprecation without impacting MWDA analysis (though the use of `toInt` downstream still had to be replaced with `toInteger` since Jenkins builds with `--warn-all --warn-error`).

Before merging this I will need to merge this branch in several ableC repos:
* ableC-dimensionalAnalysis
* ableC-refcount-closure
* ableC-halide
* ableC-tensor-algebra
* ableC-nondeterministic-search