### PR TITLE
Template for pull requests requiring documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Changes
+
+# Documentation
+Please briefly describe the documentation you have written in the following categories, or why you didn't write documentation for a category:
+* what general comments you have added
+* what doc comments you have added
+* what documentation you have added to the website for users of Silver
+* what documentation you have added to the website for developers of Silver
+
+*Please remove all the prefilled text after the "Documentation" heading before submitting your pull request.*


### PR DESCRIPTION
This provides a template for pull requests, with headings for describing the code changes made and the documentation for these changes.

This just shows up as prefilled text, so the person opening the pull request can remove it instead of following the structure; however, as Louis noted, this should be outside our threat model.