### PR TITLE
Refactor functionType to allow partially-applied function types

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/BuiltInFunctions.sv
@@ -50,7 +50,6 @@ Boolean ::= ty::Type
          | skolemType(_) -> true
          | appType(c, a) -> containsSkolem(c) || containsSkolem(a)
          | decoratedType(ty) -> containsSkolem(ty)
-         | functionType(out, params, namedParams) -> containsSkolem(out) || any(map(containsSkolem, params)) || any(map((\x::NamedArgType -> containsSkolem(x.argType)), namedParams))
          | _ -> false
          end;
 }
@@ -60,7 +59,7 @@ top::Expr ::= 'reify'
 {
   top.errors <-
     case performSubstitution(top.typerep, top.finalSubst) of
-    | functionType(appType(appType(nonterminalType("silver:core:Either", 2, _), stringType()), resultType), [nonterminalType("silver:core:AST", 0, _)], []) ->
+    | appType(appType(functionType(1, []), nonterminalType("silver:core:AST", 0, _)), appType(appType(nonterminalType("silver:core:Either", 2, _), stringType()), resultType)) ->
        case resultType of
        | skolemType(_) -> [err(top.location, "reify invocation attempts to reify to a skolem type - this will never succeed, see https://github.com/melt-umn/silver/issues/368")]
        | ty when containsSkolem(ty) -> [wrn(top.location, "reify invocation attempts to reify to a type containing a skolem - this will only succeed in the case that the value does not actually contain an instance of the skolem type, see https://github.com/melt-umn/silver/issues/368")]

--- a/grammars/silver/compiler/definition/core/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/definition/core/BuiltInFunctions.sv
@@ -84,7 +84,10 @@ top::Expr ::= 'reify'
   top.unparse = "reify";
 
   top.typerep =
-    functionType(appTypes(nonterminalType("silver:core:Either", 2, false), [stringType(), freshType()]), [nonterminalType("silver:core:AST", 0, true)], []);
+    appTypes(
+      functionType(1, []),
+      [nonterminalType("silver:core:AST", 0, true),
+       appTypes(nonterminalType("silver:core:Either", 2, false), [stringType(), freshType()])]);
 }
 
 concrete production newFunction

--- a/grammars/silver/compiler/definition/core/Type.sv
+++ b/grammars/silver/compiler/definition/core/Type.sv
@@ -94,7 +94,7 @@ top::Type ::= te::Type
 }
 
 aspect production functionType
-top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
+top::Type ::= _ _
 {
   top.applicationDispatcher = functionApplication(_, _, _, location=_);
 }

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -71,8 +71,6 @@ Boolean ::= a::Type b::Type
     | appType(c1, a1), appType(c2, a2) ->
       (isMoreSpecific(c1, c2) || isMoreSpecific(a1, a2)) && !(isMoreSpecific(c2, c1) || isMoreSpecific(a2, a1))
     | decoratedType(t1), decoratedType(t2) -> isMoreSpecific(t1, t2)
-    | functionType(out1, params1, _), functionType(out2, params2, _) -> -- TODO: Ignoring named args for now
-      any(zipWith(isMoreSpecific, out1 :: params1, out2 :: params2)) && !any(zipWith(isMoreSpecific, out2 :: params2, out1 :: params1))
     | _, _ -> false
     end;
 }

--- a/grammars/silver/compiler/definition/env/NamedSignature.sv
+++ b/grammars/silver/compiler/definition/env/NamedSignature.sv
@@ -32,7 +32,7 @@ top::NamedSignature ::= fn::String ctxs::[Context] ie::[NamedSignatureElement] o
   top.namedInputElements = np;
   top.inputNames = map((.elementName), ie);
   top.inputTypes = map((.typerep), ie); -- Does anything actually use this? TODO: eliminate?
-  local typerep::Type = functionType(oe.typerep, top.inputTypes, map((.toNamedArgType), np));
+  local typerep::Type = appTypes(functionType(length(ie), map((.elementShortName), np)), top.inputTypes ++ map((.typerep), np) ++ [oe.typerep]);
   top.typeScheme = (if null(ctxs) then polyType else constraintType(_, ctxs, _))(typerep.freeVariables, typerep);
   top.freeVariables = typerep.freeVariables;
   top.typerep = typerep; -- TODO: Only used by unifyNamedSignature.  Would be nice to eliminate, somehow.
@@ -51,10 +51,10 @@ top::NamedSignature ::=
 {--
  - Represents an elements of a signature, whether input, output, or annotation.
  -}
-nonterminal NamedSignatureElement with elementName, typerep, toNamedArgType;
+nonterminal NamedSignatureElement with elementName, typerep, elementShortName;
 
 synthesized attribute elementName :: String;
-synthesized attribute toNamedArgType :: NamedArgType;
+synthesized attribute elementShortName :: String;
 
 {--
  - Represents an element of the function/production signature.
@@ -65,11 +65,9 @@ top::NamedSignatureElement ::= n::String ty::Type
   top.elementName = n;
   top.typerep = ty;
 
-  -- When we convert from a SignatureElement to a NamedArg, we cut down to the short name only:
-  local annoShortName :: String =
+  -- When we convert from a SignatureElement to a functionType, we cut down to the short name only:
+  top.elementShortName = 
     substring(lastIndexOf(":", n) + 1, length(n), n);
-  
-  top.toNamedArgType = namedArgType(annoShortName, ty);
 }
 
 {--

--- a/grammars/silver/compiler/definition/type/Substitutions.sv
+++ b/grammars/silver/compiler/definition/type/Substitutions.sv
@@ -86,7 +86,7 @@ functor attribute substituted occurs on Context, Type;
 functor attribute flatRenamed occurs on Context, Type;
 
 propagate substituted, flatRenamed on Context, Type
-  excluding varType, skolemType, ntOrDecType, functionType;
+  excluding varType, skolemType, ntOrDecType;
 
 aspect production varType
 top::Type ::= tv::TyVar
@@ -160,21 +160,6 @@ top::Type ::= nt::Type  hidden::Type
   top.flatRenamed = ntOrDecType(nt.flatRenamed, hidden.flatRenamed);
 }
 
-aspect production functionType
-top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
-{
-  top.substituted = 
-    functionType(
-      out.substituted,
-      mapSubst(params, top.substitution),
-      mapNamedSubst(namedParams, top.substitution));
-  top.flatRenamed = 
-    functionType(
-      out.flatRenamed,
-      mapRenameSubst(params, top.substitution),
-      mapNamedRenameSubst(namedParams, top.substitution));
-}
-
 --------------------------------------------------------------------------------
 
 function performContextSubstitution
@@ -197,12 +182,6 @@ function mapSubst
   return map(performSubstitution(_, s), tes);
 }
 
-function mapNamedSubst
-[NamedArgType] ::= np::[NamedArgType] s::Substitution
-{
-  return map(mapNamedArgType(performSubstitution(_, s), _), np);
-}
-
 ----
 
 function performContextRenaming
@@ -223,22 +202,6 @@ function mapRenameSubst
 [Type] ::= tes::[Type] s::Substitution
 {
   return map(performRenaming(_, s), tes);
-}
-
-function mapNamedRenameSubst
-[NamedArgType] ::= np::[NamedArgType] s::Substitution
-{
-  return map(mapNamedArgType(performRenaming(_, s), _), np);
-}
-
-----
-
-function mapNamedArgType
-NamedArgType ::= f::(Type ::= Type) nat::NamedArgType
-{
-  return case nat of
-  | namedArgType(n, t) -> namedArgType(n, f(t))
-  end;
 }
 
 --------------------------------------------------------------------------------

--- a/grammars/silver/compiler/definition/type/Type.sv
+++ b/grammars/silver/compiler/definition/type/Type.sv
@@ -187,7 +187,7 @@ top::Type ::= fn::String
 
 {--
  - A *decorated* nonterminal type.
- - @param te  MUST be a 'nonterminalType' (TODO: should probably just put that here)
+ - @param te  MUST be a 'nonterminalType' or 'varType'/'skolemType'
  -}
 abstract production decoratedType
 top::Type ::= te::Type
@@ -222,57 +222,15 @@ top::Type ::= nt::Type  hidden::Type
 
 {--
  - Function type. (Whether production or function.)
- - @param out  The result type of the function
- - @param params  The (ordered) input types of the function
- - @param namedParams  Named parameters for this nonterminal.
+ - @param params  The number input types of the function
+ - @param namedParams  Named parameters for this function.
  -        NOTE: These must always be *IN SORTED ORDER*
  -}
 abstract production functionType
-top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
+top::Type ::= params::Integer namedParams::[String]
 {
-  top.kindArity = 0;
-  top.freeVariables = setUnionTyVarsAll(map((.freeVariables), 
-    out :: params ++ map((.argType), namedParams)));
-}
-
---------------------------------------------------------------------------------
-
-nonterminal NamedArgType with argName, argType, typepp, boundVariables;
-
-synthesized attribute argName :: String;
-synthesized attribute argType :: Type;
-
-abstract production namedArgType
-top::NamedArgType ::= s::String  ty::Type
-{
-  top.typepp = "; " ++ s ++ "::" ++ ty.typepp;
-  top.argName = s;
-  top.argType = ty;
-}
-
-function namedArgTypeLte
-Boolean ::= a::NamedArgType  b::NamedArgType
-{
-  return a.argName <= b.argName;
-}
-
-function extractNamedArg
-Pair<Maybe<NamedArgType> [NamedArgType]> ::= n::String  l::[NamedArgType]
-{
-  local recurse :: Pair<Maybe<NamedArgType> [NamedArgType]> =
-    extractNamedArg(n, tail(l));
-
-  return if null(l) then pair(nothing(), [])
-  else if head(l).argName == n then pair(just(head(l)), tail(l))
-  else pair(recurse.fst, head(l) :: recurse.snd);
-}
-
-function findNamedArgType
-Integer ::= s::String l::[NamedArgType] z::Integer
-{
-  return if null(l) then -1
-  else if s == head(l).argName then z
-  else findNamedArgType(s, tail(l), z+1);
+  top.kindArity = params + length(namedParams) + 1;
+  top.freeVariables = [];
 }
 
 --------------------------------------------------------------------------------

--- a/grammars/silver/compiler/definition/type/Unification.sv
+++ b/grammars/silver/compiler/definition/type/Unification.sv
@@ -170,12 +170,12 @@ top::Type ::= nt::Type  hidden::Type
 }
 
 aspect production functionType
-top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
+top::Type ::= params::Integer namedParams::[String]
 {
   top.unify = 
     case top.unifyWith of
-    | functionType(oo, op, onp) -> unifyFunctions(out :: params, oo :: op, namedParams, onp)
-    | _ -> errorSubst("Tried to unify function type with " ++ prettyType(top.unifyWith))
+    | functionType(op, onp) when params == op && namedParams == onp -> emptySubst()
+    | _ -> errorSubst("Tried to unify conflicting function types " ++ prettyType(top) ++ " and " ++ prettyType(top.unifyWith))
     end;
 }
 
@@ -245,28 +245,3 @@ Substitution ::= te1::[Type] te2::[Type]
          else composeSubst(first, unifyAllShortCircuit( mapSubst(tail(te1), first),
                                                         mapSubst(tail(te2), first) ));
 }
-
-function unifyAllNamed
-Substitution ::= te1::[NamedArgType]  te2::[NamedArgType]
-{
-  local first :: Substitution = unify(head(te1).argType, head(te2).argType);
-  
-  return if null(te1) && null(te2)
-         then emptySubst()
-         else if null(te1) || null(te2)
-         then errorSubst("Internal error: unifying mismatching numbers")
-         else if head(te1).argName != head(te2).argName -- additionally check names
-         then errorSubst("Mismatching named parameters")
-         else composeSubst(first, unifyAllNamed( mapNamedSubst(tail(te1), first),
-                                                 mapNamedSubst(tail(te2), first) ));  
-}
-
-function unifyFunctions
-Substitution ::= te1::[Type]  te2::[Type]  n1::[NamedArgType]  n2::[NamedArgType]
-{
-  local first :: Substitution = unifyAll(te1, te2);
-  local second :: Substitution = unifyAllNamed(mapNamedSubst(n1, first), mapNamedSubst(n2, first));
-  
-  return composeSubst(first, second);
-}
-

--- a/grammars/silver/compiler/definition/type/Util.sv
+++ b/grammars/silver/compiler/definition/type/Util.sv
@@ -8,7 +8,7 @@ synthesized attribute isApplicable :: Boolean;
 
 synthesized attribute inputTypes :: [Type];
 synthesized attribute outputType :: Type;
-synthesized attribute namedTypes :: [NamedArgType];
+synthesized attribute namedTypes :: [Pair<String Type>];
 synthesized attribute arity :: Integer;
 synthesized attribute baseType :: Type;
 synthesized attribute argTypes :: [Type];
@@ -111,7 +111,20 @@ top::Type ::= c::Type a::Type
   top.argTypes = c.argTypes ++ [a];
   top.isDecorable = c.isDecorable;
   top.unifyInstanceNonterminal = c.unifyInstanceNonterminal;
+  top.arity = c.arity;
   top.isApplicable = c.isApplicable;
+  
+  top.inputTypes = take(top.arity, top.argTypes);
+  top.outputType =
+    case top.baseType of
+    | functionType(_, _) -> last(top.argTypes)
+    | _ -> errorType()
+    end;
+  top.namedTypes =
+    case top.baseType of
+    | functionType(_, nps) -> zipWith(pair, nps, drop(top.arity, top.argTypes))
+    | _ -> []
+    end;
 }
 
 
@@ -172,12 +185,9 @@ top::Type ::= nt::Type  hidden::Type
 }
 
 aspect production functionType
-top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
+top::Type ::= params::Integer namedParams::[String]
 {
-  top.inputTypes = params;
-  top.outputType = out;
-  top.namedTypes = namedParams;
-  top.arity = length(params);
+  top.arity = params;
   top.isApplicable = true;
 }
 

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -5,11 +5,13 @@ imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
 
 nonterminal TypeExpr  with config, location, grammarName, errors, env, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, freeVariables, errorsFullyApplied;
-nonterminal Signature with config, location, grammarName, errors, env, unparse, types,   lexicalTypeVariables, lexicalTyVarKinds;
+nonterminal Signature with config, location, grammarName, errors, env, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds;
+nonterminal SignatureLHS with config, location, grammarName, errors, env, unparse, maybeType, lexicalTypeVariables, lexicalTyVarKinds;
 nonterminal TypeExprs with config, location, grammarName, errors, env, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, freeVariables;
 nonterminal BracketedTypeExprs with config, location, grammarName, errors, env, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, freeVariables, envBindingTyVars, initialEnv;
 nonterminal BracketedOptTypeExprs with config, location, grammarName, errors, env, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, freeVariables, envBindingTyVars, initialEnv;
 
+synthesized attribute maybeType :: Maybe<Type>;
 synthesized attribute types :: [Type];
 synthesized attribute missingCount::Integer;
 
@@ -27,7 +29,7 @@ synthesized attribute envBindingTyVars :: Decorated Env;
 
 synthesized attribute errorsFullyApplied::[Message];
 
-propagate errors, lexicalTypeVariables, lexicalTyVarKinds on TypeExpr, Signature, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
+propagate errors, lexicalTypeVariables, lexicalTyVarKinds on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate errorsTyVars on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 
 -- TODO: This function should go away because it doesn't do location correctly.
@@ -219,29 +221,43 @@ concrete production funTypeExpr
 top::TypeExpr ::= '(' sig::Signature ')'
 {
   top.unparse = "(" ++ sig.unparse ++ ")";
-
-  top.typerep = functionType(head(sig.types), tail(sig.types), []);
+  top.typerep = sig.typerep;
 }
 
 concrete production signatureEmptyRhs
-top::Signature ::= t::TypeExpr '::='
+top::Signature ::= l::SignatureLHS '::='
 {
-  top.unparse = t.unparse ++ " ::=";
-
-  top.types = [t.typerep];
+  top.unparse = l.unparse ++ " ::=";
+  top.typerep = appTypes(functionType(0, []), case l.maybeType of just(t) -> [t] | nothing() -> [] end);
 }
 
 concrete production psignature
-top::Signature ::= t::TypeExpr '::=' list::TypeExprs 
+top::Signature ::= l::SignatureLHS '::=' list::TypeExprs 
 {
-  top.unparse = t.unparse ++ " ::= " ++ list.unparse;
-
-  top.types = [t.typerep] ++ list.types;
-
+  top.unparse = l.unparse ++ " ::= " ++ list.unparse;
+  top.typerep =
+    appTypes(
+      functionType(length(list.types) + list.missingCount, []),
+      list.types ++ case l.maybeType of just(t) -> [t] | nothing() -> [] end);
+  
   top.errors <-
-    if list.missingCount > 0
-    then [err(list.location, "Signature type cannot contain _")]
-    else []; 
+    if l.maybeType.isJust && list.missingCount > 0
+    then [err($1.location, "Return type cannot be present when argument types are missing")]
+    else [];
+}
+
+concrete production presentSignatureLhs
+top::SignatureLHS ::= t::TypeExpr
+{
+  top.unparse = t.unparse;
+  top.maybeType = just(t.typerep);
+}
+
+concrete production missingSignatureLhs
+top::SignatureLHS ::= '_'
+{
+  top.unparse = "_";
+  top.maybeType = nothing();
 }
 
 -- Bracketed Optional Type Lists -----------------------------------------------

--- a/grammars/silver/compiler/extension/auto_ast/AutoAst.sv
+++ b/grammars/silver/compiler/extension/auto_ast/AutoAst.sv
@@ -14,18 +14,19 @@ top::ProductionStmt ::= 'abstract' v::QName ';'
   local vty :: Type = v.lookupValue.typeScheme.typerep;
   
   local hasLoc :: Boolean =
-    !null(vty.namedTypes) && head(vty.namedTypes).argName == "location";
+    !null(vty.namedTypes) && head(vty.namedTypes).fst == "location";
   
   local elems :: [NamedSignatureElement] =
     filter(hasAst(_, top.env), top.frame.signature.inputElements);
     
   local inferredType :: Type =
-    functionType(
-      astType(top.frame.signature.outputElement, top.env),
-      map(astType(_, top.env), elems),
+    appTypes(
+      functionType(length(elems), if hasLoc then ["location"] else []),
+      map(astType(_, top.env), elems) ++
       (if hasLoc
-       then [namedArgType("location", nonterminalType("silver:core:Location", 0, false))]
-       else []));
+       then [ nonterminalType("silver:core:Location", 0, false)]
+       else []) ++
+      [astType(top.frame.signature.outputElement, top.env)]);
   
   top.errors <-
     if hasAst(top.frame.signature.outputElement, top.env) then []

--- a/grammars/silver/compiler/extension/implicit_monads/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/BuiltInFunctions.sv
@@ -174,7 +174,10 @@ top::Expr ::= 'reify'
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
   top.mtyperep =
-    functionType(appTypes(nonterminalType("silver:core:Either", 2, false), [stringType(), freshType()]), [nonterminalType("silver:core:AST", 0, true)], []);
+    appTypes(
+      functionType(1, []),
+      [nonterminalType("silver:core:AST", 0, true),
+       appTypes(nonterminalType("silver:core:Either", 2, false), [stringType(), freshType()])]);
   top.monadicNames = [];
   top.monadRewritten = reifyFunctionLiteral('reify', location=top.location);
 }

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -374,7 +374,7 @@ top::Expr ::= '(' '.' q::QName ')'
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
-  top.mtyperep = functionType(q.lookupAttribute.typeScheme.typerep, [freshType()], []);
+  top.mtyperep = appTypes(functionType(1, []), [freshType(), q.lookupAttribute.typeScheme.typerep]);
   top.monadicNames = [];
   top.monadRewritten = attributeSection('(', '.', q, ')', location=top.location);
 }

--- a/grammars/silver/compiler/extension/implicit_monads/Lambda.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Lambda.sv
@@ -8,7 +8,7 @@ top::Expr ::= params::ProductionRHS e::Expr
 
   e.expectedMonad = top.expectedMonad;
 
-  top.mtyperep = functionType(e.mtyperep, map((.typerep), params.inputElements), []);
+  top.mtyperep = appTypes(functionType(length(params.inputElements), []), map((.typerep), params.inputElements) ++ [e.typerep]);
 
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;

--- a/grammars/silver/compiler/extension/implicit_monads/PatternTypes.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/PatternTypes.sv
@@ -4,19 +4,13 @@ aspect production prodAppPattern
 top::Pattern ::= prod::QName '(' ps::PatternList ')'
 {
   -- TODO: is this right?  Seems like we should unify with ps pattern types?
-  top.patternType = case prod.lookupValue.typeScheme.typerep of
-                    | functionType(out, _, _) -> out
-                    | t -> t
-                    end;
+  top.patternType = prod.lookupValue.typeScheme.typerep.outputType;
 } 
 
 aspect production prodAppPattern_named
 top::Pattern ::= prod::QName '(' ps::PatternList ',' nps::NamedPatternList ')'
 {
-  top.patternType = case prod.lookupValue.typeScheme.typerep of
-                    | functionType(out, _, _) -> out
-                    | t -> t
-                    end;
+  top.patternType = prod.lookupValue.typeScheme.typerep.outputType;
 }
 
 aspect production wildcPattern

--- a/grammars/silver/compiler/extension/rewriting/Pattern.sv
+++ b/grammars/silver/compiler/extension/rewriting/Pattern.sv
@@ -250,8 +250,8 @@ top::Pattern ::= prod::QName '(' ps::PatternList ',' nps::NamedPatternList ')'
       prodType.inputTypes);
   nps.namedTypesHaveUniversalVars =
     map(
-      \ t::NamedArgType ->
-        pair(t.argName, !null(intersect(outputFreeVars, t.argType.freeVariables))),
+      \ t::Pair<String Type> ->
+        pair(t.fst, !null(intersect(outputFreeVars, t.snd.freeVariables))),
       prodType.namedTypes);
 } 
 

--- a/grammars/silver/compiler/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/compiler/extension/rewriting/Rewriting.sv
@@ -92,12 +92,12 @@ top::Expr ::= 'traverse' n::QName '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   top.unparse = s"traverse ${n.name}(${es.unparse}, ${anns.unparse})";
   
   local numChildren::Integer = n.lookupValue.typeScheme.arity;
-  local annotations::[String] = map((.argName), n.lookupValue.typeScheme.typerep.namedTypes);
+  local annotations::[String] = map(fst, n.lookupValue.typeScheme.typerep.namedTypes);
   es.appExprTypereps = repeat(nonterminalType("silver:rewrite:Strategy", 0, false), numChildren);
   es.appExprApplied = n.unparse;
   anns.appExprApplied = n.unparse;
   anns.funcAnnotations =
-    map(namedArgType(_, nonterminalType("silver:rewrite:Strategy", 0, false)), annotations);
+    map(pair(_, nonterminalType("silver:rewrite:Strategy", 0, false)), annotations);
   anns.remainingFuncAnnotations = anns.funcAnnotations;
  
   local localErrors::[Message] =

--- a/grammars/silver/compiler/extension/treegen/Type.sv
+++ b/grammars/silver/compiler/extension/treegen/Type.sv
@@ -78,7 +78,7 @@ top::Type ::= nt::Type  hidden::Type
   top.idNameForGenArb = "WTFnrOrDecTypeExpr";
 }
 aspect production functionType
-top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
+top::Type ::= _ _
 {
   -- err, shouldn't happen?
   top.idNameForGenArb = "FUNCTION";

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -24,7 +24,7 @@ top::NameOrBOperator ::= e::Expr
   top.errors := e.errors;
   
   local checkOperationType :: TypeCheck =
-    check(e.typerep, functionType(top.operatorForType, [top.operatorForType, top.operatorForType], []));
+    check(e.typerep, appTypes(functionType(2, []), [top.operatorForType, top.operatorForType, top.operatorForType]));
   
   e.downSubst = emptySubst();
   checkOperationType.downSubst = e.upSubst;

--- a/grammars/silver/compiler/modification/ffi/Type.sv
+++ b/grammars/silver/compiler/modification/ffi/Type.sv
@@ -7,7 +7,7 @@ top::Type ::= fn::String  transType::String  params::[Type]
   top.freeVariables = setUnionTyVarsAll(map((.freeVariables), params));
   top.substituted = foreignType(fn, transType, mapSubst(params, top.substitution));
   top.flatRenamed = foreignType(fn, transType, mapRenameSubst(params, top.substitution));
-  top.typepp = fn ++ if !null(params) then "<" ++ implode(" ", mapTypePP(params, top.boundVariables)) ++ ">" else "";
+  top.typepp = fn ++ if !null(params) then "<" ++ implode(" ", map(prettyTypeWith(_, top.boundVariables), params)) ++ ">" else "";
   top.kindArity = 0;
 
   -- Unification.sv

--- a/grammars/silver/compiler/modification/impide/IdeDecl.sv
+++ b/grammars/silver/compiler/modification/impide/IdeDecl.sv
@@ -183,7 +183,7 @@ top::IdeStmt ::= 'builder' builderName::QName ';'
   
   -- IOVal<[Message]> ::= IdeProject  [IdeProperty]  IO
   local expectedType :: Type =
-    functionType(t_iomsgs, [t_proj, t_props, t_io], []);
+    appTypes(functionType(3, []), [t_proj, t_props, t_io, t_iomsgs]);
   
   local tc1 :: TypeCheck = check(builderName.lookupValue.typeScheme.typerep, expectedType);
   tc1.downSubst = emptySubst();
@@ -203,7 +203,7 @@ top::IdeStmt ::= 'postbuilder' postbuilderName::QName ';'
   
   -- IOVal<[Message]> ::= IdeProject  [IdeProperty]  IO
   local expectedType :: Type =
-    functionType(t_iomsgs, [t_proj, t_props, t_io], []);
+    appTypes(functionType(3, []), [t_proj, t_props, t_io, t_iomsgs]);
   
   local tc1 :: TypeCheck = check(postbuilderName.lookupValue.typeScheme.typerep, expectedType);
   tc1.downSubst = emptySubst();
@@ -223,7 +223,7 @@ top::IdeStmt ::= 'exporter' exporterName::QName ';'
   
   -- IOVal<[Message]> ::= IdeProject  [IdeProperty]  IO
   local expectedType :: Type =
-    functionType(t_iomsgs, [t_proj, t_props, t_io], []);
+    appTypes(functionType(3, []), [t_proj, t_props, t_io, t_iomsgs]);
   
   local tc1 :: TypeCheck = check(exporterName.lookupValue.typeScheme.typerep, expectedType);
   tc1.downSubst = emptySubst();
@@ -243,7 +243,7 @@ top::IdeStmt ::= 'folder' folderName::QName ';'
   
   -- [Location] ::= <<CST root's type>>
   local expectedType :: Type =
-    functionType(listType(t_loc), [nonterminalType(top.startNTName, 0, false)], []);
+    appTypes(functionType(1, []), [nonterminalType(top.startNTName, 0, false), listType(t_loc)]);
   
   local tc1 :: TypeCheck = check(folderName.lookupValue.typeScheme.typerep, expectedType);
   tc1.downSubst = emptySubst();
@@ -323,10 +323,7 @@ top::StubGenerator ::= 'stub generator' genName::QName ';'
 
   -- String ::= [IdeProperty]
   local stubGenTypeExpected :: Type =
-    functionType(
-      stringType(),  -- return type
-      [listType(nonterminalType("ide:IdeProperty", 0, false))], -- argument type list
-      []);
+    appTypes(functionType(1, []), [listType(nonterminalType("ide:IdeProperty", 0, false)), stringType()]);
   
   local tc1 :: TypeCheck = check(genName.lookupValue.typeScheme.typerep, stubGenTypeExpected);
   tc1.downSubst = emptySubst();

--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -29,7 +29,7 @@ top::Expr ::= params::ProductionRHS e::Expr
   
   propagate errors;
   
-  top.typerep = functionType(e.typerep, map((.typerep), params.inputElements), []);
+  top.typerep = appTypes(functionType(length(params.inputElements), []), map((.typerep), params.inputElements) ++ [e.typerep]);
 
   propagate downSubst, upSubst;
   propagate flowDeps, flowDefs;

--- a/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
@@ -28,7 +28,7 @@ ${params.lambdaTranslation}
 				}
 	
 				@Override
-				public final common.FunctionTypeRep getType() {
+				public final common.TypeRep getType() {
 ${makeTyVarDecls(5, finTy.freeVariables)}
 					return ${finTy.transTypeRep};
 				}

--- a/grammars/silver/compiler/modification/primitivepattern/Types.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/Types.sv
@@ -205,11 +205,11 @@ top::Type ::= te::Type
 }
 
 aspect production functionType
-top::Type ::= out::Type params::[Type] namedParams::[NamedArgType]
+top::Type ::= params::Integer namedParams::[String]
 {
   top.refine = 
     case top.refineWith of
-    | functionType(oo, op, onp) -> refineAll(out :: params ++ map((.argType), namedParams), oo :: op ++ map((.argType), onp))
+    | functionType(op, onp) when params == op && namedParams == onp -> emptySubst()
     | _ -> errorSubst("Tried to refine function type with " ++ prettyType(top.refineWith))
     end;
 }

--- a/grammars/silver/compiler/translation/java/core/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/translation/java/core/BuiltInFunctions.sv
@@ -88,7 +88,7 @@ ${makeTyVarDecls(5, resultType.freeVariables)}
 				}
 				
 				@Override
-				public final common.FunctionTypeRep getType() {
+				public final common.TypeRep getType() {
 ${makeTyVarDecls(5, finalType(top).freeVariables)}
 					return ${finalType(top).transTypeRep};
 				}

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -31,9 +31,11 @@ s"""			final common.DecoratedNode context = new P${id.name}(${argsAccess}).decor
   top.errors <-
     if id.name == "main" &&
        unify(namedSig.typerep,
-         functionType(appType(nonterminalType("silver:core:IOVal", 1, false), intType()), [
-           appType(nonterminalType("silver:core:List", 1, false), stringType()),
-           ioForeignType], [])).failure
+         appTypes(
+           functionType(2, []),
+           [appType(nonterminalType("silver:core:List", 1, false), stringType()),
+            ioForeignType,
+            appType(nonterminalType("silver:core:IOVal", 1, false), intType())])).failure
     then [err(top.location, "main function must have type signature (IOVal<Integer> ::= [String] IO). Instead it has type " ++ prettyType(namedSig.typerep))]
     else [];
 }
@@ -162,7 +164,7 @@ ${sflatMap((.contextInitTrans), whatSig.contexts)}
 		}
 		
 		@Override
-		public final common.FunctionTypeRep getType() {
+		public final common.AppTypeRep getType() {
 ${makeTyVarDecls(3, whatSig.typerep.freeVariables)}
 			return ${whatSig.typerep.transFreshTypeRep};
 		}

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -225,7 +225,7 @@ ${sflatMap((.contextInitTrans), namedSig.contexts)}
         }
 		
         @Override
-        public final common.FunctionTypeRep getType() {
+        public final common.AppTypeRep getType() {
 ${makeTyVarDecls(3, namedSig.typerep.freeVariables)}
 			return ${namedSig.typerep.transFreshTypeRep};
 		}

--- a/grammars/silver/core/Function.sv
+++ b/grammars/silver/core/Function.sv
@@ -5,7 +5,7 @@ a ::= x::a
 { return x; }
 
 function compose
-(c ::= a) ::= f1::(b ::= a) f2::(c ::= b)
+(c ::= a) ::= f1::(c ::= b) f2::(b ::= a)
 {
-  return \ x::a -> f2(f1(x));
+  return \ x::a -> f1(f2(x));
 }

--- a/runtime/java/src/common/AttributeSection.java
+++ b/runtime/java/src/common/AttributeSection.java
@@ -1,8 +1,5 @@
 package common;
 
-import silver.core.NOriginInfo;
-
-
 /**
  * Returns a function reference (a NodeFactory) that accesses the attribute
  * provided to the constructor.  Used to implement attribute sections (.pp)

--- a/runtime/java/src/common/FunctionTypeRep.java
+++ b/runtime/java/src/common/FunctionTypeRep.java
@@ -1,85 +1,56 @@
 package common;
 
 /**
- * Representation of a (possibly parametric) basic Silver type, used for run-time type checking in reification.  
+ * Representation of a Silver function type, used for run-time type checking in reification.  
  * 
  * @author krame505
  */
 public class FunctionTypeRep extends TypeRep {
 	/**
-	 * The result type of the function.
+	 * The number of parameters to the function.
 	 */
-	public final TypeRep result;
-	
-	/**
-	 * The types of the parameters to the function.
-	 */
-	public final TypeRep[] params;
+	public final int params;
 	
 	/**
 	 * The names of the named parameters to the function.
 	 */
-	public final String[] namedParamNames;
-	
-	/**
-	 * The types of the named parameters to the function.
-	 */
-	public final TypeRep[] namedParamTypes;
+	public final String[] namedParams;
 	
 	/**
 	 * Create a FunctionTypeRep.
-	 * 
-	 * @param result The result type of the function.
-	 * @param params The parameter types of the function.
-	 * @param namedParamNames The names of the named parameters to the function.
-	 * @param namedParamTypes The types of the named parameters to the function.
+	 *
+	 * @param params The number of parameters to the function.
+	 * @param namedParams The names of the named parameters to the function.
 	 */
-	public FunctionTypeRep(final TypeRep result, final TypeRep[] params, final String[] namedParamNames, final TypeRep[] namedParamTypes) {
-		this.result = result;
+	public FunctionTypeRep(final int params, final String[] namedParams) {
 		this.params = params;
-		this.namedParamNames = namedParamNames;
-		this.namedParamTypes = namedParamTypes;
-		
-		assert namedParamNames.length == namedParamTypes.length;
+		this.namedParams = namedParams;
 	}
 	
 	@Override
 	protected final boolean unifyPartial(final TypeRep other) {
 		if (!(other instanceof FunctionTypeRep) ||
-				!TypeRep.unify(result, ((FunctionTypeRep)other).result) ||
-				params.length != ((FunctionTypeRep)other).params.length ||
-				namedParamNames.length != ((FunctionTypeRep)other).namedParamNames.length) {
+				params != ((FunctionTypeRep)other).params ||
+				namedParams.length != ((FunctionTypeRep)other).namedParams.length) {
 			return false;
 		}
-		
-		for (int i = 0; i < params.length; i++) {
-			if (!TypeRep.unify(params[i], ((FunctionTypeRep)other).params[i])) {
+		for (int i = 0; i < namedParams.length; i++) {
+			if (!namedParams[i].equals(((FunctionTypeRep)other).namedParams[i])) {
 				return false;
 			}
 		}
-		
-		for (int i = 0; i < namedParamNames.length; i++) {
-			if (!namedParamNames[i].equals(((FunctionTypeRep)other).namedParamNames[i]) ||
-					!TypeRep.unify(namedParamTypes[i], ((FunctionTypeRep)other).namedParamTypes[i])) {
-				return false;
-			}
-		}
-		
 		return true;
 	}
 	
 	@Override
 	public final String toString() {
 		String paramsToString = "";
-		if (params.length > 0) {
-			paramsToString += params[0].toString();
+		for (int i = 0; i < params; i++) {
+			paramsToString += " _";
 		}
-		for (int i = 1; i < params.length; i++) {
-			paramsToString += " " + params[i].toString();
+		for (int i = 0; i < namedParams.length; i++) {
+			paramsToString += "; " + namedParams[i] + "::_";
 		}
-		for (int i = 0; i < namedParamNames.length; i++) {
-			paramsToString += "; " + namedParamNames[i] + "::" + namedParamTypes[i].toString();
-		}
-		return "(" + result.toString() + " ::= " + paramsToString + ")";
+		return "(_ ::=" + paramsToString + ")";
 	}
 }

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -1,7 +1,5 @@
 package common;
 
-import common.exceptions.*;
-
 /**
  * Node represents undecorated nodes.  That is, we have children, but no inherited attributes, yet.
  * 

--- a/runtime/java/src/common/NodeFactory.java
+++ b/runtime/java/src/common/NodeFactory.java
@@ -18,10 +18,6 @@ public abstract class NodeFactory<T> implements Typed {
 	 */
 	public abstract T invoke(final common.OriginContext originCtx, final Object[] args, final Object[] namedArgs);
 	
-	// Override with a more specific return type
-	@Override
-	public abstract FunctionTypeRep getType();
-	
 	// Below are just utilities
 	
 	/**

--- a/runtime/java/src/common/PartialNodeFactory.java
+++ b/runtime/java/src/common/PartialNodeFactory.java
@@ -1,6 +1,6 @@
 package common;
 
-import silver.core.NOriginInfo;
+import java.util.*;
 
 
 /**
@@ -64,21 +64,40 @@ public class PartialNodeFactory<T> extends NodeFactory<T> {
 	}
 	
 	@Override
-	public final FunctionTypeRep getType() {
-		final FunctionTypeRep baseType = ref.getType();
-		
-		final TypeRep[] newParams = new TypeRep[baseType.params.length - indices.length];
+	public final TypeRep getType() {
+		// Unpack the function type
+		List<TypeRep> typeArgs = new LinkedList<>();
+		TypeRep a = ref.getType();
+		for (; a instanceof AppTypeRep; a = ((AppTypeRep)a).cons) {
+			typeArgs.add(0, ((AppTypeRep)a).arg);
+		}
+		FunctionTypeRep fnType = (FunctionTypeRep)a;
+		List<TypeRep> params = typeArgs.subList(0, fnType.params);
+		List<TypeRep> namedParamTypes = typeArgs.subList(fnType.params, fnType.params + fnType.namedParams.length);
+		TypeRep resultType = typeArgs.get(fnType.params + fnType.namedParams.length);
+
+		// Copy the unapplied named args
+		List<TypeRep> newArgs = new LinkedList<>();
 		int i = 0, j = 0;
-		while (j < newParams.length) {
+		while (j < fnType.params - indices.length) {
 			if (i < indices.length && indices[i] == i + j) {
 				i++;
 			} else {
-				newParams[j] = baseType.params[i + j];
+				newArgs.add(params.get(i + j));
 				j++;
 			}
 		}
-		// We pass through namedParams unchanged here.
-		return new FunctionTypeRep(baseType.result, newParams, baseType.namedParamNames, baseType.namedParamTypes);
+		
+		// We pass through namedParams and result unchanged here.
+		newArgs.addAll(namedParamTypes);
+		newArgs.add(resultType);
+
+		// Re-pack the function type
+		TypeRep result = new FunctionTypeRep(fnType.params - indices.length, fnType.namedParams);
+		for (TypeRep arg : newArgs) {
+			result = new AppTypeRep(result, arg);
+		}
+		return result;
 	}
 	
 	@Override

--- a/test/silver_features/FuncProdTypes.sv
+++ b/test/silver_features/FuncProdTypes.sv
@@ -61,6 +61,14 @@ wrongCode "f is not fully applied, it has kind arity 1" {
   { return error(""); }
 }
 
-wrongCode "Signature type cannot contain _" {
+wrongCode "Missing type argument cannot be followed by a provided argument" {
+  type BadFunc = (_ ::= _ String);
+}
+
+wrongCode "Return type cannot be present when argument types are missing" {
   type BadFunc = (Integer ::= String _);
 }
+
+global idInt1::(Integer ::= Integer) = id;
+global idInt2::(_ ::= Integer)<Integer> = id;
+global idInt3::(_ ::= _)<Integer Integer> = id;

--- a/test/silver_features/TypeClasses.sv
+++ b/test/silver_features/TypeClasses.sv
@@ -271,14 +271,32 @@ global isSingleDigit::(Boolean ::= String) = contains(_, ["1", "2", "3", "4", "5
 equalityTest(isSingleDigit("5"), true, Boolean, silver_tests);
 equalityTest(isSingleDigit("42"), false, Boolean, silver_tests);
 
+class Semigroupoid a {
+  sgcompose :: (a<b d> ::= a<c d> a<b c>);
+}
+
+instance Semigroupoid (_ ::= _) {
+  sgcompose = compose;
+}
+
+equalityTest(sgcompose(\ x::Integer -> x * 2, \ s::String -> toInteger(s))("42"), 84, Integer, silver_tests);
+
+wrongCode "(_ ::= _ _) has kind arity 3, but the class Semigroupoid expected kind arity 2" {
+  instance Semigroupoid (_ ::= _ _) {
+    sgcompose = compose;
+  }
+}
+
+wrongCode "Member sgcompose has expected type ((b ::= Integer c) ::= (b ::= Integer a) (a ::= Integer c)), but the expression has actual type ((b ::= c) ::= (b ::= a) (a ::= c))" {
+  instance Semigroupoid (_ ::= Integer _) {
+    sgcompose = compose;
+  }
+}
 
 wrongCode "is a type alias" {
   -- This caused a kind mismatch crash previously
-  class Semigroupoid a {
-    compose :: (a<b d> ::= a<c d> a<b c>);
-  }
   type Func<a b> = (b ::= a);
   instance Semigroupoid Func {
-    compose = error("compose"); --\f::(d ::= c)  g::(c ::= b) -> \x::b -> f(g(x));
+    sgcompose = error("compose"); --\f::(d ::= c)  g::(c ::= b) -> \x::b -> f(g(x));
   }
 }


### PR DESCRIPTION
This refactors how function types are represented to bring them in line with the changes to `nonterminalType` made in #402.  The type `(String ::= Integer Float)` that was formerly represented as
```
functionType(stringType(), [integerType(), floatType()], [])
```
is now represented as
```
appType(appType(appType(functionType(2, []), integerType()), floatType()), stringType())
```
This enables us to write partially-applied function types (e.g. `(_ ::= _)`, of kind arity 2 - this is equivalent to the type `(->)` in Haskell.) This is useful as function types are instances of certain type classes, e.g. `instance Semigroupoid (_ ::= _) { ... }` - proposed by @remexre.

This change also dramatically simplifies the unification/substitution code, since we are no longer operating on lists of types and named types as the children of `functionType`.  This makes it more practical in the future to re-implement unification as some sort of automatically-propagated "unification attribute" or something in the future.  