### PR TITLE
Add prefix to names of globals in Java translation to avoid keywords

### DIFF
--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -154,7 +154,7 @@ aspect production globalValueReference
 top::Expr ::= q::Decorated QName
 {
   local directThunk :: String =
-    s"${makeName(q.lookupValue.dcl.sourceGrammar)}.Init.${fullNameToShort(q.lookupValue.fullName)}";
+    s"${makeName(q.lookupValue.dcl.sourceGrammar)}.Init.global_${fullNameToShort(q.lookupValue.fullName)}";
 
   top.translation = s"((${finalType(top).transType})${directThunk}.eval())";
   top.lazyTranslation = 

--- a/grammars/silver/compiler/translation/java/core/GlobalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/GlobalDcl.sv
@@ -4,5 +4,5 @@ aspect production globalValueDclConcrete
 top::AGDcl ::= 'global' id::Name '::' t::TypeExpr '=' e::Expr ';'
 {
   top.initValues :=
-    s"\tpublic static final common.Thunk<${t.typerep.transType}> ${id.name} = ${wrapThunkText(e.translation, t.typerep.transType)};\n";
+    s"\tpublic static final common.Thunk<${t.typerep.transType}> global_${id.name} = ${wrapThunkText(e.translation, t.typerep.transType)};\n";
 }


### PR DESCRIPTION
Resolves #316 
As suggested in the issue, I fixed this just by prepending "global_" to the name of any global when we emit it or use it, which should avoid the names conflicting with Java keywords.