### PR TITLE
Build all the tests on Jenkins, fix origins tests broken by #406

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh '''find . -name '*.test' -exec sed -i'' 's/\(run: [^ ]*silver[^ ]*\) /\1 -G ${GEN} /g' {} \;'''
+        sh '''find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;'''
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\\\(run: [^ ]*silver[^ ]*\\\\) /\\\\1 -G ${GEN.replaceAll("/", "\\\\/")} /g\\' {} \\\\;"
+        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\\(run: [^ ]*silver[^ ]*\\\) /\\\\1 -G ${GEN.replaceAll("/", "\\\\/")} /g\\' {} \\\\;"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\(run: [^ ]*silver[^ ]*\\) /\\\\1 -G ${GEN.replaceAll("/", "\\/")} /g\\' {} \\\\;"
+        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\(run: [^ ]*silver[^ ]*\\) /\\\\1 -G ${GEN.replaceAll("/", "\\/")} /g\\' {} \\\;"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ melt.trynode('silver') {
       sh "./fetch-jars --copper"
     }
     // Build
-    //sh "./deep-rebuild"
+    sh "./deep-rebuild"
     // Clean (but leave generated files)
     sh "./deep-clean -delete"
     // Package
@@ -99,7 +99,7 @@ melt.trynode('silver') {
     // Clean
     sh "rm -rf silver-latest"
   }
-/*
+
   stage("Integration") {
     // Projects with 'develop' as main branch, we'll try to build specific branch names if they exist
     def github_projects = ["/melt-umn/ableC", "/melt-umn/Oberon0", "/melt-umn/ableJ14", "/melt-umn/meta-ocaml-lite",
@@ -133,7 +133,7 @@ melt.trynode('silver') {
       sh "cp silver-latest.tar.gz ${melt.ARTIFACTS}/"
       sh "cp jars/*.jar ${melt.ARTIFACTS}/"
     }
-  }*/
+  }
 
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh """find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"""
+        sh '''find . -name '*.test' -exec sed -i'' 's/\(run: [^ ]*silver[^ ]*\) /\1 -G ${GEN} /g' {} \;'''
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "./set-generated-dir ${GEN}"
+        sh "../set-generated-dir ${GEN}"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g\\' {} \\;"
+        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\(run: [^ ]*silver[^ ]*\\) /\\\\1 -G ${GEN.replaceAll("/", "\\/")} /g\\' {} \\;"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\(run: [^ ]*silver[^ ]*\\) /\\\\1 -G ${GEN.replaceAll("/", "\\/")} /g\\' {} \\;"
+        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\(run: [^ ]*silver[^ ]*\\) /\\\\1 -G ${GEN.replaceAll("/", "\\/")} /g\\' {} \\\\;"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ melt.trynode('silver') {
 
     // Build test driver
     withEnv (newenv) {
-      dir ("${WS}/tests") {
+      dir ("${WS}/test") {
         sh "silver silver:testing:bin"
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name \'*.test\' -exec sed -i\'\' \'s/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g\' {} \\;"
+        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g\\' {} \\;"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\\(run: [^ ]*silver[^ ]*\\\) /\\\\1 -G ${GEN.replaceAll("/", "\\\\/")} /g\\' {} \\\\;"
+        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\\\\\\\(run: [^ ]*silver[^ ]*\\\\\\\\) /\\\\1 -G ${GEN.replaceAll("/", "\\\\\\\\/")} /g\\' {} \\\\\\\\;"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh """find . -name '*.test' -exec sed -i'' 's/\(run: [^ ]*silver[^ ]*\) /\1 -G ${GEN} /g' {} \;"""
+        sh """find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"""
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh '''find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;'''
+        sh "find . -name \'*.test\' -exec sed -i\'\' \'s/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g\' {} \\;"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ melt.trynode('silver') {
       sh "./fetch-jars --copper"
     }
     // Build
-    sh "./deep-rebuild"
+    //sh "./deep-rebuild"
     // Clean (but leave generated files)
     sh "./deep-clean -delete"
     // Package
@@ -99,7 +99,7 @@ melt.trynode('silver') {
     // Clean
     sh "rm -rf silver-latest"
   }
-
+/*
   stage("Integration") {
     // Projects with 'develop' as main branch, we'll try to build specific branch names if they exist
     def github_projects = ["/melt-umn/ableC", "/melt-umn/Oberon0", "/melt-umn/ableJ14", "/melt-umn/meta-ocaml-lite",
@@ -133,7 +133,7 @@ melt.trynode('silver') {
       sh "cp silver-latest.tar.gz ${melt.ARTIFACTS}/"
       sh "cp jars/*.jar ${melt.ARTIFACTS}/"
     }
-  }
+  }*/
 
 }
 
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\(run: [^ ]*silver[^ ]*\\) /\\\\1 -G ${GEN.replaceAll("/", "\\/")} /g\\' {} \\\;"
+        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\\\(run: [^ ]*silver[^ ]*\\\\) /\\\\1 -G ${GEN.replaceAll("/", "\\\\/")} /g\\' {} \\\\;"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name \\'*.test\\' -exec sed -i\\'\\' \\'s/\\\\\\\\(run: [^ ]*silver[^ ]*\\\\\\\\) /\\\\1 -G ${GEN.replaceAll("/", "\\\\\\\\/")} /g\\' {} \\\\\\\\;"
+        sh "./set-generated-dir ${GEN}"
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ melt.trynode('silver') {
     tasks << tuts.collectEntries { t -> [(t): task_tutorial(t, WS)] }
 
     // Build test driver
-    env (newenv) {
+    withEnv (newenv) {
       dir ("${WS}/tests") {
         sh "silver silver:testing:bin"
       }
@@ -160,7 +160,7 @@ def task_test(String testname, String WS) {
         // HACK: edit the test specs to specify the generated directory
         sh "find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"
         // Run the tests
-        env (newenv) {
+        withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,8 +85,7 @@ melt.trynode('silver') {
     tasks << tuts.collectEntries { t -> [(t): task_tutorial(t, WS)] }
 
     // Build test driver
-    def newenv = getSilverEnv(WS)
-    env (newenv) {
+    env (silver.getSilverEnv(WS)) {
       dir ("${WS}/tests") {
         sh "silver silver:testing:bin"
       }
@@ -158,9 +157,9 @@ def task_test(String testname, String WS) {
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
         sh "find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"
+
         // Run the tests
-        def newenv = getSilverEnv(WS)
-        env (newenv) {
+        env (silver.getSilverEnv(WS)) {
           sh "java -jar ../silver.testing.bin.jar"
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"
+        sh """find . -name '*.test' -exec sed -i'' 's/\(run: [^ ]*silver[^ ]*\) /\1 -G ${GEN} /g' {} \;"""
         // Run the tests
         withEnv (newenv) {
           sh "java -jar ../silver.testing.bin.jar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,8 @@ melt.trynode('silver') {
     tasks << tuts.collectEntries { t -> [(t): task_tutorial(t, WS)] }
 
     // Build test driver
-    env (getSilverEnv(WS)) {
+    def newenv = getSilverEnv(WS)
+    env (newenv) {
       dir ("${WS}/tests") {
         sh "silver silver:testing:bin"
       }
@@ -158,7 +159,8 @@ def task_test(String testname, String WS) {
         // HACK: edit the test specs to specify the generated directory
         sh "find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"
         // Run the tests
-        env (getSilverEnv(WS)) {
+        def newenv = getSilverEnv(WS)
+        env (newenv) {
           sh "java -jar ../silver.testing.bin.jar"
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,8 @@ melt.trynode('silver') {
     tasks << tuts.collectEntries { t -> [(t): task_tutorial(t, WS)] }
 
     // Build test driver
-    env (silver.getSilverEnv(WS)) {
+    def newenv = silver.getSilverEnv(WS)
+    env (newenv) {
       dir ("${WS}/tests") {
         sh "silver silver:testing:bin"
       }
@@ -157,9 +158,9 @@ def task_test(String testname, String WS) {
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
         sh "find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"
-
         // Run the tests
-        env (silver.getSilverEnv(WS)) {
+        def newenv = silver.getSilverEnv(WS)
+        env (newenv) {
           sh "java -jar ../silver.testing.bin.jar"
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ melt.setProperties(overrideJars: true)
 melt.trynode('silver') {
   def WS = pwd()
   def SILVER_GEN = "${WS}/generated"
+  def newenv = silver.getSilverEnv(WS)
 
   stage("Build") {
 
@@ -85,7 +86,6 @@ melt.trynode('silver') {
     tasks << tuts.collectEntries { t -> [(t): task_tutorial(t, WS)] }
 
     // Build test driver
-    def newenv = silver.getSilverEnv(WS)
     env (newenv) {
       dir ("${WS}/tests") {
         sh "silver silver:testing:bin"
@@ -150,6 +150,7 @@ def getMergedBranch() {
 
 // Test in local workspace
 def task_test(String testname, String WS) {
+  def newenv = silver.getSilverEnv(WS)
   return {
     node {
       sh "touch ensure_workspace" // convince jenkins to create our workspace
@@ -159,7 +160,6 @@ def task_test(String testname, String WS) {
         // HACK: edit the test specs to specify the generated directory
         sh "find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"
         // Run the tests
-        def newenv = silver.getSilverEnv(WS)
         env (newenv) {
           sh "java -jar ../silver.testing.bin.jar"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,8 +85,10 @@ melt.trynode('silver') {
     tasks << tuts.collectEntries { t -> [(t): task_tutorial(t, WS)] }
 
     // Build test driver
-    dir ("${WS}/tests") {
-      sh "silver silver:testing:bin"
+    env (getSilverEnv(WS)) {
+      dir ("${WS}/tests") {
+        sh "silver silver:testing:bin"
+      }
     }
 
     // Unpack tarball (into ./silver-latest/) (for tutorial testing)
@@ -156,7 +158,9 @@ def task_test(String testname, String WS) {
         // HACK: edit the test specs to specify the generated directory
         sh "find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"
         // Run the tests
-        sh "java -jar ../silver.testing.bin.jar"
+        env (getSilverEnv(WS)) {
+          sh "java -jar ../silver.testing.bin.jar"
+        }
       }
       // Blow away these generated files in our private workspace
       deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,7 +154,7 @@ def task_test(String testname, String WS) {
       // Go back to our "parent" workspace, into the test
       dir(WS + '/test/' + testname) {
         // HACK: edit the test specs to specify the generated directory
-        sh "find . -name '*.test' -exec sed -i'' 's/\(run: [^ ]*silver[^ ]*\) /\1 -G ${GEN} /g' {} \;"
+        sh "find . -name '*.test' -exec sed -i'' 's/\\(run: [^ ]*silver[^ ]*\\) /\\1 -G ${GEN} /g' {} \\;"
         // Run the tests
         sh "java -jar ../silver.testing.bin.jar"
       }

--- a/test/origintracking/common/common.sv
+++ b/test/origintracking/common/common.sv
@@ -1,10 +1,8 @@
-imports core;
 imports silver:testing;
 imports silver:reflect;
 imports silver:langutil;
 
 exports silver:testing;
-exports lib:extcore;
 exports silver:reflect;
 exports silver:langutil;
 

--- a/test/origintracking/force_origins/defns.sv
+++ b/test/origintracking/force_origins/defns.sv
@@ -1,4 +1,3 @@
-imports core;
 imports silver:testing;
 imports silver:reflect;
 imports silver:langutil;

--- a/test/set-generated-dir
+++ b/test/set-generated-dir
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+escaped=${1//\//\\\/}
+
+echo $escaped
+
+find . -name '*.test' -exec sed -i'' "s/\(run: [^ ]*silver[^ ]*\) /\1 -G $escaped /g" {} \;

--- a/test/set-generated-dir
+++ b/test/set-generated-dir
@@ -2,6 +2,4 @@
 
 escaped=${1//\//\\\/}
 
-echo $escaped
-
 find . -name '*.test' -exec sed -i'' "s/\(run: [^ ]*silver[^ ]*\) /\1 -G $escaped /g" {} \;


### PR DESCRIPTION
This uses the silver test driver to build all of the silver tests, not just the ones under the top-level `test/` directory.  Also fixes failing origins test cases broken by #406 that were missed due to not being built on Jenkins.  