### PR TITLE
Properly fix function type translation bug with covariance

### DIFF
--- a/grammars/silver/compiler/extension/list/java/Type.sv
+++ b/grammars/silver/compiler/extension/list/java/Type.sv
@@ -11,6 +11,7 @@ aspect production listCtrType
 top::Type ::=
 {
   top.transType = "common.ConsCell";
+  top.transCovariantType = "common.ConsCell";
   top.transClassType = "common.ConsCell";
   top.transTypeRep = "new common.BaseTypeRep(\"[]\")";
   top.transFreshTypeRep = top.transTypeRep;

--- a/grammars/silver/compiler/translation/java/core/ClassDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ClassDcl.sv
@@ -40,14 +40,14 @@ top::ClassBody ::=
 aspect production constraintClassBodyItem
 top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr ';'
 {
-  top.translation = s"\t${ty.typerep.transType} ${makeInstanceMemberAccessorName(id.name)}(${implode(", ", map((.contextParamTrans), cl.contexts))});";
+  top.translation = s"\t${ty.typerep.transCovariantType} ${makeInstanceMemberAccessorName(id.name)}(${implode(", ", map((.contextParamTrans), cl.contexts))});";
 }
 
 aspect production defaultConstraintClassBodyItem
 top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e::Expr ';'
 {
   top.translation = s"""
-	default ${ty.typerep.transClassType} ${makeInstanceMemberAccessorName(id.name)}(${implode(", ", map((.contextParamTrans), cl.contexts))}) {
+	default ${ty.typerep.transCovariantType} ${makeInstanceMemberAccessorName(id.name)}(${implode(", ", map((.contextParamTrans), cl.contexts))}) {
 		final common.DecoratedNode context = common.TopNode.singleton;
 		return ${e.translation};
 	}

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -133,7 +133,7 @@ ${implode("", map(makeChildAccessCaseLazy, whatSig.inputElements))}
 		return "${whatSig.fullName}";
 	}
 
-	public static ${whatSig.outputElement.typerep.transClassType} invoke(final common.OriginContext originCtx ${commaIfArgs} ${whatSig.javaSignature}) {
+	public static ${whatSig.outputElement.typerep.transCovariantType} invoke(final common.OriginContext originCtx ${commaIfArgs} ${whatSig.javaSignature}) {
 		try {
 ${whatResult}
 		} catch(Throwable t) {
@@ -144,14 +144,14 @@ ${whatResult}
 ${if null(whatSig.contexts) -- Can only use a singleton when there aren't contexts.
   then s"""
 	// Use of ? to permit casting to more specific types
-	public static final common.NodeFactory<? extends ${whatSig.outputElement.typerep.transType}> factory = new Factory();
+	public static final common.NodeFactory<? extends ${whatSig.outputElement.typerep.transCovariantType}> factory = new Factory();
 """ else s"""
-	public static final common.NodeFactory<? extends ${whatSig.outputElement.typerep.transType}> getFactory(${implode(", ", map((.contextParamTrans), whatSig.contexts))}) {
+	public static final common.NodeFactory<? extends ${whatSig.outputElement.typerep.transCovariantType}> getFactory(${implode(", ", map((.contextParamTrans), whatSig.contexts))}) {
 		return new Factory(${implode(", ", map((.contextRefElem), whatSig.contexts))});
 	}
 """}
 
-	public static final class Factory extends common.NodeFactory<${whatSig.outputElement.typerep.transType}> {
+	public static final class Factory extends common.NodeFactory<${whatSig.outputElement.typerep.transCovariantType}> {
 ${flatMap((.contextMemberDeclTrans), whatSig.contexts)}
 
 		public Factory(${implode(", ", map((.contextParamTrans), whatSig.contexts))}) {
@@ -159,7 +159,7 @@ ${flatMap((.contextInitTrans), whatSig.contexts)}
 		}
 
 		@Override
-		public final ${whatSig.outputElement.typerep.transType} invoke(final common.OriginContext originCtx, final Object[] children, final Object[] namedNotApplicable) {
+		public final ${whatSig.outputElement.typerep.transCovariantType} invoke(final common.OriginContext originCtx, final Object[] children, final Object[] namedNotApplicable) {
 			return ${className}.invoke(${implode(", ", ["originCtx"] ++ map((.contextRefElem), whatSig.contexts) ++ unpackChildren(0, whatSig.inputElements))});
 		}
 		

--- a/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
@@ -54,7 +54,7 @@ aspect production instanceBodyItem
 top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
 {
   top.translation = s"""
-	public ${id.lookupValue.typeScheme.typerep.transClassType} ${makeInstanceMemberAccessorName(top.fullName)}(${implode(", ", map((.contextParamTrans), memberContexts))}) {
+	public ${id.lookupValue.typeScheme.typerep.transCovariantType} ${makeInstanceMemberAccessorName(top.fullName)}(${implode(", ", map((.contextParamTrans), memberContexts))}) {
 		return ${e.translation};
 	}
 """;


### PR DESCRIPTION
Thought I had this fixed before, but it popped up again in defining `Functor`, so I guess not.  

Basically there are some places in the translation where we might want a more specific type of function (`NodeFactory`) than what is returned in the translation, so we need to translate the types of type class members and function references as e.g. `common.NodeFactory<? extends Object>` instead of `common.NodeFactory<Object>`.  