### PR TITLE
Fix Error Checking on Occurs

### DIFF
--- a/grammars/silver/compiler/definition/core/OccursDcl.sv
+++ b/grammars/silver/compiler/definition/core/OccursDcl.sv
@@ -95,7 +95,7 @@ top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::B
     else [];
 
   top.errors <-
-    if !nt.lookupType.dcl.isType || !ntTypeScheme.typerep.isDecorable
+    if nt.lookupType.found && (!nt.lookupType.dcl.isType || !ntTypeScheme.typerep.isDecorable)
     then [err(nt.location, nt.name ++ " is not a nonterminal. Attributes can only occur on nonterminals.")]
     else [];
                 


### PR DESCRIPTION
# Changes
This changes the error checking so the decl for the name is only checked for being a nonterminal if it is found.  Before this, it would throw an error.

# Documentation
I didn't write any documentation because it changes one line in the obvious way.