### PR TITLE
Replaces CopperRuntime.jar with CopperCompiler.jar.

### DIFF
--- a/fetch-jars
+++ b/fetch-jars
@@ -7,9 +7,9 @@ REMOTE_STORE="http://melt.cs.umn.edu/downloads/silver-dev/jars"
 
 if [[ $* == *--copper* ]]; then
     # Only fetch the Copper jars, if requested
-    FILES="CopperCompiler.jar CopperRuntime.jar"
+    FILES="CopperCompiler.jar"
 else
-    FILES="CopperCompiler.jar CopperRuntime.jar silver.compiler.composed.Default.jar SilverRuntime.jar IDEPluginRuntime.jar"
+    FILES="CopperCompiler.jar silver.compiler.composed.Default.jar SilverRuntime.jar IDEPluginRuntime.jar"
 fi
 
 mkdir -p jars

--- a/grammars/silver/compiler/modification/copper/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper/BuildProcess.sv
@@ -28,7 +28,7 @@ aspect production compilation
 top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
 {
   classpathCompiler <- ["${sh}/jars/CopperCompiler.jar"];
-  classpathRuntime <- ["${sh}/jars/CopperRuntime.jar"];
+  classpathRuntime <- ["${sh}/jars/CopperCompiler.jar"];
 
   -- Get the parsers
   production allParsers :: [ParserSpec] =

--- a/grammars/silver/compiler/modification/copper/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper/BuildProcess.sv
@@ -27,7 +27,6 @@ Either<String  Decorated CmdArgs> ::= args::[String]
 aspect production compilation
 top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
 {
-  classpathCompiler <- ["${sh}/jars/CopperCompiler.jar"];
   classpathRuntime <- ["${sh}/jars/CopperCompiler.jar"];
 
   -- Get the parsers

--- a/grammars/silver/compiler/modification/impide/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/impide/BuildProcess.sv
@@ -69,7 +69,7 @@ top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
 
     <!-- 5. plugin dependencies -->
       <copy file="$${lang.composed}.jar" tofile="$${ide.proj.plugin.path}/$${lang.composed}.jar"/>
-      <copy file="$${sh}/jars/CopperRuntime.jar" tofile="$${ide.proj.plugin.path}/CopperRuntime.jar"/>
+      <copy file="$${sh}/jars/CopperCompiler.jar" tofile="$${ide.proj.plugin.path}/CopperCompiler.jar"/>
       <copy file="$${sh}/jars/SilverRuntime.jar" tofile="$${ide.proj.plugin.path}/SilverRuntime.jar"/>
       <copy file="$${sh}/jars/IDEPluginRuntime.jar" tofile="$${ide.proj.plugin.path}/IDEPluginRuntime.jar"/>
     <!-- 10. Ide resources -->

--- a/resources/ide_skeleton/plugin/META-INF/MANIFEST.MF
+++ b/resources/ide_skeleton/plugin/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: @IDE_VERSION@.@IDE_BUILD_TIMESTAMP@
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .,
  @LANG_COMPOSED@.jar,
- CopperRuntime.jar,
+ CopperCompiler.jar,
  SilverRuntime.jar,
  IDEPluginRuntime.jar
 Require-Bundle: org.eclipse.core.runtime,

--- a/resources/ide_skeleton/plugin/build.properties
+++ b/resources/ide_skeleton/plugin/build.properties
@@ -5,7 +5,7 @@ bin.includes = META-INF/,\
                resource/,\
                .,\
                @LANG_COMPOSED@.jar,\
-               CopperRuntime.jar,\
+               CopperCompiler.jar,\
                SilverRuntime.jar,\
                IDEPluginRuntime.jar,\
                plugin.xml

--- a/runtime/imp/main/pom.xml
+++ b/runtime/imp/main/pom.xml
@@ -73,7 +73,7 @@
               <artifactId>copper</artifactId>
               <version>1.0.0</version>
               <scope>system</scope>
-              <systemPath>${basedir}/../../../jars/CopperRuntime.jar</systemPath>
+              <systemPath>${basedir}/../../../jars/CopperCompiler.jar</systemPath>
             </extraClasspathElement>
           </extraClasspathElements>
         </configuration>
@@ -104,7 +104,7 @@
     
     So, we use Tycho because we need to depend on OSGi packages for eclipse.
     But we directly inject custom classpath entires for SilverRuntime,
-    CopperRuntime, and as a hack just use the silver compiler to see core
+    CopperCompiler, and as a hack just use the silver compiler to see core
     in the classpath at compile time.
     
     We won't be using this package as an OSGI bundle anyway. Instead,

--- a/runtime/java/build.xml
+++ b/runtime/java/build.xml
@@ -9,7 +9,7 @@
   <property name='version' value='0.0.1'/><!--dummy value for OSGi-->
 
   <path id='compile.classpath'>
-    <fileset dir='../../jars' includes='CopperRuntime.jar CopperCompiler.jar' />
+    <fileset dir='../../jars' includes='CopperCompiler.jar' />
   </path>
 
   <target name='init'>

--- a/self-compile
+++ b/self-compile
@@ -12,6 +12,6 @@ SV_BUILD_TARGET=${SV_BUILD_TARGET:-"silver:compiler:composed:Default"}
 mkdir -p build
 cd build
 
-time java ${SVJVM_FLAGS} -jar ../jars/silver.compiler.composed.Default.jar $@ ${SV_BUILD_TARGET}
+time java ${SVJVM_FLAGS} -cp ../jars/CopperCompiler.jar -jar ../jars/silver.compiler.composed.Default.jar $@ ${SV_BUILD_TARGET}
 ant
 

--- a/support/jenkins/cron-job-publish-jars-from-foundry.py
+++ b/support/jenkins/cron-job-publish-jars-from-foundry.py
@@ -12,12 +12,12 @@ import sys
 from tempfile import TemporaryFile
 from urllib.request import Request, urlopen
 
-WEB_STORE = environ.get("WEB_STORE", "/web/research/melt.cs.umn.edu/downloads/silver-dev/jars")
+WEB_STORE = environ.get(
+    "WEB_STORE", "/web/research/melt.cs.umn.edu/downloads/silver-dev/jars")
 SLACK_WEBHOOK_URL = environ.get("SLACK_WEBHOOK_URL", None)
 
 files = [
     "CopperCompiler.jar",
-    "CopperRuntime.jar",
     "IDEPluginRuntime.jar",
     "SilverRuntime.jar",
     "edu.umn.cs.melt.exts.silver.ableC.composed.with_ableC.jar",
@@ -43,13 +43,16 @@ if SLACK_WEBHOOK_URL is None:
     except:
         pass
 
+
 def send_to_slack(fmt, *args):
     if SLACK_WEBHOOK_URL is None:
         print(fmt.format(*args), file=sys.stderr)
     else:
         urlopen(Request(SLACK_WEBHOOK_URL,
-            data=json.dumps({"text": fmt.format(*args)}).encode("utf-8"),
-            headers={"Content-type": "application/json"}))
+                        data=json.dumps(
+                            {"text": fmt.format(*args)}).encode("utf-8"),
+                        headers={"Content-type": "application/json"}))
+
 
 try:
     old_hashes = None
@@ -60,7 +63,8 @@ try:
         pass
     for name in files:
         with open(join(WEB_STORE, name), "wb") as f:
-            resp = urlopen("https://foundry.remexre.xyz/custom-stable-dump/" + name)
+            resp = urlopen(
+                "https://foundry.remexre.xyz/custom-stable-dump/" + name)
             f.write(resp.read())
     hashes = check_output(["sha256sum"] + files, cwd=WEB_STORE)
     updated = False


### PR DESCRIPTION
Currently I can't build the IDE tooling (even on `develop`) to check if this broke it, so that's maybe an area of concern.

Otherwise, this'll make it less annoying to finish `feature/copper-api`, and would be part of it anyway.