### PR TITLE
Implement Alternative, MonadFail, MonadPlus & friends

### DIFF
--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Regex.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Regex.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:definition:concrete_syntax:ast;
 
-imports silver:core with empty as mempty;
+imports silver:core hiding empty, alt, fail;
 
 -- Translation of regex to Copper XML format.
 attribute xmlCopper occurs on Regex;

--- a/grammars/silver/compiler/extension/strategyattr/Project.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Project.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:extension:strategyattr;
 
-imports silver:core hiding id, sequence;
+imports silver:core hiding id, sequence, fail;
 
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;

--- a/grammars/silver/core/Alternative.sv
+++ b/grammars/silver/core/Alternative.sv
@@ -1,0 +1,78 @@
+grammar silver:core;
+
+{-
+The Alt type class identifies an associative operation on a type constructor.
+It is similar to Semigroup, except that it applies to types of kind arity 1,
+like Maybe or [], rather than concrete types String or [a].
+
+Instances should satisfy the following:
+
+Associativity
+  alt(alt(x, y), z) == alt(x, alt(y, z))
+Distributivity
+  map(f, alt(x, y)) == alt(map(f, x), map(f, y))
+-}
+class Functor f => Alt f {
+  alt :: (f<a> ::= f<a> f<a>);
+}
+
+instance Alt List {
+  alt = append;
+}
+
+instance Alt Maybe {
+  alt = orElse;
+}
+
+instance Alt Either<a _> {
+  alt = \ e1::Either<a b> e2::Either<a b> ->
+    case e1, e2 of
+    | right(x), _ -> right(x)
+    | _, right(x) -> right(x)
+    -- If they're both left, arbitrarily take the first one
+    | _, _ -> e1
+    end;
+}
+
+{-
+The Plus type class extends the Alt type class with a value that should be the
+left and right identity for (<|>).
+
+It is similar to Monoid, except that it applies to types of kind arity 1,
+like Array or List, rather than concrete types like String or Number.
+
+Instances should satisfy the following laws:
+
+Left identity
+  alt(empty, x) == x
+Right identity
+  alt(x, empty) == x
+Annihilation
+  map(f, empty) == empty
+-}
+class Alt f => Plus f {
+  empty :: f<a>;
+}
+
+instance Plus [] {
+  empty = [];
+}
+
+instance Plus Maybe {
+  empty = nothing();
+}
+
+{-
+The Alternative class is for members of Plus that are also Applicative functors,
+and specifies some additional laws:
+
+Distributivity
+  ap(alt(f, g), x) == alt(ap(f, x), ap(g, x))
+Annihilation
+  ap(empty, x) = empty
+-}
+class Applicative f, Plus f => Alternative f {}
+
+instance Alternative [] {}
+instance Alternative Maybe {}
+

--- a/grammars/silver/core/Monad.sv
+++ b/grammars/silver/core/Monad.sv
@@ -62,7 +62,7 @@ The MonadZero type class has no members of its own; it just specifies that the t
 Instances should satisfy the following:
 
 Annihilation
-  bind(empty, f) = empty
+  bind(fail(s), f) = fail(s)
 -}
 class Monad m, Alternative m => MonadZero m {}
 

--- a/grammars/silver/core/Monad.sv
+++ b/grammars/silver/core/Monad.sv
@@ -70,14 +70,14 @@ instance MonadZero [] {}
 instance MonadZero Maybe {}
 
 {-
-The MonadZero type class has no members of its own; it just extends MonadZero with an additional law.
+The MonadPlus type class has no members of its own; it just extends MonadZero with an additional law.
 
 Instances should satisfy the following:
 
 Distributivity
   bind(alt(x, y), f) = alt(bind(x, f), bind(y, f))
 -}
-class Monad m, Alternative m => MonadPlus m {}
+class MonadZero m, Alternative m => MonadPlus m {}
 
 instance MonadPlus [] {}
 instance MonadPlus Maybe {}

--- a/grammars/silver/core/Monad.sv
+++ b/grammars/silver/core/Monad.sv
@@ -1,7 +1,5 @@
 grammar silver:core;
 
---TODO: {Alt, Plus, Alternative, MonadZero, MonadPlus, MonadFail}
-
 {-
 Monads support both lifting functions/values of arbitrary arity and sequential compostion.
 
@@ -33,3 +31,53 @@ Monad m => m<Unit> ::= cond::m<Boolean>  body::m<Unit>
 function unlessM
 Monad m => m<Unit> ::= cond::m<Boolean>  body::m<Unit>
 { return bind(cond, unless(_, body)); }
+
+{-
+Monads that support failure with an error message.
+
+Instances should satisfy the following:
+
+Annihilation
+  bind(empty, f) = empty
+-}
+class Monad m => MonadFail m {
+  fail :: (m<a> ::= String);
+}
+
+instance MonadFail [] {
+  fail = \ String -> [];
+}
+
+instance MonadFail Maybe {
+  fail = \ String -> nothing();
+}
+
+instance MonadFail Either<String _> {
+  fail = left;
+}
+
+{-
+The MonadZero type class has no members of its own; it just specifies that the type has both Monad and Alternative instances.
+
+Instances should satisfy the following:
+
+Annihilation
+  bind(empty, f) = empty
+-}
+class Monad m, Alternative m => MonadZero m {}
+
+instance MonadZero [] {}
+instance MonadZero Maybe {}
+
+{-
+The MonadZero type class has no members of its own; it just extends MonadZero with an additional law.
+
+Instances should satisfy the following:
+
+Distributivity
+  bind(alt(x, y), f) = alt(bind(x, f), bind(y, f))
+-}
+class Monad m, Alternative m => MonadPlus m {}
+
+instance MonadPlus [] {}
+instance MonadPlus Maybe {}

--- a/grammars/silver/regex/AbstractSyntax.sv
+++ b/grammars/silver/regex/AbstractSyntax.sv
@@ -1,6 +1,6 @@
 grammar silver:regex;
 
-imports silver:core with empty as mempty;
+imports silver:core hiding empty, alt;
 imports silver:rewrite;
 imports silver:langutil;
 imports silver:langutil:pp;

--- a/grammars/silver/rewrite/Strategy.sv
+++ b/grammars/silver/rewrite/Strategy.sv
@@ -4,7 +4,7 @@ grammar silver:rewrite;
 -- Users must explicitly import silver:core hiding these names, or perform a qualified import,
 -- e.g. import silver:rewrite as s;
 
-imports silver:core hiding id, all, repeat, sequence;
+imports silver:core hiding id, all, repeat, sequence, fail;
 
 inherited attribute term::AST;
 synthesized attribute result::Maybe<AST>;


### PR DESCRIPTION
This adds the type classes `Alt`, `Plus`, `Alternative`, `MonadZero`, `MonadPlus`, and `MonadFail`.  I believe these should be sufficient to avoid the hard-coding in the implicit monads extension, although I left out the more controversial `Either` instances for `MonadFail`/`MonadZero` until we have a chance to better discuss this (I'm still not convinced that these are safe/useful.)  

I also left out instances for `IOMonad`, since we don't do exception handling.  