### PR TITLE
Add proper kind support, implement monad transformers

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/Annotation.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Annotation.sv
@@ -3,5 +3,5 @@ grammar silver:compiler:analysis:typechecking:core;
 aspect production annotationDcl
 top::AGDcl ::= 'annotation' a::QName tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
-  top.errors <- te.errorsFullyApplied;
+  top.errors <- te.errorsKindStar;
 }

--- a/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
@@ -3,12 +3,12 @@ grammar silver:compiler:analysis:typechecking:core;
 aspect production attributeDclInh
 top::AGDcl ::= 'inherited' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
-  top.errors <- te.errorsFullyApplied;
+  top.errors <- te.errorsKindStar;
 }
 
 aspect production attributeDclSyn
 top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
-  top.errors <- te.errorsFullyApplied;
+  top.errors <- te.errorsKindStar;
 }
 

--- a/grammars/silver/compiler/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/BuiltInFunctions.sv
@@ -77,7 +77,7 @@ top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
   thread downSubst, upSubst on top, es, el, errCheck1, errCheck2, top;
   
   errCheck1 = check(es.typerep, stringType());
-  errCheck2 = check(el.typerep, nonterminalType("silver:core:Location", 0, false));
+  errCheck2 = check(el.typerep, nonterminalType("silver:core:Location", [], false));
   top.errors <-
     if errCheck1.typeerror
     then [err(es.location, "Second operand to 'terminal(type,lexeme,location)' must be a String, instead it is " ++ errCheck1.leftpp)]

--- a/grammars/silver/compiler/analysis/typechecking/core/ClassDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ClassDcl.sv
@@ -3,7 +3,7 @@ grammar silver:compiler:analysis:typechecking:core;
 aspect production defaultConstraintClassBodyItem
 top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e::Expr ';'
 {
-  top.errors <- ty.errorsFullyApplied;
+  top.errors <- ty.errorsKindStar;
 
   local errCheck1::TypeCheck = check(ty.typerep, e.typerep);
   top.errors <-

--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -132,7 +132,7 @@ top::Expr ::= 'attachNote' note::Expr 'on' e::Expr 'end'
 
   thread downSubst, upSubst on top, note, e, errCheck1, top;
   
-  errCheck1 = check(note.typerep, nonterminalType("silver:core:OriginNote", 0, false));
+  errCheck1 = check(note.typerep, nonterminalType("silver:core:OriginNote", [], false));
   top.errors <-
        if errCheck1.typeerror
        then [err(top.location, "First argument to attachNote must be OriginNote, was " ++ errCheck1.leftpp)]

--- a/grammars/silver/compiler/analysis/typechecking/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/FunctionDcl.sv
@@ -9,5 +9,5 @@ top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody
 aspect production functionLHS
 top::FunctionLHS ::= t::TypeExpr
 {
-  top.errors <- t.errorsFullyApplied;
+  top.errors <- t.errorsKindStar;
 }

--- a/grammars/silver/compiler/analysis/typechecking/core/GlobalDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/GlobalDcl.sv
@@ -3,7 +3,7 @@ grammar silver:compiler:analysis:typechecking:core;
 aspect production globalValueDclConcrete
 top::AGDcl ::= 'global' id::Name '::' t::TypeExpr '=' e::Expr ';'
 {
-  top.errors <- t.errorsFullyApplied;
+  top.errors <- t.errorsKindStar;
 
   local attribute errCheck1 :: TypeCheck;
 

--- a/grammars/silver/compiler/analysis/typechecking/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/InstanceDcl.sv
@@ -4,8 +4,8 @@ aspect production instanceDcl
 top::AGDcl ::= 'instance' cl::ConstraintList '=>' id::QNameType ty::TypeExpr '{' body::InstanceBody '}'
 {
   top.errors <-
-    if ty.typerep.kindArity == id.lookupType.typeScheme.typerep.kindArity then []
-    else [err(ty.location, s"${ty.unparse} has kind arity ${toString(ty.typerep.kindArity)}, but the class ${id.name} expected kind arity ${toString(id.lookupType.typeScheme.typerep.kindArity)}")];
+    if ty.typerep.kindrep == id.lookupType.typeScheme.typerep.kindrep then []
+    else [err(ty.location, s"${ty.unparse} has kind ${prettyKind(ty.typerep.kindrep)}, but the class ${id.name} expected kind ${prettyKind(id.lookupType.typeScheme.typerep.kindrep)}")];
 
   superContexts.contextLoc = id.location;
   superContexts.contextSource = "instance superclasses";

--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
@@ -81,7 +81,7 @@ top::ProductionStmt ::= 'attachNote' e::Expr ';'
 
   thread downSubst, upSubst on top, e, errCheck1, top;
   
-  errCheck1 = check(e.typerep, nonterminalType("silver:core:OriginNote", 0, false));
+  errCheck1 = check(e.typerep, nonterminalType("silver:core:OriginNote", [], false));
   top.errors <-
        if errCheck1.typeerror
        then [err(top.location, "Origin note must have type silver:core:OriginNote, but the expression has actual type " ++ errCheck1.leftpp)]

--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
@@ -153,7 +153,7 @@ top::DefLHS ::= q::Decorated QName
 aspect production localAttributeDcl
 top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
 {
-  top.errors <- te.errorsFullyApplied;
+  top.errors <- te.errorsKindStar;
 }
 
 aspect production localValueDef

--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionDcl.sv
@@ -9,11 +9,11 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
 aspect production productionLHS
 top::ProductionLHS ::= id::Name '::' t::TypeExpr
 {
-  top.errors <- t.errorsFullyApplied;
+  top.errors <- t.errorsKindStar;
 }
 
 aspect production productionRHSElem
 top::ProductionRHSElem ::= id::Name '::' t::TypeExpr
 {
-  top.errors <- t.errorsFullyApplied;
+  top.errors <- t.errorsKindStar;
 }

--- a/grammars/silver/compiler/analysis/typechecking/core/TypeDecl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/TypeDecl.sv
@@ -3,5 +3,5 @@ grammar silver:compiler:analysis:typechecking:core;
 aspect production typeAliasDecl
 top::AGDcl ::= 'type' id::Name tl::BracketedOptTypeExprs '=' te::TypeExpr ';'
 {
-  top.errors <- te.errorsFullyApplied;
+  top.errors <- te.errorsKindStar;
 }

--- a/grammars/silver/compiler/definition/concrete_syntax/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/NonTerminalDcl.sv
@@ -26,7 +26,7 @@ top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTy
   
   top.syntaxAst :=
     [syntaxNonterminal(
-      nonterminalType(fName, length(tl.types), isThisTracked), nilSyntax(),
+      nonterminalType(fName, map((.kindrep), tl.types), isThisTracked), nilSyntax(),
       exportedProds, exportedLayoutTerms,
       foldr(consNonterminalMod, nilNonterminalMod(), nm.nonterminalModifiers))];
 }

--- a/grammars/silver/compiler/definition/concrete_syntax/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ProductionDcl.sv
@@ -143,9 +143,9 @@ top::Type ::=
 }
 
 aspect production nonterminalType
-top::Type ::= fn::String k::Integer tracked::Boolean
+top::Type ::= fn::String ks::[Kind] tracked::Boolean
 {
-  top.permittedInConcreteSyntax = k == 0;
+  top.permittedInConcreteSyntax = null(ks);
 }
 
 aspect production terminalType

--- a/grammars/silver/compiler/definition/core/ClassDcl.sv
+++ b/grammars/silver/compiler/definition/core/ClassDcl.sv
@@ -11,12 +11,12 @@ top::AGDcl ::= 'class' cl::ConstraintList '=>' id::QNameType var::TypeExpr '{' b
   production tv :: TyVar =
     case var.typerep.freeVariables of
     | v :: _ -> v
-    | _ -> freshTyVar(0)
+    | _ -> freshTyVar(starKind())
     end;
   production supers::[Context] = cl.contexts; -- *Direct* super classes only, not transitive
   production boundVars::[TyVar] = [tv];
   
-  top.defs := classDef(top.grammarName, id.location, fName, supers, tv, var.typerep.kindArity, body.classMembers) :: body.defs;
+  top.defs := classDef(top.grammarName, id.location, fName, supers, tv, var.typerep.kindrep, body.classMembers) :: body.defs;
   
   -- id *should* be just a Name, but it has to be a QNameType to avoid a reduce/reduce conflict
   top.errors <-

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -436,7 +436,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     else if q.name == "line" || q.name == "column"
     then intType()
     else if q.name == "location"
-    then nonterminalType("silver:core:Location", 0, false)
+    then nonterminalType("silver:core:Location", [], false)
     else errorType();
 }
 

--- a/grammars/silver/compiler/definition/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/definition/core/InstanceDcl.sv
@@ -129,7 +129,11 @@ top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
 
   top.fullName = id.lookupValue.fullName;
 
-  e.env = newScopeEnv(map(\ c::Context -> c.contextMemberDef(top.grammarName, top.location), memberContexts), top.env);
+  e.env = newScopeEnv(flatMap(\ c::Context ->
+      let instDcl::DclInfo = c.contextMemberDcl(top.grammarName, top.location)
+      in tcInstDef(instDcl) :: transitiveSuperDefs(top.env, top.instanceType, [], instDcl)
+      end, memberContexts),
+    top.env);
   e.originRules = [];
   e.isRoot = true;
 

--- a/grammars/silver/compiler/definition/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/definition/core/NonTerminalDcl.sv
@@ -14,7 +14,7 @@ top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTy
   top.defs := [ntDef(top.grammarName,
                     id.location,
                     fName,
-                    length(tl.types),
+                    map((.kindrep), tl.types),
                     quals.closed,
                     quals.tracked)];
   -- TODO: It's probably reasonable to skip listing

--- a/grammars/silver/compiler/definition/core/OccursDcl.sv
+++ b/grammars/silver/compiler/definition/core/OccursDcl.sv
@@ -33,20 +33,30 @@ top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::B
   local ntTypeScheme::PolyType = nt.lookupType.typeScheme;
   local atTypeScheme::PolyType = at.lookupAttribute.typeScheme;
   
-  -- Make sure we get the number of tyvars correct for the NT
+  -- Make sure we get the number and kind of type variables correct for the NT
   top.errors <-
     case nt.lookupType.dcls of
-    | ntDcl(_, arity, _, _) :: _ when arity != length(nttl.types) ->
-        [err(nt.location, nt.name ++ " expects " ++ toString(arity) ++
-                          " type variables, but " ++ toString(length(nttl.types)) ++ " were provided.")]
+    | ntDcl(_, ks, _, _) :: _ when length(ks) != length(nttl.types) ->
+      [err(nt.location,
+        nt.name ++ " expects " ++ toString(length(ks)) ++
+        " type variables, but " ++ toString(length(nttl.types)) ++ " were provided.")]
+    | ntDcl(_, ks, _, _) :: _ when ks != map((.kindrep), nttl.types) ->
+      [err(nt.location,
+        nt.name ++ " had kind " ++ foldr(arrowKind, starKind(), ks).typepp ++
+        "but type variable(s) have kind(s) " ++ implode(", ", map(compose(prettyKind, (.kindrep)), nttl.types)) ++ ".")]
     | _ -> []
     end;
 
-  -- Make sure we get the number of tyvars correct for the ATTR
+  -- Make sure we get the number and kind of type variables correct for the ATTR
   top.errors <-
     if length(atTypeScheme.boundVars) != length(attl.types)
-    then [err(at.location, at.name ++ " expects " ++ toString(length(atTypeScheme.boundVars)) ++
-                           " type variables, but " ++ toString(length(attl.types)) ++ " were provided.")]
+    then [err(at.location,
+      at.name ++ " expects " ++ toString(length(atTypeScheme.boundVars)) ++
+      " type variables, but " ++ toString(length(attl.types)) ++ " were provided.")]
+    else if map((.kindrep), atTypeScheme.boundVars) != map((.kindrep), attl.types)
+    then [err(at.location,
+      at.name ++ " has kind " ++ prettyKind(foldr(arrowKind, starKind(), map((.kindrep), atTypeScheme.boundVars))) ++
+        "but type variable(s) have kind(s) " ++ implode(", ", map(compose(prettyKind, (.kindrep)), attl.types)) ++ ".")]
     else [];
 
   -- We have 4 types.
@@ -123,12 +133,17 @@ top::AGDcl ::= msg::[Message] at::Decorated QName attl::BracketedOptTypeExprs nt
     -- The nonterminal type list is strictly type VARIABLES only
     nttl.errorsTyVars;
   
-  -- Make sure we get the number of tyvars correct for the NT
+  -- Make sure we get the number and kinds of tyvars correct for the NT
   top.errors <-
     case nt.lookupType.dcls of
-    | ntDcl(_, arity, _, _) :: _ when arity != length(nttl.types) ->
-        [err(nt.location, nt.name ++ " expects " ++ toString(arity) ++
-                          " type variables, but " ++ toString(length(nttl.types)) ++ " were provided.")]
+    | ntDcl(_, ks, _, _) :: _ when length(ks) != length(nttl.types) ->
+      [err(nt.location,
+        nt.name ++ " expects " ++ toString(length(ks)) ++
+        " type variables, but " ++ toString(length(nttl.types)) ++ " were provided.")]
+    | ntDcl(_, ks, _, _) :: _ when ks != map((.kindrep), nttl.types) ->
+      [err(nt.location,
+        nt.name ++ " had kind " ++ foldr(arrowKind, starKind(), ks).typepp ++
+        "but type variable(s) have kind(s) " ++ implode(", ", map(compose(prettyKind, (.kindrep)), nttl.types)) ++ ".")]
     | _ -> []
     end;
 }

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -16,8 +16,8 @@ top::Contexts ::=
 
 global foldContexts::(Contexts ::= [Context]) = foldr(consContext, nilContext(), _);
 
-synthesized attribute contextSuperDef::(Def ::= String Location DclInfo) occurs on Context;  -- Instances from context's superclasses
-synthesized attribute contextMemberDef::(Def ::= String Location) occurs on Context; -- Instances from a context on a class member
+synthesized attribute contextSuperDcl::(DclInfo ::= DclInfo String Location) occurs on Context;  -- Instances from context's superclasses
+synthesized attribute contextMemberDcl::(DclInfo ::= String Location) occurs on Context; -- Instances from a context on a class member
 synthesized attribute contextClassName::Maybe<String> occurs on Context;
 
 synthesized attribute resolved::[DclInfo] occurs on Context;
@@ -25,8 +25,8 @@ synthesized attribute resolved::[DclInfo] occurs on Context;
 aspect production instContext
 top::Context ::= cls::String t::Type
 {
-  top.contextSuperDef = instSuperDef(_, _, cls, _);
-  top.contextMemberDef = instConstraintDef(_, _, cls, t); -- Could be a different kind of def, but these are essentially the same as regular instance constraints
+  top.contextSuperDcl = instSuperDcl(cls, _, sourceGrammar=_, sourceLocation=_);
+  top.contextMemberDcl = instConstraintDcl(cls, t, sourceGrammar=_, sourceLocation=_); -- Could be a different kind of def, but these are essentially the same as regular instance constraints
   top.contextClassName = just(cls);
   
   -- Here possibly-decorated types that are still unspecialized at this point
@@ -64,8 +64,8 @@ top::Context ::= cls::String t::Type
 aspect production typeableContext
 top::Context ::= t::Type
 {
-  top.contextSuperDef = typeableSuperDef(_, _, _);
-  top.contextMemberDef = typeableInstConstraintDef(_, _, t); -- Could be a different kind of def, but these are essentially the same as regular instance constraints
+  top.contextSuperDcl = typeableSuperDcl(_, sourceGrammar=_, sourceLocation=_);
+  top.contextMemberDcl = typeableInstConstraintDcl(t, sourceGrammar=_, sourceLocation=_); -- Could be a different kind of def, but these are essentially the same as regular instance constraints
   top.contextClassName = nothing();
 
   top.resolved =

--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -175,11 +175,11 @@ top::DclInfo ::= fn::String ty::Type
 
 -- TypeDclInfos
 abstract production ntDcl
-top::DclInfo ::= fn::String arity::Integer closed::Boolean tracked::Boolean
+top::DclInfo ::= fn::String ks::[Kind] closed::Boolean tracked::Boolean
 {
   top.fullName = fn;
 
-  top.typeScheme = monoType(nonterminalType(fn, arity, tracked));
+  top.typeScheme = monoType(nonterminalType(fn, ks, tracked));
   top.isType = true;
 }
 abstract production termDcl
@@ -210,7 +210,7 @@ top::DclInfo ::= fn::String bound::[TyVar] ty::Type
   top.typeScheme = if null(bound) then monoType(ty) else polyType(bound, ty);
 }
 abstract production clsDcl
-top::DclInfo ::= fn::String supers::[Context] tv::TyVar k::Integer members::[Pair<String Boolean>]
+top::DclInfo ::= fn::String supers::[Context] tv::TyVar k::Kind members::[Pair<String Boolean>]
 {
   top.fullName = fn;
   

--- a/grammars/silver/compiler/definition/env/Defs.sv
+++ b/grammars/silver/compiler/definition/env/Defs.sv
@@ -163,9 +163,9 @@ Def ::= sg::String  sl::Location  fn::String  bound::[TyVar] head::Context conte
   return valueDef(defaultEnvItem(classMemberDcl(fn,bound,head,contexts,ty,sourceGrammar=sg,sourceLocation=sl)));
 }
 function ntDef
-Def ::= sg::String  sl::Location  fn::String  arity::Integer  closed::Boolean  tracked::Boolean
+Def ::= sg::String  sl::Location  fn::String  ks::[Kind]  closed::Boolean  tracked::Boolean
 {
-  return typeDef(defaultEnvItem(ntDcl(fn,arity,closed,tracked,sourceGrammar=sg,sourceLocation=sl)));
+  return typeDef(defaultEnvItem(ntDcl(fn,ks,closed,tracked,sourceGrammar=sg,sourceLocation=sl)));
 }
 function termDef
 Def ::= sg::String  sl::Location  fn::String  regex::Regex  easyName::Maybe<String>
@@ -225,7 +225,7 @@ Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
   return attrDef(defaultEnvItem(annoDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
 }
 function classDef
-Def ::= sg::String  sl::Location  fn::String  supers::[Context]  tv::TyVar  k::Integer  members::[Pair<String Boolean>]
+Def ::= sg::String  sl::Location  fn::String  supers::[Context]  tv::TyVar  k::Kind  members::[Pair<String Boolean>]
 {
   return typeDef(defaultEnvItem(clsDcl(fn,supers,tv,k,members,sourceGrammar=sg,sourceLocation=sl)));
 }

--- a/grammars/silver/compiler/definition/type/Kind.sv
+++ b/grammars/silver/compiler/definition/type/Kind.sv
@@ -1,0 +1,29 @@
+grammar silver:compiler:definition:type;
+
+synthesized attribute baseKind::Kind;
+synthesized attribute argKinds::[Kind];
+
+nonterminal Kind with isEqualTo, isEqual, baseKind, argKinds;
+propagate isEqualTo, isEqual on Kind;
+
+abstract production starKind
+top::Kind ::=
+{
+  top.baseKind = top;
+  top.argKinds = [];
+}
+
+abstract production arrowKind
+top::Kind ::= k1::Kind k2::Kind
+{
+  top.baseKind = k2.baseKind;
+  top.argKinds = k1 :: k2.argKinds;
+}
+
+-- TODO: Replace with default instance
+instance Eq Kind {
+  eq = \ k1::Kind k2::Kind -> decorate k1 with {isEqualTo = k2;}.isEqual;
+}
+
+global constructorKind::(Kind ::= Integer) = \ arity::Integer ->
+  foldr(arrowKind, starKind(), repeat(starKind(), arity));

--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -104,7 +104,7 @@ top::Type ::= c::Type a::Type
     | _ -> prettyTypeWith(top.baseType, top.boundVariables) ++
       if null(top.argTypes) then ""
       else "<" ++ implode(" ", map(prettyTypeWith(_, top.boundVariables), top.argTypes)) ++
-        replicate(length(top.argTypes) - length(top.baseType.kindrep.argKinds), " _") ++ ">"
+        replicate(max(length(top.argTypes) - length(top.baseType.kindrep.argKinds), 0), " _") ++ ">"
     end;
 }
 

--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -104,7 +104,7 @@ top::Type ::= c::Type a::Type
     | _ -> prettyTypeWith(top.baseType, top.boundVariables) ++
       if null(top.argTypes) then ""
       else "<" ++ implode(" ", map(prettyTypeWith(_, top.boundVariables), top.argTypes)) ++
-        replicate(max(length(top.argTypes) - length(top.baseType.kindrep.argKinds), 0), " _") ++ ">"
+        replicate(max(length(top.baseType.kindrep.argKinds) - length(top.argTypes), 0), " _") ++ ">"
     end;
 }
 

--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -1,7 +1,7 @@
 grammar silver:compiler:definition:type;
 
 
-synthesized attribute typepp :: String occurs on PolyType, Context, Type;
+synthesized attribute typepp :: String occurs on PolyType, Context, Type, Kind;
 autocopy attribute boundVariables :: [TyVar] occurs on Context, Type;
 
 function prettyType
@@ -31,6 +31,13 @@ String ::= c::Context tvs::[TyVar]
   c.boundVariables = tvs;
   return c.typepp;
 }
+
+function prettyKind
+String ::= k::Kind
+{
+  return k.typepp;
+}
+
 --------------------------------------------------------------------------------
 
 aspect production monoType
@@ -97,7 +104,7 @@ top::Type ::= c::Type a::Type
     | _ -> prettyTypeWith(top.baseType, top.boundVariables) ++
       if null(top.argTypes) then ""
       else "<" ++ implode(" ", map(prettyTypeWith(_, top.boundVariables), top.argTypes)) ++
-        replicate(length(top.argTypes) - top.baseType.kindArity, " _") ++ ">"
+        replicate(length(top.argTypes) - length(top.baseType.kindrep.argKinds), " _") ++ ">"
     end;
 }
 
@@ -166,6 +173,22 @@ aspect production functionType
 top::Type ::= params::Integer namedParams::[String]
 {
   top.typepp = s"(_ ::=${replicate(params, " _") }${if null(namedParams) then "" else "; " ++ implode("::_; ", namedParams) ++ "::_"})";
+}
+
+aspect production starKind
+top::Kind ::=
+{
+  top.typepp = "*";
+}
+
+aspect production arrowKind
+top::Kind ::= k1::Kind k2::Kind
+{
+  top.typepp =
+    case k1 of
+    | arrowKind(_, _) -> s"(${k1.typepp}) -> ${k2.typepp}"
+    | _ -> s"${k1.typepp} -> ${k2.typepp}"
+    end;
 }
 
 --------------------------------------------------------------------------------

--- a/grammars/silver/compiler/definition/type/Substitutions.sv
+++ b/grammars/silver/compiler/definition/type/Substitutions.sv
@@ -97,7 +97,7 @@ top::Type ::= tv::TyVar
   -- Perform one iteration of substitution
   local partialsubst :: Maybe<Type> =
     case findSubst(tv, top.substitution) of
-    | just(s) when s.kindArity != tv.kindArity -> error("Kind mismatch in applying substitution!")
+    | just(s) when s.kindrep != tv.kindrep -> error("Kind mismatch in applying substitution!")
     | ps -> ps
     end;
   
@@ -131,7 +131,7 @@ top::Type ::= tv::TyVar
   
   local partialsubst :: Maybe<Type> =
     case findSubst(tv, top.substitution) of
-    | just(s) when s.kindArity != tv.kindArity -> nothing()
+    | just(s) when s.kindrep != tv.kindrep -> nothing()
     | ps -> ps
     end;
   
@@ -210,7 +210,7 @@ function mapRenameSubst
 function freshTyVars
 [TyVar] ::= tvs::[TyVar]
 {
-  return map(freshTyVar, map((.kindArity), tvs));
+  return map(freshTyVar, map((.kindrep), tvs));
 }
 
 function zipVarsIntoSubstitution

--- a/grammars/silver/compiler/definition/type/Unification.sv
+++ b/grammars/silver/compiler/definition/type/Unification.sv
@@ -9,7 +9,7 @@ top::Type ::= tv::TyVar
 {
   top.unify = 
     case top.unifyWith of
-    | varType(j) ->
+    | varType(j) when j.kindrep == tv.kindrep ->
         if tv == j
         then emptySubst()
         else subst(tv, top.unifyWith)
@@ -26,7 +26,7 @@ top::Type ::= tv::TyVar
 {
   top.unify = 
     case top.unifyWith of
-    | skolemType(otv) ->
+    | skolemType(otv) when tv.kindrep == otv.kindrep ->
         if tv == otv
         then emptySubst()
         else errorSubst("Tried to unify skolem constant with incompatible skolem constant")

--- a/grammars/silver/compiler/definition/type/Unification.sv
+++ b/grammars/silver/compiler/definition/type/Unification.sv
@@ -13,7 +13,7 @@ top::Type ::= tv::TyVar
         if tv == j
         then emptySubst()
         else subst(tv, top.unifyWith)
-    | t when t.kindArity == tv.kindArity ->
+    | t when t.kindrep == tv.kindrep ->
         if contains(tv, top.unifyWith.freeVariables)
         then errorSubst("Infinite type! Tried to unify with " ++ prettyType(top.unifyWith))
         else subst(tv, top.unifyWith)
@@ -104,13 +104,13 @@ top::Type ::=
 }
 
 aspect production nonterminalType
-top::Type ::= fn::String k::Integer tracked::Boolean
+top::Type ::= fn::String ks::[Kind] tracked::Boolean
 {
   top.unify = 
     case top.unifyWith of
-    | nonterminalType(ofn, ok, otracked) ->
+    | nonterminalType(ofn, oks, otracked) ->
         if fn == ofn
-        then if k == ok
+        then if ks == oks
           then if tracked!=otracked 
             then error("Internal Error: Mismatching trackedness for " ++ fn ++ " when unifying. Try rebuilding with --clean. \nSee https://github.com/melt-umn/silver/pull/333 and https://github.com/melt-umn/silver/issues/36 .")
             else emptySubst()

--- a/grammars/silver/compiler/definition/type/syntax/AspectDcl.sv
+++ b/grammars/silver/compiler/definition/type/syntax/AspectDcl.sv
@@ -6,10 +6,10 @@ flowtype lexicalTypeVariables {realSignature, env} on AspectProductionSignature,
 flowtype lexicalTypeVariables {deterministicCount, realSignature, env} on AspectRHSElem;
 
 function addNewLexicalTyVars_ActuallyVariables
-[Def] ::= gn::String sl::Location lk::[Pair<String Integer>] l::[String]
+[Def] ::= gn::String sl::Location lk::[Pair<String Kind>] l::[String]
 {
   return if null(l) then []
-         else aspectLexTyVarDef(gn, sl, head(l), freshTyVar(fromMaybe(0, lookup(head(l), lk)))) ::
+         else aspectLexTyVarDef(gn, sl, head(l), freshTyVar(fromMaybe(starKind(), lookup(head(l), lk)))) ::
                   addNewLexicalTyVars_ActuallyVariables(gn, sl, lk, tail(l));
 }
 

--- a/grammars/silver/compiler/definition/type/syntax/Constraint.sv
+++ b/grammars/silver/compiler/definition/type/syntax/Constraint.sv
@@ -77,7 +77,7 @@ top::Constraint ::= c::QNameType t::TypeExpr
     | typeVariableTypeExpr(tv)
       -- Avoid circular inference if someone uses a class constraint within its own definition
       when top.classDefName != just(fName) ->
-      [pair(tv.lexeme, c.lookupType.typeScheme.monoType.kindArity)]
+      [pair(tv.lexeme, c.lookupType.typeScheme.monoType.kindrep)]
     | _ -> []
     end;
 }

--- a/grammars/silver/compiler/definition/type/syntax/Constraint.sv
+++ b/grammars/silver/compiler/definition/type/syntax/Constraint.sv
@@ -146,6 +146,6 @@ function transitiveSuperDefs
     else
       -- This might introduce duplicate defs in "diamond subclassing" cases,
       -- but that shouldn't actually be an issue besides the (minor) added lookup overhead.
-      map(\ c::Context -> c.contextSuperDef(dcl.sourceGrammar, dcl.sourceLocation, instDcl), dcl.superContexts) ++
+      map(\ c::Context -> tcInstDef(c.contextSuperDcl(instDcl, dcl.sourceGrammar, dcl.sourceLocation)), dcl.superContexts) ++
       flatMap(transitiveSuperDefs(env, ty, dcl.fullName :: seenClasses, _), superInstDcls);
 }

--- a/grammars/silver/compiler/definition/type/syntax/KindExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/KindExpr.sv
@@ -1,0 +1,24 @@
+grammar silver:compiler:definition:type:syntax;
+
+nonterminal KindExpr with config, location, grammarName, errors, env, unparse, kindrep;
+
+concrete production starKindExpr
+top::KindExpr ::= '*'
+{
+  top.unparse = "*";
+  top.kindrep = starKind();
+}
+
+concrete production arrowKindExpr
+top::KindExpr ::= k1::KindExpr '->' k2::KindExpr
+{
+  top.unparse = s"${k1.unparse} -> ${k2.unparse}";
+  top.kindrep = arrowKind(k1.kindrep, k2.kindrep);
+}
+
+concrete production parenKindExpr
+top::KindExpr ::= '(' k::KindExpr ')'
+{
+  top.unparse = s"(${k.unparse})";
+  forwards to k;
+}

--- a/grammars/silver/compiler/definition/type/syntax/KindExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/KindExpr.sv
@@ -2,6 +2,8 @@ grammar silver:compiler:definition:type:syntax;
 
 nonterminal KindExpr with config, location, grammarName, errors, env, unparse, kindrep;
 
+propagate errors on KindExpr; -- TODO: Are errors even possible here?
+
 concrete production starKindExpr
 top::KindExpr ::= '*'
 {

--- a/grammars/silver/compiler/definition/type/syntax/Terminals.sv
+++ b/grammars/silver/compiler/definition/type/syntax/Terminals.sv
@@ -2,6 +2,8 @@ grammar silver:compiler:definition:type:syntax;
 
 -- '<' has precedence 9, assoc = left
 
+terminal Arrow_t '->' association = right, lexer classes {SPECOP};
+
 terminal Boolean_tkwd    'Boolean'    lexer classes {TYPE,RESERVED};
 terminal Decorated_tkwd  'Decorated'  lexer classes {TYPE,RESERVED}, precedence=1;
 terminal Float_tkwd      'Float'      lexer classes {TYPE,RESERVED};

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -361,8 +361,6 @@ top::TypeExprs ::= t::TypeExpr list::TypeExprs
   top.types = t.typerep :: list.types;
   top.missingCount = list.missingCount;
   top.freeVariables = t.freeVariables ++ list.freeVariables;
-  
-  top.errors <- t.errorsKindStar;
 }
 
 concrete production typeListConsMissing

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -4,7 +4,7 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
 
-nonterminal TypeExpr  with config, location, grammarName, errors, env, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, freeVariables, errorsFullyApplied;
+nonterminal TypeExpr  with config, location, grammarName, errors, env, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, freeVariables, errorsKindStar;
 nonterminal Signature with config, location, grammarName, errors, env, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds;
 nonterminal SignatureLHS with config, location, grammarName, errors, env, unparse, maybeType, lexicalTypeVariables, lexicalTyVarKinds;
 nonterminal TypeExprs with config, location, grammarName, errors, env, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, freeVariables;
@@ -19,7 +19,7 @@ synthesized attribute missingCount::Integer;
 monoid attribute lexicalTypeVariables :: [String];
 -- freeVariables also occurs on TypeExprs, and should be IN ORDER
 
-monoid attribute lexicalTyVarKinds :: [Pair<String Integer>];
+monoid attribute lexicalTyVarKinds :: [Pair<String Kind>];
 
 -- These attributes are used if we're using the TypeExprs as type variables-only.
 monoid attribute errorsTyVars :: [Message];
@@ -27,7 +27,7 @@ monoid attribute errorsTyVars :: [Message];
 inherited attribute initialEnv :: Decorated Env;
 synthesized attribute envBindingTyVars :: Decorated Env;
 
-synthesized attribute errorsFullyApplied::[Message];
+synthesized attribute errorsKindStar::[Message];
 
 propagate errors, lexicalTypeVariables, lexicalTyVarKinds on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate errorsTyVars on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
@@ -36,10 +36,10 @@ propagate errorsTyVars on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 -- But for now, we'll use it. It might be easier to get rid of once we know exactly
 -- how ty vars end up in the environment.
 function addNewLexicalTyVars
-[Def] ::= gn::String sl::Location lk::[Pair<String Integer>] l::[String]
+[Def] ::= gn::String sl::Location lk::[Pair<String Kind>] l::[String]
 {
   return if null(l) then []
-         else lexTyVarDef(gn, sl, head(l), freshTyVar(fromMaybe(0, lookup(head(l), lk)))) ::
+         else lexTyVarDef(gn, sl, head(l), freshTyVar(fromMaybe(starKind(), lookup(head(l), lk)))) ::
                   addNewLexicalTyVars(gn, sl, lk, tail(l));
 }
 
@@ -51,9 +51,9 @@ top::TypeExpr ::=
   -- "semantic" errors, rather than parse errors for this.
   top.errorsTyVars := [err(top.location, top.unparse ++ " is not permitted here, only type variables are")];
   top.freeVariables = top.typerep.freeVariables;
-  top.errorsFullyApplied =
-    if top.typerep.kindArity > 0
-    then [err(top.location, s"${top.unparse} is not fully applied, it has kind arity ${toString(top.typerep.kindArity)}")]
+  top.errorsKindStar =
+    if top.typerep.kindrep != starKind()
+    then [err(top.location, s"${top.unparse} has kind ${prettyKind(top.typerep.kindrep)} where kind * is expected")]
     else [];
 }
 
@@ -145,6 +145,22 @@ top::TypeExpr ::= tv::IdLower_t
   top.lexicalTypeVariables <- [tv.lexeme];
 }
 
+concrete production kindSigTypeVariableTypeExpr
+top::TypeExpr ::= '(' tv::IdLower_t '::' k::KindExpr ')'
+{
+  top.unparse = s"(${tv.lexeme} :: ${k.unparse})";
+  
+  local attribute hack::QNameLookup;
+  hack = customLookup("type", getTypeDcl(tv.lexeme, top.env), tv.lexeme, top.location);
+  
+  top.typerep = hack.typeScheme.monoType;
+  top.errors <- hack.errors;
+  top.errorsTyVars := [];
+
+  top.lexicalTypeVariables <- [tv.lexeme];
+  top.lexicalTyVarKinds <- [pair(tv.lexeme, k.kindrep)];
+}
+
 concrete production appTypeExpr
 top::TypeExpr ::= ty::TypeExpr tl::BracketedTypeExprs
 {
@@ -189,14 +205,21 @@ top::TypeExpr ::= ty::Decorated TypeExpr tl::BracketedTypeExprs
   top.errors <- ty.errors;
 
   local tlCount::Integer = length(tl.types) + tl.missingCount;
+  local tlKinds::[Kind] = map((.kindrep), tl.types);
   top.errors <-
-    if tlCount != ty.typerep.kindArity
-    then [err(top.location, ty.unparse ++ " has kind arity " ++ toString(ty.typerep.kindArity) ++ ", but there are " ++ toString(tlCount) ++ " type arguments supplied here.")]
+    if tlCount != length(ty.typerep.kindrep.argKinds)
+    then [err(top.location, ty.unparse ++ " has kind " ++ prettyKind(ty.typerep.kindrep) ++ ", but there are " ++ toString(tlCount) ++ " type arguments supplied here.")]
+    else if take(length(tlKinds), ty.typerep.kindrep.argKinds) != tlKinds
+    then [err(top.location, ty.unparse ++ " has kind " ++ prettyKind(ty.typerep.kindrep) ++ ", but argument(s) have kind(s) " ++ implode(", ", map(prettyKind, tlKinds)))]
     else [];
 
   top.lexicalTyVarKinds <-
     case ty of
-    | typeVariableTypeExpr(tv) -> [pair(tv.lexeme, tlCount)]
+    | typeVariableTypeExpr(tv) ->
+      -- This assumes that all type args have kind *.
+      -- If that is not the case, then an explcit kind signature is needed on ty,
+      -- which will shadow this entry in the lexicalTyVarKinds list.
+      [pair(tv.lexeme, constructorKind(tlCount))]
     | _ -> []
     end;
 }
@@ -214,7 +237,7 @@ top::TypeExpr ::= 'Decorated' t::TypeExpr
     | skolemType(_) -> []
     | _ -> [err(t.location, t.unparse ++ " is not a nonterminal, and cannot be Decorated.")]
     end;
-  top.errors <- t.errorsFullyApplied;
+  top.errors <- t.errorsKindStar;
 }
 
 concrete production funTypeExpr
@@ -339,7 +362,7 @@ top::TypeExprs ::= t::TypeExpr list::TypeExprs
   top.missingCount = list.missingCount;
   top.freeVariables = t.freeVariables ++ list.freeVariables;
   
-  top.errors <- t.errorsFullyApplied;
+  top.errors <- t.errorsKindStar;
 }
 
 concrete production typeListConsMissing

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -53,7 +53,7 @@ top::TypeExpr ::=
   top.freeVariables = top.typerep.freeVariables;
   top.errorsKindStar =
     if top.typerep.kindrep != starKind()
-    then [err(top.location, s"${top.unparse} has kind ${prettyKind(top.typerep.kindrep)} where kind * is expected")]
+    then [err(top.location, s"${top.unparse} has kind ${prettyKind(top.typerep.kindrep)}, but kind * is expected here")]
     else [];
 }
 

--- a/grammars/silver/compiler/extension/auto_ast/AutoAst.sv
+++ b/grammars/silver/compiler/extension/auto_ast/AutoAst.sv
@@ -24,7 +24,7 @@ top::ProductionStmt ::= 'abstract' v::QName ';'
       functionType(length(elems), if hasLoc then ["location"] else []),
       map(astType(_, top.env), elems) ++
       (if hasLoc
-       then [ nonterminalType("silver:core:Location", 0, false)]
+       then [ nonterminalType("silver:core:Location", [], false)]
        else []) ++
       [astType(top.frame.signature.outputElement, top.env)]);
   

--- a/grammars/silver/compiler/extension/autoattr/Equality.sv
+++ b/grammars/silver/compiler/extension/autoattr/Equality.sv
@@ -22,7 +22,7 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
   
   forwards to
     defsAGDcl(
-      [attrDef(defaultEnvItem(equalityInhDcl(inhFName, freshTyVar(0), sourceGrammar=top.grammarName, sourceLocation=inh.location))),
+      [attrDef(defaultEnvItem(equalityInhDcl(inhFName, freshTyVar(starKind()), sourceGrammar=top.grammarName, sourceLocation=inh.location))),
        attrDef(defaultEnvItem(equalitySynDcl(inhFName, synFName, sourceGrammar=top.grammarName, sourceLocation=syn.location)))],
       location=top.location);
 }

--- a/grammars/silver/compiler/extension/autoattr/Functor.sv
+++ b/grammars/silver/compiler/extension/autoattr/Functor.sv
@@ -16,7 +16,7 @@ top::AGDcl ::= 'functor' 'attribute' a::Name ';'
   
   forwards to
     defsAGDcl(
-      [attrDef(defaultEnvItem(functorDcl(fName, freshTyVar(0), sourceGrammar=top.grammarName, sourceLocation=a.location)))],
+      [attrDef(defaultEnvItem(functorDcl(fName, freshTyVar(starKind()), sourceGrammar=top.grammarName, sourceLocation=a.location)))],
       location=top.location);
 }
 

--- a/grammars/silver/compiler/extension/autoattr/Unification.sv
+++ b/grammars/silver/compiler/extension/autoattr/Unification.sv
@@ -28,7 +28,7 @@ top::AGDcl ::= 'unification' 'attribute' inh::Name ',' synPartial::Name  ',' syn
   
   forwards to
     defsAGDcl(
-      [attrDef(defaultEnvItem(unificationInhDcl(inhFName, freshTyVar(0), sourceGrammar=top.grammarName, sourceLocation=inh.location))),
+      [attrDef(defaultEnvItem(unificationInhDcl(inhFName, freshTyVar(starKind()), sourceGrammar=top.grammarName, sourceLocation=inh.location))),
        attrDef(defaultEnvItem(unificationSynPartialDcl(inhFName, synPartialFName, synFName, sourceGrammar=top.grammarName, sourceLocation=synPartial.location))),
        attrDef(defaultEnvItem(unificationSynDcl(inhFName, synPartialFName, synFName, sourceGrammar=top.grammarName, sourceLocation=syn.location)))],
       location=top.location);

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -584,7 +584,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     else if q.name == "line" || q.name == "column"
     then intType()
     else if q.name == "location"
-    then nonterminalType("silver:core:Location", 0, false)
+    then nonterminalType("silver:core:Location", [], false)
     else errorType();
 
   top.monadRewritten = access(ne.monadRewritten, '.', new(q), location=top.location);

--- a/grammars/silver/compiler/extension/implicit_monads/Util.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Util.sv
@@ -161,13 +161,13 @@ String ::= ty::Type
   return case ty of
          | listType(_) ->
            "[a]"
-         | appType(nonterminalType("silver:core:Maybe", 1, _), _) ->
+         | appType(nonterminalType("silver:core:Maybe", _, _), _) ->
            "Maybe<a>"
-         | appType(appType(nonterminalType("silver:core:Either", 2, _), p), _) ->
+         | appType(appType(nonterminalType("silver:core:Either", _, _), p), _) ->
            "Either<" ++ prettyType(p) ++ " a>"
-         | appType(nonterminalType("silver:core:IOMonad", 1, _), _) ->
+         | appType(nonterminalType("silver:core:IOMonad", _, _), _) ->
            "IOMonad<a>"
-         | appType(appType(nonterminalType("silver:core:state", 2, _), p), _) ->
+         | appType(appType(nonterminalType("silver:core:state", _, _), p), _) ->
            "State<" ++ prettyType(p) ++ " a>"
          | decoratedType(t) -> monadToString(t)
          | _ -> error("Tried to get monadToString for a non-monadic type")
@@ -230,7 +230,7 @@ Either<String Expr> ::= ty::Type l::Location
   local unit::Expr = Silver_Expr { unit() };
   return
     case ty of
-    | appType(appType(nonterminalType("silver:core:Either", 2, _), a), b) ->
+    | appType(appType(nonterminalType("silver:core:Either", _, _), a), b) ->
            case a of
            | stringType() -> right(Silver_Expr { silver:core:failEither($Expr{string}) })
            | intType() -> right(Silver_Expr { silver:core:failEither($Expr{int}) })
@@ -289,7 +289,7 @@ Either<String Expr> ::= ty::Type l::Location
 {
   return
     case ty of
-    | appType(appType(nonterminalType("silver:core:Either", 2, _), a), b) ->
+    | appType(appType(nonterminalType("silver:core:Either", _, _), a), b) ->
            case a of
            | stringType() -> right(Silver_Expr{ silver:core:left("mzero") })
            | intType() -> right(Silver_Expr{ silver:core:left(0) })

--- a/grammars/silver/compiler/extension/list/List.sv
+++ b/grammars/silver/compiler/extension/list/List.sv
@@ -14,8 +14,8 @@ top::TypeExpr ::= '[' te::TypeExpr ']'
   top.typerep = listType(te.typerep);
   
   top.errorsKindStar =
-    if top.typerep.kindArity > 0
-    then [err(top.location, s"${top.unparse} is not fully applied, it has kind arity ${toString(top.typerep.kindArity)}")]
+    if top.typerep.kindrep != starKind()
+    then [err(top.location, s"${top.unparse} has kind ${prettyKind(top.typerep.kindrep)}, but kind * is expected here")]
     else [];
 
   forwards to
@@ -33,8 +33,8 @@ top::TypeExpr ::= '[' ']'
   top.typerep = listCtrType();
   
   top.errorsKindStar =
-    if top.typerep.kindArity > 0
-    then [err(top.location, s"${top.unparse} is not fully applied, it has kind arity ${toString(top.typerep.kindArity)}")]
+    if top.typerep.kindrep != starKind()
+    then [err(top.location, s"${top.unparse} has kind ${prettyKind(top.typerep.kindrep)}, but kind * is expected here")]
     else [];
 
   forwards to nominalTypeExpr(qNameTypeId(terminal(IdUpper_t, "silver:core:List"), location=top.location), location=top.location);

--- a/grammars/silver/compiler/extension/list/List.sv
+++ b/grammars/silver/compiler/extension/list/List.sv
@@ -13,7 +13,7 @@ top::TypeExpr ::= '[' te::TypeExpr ']'
 
   top.typerep = listType(te.typerep);
   
-  top.errorsFullyApplied =
+  top.errorsKindStar =
     if top.typerep.kindArity > 0
     then [err(top.location, s"${top.unparse} is not fully applied, it has kind arity ${toString(top.typerep.kindArity)}")]
     else [];
@@ -32,7 +32,7 @@ top::TypeExpr ::= '[' ']'
 
   top.typerep = listCtrType();
   
-  top.errorsFullyApplied =
+  top.errorsKindStar =
     if top.typerep.kindArity > 0
     then [err(top.location, s"${top.unparse} is not fully applied, it has kind arity ${toString(top.typerep.kindArity)}")]
     else [];

--- a/grammars/silver/compiler/extension/list/Type.sv
+++ b/grammars/silver/compiler/extension/list/Type.sv
@@ -42,5 +42,5 @@ top::Type ::=
   -- i_emptyList, i_lengthList, etc. in the non-specialized translation.
   -- That's no longer possible with the switch to appType, but this has no
   -- effect on the performance of the java translation.
-  forwards to nonterminalType("silver:core:List", 1, false);
+  forwards to nonterminalType("silver:core:List", [starKind()], false);
 }

--- a/grammars/silver/compiler/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/compiler/extension/rewriting/Rewriting.sv
@@ -48,11 +48,11 @@ top::Expr ::= 'traverse' n::QName '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   
   local numChildren::Integer = n.lookupValue.typeScheme.arity;
   local annotations::[String] = map(fst, n.lookupValue.typeScheme.typerep.namedTypes);
-  es.appExprTypereps = repeat(nonterminalType("silver:rewrite:Strategy", 0, false), numChildren);
+  es.appExprTypereps = repeat(nonterminalType("silver:rewrite:Strategy", [], false), numChildren);
   es.appExprApplied = n.unparse;
   anns.appExprApplied = n.unparse;
   anns.funcAnnotations =
-    map(pair(_, nonterminalType("silver:rewrite:Strategy", 0, false)), annotations);
+    map(pair(_, nonterminalType("silver:rewrite:Strategy", [], false)), annotations);
   anns.remainingFuncAnnotations = anns.funcAnnotations;
  
   local localErrors::[Message] =

--- a/grammars/silver/compiler/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/compiler/extension/rewriting/Rewriting.sv
@@ -224,7 +224,7 @@ top::Expr ::= 'rule' 'on' ty::TypeExpr 'of' Opt_Vbar_t ml::MRuleList 'end'
   
   local localErrors::[Message] =
     ty.errors ++ ml.errors ++ checkExpr.errors ++
-    ty.errorsFullyApplied ++
+    ty.errorsKindStar ++
     if null(getTypeDcl("silver:rewrite:Strategy", top.env))
     then [err(top.location, "Term rewriting requires import of silver:rewrite")]
     else [];

--- a/grammars/silver/compiler/extension/strategyattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/strategyattr/DclInfo.sv
@@ -34,7 +34,7 @@ top::DclInfo ::=
   top.typeScheme = polyType([tyVar],
     if isTotal
     then varType(tyVar)
-    else appType(nonterminalType("silver:core:Maybe", 1, false), varType(tyVar)));
+    else appType(nonterminalType("silver:core:Maybe", [starKind()], false), varType(tyVar)));
   top.isSynthesized = true;
   top.isStrategy = true;
   

--- a/grammars/silver/compiler/extension/strategyattr/Project.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Project.sv
@@ -5,7 +5,7 @@ imports silver:core hiding id, sequence, fail;
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
-imports silver:compiler:definition:type:syntax;
+imports silver:compiler:definition:type:syntax hiding Arrow_t;
 imports silver:compiler:extension:autoattr;
 imports silver:compiler:extension:patternmatching;
 imports silver:compiler:extension:list;

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -44,7 +44,7 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
         [attrDef(
            defaultEnvItem(
              strategyDcl(
-               fName, isTotal, freshTyVar(0),
+               fName, isTotal, freshTyVar(starKind()),
                !null(top.errors), map(fst, e.liftedStrategies), recVarNameEnv, recVarTotalEnv, e.partialRefs, e.totalRefs, e,
                sourceGrammar=top.grammarName, sourceLocation=a.location)))],
         location=top.location),

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -335,7 +335,7 @@ top::StrategyExpr ::= s::StrategyExpr
            },
            location=top.location)],
         Silver_Expr { silver:core:nothing() },
-        appType(nonterminalType("silver:core:Maybe", 1, false), top.frame.signature.outputElement.typerep),
+        appType(nonterminalType("silver:core:Maybe", [starKind()], false), top.frame.signature.outputElement.typerep),
         location=top.location);
   top.totalTranslation =
     if sTotal
@@ -510,7 +510,7 @@ top::StrategyExpr ::= s::StrategyExpr
             end end,
             range(0, length(matchingChildren))),
         Silver_Expr { silver:core:nothing() },
-        appType(nonterminalType("silver:core:Maybe", 1, false), top.frame.signature.outputElement.typerep),
+        appType(nonterminalType("silver:core:Maybe", [starKind()], false), top.frame.signature.outputElement.typerep),
         location=top.location);
   top.totalTranslation =
     if sTotal && !null(matchingChildren)
@@ -605,7 +605,7 @@ top::StrategyExpr ::= prod::QName s::StrategyExprs
            },
            location=top.location)],
         Silver_Expr { silver:core:nothing() },
-        appType(nonterminalType("silver:core:Maybe", 1, false), top.frame.signature.outputElement.typerep),
+        appType(nonterminalType("silver:core:Maybe", [starKind()], false), top.frame.signature.outputElement.typerep),
         location=top.location)
     else Silver_Expr { silver:core:nothing() };
 }
@@ -734,7 +734,7 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
       [Silver_Expr { $name{top.frame.signature.outputElement.elementName} }],
       ml.translation,
       Silver_Expr { silver:core:nothing() },
-      appType(nonterminalType("silver:core:Maybe", 1, false), ty.typerep),
+      appType(nonterminalType("silver:core:Maybe", [starKind()], false), ty.typerep),
       location=top.location);
   top.partialTranslation =
     if unify(ty.typerep, top.frame.signature.outputElement.typerep).failure

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -723,7 +723,7 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
     if !ty.typerep.isDecorable
     then [wrn(ty.location, "Only rules on nonterminals can have an effect")]
     else [];
-  top.errors <- ty.errorsFullyApplied;
+  top.errors <- ty.errorsKindStar;
   
   top.flowDefs <- checkExpr.flowDefs;
   

--- a/grammars/silver/compiler/extension/tuple/Type.sv
+++ b/grammars/silver/compiler/extension/tuple/Type.sv
@@ -30,7 +30,7 @@ top::Type ::= c::Type a::Type
   top.tupleElems =
     -- c.argTypes should only have a single element
     case c.baseType of
-    | nonterminalType("silver:core:Pair", 2, false) -> c.argTypes ++ a.tupleElems
+    | nonterminalType("silver:core:Pair", [starKind(), starKind()], false) -> c.argTypes ++ a.tupleElems
     | _ -> [top]
     end;
 
@@ -66,9 +66,9 @@ top::Type ::= ts::[Type]
   top.typepp = "(" ++ implode(", ", map(prettyTypeWith(_, top.boundVariables), ts)) ++ ")";
   
   forwards to case ts of
-    | [] -> nonterminalType("silver:core:Unit", 0, false)
+    | [] -> nonterminalType("silver:core:Unit", [], false)
     | [t] -> t
-    | t1::t1s -> appType(appType(nonterminalType("silver:core:Pair", 2, false), t1), tupleType(t1s))
+    | t1::t1s -> appType(appType(nonterminalType("silver:core:Pair", [starKind(), starKind()], false), t1), tupleType(t1s))
     end;
 
 }

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -154,7 +154,7 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
   propagate errors, flowDefs;
   
   top.errors <- tl.errorsTyVars;
-  top.errors <- te.errorsFullyApplied;
+  top.errors <- te.errorsKindStar;
 
   top.errors <-
         if length(getAttrDclAll(fName, top.env)) > 1
@@ -181,7 +181,7 @@ top::AGDcl ::= 'inherited' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te
   propagate errors, flowDefs;
   
   top.errors <- tl.errorsTyVars;
-  top.errors <- te.errorsFullyApplied;
+  top.errors <- te.errorsKindStar;
 
   top.errors <-
         if length(getAttrDclAll(fName, top.env)) > 1

--- a/grammars/silver/compiler/modification/copper/ParserAttributes.sv
+++ b/grammars/silver/compiler/modification/copper/ParserAttributes.sv
@@ -14,7 +14,7 @@ top::AGDcl ::= 'parser' 'attribute' a::Name '::' te::TypeExpr 'action' acode::Ac
   top.errors <- if length(getValueDclAll(fName, top.env)) > 1
                 then [err(a.location, "Attribute '" ++ fName ++ "' is already bound.")]
                 else [];
-  top.errors <- te.errorsFullyApplied;
+  top.errors <- te.errorsKindStar;
   
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;

--- a/grammars/silver/compiler/modification/copper/ParserDcl.sv
+++ b/grammars/silver/compiler/modification/copper/ParserDcl.sv
@@ -32,7 +32,7 @@ top::AGDcl ::= 'parser' n::Name '::' t::TypeExpr '{' m::ParserComponents '}'
     namedSignature(fName, [],
       [namedSignatureElement("stringToParse", stringType()),
        namedSignatureElement("filenameToReport", stringType())],
-      namedSignatureElement("__func__lhs", appType(nonterminalType("silver:core:ParseResult", 1, false), t.typerep)),
+      namedSignatureElement("__func__lhs", appType(nonterminalType("silver:core:ParseResult", [starKind()], false), t.typerep)),
       []);
 
   production spec :: ParserSpec =

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -28,7 +28,7 @@ top::AGDcl ::= 'aspect' 'default' 'production'
 
   propagate errors, flowDefs;
 
-  top.errors <- te.errorsFullyApplied;
+  top.errors <- te.errorsKindStar;
 
   local fakedDefs :: [Def] =
     [defaultLhsDef(top.grammarName, lhs.location, lhs.name, te.typerep)];

--- a/grammars/silver/compiler/modification/ffi/Type.sv
+++ b/grammars/silver/compiler/modification/ffi/Type.sv
@@ -8,7 +8,7 @@ top::Type ::= fn::String  transType::String  params::[Type]
   top.substituted = foreignType(fn, transType, mapSubst(params, top.substitution));
   top.flatRenamed = foreignType(fn, transType, mapRenameSubst(params, top.substitution));
   top.typepp = fn ++ if !null(params) then "<" ++ implode(" ", map(prettyTypeWith(_, top.boundVariables), params)) ++ ">" else "";
-  top.kindArity = 0;
+  top.kindrep = starKind();
   top.isTypeable = false; -- TODO: May want to add extra syntax to indicate that a foreign type's translation is an instance of Typed
 
   -- Unification.sv

--- a/grammars/silver/compiler/modification/impide/IdeDecl.sv
+++ b/grammars/silver/compiler/modification/impide/IdeDecl.sv
@@ -169,11 +169,11 @@ top::IdeStmt ::=
 }
 
 -- Helpers for writing expected types
-global t_iomsgs :: Type = appType(nonterminalType("silver:core:IOVal", 1, false), listType(nonterminalType("silver:langutil:Message", 0, true)));
-global t_props :: Type = listType(nonterminalType("ide:IdeProperty", 0, false));
+global t_iomsgs :: Type = appType(nonterminalType("silver:core:IOVal", [starKind()], false), listType(nonterminalType("silver:langutil:Message", [], true)));
+global t_props :: Type = listType(nonterminalType("ide:IdeProperty", [], false));
 global t_io :: Type = ioForeignType;
 global t_proj :: Type = foreignType("ide:IdeProject", "Object", []);
-global t_loc :: Type = nonterminalType("silver:core:Location", 0, false);
+global t_loc :: Type = nonterminalType("silver:core:Location", [], false);
 
 concrete production makeIdeStmt_Builder
 top::IdeStmt ::= 'builder' builderName::QName ';' 
@@ -243,7 +243,7 @@ top::IdeStmt ::= 'folder' folderName::QName ';'
   
   -- [Location] ::= <<CST root's type>>
   local expectedType :: Type =
-    appTypes(functionType(1, []), [nonterminalType(top.startNTName, 0, false), listType(t_loc)]);
+    appTypes(functionType(1, []), [nonterminalType(top.startNTName, [], false), listType(t_loc)]);
   
   local tc1 :: TypeCheck = check(folderName.lookupValue.typeScheme.typerep, expectedType);
   tc1.downSubst = emptySubst();
@@ -323,7 +323,7 @@ top::StubGenerator ::= 'stub generator' genName::QName ';'
 
   -- String ::= [IdeProperty]
   local stubGenTypeExpected :: Type =
-    appTypes(functionType(1, []), [listType(nonterminalType("ide:IdeProperty", 0, false)), stringType()]);
+    appTypes(functionType(1, []), [listType(nonterminalType("ide:IdeProperty", [], false)), stringType()]);
   
   local tc1 :: TypeCheck = check(genName.lookupValue.typeScheme.typerep, stubGenTypeExpected);
   tc1.downSubst = emptySubst();

--- a/grammars/silver/compiler/modification/let_fix/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/Let.sv
@@ -102,7 +102,7 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
     then [err(id.location, "Value '" ++ id.name ++ "' is already bound.")]
     else [];
 
-  top.errors <- t.errorsFullyApplied;
+  top.errors <- t.errorsKindStar;
 
   thread downSubst, upSubst on top, e, errCheck1, top;
 

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -6,7 +6,7 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 
-import silver:compiler:definition:type:syntax only typerepType, TypeExpr, errorsFullyApplied;
+import silver:compiler:definition:type:syntax only typerepType, TypeExpr, errorsKindStar;
 import silver:compiler:extension:patternmatching only Arrow_kwd, Vbar_kwd, ensureDecoratedExpr; -- TODO remove
 
 import silver:compiler:translation:java:core;
@@ -72,7 +72,7 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
   propagate errors, freeVars;
   top.typerep = t.typerep;
 
-  top.errors <- t.errorsFullyApplied;
+  top.errors <- t.errorsKindStar;
   
   {--
    - Invariant: if we were given an undecorated expression, it should have been

--- a/grammars/silver/compiler/modification/primitivepattern/Types.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/Types.sv
@@ -74,7 +74,7 @@ top::Type ::= tv::TyVar
         if tv == j
         then emptySubst()
         else subst(tv, top.refineWith)
-    | t when t.kindArity == tv.kindArity ->
+    | t when t.kindrep == tv.kindrep ->
         if contains(tv, t.freeVariables)
         then errorSubst("Infinite type! Tried to refine with " ++ prettyType(t))
         else subst(tv, t)
@@ -91,7 +91,7 @@ top::Type ::= tv::TyVar
         if tv == j
         then emptySubst()
         else subst(tv, top.refineWith)
-    | t when t.kindArity == tv.kindArity ->
+    | t when t.kindrep == tv.kindrep ->
         if contains(tv, t.freeVariables)
         then errorSubst("Infinite type! Tried to refine with " ++ prettyType(t))
         else subst(tv, t)
@@ -169,12 +169,12 @@ top::Type ::=
 }
 
 aspect production nonterminalType
-top::Type ::= fn::String k::Integer _
+top::Type ::= fn::String ks::[Kind] _
 {
   top.refine = 
     case top.refineWith of
-    | nonterminalType(ofn, ok, _) ->
-        if fn == ofn && k == ok
+    | nonterminalType(ofn, oks, _) ->
+        if fn == ofn && ks == oks
         then emptySubst()
         else errorSubst("Tried to refine conflicting nonterminal types " ++ fn ++ " and " ++ ofn)
     | _ -> errorSubst("Tried to refine nonterminal type " ++ fn ++ " with " ++ prettyType(top.refineWith))

--- a/grammars/silver/compiler/modification/primitivepattern/Types.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/Types.sv
@@ -70,7 +70,7 @@ top::Type ::= tv::TyVar
 {
   top.refine = 
     case top.refineWith of
-    | varType(j) ->
+    | varType(j) when j.kindrep == tv.kindrep ->
         if tv == j
         then emptySubst()
         else subst(tv, top.refineWith)
@@ -87,7 +87,7 @@ top::Type ::= tv::TyVar
 {
   top.refine = 
     case top.refineWith of
-    | skolemType(j) -> 
+    | skolemType(j) when j.kindrep == tv.kindrep -> 
         if tv == j
         then emptySubst()
         else subst(tv, top.refineWith)

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -33,9 +33,9 @@ s"""			final common.DecoratedNode context = new P${id.name}(${argsAccess}).decor
        unify(namedSig.typerep,
          appTypes(
            functionType(2, []),
-           [appType(nonterminalType("silver:core:List", 1, false), stringType()),
+           [appType(nonterminalType("silver:core:List", [starKind()], false), stringType()),
             ioForeignType,
-            appType(nonterminalType("silver:core:IOVal", 1, false), intType())])).failure
+            appType(nonterminalType("silver:core:IOVal", [starKind()], false), intType())])).failure
     then [err(top.location, "main function must have type signature (IOVal<Integer> ::= [String] IO). Instead it has type " ++ prettyType(namedSig.typerep))]
     else [];
 }

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -9,10 +9,10 @@ top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTy
   local synVar :: String = "count_syn__ON__" ++ id.name;
   
   local myAnnos :: [NamedSignatureElement] =
-    annotationsForNonterminal(nonterminalType(fName, length(tl.types), quals.tracked), top.env);
+    annotationsForNonterminal(nonterminalType(fName, map((.kindrep), tl.types), quals.tracked), top.env);
 
   local commaIfAnnos :: String = if length(myAnnos)!=0 then "," else "";
-  local wantsTracking :: Boolean = typeWantsTracking(nonterminalType(fName, length(tl.types), quals.tracked), top.config, top.env);
+  local wantsTracking :: Boolean = typeWantsTracking(nonterminalType(fName, map((.kindrep), tl.types), quals.tracked), top.config, top.env);
 
   top.initWeaving := s"""
 	public static int ${inhVar} = 0;

--- a/grammars/silver/core/Either.sv
+++ b/grammars/silver/core/Either.sv
@@ -63,6 +63,10 @@ instance Bind Either<a _> {
 
 instance Monad Either<a _> {}
 
+instance MonadFail Either<String _> {
+  fail = left;
+}
+
 {--
  - Order preserving partitioning of a list of eithers into a pair
  - of lists of the two different results.

--- a/grammars/silver/core/List.sv
+++ b/grammars/silver/core/List.sv
@@ -20,6 +20,13 @@ instance Bind [] {
 
 instance Monad [] {}
 
+instance MonadFail [] {
+  fail = \ String -> [];
+}
+
+instance MonadZero [] {}
+instance MonadPlus [] {}
+
 {--
  - Applies an operator right-associatively over a list.
  - (i.e. replaces cons with 'f', nil with 'i' in the list)

--- a/grammars/silver/core/Maybe.sv
+++ b/grammars/silver/core/Maybe.sv
@@ -49,6 +49,13 @@ instance Bind Maybe {
 
 instance Monad Maybe {}
 
+instance MonadFail Maybe {
+  fail = \ String -> nothing();
+}
+
+instance MonadZero Maybe {}
+instance MonadPlus Maybe {}
+
 --------------------------------------------------------------------------------
 
 {--

--- a/grammars/silver/core/Monad.sv
+++ b/grammars/silver/core/Monad.sv
@@ -64,6 +64,13 @@ Distributivity
 -}
 class MonadZero m, Alternative m => MonadPlus m {}
 
+{-
+Monad transformers lift a monadic computation into an additional monad.
+
+Instances should satisfy the following:
+  compose(lift, pure) = pure
+  lift(bind(m, f)) = bind(lift(m), compose(lift, f))
+-}
 class MonadTrans (t :: (* -> *) -> * -> *) {
   lift :: Monad m => (t<m a> ::= m<a>);
 }

--- a/grammars/silver/core/Monad.sv
+++ b/grammars/silver/core/Monad.sv
@@ -44,18 +44,6 @@ class Monad m => MonadFail m {
   fail :: (m<a> ::= String);
 }
 
-instance MonadFail [] {
-  fail = \ String -> [];
-}
-
-instance MonadFail Maybe {
-  fail = \ String -> nothing();
-}
-
-instance MonadFail Either<String _> {
-  fail = left;
-}
-
 {-
 The MonadZero type class has no members of its own; it just specifies that the type has both Monad and Alternative instances.
 
@@ -66,9 +54,6 @@ Annihilation
 -}
 class Monad m, Alternative m => MonadZero m {}
 
-instance MonadZero [] {}
-instance MonadZero Maybe {}
-
 {-
 The MonadPlus type class has no members of its own; it just extends MonadZero with an additional law.
 
@@ -78,6 +63,3 @@ Distributivity
   bind(alt(x, y), f) = alt(bind(x, f), bind(y, f))
 -}
 class MonadZero m, Alternative m => MonadPlus m {}
-
-instance MonadPlus [] {}
-instance MonadPlus Maybe {}

--- a/test/silver_features/FuncProdTypes.sv
+++ b/test/silver_features/FuncProdTypes.sv
@@ -55,7 +55,7 @@ global foldMaybeInt::(Integer ::= (Integer ::= Integer Integer) Integer Maybe<In
 equalityTest(fints(foldMaybeInt, just(42)).intValue, 42, Integer, silver_tests);
 
 -- Kind mismatch
-wrongCode "f is not fully applied, it has kind arity 1" {
+wrongCode "f has kind * -> *, but kind * is expected here" {
   function badKind
   f ::= f<a>
   { return error(""); }

--- a/test/silver_features/TypeClasses.sv
+++ b/test/silver_features/TypeClasses.sv
@@ -222,11 +222,11 @@ equalityTest(myfmap(\ x::Integer -> toFloat(x), just(42)).fromJust, 42.0, Float,
 equalityTest(myfmap(\ x::Integer -> toFloat(x), left("abc")).fromLeft, "abc", String, silver_tests);
 equalityTest(myfmap(\ x::Integer -> toFloat(x), right(42)).fromRight, 42.0, Float, silver_tests);
 
-wrongCode "Either has kind arity 2, but the class MyFunctor expected kind arity 1" {
+wrongCode "Either has kind * -> * -> *, but the class MyFunctor expected kind * -> *" {
   instance MyFunctor Either {}
 }
 
-wrongCode "f has kind arity 1, but there are 2 type arguments supplied here" {
+wrongCode "f has kind * -> *, but there are 2 type arguments supplied here" {
   class MyFunctorBad f {
     myfmap2 :: (f<b> ::= (b ::= a) f<a b>);
   }
@@ -274,7 +274,7 @@ global isSingleDigit::(Boolean ::= String) = contains(_, ["1", "2", "3", "4", "5
 equalityTest(isSingleDigit("5"), true, Boolean, silver_tests);
 equalityTest(isSingleDigit("42"), false, Boolean, silver_tests);
 
-class Semigroupoid a {
+class Semigroupoid (a :: * -> * -> *) {
   sgcompose :: (a<b d> ::= a<c d> a<b c>);
 }
 
@@ -284,7 +284,7 @@ instance Semigroupoid (_ ::= _) {
 
 equalityTest(sgcompose(\ x::Integer -> x * 2, \ s::String -> toInteger(s))("42"), 84, Integer, silver_tests);
 
-wrongCode "(_ ::= _ _) has kind arity 3, but the class Semigroupoid expected kind arity 2" {
+wrongCode "(_ ::= _ _) has kind * -> * -> * -> *, but the class Semigroupoid expected kind * -> * -> *" {
   instance Semigroupoid (_ ::= _ _) {
     sgcompose = compose;
   }

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -3,22 +3,22 @@ import silver:testing;
 ------------------------------------- Number of parameters to type constructors
 terminal ATerminalType 'doesnotmatter';
 
-wrongCode "ATerminalType has kind arity 0, but there are 1 type arguments supplied here" {
+wrongCode "ATerminalType has kind *, but there are 1 type arguments supplied here" {
  global t :: ATerminalType<String> = error("");
 }
 
 nonterminal NTZero;
 
-wrongCode "NTZero has kind arity 0, but there are 1 type arguments supplied here" {
+wrongCode "NTZero has kind *, but there are 1 type arguments supplied here" {
  global t :: NTZero<String> = error("");
 }
 
 nonterminal NTOne<a>;
 
-wrongCode "NTOne is not fully applied, it has kind arity 1" {
+wrongCode "NTOne has kind * -> *, but kind * is expected here" {
  global t :: NTOne = error("");
 }
-wrongCode "NTOne has kind arity 1, but there are 2 type arguments supplied here" {
+wrongCode "NTOne has kind * -> *, but there are 2 type arguments supplied here" {
  global t :: NTOne<String String> = error("");
 }
 
@@ -36,13 +36,13 @@ wrongCode "cannot contain _" {
 nonterminal NTTwo<a b>;
 production ntt top::NTTwo<a b> ::= a b {}
 
-wrongCode "NTTwo is not fully applied, it has kind arity 2" {
+wrongCode "NTTwo has kind * -> * -> *, but kind * is expected here" {
  global t :: NTTwo = error("");
 }
-wrongCode "NTTwo<_ _> is not fully applied, it has kind arity 2" {
+wrongCode "NTTwo<_ _> has kind * -> * -> *, but kind * is expected here" {
  global t :: NTTwo<_ _> = error("");
 }
-wrongCode "NTTwo<Integer _> is not fully applied, it has kind arity 1" {
+wrongCode "NTTwo<Integer _> has kind * -> *, but kind * is expected here" {
  global t :: NTTwo<Integer _> = error("");
 }
 wrongCode "Missing type argument cannot be followed by a provided argument" {
@@ -67,13 +67,13 @@ wrongCode "Attribute type arguments cannot contain _" {
 
 global ctrList::[]<Integer> = [1, 2, 3];
 
-wrongCode "[] is not fully applied, it has kind arity 1" {
+wrongCode "[] has kind * -> *, but kind * is expected here" {
   global badCtrList1::[] = [1, 2, 3];
 }
-wrongCode "[] has kind arity 1, but there are 2 type arguments supplied here" {
+wrongCode "[] has kind * -> *, but there are 2 type arguments supplied here" {
   global badCtrList2::[]<Integer Integer> = [1, 2, 3];
 }
-wrongCode "[Integer] has kind arity 0, but there are 1 type arguments supplied here" {
+wrongCode "[Integer] has kind *, but there are 1 type arguments supplied here" {
   global badCtrList2::[Integer]<Integer> = [1, 2, 3];
 }
 
@@ -108,10 +108,10 @@ wrongCode "repeats type variable names" {
  type TypeTwo<a a> = Integer;
 }
 
-wrongCode "NTTwo<a _> is not fully applied, it has kind arity 1" {
+wrongCode "NTTwo<a _> has kind * -> *, but kind * is expected here" {
  type MyTypeErr<a> = NTTwo<a _>;
 }
-wrongCode "NTTwo<_ _> is not fully applied, it has kind arity 2" {
+wrongCode "NTTwo<_ _> has kind * -> * -> *, but kind * is expected here" {
  type MyTypeErr = NTTwo<_ _>;
 }
 

--- a/test/stdlib/Maybe.sv
+++ b/test/stdlib/Maybe.sv
@@ -16,3 +16,21 @@ equalityTest ( orElse(just(false), nothing()).fromJust, false,
 equalityTest ( orElse(nothing(), nothing()).isJust, false,
                Boolean, core_tests ) ;
 
+-- MaybeT
+global mts::MaybeT<State<Integer _> String> =
+  do {
+    x::Integer <- lift(getState());
+    lift(setState(x + 2));
+    if x < 0 then fail("negative") else pure(unit());
+    when_(x % 2 != 0, lift(setState(x + 1)));
+    y::Integer <- lift(getState());
+    return toString(y / (x + 1));
+  };
+
+equalityTest(runState(mts.run, -4), pair(-2, nothing()), Pair<Integer Maybe<String>>, core_tests);
+equalityTest(runState(mts.run, -1), pair(1, nothing()), Pair<Integer Maybe<String>>, core_tests);
+equalityTest(runState(mts.run, 0), pair(2, just("2")), Pair<Integer Maybe<String>>, core_tests);
+equalityTest(runState(mts.run, 1), pair(2, just("1")), Pair<Integer Maybe<String>>, core_tests);
+equalityTest(runState(mts.run, 2), pair(4, just("1")), Pair<Integer Maybe<String>>, core_tests);
+equalityTest(runState(mts.run, 3), pair(4, just("1")), Pair<Integer Maybe<String>>, core_tests);
+equalityTest(runState(mts.run, 5), pair(6, just("1")), Pair<Integer Maybe<String>>, core_tests);


### PR DESCRIPTION
# Changes
This adds actual kinds, needed for #115, to replace my shortcut notion of a "kind arity".  Syntax is copied from Haskell.

Also adding monad transformers and the `MonadTrans` type class - this started out as a test case, but I figured I might as well make it part of the standard library.

Still TODO:
- [ ] Monad transformers for `Either`, `State`, `IO` and lists for completeness, probably
- [x] Tests for monad transformers
- [x] Fill in missing doc comments

# Documentation
This should be documented on the website, eventually - I am planning to write up something more comprehensive about the type system in Silver once #115 is finished.  For now we can tell people that kinds are essentially the same as in Haskell without extensions.  

Comments on the `MonadTrans` class and instance types will become doc comments.
