### PR TITLE
Add instances Alt m => Semigroup m<a> and Plus m => Monoid m<a>

### DIFF
--- a/grammars/silver/core/Alternative.sv
+++ b/grammars/silver/core/Alternative.sv
@@ -17,7 +17,7 @@ class Functor f => Alt f {
 }
 
 instance Alt List {
-  alt = append;
+  alt = appendList;
 }
 
 instance Alt Maybe {

--- a/grammars/silver/core/Monoid.sv
+++ b/grammars/silver/core/Monoid.sv
@@ -19,16 +19,13 @@ class Semigroup a => Monoid a {
   concat :: (a ::= [a]) = foldr(append, mempty, _);
 }
 
-instance Monoid [a] {
-  mempty = [];
+-- e.g. [] and Maybe
+instance Plus m => Monoid m<a> {
+  mempty = empty;
 }
 
 instance Monoid String {
   mempty = "";
-}
-
-instance Monoid a => Monoid Maybe<a> {
-  mempty = nothing();
 }
 
 instance Monoid Unit {

--- a/grammars/silver/core/Semigroup.sv
+++ b/grammars/silver/core/Semigroup.sv
@@ -12,8 +12,9 @@ class Semigroup a {
   append :: (a ::= a a);
 }
 
-instance Semigroup [a] {
-  append = appendList;
+-- e.g. []
+instance Alt m => Semigroup m<a> {
+  append = alt;
 }
 
 instance Semigroup String {


### PR DESCRIPTION
# Changes
Just a random thought I had, since every `Alt` is type constructor for a `Semigroup` and every `Plus` is a type constructor for a `Monoid`, we can add these as default instances.  I don't know of any other languages that do this, but I don't see why not.  

This change means that one doesn't need to write as many instances when introducing a type similar to `Maybe` or lists.  

This is a pretty simple change but could be confusing, so I wouldn't be too disappointed if someone objects.  

# Documentation
Added a couple of comments.
