### PR TITLE
Add runtime check for base definition of production collection attribute

### DIFF
--- a/grammars/silver/compiler/modification/collection/java/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/java/Collection.sv
@@ -103,12 +103,17 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr 'with
   top.setupInh <-
         "\t\t" ++ top.frame.className ++ ".localAttributes[" ++ ugh_dcl_hack.attrOccursIndex ++ "] = new common.CollectionAttribute(){\n" ++ 
         "\t\t\tpublic Object eval(common.DecoratedNode context) {\n" ++ 
-        "\t\t\t\t common.OriginContext originCtx = context.originCtx;\n" ++
-        "\t\t\t\t" ++ te.typerep.transType ++ " result = (" ++ te.typerep.transType ++ ")this.getBase().eval(context);\n" ++ 
-        "\t\t\t\tfor(int i = 0; i < this.getPieces().size(); i++){\n" ++ 
-        "\t\t\t\t\tresult = " ++ o.translation ++ ";\n" ++ 
-        "\t\t\t\t}\n" ++ 
-        "\t\t\t\treturn result;\n" ++ 
+        "\t\t\t\tcommon.OriginContext originCtx = context.originCtx;\n" ++
+        "\t\t\t\tcommon.Lazy base = this.getBase();\n" ++
+        "\t\t\t\tif(base != null){\n" ++
+        "\t\t\t\t\t" ++ te.typerep.transType ++ " result = (" ++ te.typerep.transType ++ ")this.getBase().eval(context);\n" ++ 
+        "\t\t\t\t\tfor(int i = 0; i < this.getPieces().size(); i++){\n" ++ 
+        "\t\t\t\t\t\tresult = " ++ o.translation ++ ";\n" ++ 
+        "\t\t\t\t\t}\n" ++ 
+        "\t\t\t\t\treturn result;\n" ++ 
+        "\t\t\t\t} else {\n" ++
+        "\t\t\t\t\tthrow new common.exceptions.MissingDefinitionException(\"Production attribute '" ++ a.name ++ "' in '" ++ top.frame.fullName ++ "' has no base definition\"); \n" ++
+        "\t\t\t\t}\n" ++
         "\t\t\t}\n" ++ 
         "\t\t};\n";
 }

--- a/grammars/silver/compiler/modification/collection/java/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/java/Collection.sv
@@ -100,22 +100,23 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr 'with
   o.leftOpTranslation = "result";
   o.rightOpTranslation = s"(${te.typerep.transType})this.getPieces().get(i).eval(context)";
 
-  top.setupInh <-
-        "\t\t" ++ top.frame.className ++ ".localAttributes[" ++ ugh_dcl_hack.attrOccursIndex ++ "] = new common.CollectionAttribute(){\n" ++ 
-        "\t\t\tpublic Object eval(common.DecoratedNode context) {\n" ++ 
-        "\t\t\t\tcommon.OriginContext originCtx = context.originCtx;\n" ++
-        "\t\t\t\tcommon.Lazy base = this.getBase();\n" ++
-        "\t\t\t\tif(base != null){\n" ++
-        "\t\t\t\t\t" ++ te.typerep.transType ++ " result = (" ++ te.typerep.transType ++ ")this.getBase().eval(context);\n" ++ 
-        "\t\t\t\t\tfor(int i = 0; i < this.getPieces().size(); i++){\n" ++ 
-        "\t\t\t\t\t\tresult = " ++ o.translation ++ ";\n" ++ 
-        "\t\t\t\t\t}\n" ++ 
-        "\t\t\t\t\treturn result;\n" ++ 
-        "\t\t\t\t} else {\n" ++
-        "\t\t\t\t\tthrow new common.exceptions.MissingDefinitionException(\"Production attribute '" ++ a.name ++ "' in '" ++ top.frame.fullName ++ "' has no base definition\"); \n" ++
-        "\t\t\t\t}\n" ++
-        "\t\t\t}\n" ++ 
-        "\t\t};\n";
+  top.setupInh <- s"""
+    ${top.frame.className}.localAttributes[${ugh_dcl_hack.attrOccursIndex}] = new common.CollectionAttribute() {
+      public Object eval(common.DecoratedNode context) {
+        common.OriginContext originCtx = context.originCtx;
+        common.Lazy base = this.getBase();
+        if (base != null) {
+          ${te.typerep.transType} result = (${te.typerep.transType})base.eval(context);
+          for (int i = 0; i < this.getPieces().size(); i++) {
+            result = ${o.translation};
+          }
+          return result;
+        } else {
+          throw new common.exceptions.MissingDefinitionException("Production attribute '${a.name}' in '${top.frame.fullName}' has no base definition");
+        }
+      }
+    };
+""";
 }
 
 aspect production collectionAttributeDclSyn
@@ -129,25 +130,26 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
   o.rightOpTranslation = s"(${te.typerep.transType})this.getPieces().get(i).eval(context)";
 
   top.genFiles := [pair(className ++ ".java",
-                
-"package " ++ makeName(top.grammarName) ++ ";\n\n" ++
+s"""
+package ${makeName(top.grammarName)};
 
-"public class " ++ className ++ " extends common.CollectionAttribute {\n\n" ++
+public class ${className} extends common.CollectionAttribute {
 
-"\tpublic " ++ className ++ "(final int index) {\n" ++
-"\t\tsuper(index);\n" ++
-"\t}\n\n" ++
+  public ${className}(final int index) {
+    super(index);
+  }
 
-"\tpublic Object eval(common.DecoratedNode context) {\n" ++ 
-"\t\t common.OriginContext originCtx = context.originCtx;\n" ++
-"\t\t" ++ te.typerep.transType ++ " result = (" ++ te.typerep.transType ++ ")this.getBase().eval(context);\n" ++ 
-"\t\tfor(int i = 0; i < this.getPieces().size(); i++){\n" ++ 
-"\t\t\tresult = " ++ o.translation ++ ";\n" ++ 
-"\t\t}\n" ++ 
-"\t\treturn result;\n" ++ 
-"\t}\n\n" ++ 
+  public Object eval(common.DecoratedNode context) {
+    common.OriginContext originCtx = context.originCtx;
+    ${te.typerep.transType} result = (${te.typerep.transType})this.getBase().eval(context);
+    for (int i = 0; i < this.getPieces().size(); i++) {
+      result = ${o.translation};
+    }
+    return result;
+  }
 
-"}\n")];
+}
+""")];
 }
 
 aspect production collectionAttributeDclInh
@@ -161,25 +163,26 @@ top::AGDcl ::= 'inherited' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te
   o.rightOpTranslation = s"(${te.typerep.transType})this.getPieces().get(i).eval(context)";
 
   top.genFiles := [pair(className ++ ".java",
-                
-"package " ++ makeName(top.grammarName) ++ ";\n\n" ++
+s"""
+package ${makeName(top.grammarName)};
 
-"public class " ++ className ++ " extends common.CollectionAttribute {\n\n" ++
+public class ${className} extends common.CollectionAttribute {
 
-"\tpublic " ++ className ++ "() {\n" ++
-"\t\tsuper();\n" ++
-"\t}\n\n" ++
+  public ${className}() {
+    super();
+  }
 
-"\tpublic Object eval(common.DecoratedNode context) {\n" ++ 
-"\t\t common.OriginContext originCtx = context.originCtx;\n" ++
-"\t\t" ++ te.typerep.transType ++ " result = (" ++ te.typerep.transType ++ ")this.getBase().eval(context);\n" ++ 
-"\t\tfor(int i = 0; i < this.getPieces().size(); i++){\n" ++ 
-"\t\t\tresult = " ++ o.translation ++ ";\n" ++ 
-"\t\t}\n" ++ 
-"\t\treturn result;\n" ++ 
-"\t}\n\n" ++ 
+  public Object eval(common.DecoratedNode context) {
+    common.OriginContext originCtx = context.originCtx;
+    ${te.typerep.transType} result = (${te.typerep.transType})this.getBase().eval(context);
+    for (int i = 0; i < this.getPieces().size(); i++) {
+      result = ${o.translation};
+    }
+    return result;
+  }
 
-"}\n")];
+}
+""")];
 }
 
 --- Use semantics translation --------------------------------------------------
@@ -189,57 +192,63 @@ aspect production baseCollectionValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
   -- for locals, the CA object was created already
-  top.translation =
-        "\t\t// " ++ val.unparse ++ " := " ++ e.unparse ++ "\n" ++
-        "\t\t((common.CollectionAttribute)" ++ top.frame.className ++ ".localAttributes[" ++ val.lookupValue.dcl.attrOccursIndex ++ "]).setBase(" ++ wrapLazy(e) ++ ");\n";
+  top.translation = s"""
+    // ${val.unparse} := ${e.unparse}
+    ((common.CollectionAttribute)${top.frame.className}.localAttributes[${val.lookupValue.dcl.attrOccursIndex}]).setBase(${wrapLazy(e)});
+""";
 }
 aspect production appendCollectionValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {
   -- for locals, the CA object was created already
-  top.translation = 
-        "\t\t// " ++ val.unparse ++ " <- " ++ e.unparse ++ "\n" ++
-        "\t\t((common.CollectionAttribute)" ++ top.frame.className ++ ".localAttributes[" ++ val.lookupValue.dcl.attrOccursIndex ++ "]).addPiece(" ++ wrapLazy(e) ++ ");\n";
+  top.translation = s"""
+    // ${val.unparse} <- ${e.unparse}
+    ((common.CollectionAttribute)${top.frame.className}.localAttributes[${val.lookupValue.dcl.attrOccursIndex}]).addPiece(${wrapLazy(e)});
+""";
 }
 
 ---------- SYNTHESIZED ----
 aspect production synBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- := -} e::Expr
 {
-  top.translation =
-        "\t\t// " ++ dl.unparse ++ "." ++ attr.unparse ++ " := " ++ e.unparse ++ "\n" ++
-        "\t\tif(" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "] == null)\n" ++
-        "\t\t\t" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "] = new " ++ makeCAClassName(attr.attrDcl.fullName) ++"(" ++ attr.dcl.attrOccursIndex ++ ");\n" ++
-        "\t\t((common.CollectionAttribute)" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "]).setBase(" ++ wrapLazy(e) ++ ");\n";
+  top.translation = s"""
+    // ${dl.unparse}.${attr.unparse} := ${e.unparse}
+    if (${dl.translation}[${attr.dcl.attrOccursIndex}] == null)
+      ${dl.translation}[${attr.dcl.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}(${attr.dcl.attrOccursIndex});
+    ((common.CollectionAttribute)${dl.translation}[${attr.dcl.attrOccursIndex}]).setBase(${wrapLazy(e)});
+""";
 }
 aspect production synAppendColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- <- -} e::Expr
 {
-  top.translation = 
-	"\t\t// " ++ dl.unparse ++ "." ++ attr.unparse ++ " <- " ++ e.unparse ++ "\n" ++
-        "\t\tif(" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "] == null)\n" ++
-        "\t\t\t" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "] = new " ++ makeCAClassName(attr.attrDcl.fullName) ++"(" ++ attr.dcl.attrOccursIndex ++ ");\n" ++
-        "\t\t((common.CollectionAttribute)" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "]).addPiece(" ++ wrapLazy(e) ++ ");\n";
+  top.translation = s"""
+    // ${dl.unparse}.${attr.unparse} <- ${e.unparse}
+    if (${dl.translation}[${attr.dcl.attrOccursIndex}] == null)
+      ${dl.translation}[${attr.dcl.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}(${attr.dcl.attrOccursIndex});
+    ((common.CollectionAttribute)${dl.translation}[${attr.dcl.attrOccursIndex}]).addPiece(${wrapLazy(e)});
+""";
 }
 
 ---------- INHERITED ----
 aspect production inhBaseColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- := -} e::Expr
 {
-  top.translation =
-        "\t\t// " ++ dl.unparse ++ "." ++ attr.unparse ++ " := " ++ e.unparse ++ "\n" ++
-        "\t\tif(" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "] == null)\n" ++
-        "\t\t\t" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "] = new " ++ makeCAClassName(attr.attrDcl.fullName) ++ "();\n" ++
-        "\t\t((common.CollectionAttribute)" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "]).setBase(" ++ wrapLazy(e) ++ ");\n";
+  top.translation = s"""
+    // ${dl.unparse}.${attr.unparse} := ${e.unparse}
+    if (${dl.translation}[${attr.dcl.attrOccursIndex}] == null)
+      ${dl.translation}[${attr.dcl.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}();
+    ((common.CollectionAttribute)${dl.translation}[${attr.dcl.attrOccursIndex}]).setBase(${wrapLazy(e)});
+""";
 }
 aspect production inhAppendColAttributeDef
 top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- <- -} e::Expr
 {
-  top.translation = 
-	"\t\t// " ++ dl.unparse ++ "." ++ attr.unparse ++ " <- " ++ e.unparse ++ "\n" ++
-        "\t\tif(" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "] == null)\n" ++
-        "\t\t\t" ++ dl.translation ++ "[" ++ attr.dcl.attrOccursIndex ++ "] = new " ++ makeCAClassName(attr.attrDcl.fullName) ++ "();\n" ++
-        "\t\t((common.CollectionAttribute)" ++ dl.translation ++"[" ++ attr.dcl.attrOccursIndex ++ "]).addPiece(" ++ wrapLazy(e) ++ ");\n";
+  top.translation = s"""
+    // ${dl.unparse}.${attr.unparse} <- ${e.unparse}
+    if (${dl.translation}[${attr.dcl.attrOccursIndex}] == null)
+      ${dl.translation}[${attr.dcl.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}();
+    ((common.CollectionAttribute)${dl.translation}[${attr.dcl.attrOccursIndex}]).addPiece(${wrapLazy(e)});
+""";
 }
 
 


### PR DESCRIPTION
Resolves #322 
My solution is to check the result from `getBase()` in the Java translation and if the result is null report out own exception rather than continuing which produces the NPE the issue notes. Open to comments on what exactly the exception and message should be.