### PR TITLE
Normalize generated instance names to avoid translation bug with non-clean builds

### DIFF
--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -171,9 +171,13 @@ String ::= tv::TyVar  bv::[TyVar]
 function findAbbrevHelp
 String ::= tv::TyVar  bv::[TyVar]  vn::[String]
 {
-  return if null(vn) then "a" ++ toString(length(bv))
-         else if null(bv) then "V_" ++ toString(tv.extractTyVarRep)
-         else if tv == head(bv)
-              then head(vn)
-              else findAbbrevHelp(tv, tail(bv), tail(vn));
+  return
+    case bv, vn of
+    | hbv :: tbv, hvn :: tvn -> if tv == hbv then hvn else findAbbrevHelp(tv, tbv, tvn)
+    | _, _ ->
+      case positionOf(tv, bv) of
+      | -1 -> "V_" ++ toString(tv.extractTyVarRep)
+      | i -> "a" ++ toString(i)
+      end
+  end;
 }

--- a/grammars/silver/compiler/modification/ffi/java/Type.sv
+++ b/grammars/silver/compiler/modification/ffi/java/Type.sv
@@ -19,6 +19,6 @@ top::Type ::= fn::String  transType::String  params::[Type]
     foldl(
       \ c::String a::Type -> s"new common.AppTypeRep(${c}, ${a.transFreshTypeRep})",
       s"new common.BaseTypeRep(\"${fn}\")", params);
-  top.transTypeName = implode("_", substitute(":", "_", fn) :: map((.transTypeName), params));
+  top.transTypeName = implode("_", substitute(":", "_", fn) :: map(transTypeNameWith(_, top.boundVariables), params));
 }
 

--- a/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
@@ -3,7 +3,7 @@ grammar silver:compiler:translation:java:core;
 aspect production instanceDcl
 top::AGDcl ::= 'instance' cl::ConstraintList '=>' id::QNameType ty::TypeExpr '{' body::InstanceBody '}'
 {
-  local className :: String = "I" ++ substitute(":", "_", fName) ++ "_" ++ ty.typerep.transTypeName;
+  local className :: String = "I" ++ substitute(":", "_", fName) ++ "_" ++ transTypeName(ty.typerep);
 
   top.genFiles := [pair(className ++ ".java", s"""
 
@@ -32,7 +32,7 @@ synthesized attribute contextInitTrans::String occurs on Context;
 aspect production instContext
 top::Context ::= fn::String t::Type
 {
-  top.contextMemberDeclTrans = s"\tpublic final ${top.transType} ${makeConstraintDictName(fn, t)};\n";
+  top.contextMemberDeclTrans = s"\tprivate final ${top.transType} ${makeConstraintDictName(fn, t)};\n";
   top.contextParamTrans = s"${top.transType} ${makeConstraintDictName(fn, t)}";
   top.contextInitTrans = s"\t\tthis.${makeConstraintDictName(fn, t)} = ${makeConstraintDictName(fn, t)};\n";
 }

--- a/grammars/silver/compiler/translation/java/core/Project.sv
+++ b/grammars/silver/compiler/translation/java/core/Project.sv
@@ -60,7 +60,7 @@ String ::= s::String
 function makeInstanceName
 String ::= g::String s::String t::Type
 {
-  return substituteLast(".", ".I", makeName(g ++ ":" ++ substitute(":", "_", s))) ++ "_" ++ t.transTypeName;
+  return substituteLast(".", ".I", makeName(g ++ ":" ++ substitute(":", "_", s))) ++ "_" ++ transTypeName(t);
 }
 
 function substituteLast

--- a/grammars/silver/compiler/translation/java/type/Context.sv
+++ b/grammars/silver/compiler/translation/java/type/Context.sv
@@ -81,6 +81,7 @@ top::DclInfo ::= fntc::String baseDcl::DclInfo ty::Type
 function makeConstraintDictName
 String ::= s::String t::Type
 {
+  t.boundVariables = [];
   return "d_" ++ substitute(":", "_", s) ++ "_" ++ t.transTypeName;
 }
 

--- a/grammars/silver/compiler/translation/java/type/Type.sv
+++ b/grammars/silver/compiler/translation/java/type/Type.sv
@@ -19,6 +19,20 @@ synthesized attribute transFreshTypeRep :: String;
 -- A valid Java identifier, unique to the type
 synthesized attribute transTypeName :: String;
 
+function transTypeName
+String ::= te::Type
+{
+  te.boundVariables = te.freeVariables;
+  return te.transTypeName;
+}
+
+function transTypeNameWith
+String ::= te::Type tvs::[TyVar]
+{
+  te.boundVariables = tvs;
+  return te.transTypeName;
+}
+
 attribute transType, transCovariantType, transClassType, transTypeRep, transFreshTypeRep, transTypeName occurs on Type;
 
 aspect default production
@@ -34,7 +48,7 @@ top::Type ::= tv::TyVar
   top.transClassType = "Object";
   top.transTypeRep = s"freshTypeVar_${toString(tv.extractTyVarRep)}";
   top.transFreshTypeRep = top.transTypeRep;
-  top.transTypeName = "a" ++ toString(tv.extractTyVarRep);
+  top.transTypeName = findAbbrevFor(tv, top.boundVariables);
 }
 
 aspect production skolemType
@@ -43,7 +57,7 @@ top::Type ::= tv::TyVar
   top.transClassType = "Object";
   top.transTypeRep = s"new common.BaseTypeRep(\"b${toString(tv.extractTyVarRep)}\")";
   top.transFreshTypeRep = s"freshTypeVar_${toString(tv.extractTyVarRep)}";
-  top.transTypeName = "a" ++ toString(tv.extractTyVarRep);
+  top.transTypeName = findAbbrevFor(tv, top.boundVariables);
 }
 
 aspect production appType


### PR DESCRIPTION
I originally thought that this was a symptom of #36, but that doesn't actually seem to be the case.  

The names of instance classes that we generate are derived from the type of the instance, which could include the id of type variables - e.g. `instance Eq Maybe<a>` would become `Isilver_core_Eq_Maybe_a123`.  This is an issue because if a grammar depending on this instance was first compiled in a subsequent build, the generated type variable for the instance's entry in the environment (which is created by `genInt()`) would have a different value, resulting in a reference to an instance class that does not exist.  

The fix is to simply normalize the names of type variables occurring in this translation, similar to how types are pretty-printed - for example `Isilver_core_Eq_Maybe_a` instead of the above.  