### PR TITLE
Allow lexical type variables to be introduced in lambda parameters

### DIFF
--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -31,10 +31,18 @@ top::Expr ::= params::ProductionRHS e::Expr
   
   top.typerep = appTypes(functionType(length(params.inputElements), []), map((.typerep), params.inputElements) ++ [e.typerep]);
 
+  production attribute sigDefs::[Def] with ++;
+  sigDefs := params.lambdaDefs;
+  sigDefs <-
+    addNewLexicalTyVars_ActuallyVariables(
+      top.grammarName, top.location, params.lexicalTyVarKinds,
+      filter(\ tv::String -> null(getTypeDcl(tv, top.env)), nub(params.lexicalTypeVariables)));
+
   propagate downSubst, upSubst;
   propagate flowDeps, flowDefs;
   
-  e.env = newScopeEnv(params.lambdaDefs, top.env);
+  params.env = newScopeEnv(sigDefs, top.env);
+  e.env = params.env;
   e.frame = inLambdaContext(top.frame, sourceGrammar=top.frame.sourceGrammar); --TODO: Is this sourceGrammar correct?
 }
 

--- a/test/silver_features/TypeClasses.sv
+++ b/test/silver_features/TypeClasses.sv
@@ -306,14 +306,8 @@ class BoolThing a {
 }
 
 instance BoolThing Maybe<Unit> {
-  bteq = mbteq;
+  bteq = \ x::b y::b -> if x == y then just(unit()) else nothing();
 }
-
-function mbteq
-Eq b => Maybe<Unit> ::= x::b y::b
-{
-  return if x == y then just(unit()) else nothing();
-} 
 
 equalityTest(bteq(42, 42), just(unit()), Maybe<Unit>, silver_tests);
 equalityTest(bteq(234, 42), nothing(), Maybe<Unit>, silver_tests);


### PR DESCRIPTION
This allows one to write lambda expressions involving type variables as arguments inside of type class instances, for example.