### PR TITLE
Make `new` a foreign function

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/BuiltInFunctions.sv
@@ -43,20 +43,6 @@ top::Expr ::= 'toString' '(' e1::Expr ')'
     else [err(top.location, "Operand to toString must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
-aspect production newFunction
-top::Expr ::= 'new' '(' e1::Expr ')'
-{
-  local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
-
-  thread downSubst, upSubst on top, e1, errCheck1, top;
-  
-  errCheck1 = checkDecorated(e1.typerep);
-  top.errors <-
-    if errCheck1.typeerror
-    then [err(top.location, "Operand to new must be a decorated nonterminal.  Instead it is of type " ++ errCheck1.leftpp)]
-    else [];
-}
-
 aspect production terminalConstructor
 top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
 {

--- a/grammars/silver/compiler/analysis/typechecking/core/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/BuiltInFunctions.sv
@@ -43,17 +43,6 @@ top::Expr ::= 'toString' '(' e1::Expr ')'
     else [err(top.location, "Operand to toString must be concrete types String, Integer, Float, or Boolean.  Instead it is of type " ++ prettyType(performSubstitution(e1.typerep, top.finalSubst)))];
 }
 
-function containsSkolem
-Boolean ::= ty::Type
-{
-  return case ty of
-         | skolemType(_) -> true
-         | appType(c, a) -> containsSkolem(c) || containsSkolem(a)
-         | decoratedType(ty) -> containsSkolem(ty)
-         | _ -> false
-         end;
-}
-
 aspect production newFunction
 top::Expr ::= 'new' '(' e1::Expr ')'
 {

--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -8,7 +8,7 @@ propagate upSubst, downSubst
      undecoratedAccessHandler, forwardAccess, decoratedAccessHandler,
      and, or, not, ifThenElse, plus, minus, multiply, divide, modulus,
      decorateExprWith, exprInh, presentAppExpr,
-     newFunction, terminalConstructor, noteAttachment;
+     terminalConstructor, noteAttachment;
 
 attribute contexts occurs on Expr;
 aspect default production

--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -82,7 +82,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     then [err(top.location, "Access of " ++ q.name ++ " from a decorated type.")]
     else [];
   
-  thread downSubst, upSubst on top, errCheck1, top;
+  thread downSubst, upSubst on top, errCheck1, forward;
 }
 
 aspect production accessBouncer
@@ -120,7 +120,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
     then [err(top.location, "Attribute " ++ q.name ++ " being accessed from an undecorated type.")]
     else [];
 
-  thread downSubst, upSubst on top, errCheck1, top;
+  thread downSubst, upSubst on top, errCheck1, forward;
 }
   
 

--- a/grammars/silver/compiler/definition/core/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/definition/core/BuiltInFunctions.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:definition:core;
 
--- TODO: Everything in this file should become type class methods, except (possibly) new and terminal
+-- TODO: Everything in this file should become type class methods, except (probably) terminal
 
 concrete production lengthFunction
 top::Expr ::= 'length' '(' e::Expr ')'
@@ -76,16 +76,6 @@ top::Expr ::= 'toString' '(' e::Expr ')'
   top.unparse = "toString(" ++ e.unparse ++ ")";
 
   top.typerep = stringType();
-
-  e.isRoot = false;
-}
-
-concrete production newFunction
-top::Expr ::= 'new' '(' e::Expr ')'
-{
-  top.unparse = "new(" ++ e.unparse ++ ")";
-
-  top.typerep = performSubstitution(e.typerep, top.upSubst).decoratedType;
 
   e.isRoot = false;
 }

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -478,7 +478,7 @@ Expr ::= target::(Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) e
 function accessBounceUndecorate
 Expr ::= target::(Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) e::Decorated Expr  q::Decorated QNameAttrOccur  l::Location
 {
-  return accessBouncer(target, newFunction('new', '(', exprRef(e, location=l), ')', location=l), q, location=l);
+  return accessBouncer(target, mkStrFunctionInvocationDecorated(l, "silver:core:new", [e]), q, location=l);
 }
 
 abstract production decoratedAccessHandler

--- a/grammars/silver/compiler/definition/core/Terminals.sv
+++ b/grammars/silver/compiler/definition/core/Terminals.sv
@@ -49,7 +49,7 @@ terminal If_kwd          'if'           lexer classes {KEYWORD,RESERVED};
 terminal Inherited_kwd   'inherited'    lexer classes {KEYWORD,RESERVED};
 terminal Instance_kwd    'instance'     lexer classes {KEYWORD};
 terminal Local_kwd       'local'        lexer classes {KEYWORD,RESERVED};
-terminal New_kwd         'new'          lexer classes {KEYWORD,RESERVED};
+terminal New_kwd         'new'          lexer classes {KEYWORD};
 terminal NonTerminal_kwd 'nonterminal'  lexer classes {KEYWORD,RESERVED};
 terminal Occurs_kwd      'occurs'       lexer classes {KEYWORD,RESERVED};
 terminal On_kwd          'on'           lexer classes {KEYWORD,RESERVED};
@@ -61,6 +61,8 @@ terminal Then_kwd        'then'         lexer classes {KEYWORD,RESERVED};
 terminal To_kwd          'to'           lexer classes {KEYWORD,RESERVED};
 terminal Type_t          'type'         lexer classes {KEYWORD};
 terminal With_kwd        'with'         lexer classes {KEYWORD,RESERVED};
+
+disambiguate New_kwd, IdLower_t { pluck New_kwd; }
 
 terminal Length_kwd     'length'     lexer classes {BUILTIN,RESERVED};
 terminal ToBoolean_kwd  'toBoolean'  lexer classes {BUILTIN,RESERVED};

--- a/grammars/silver/compiler/definition/core/Terminals.sv
+++ b/grammars/silver/compiler/definition/core/Terminals.sv
@@ -49,7 +49,6 @@ terminal If_kwd          'if'           lexer classes {KEYWORD,RESERVED};
 terminal Inherited_kwd   'inherited'    lexer classes {KEYWORD,RESERVED};
 terminal Instance_kwd    'instance'     lexer classes {KEYWORD};
 terminal Local_kwd       'local'        lexer classes {KEYWORD,RESERVED};
-terminal New_kwd         'new'          lexer classes {KEYWORD};
 terminal NonTerminal_kwd 'nonterminal'  lexer classes {KEYWORD,RESERVED};
 terminal Occurs_kwd      'occurs'       lexer classes {KEYWORD,RESERVED};
 terminal On_kwd          'on'           lexer classes {KEYWORD,RESERVED};
@@ -61,8 +60,6 @@ terminal Then_kwd        'then'         lexer classes {KEYWORD,RESERVED};
 terminal To_kwd          'to'           lexer classes {KEYWORD,RESERVED};
 terminal Type_t          'type'         lexer classes {KEYWORD};
 terminal With_kwd        'with'         lexer classes {KEYWORD,RESERVED};
-
-disambiguate New_kwd, IdLower_t { pluck New_kwd; }
 
 terminal Length_kwd     'length'     lexer classes {BUILTIN,RESERVED};
 terminal ToBoolean_kwd  'toBoolean'  lexer classes {BUILTIN,RESERVED};

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -24,7 +24,7 @@ attribute flowVertexInfo occurs on Expr;
 propagate flowDeps on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr
   excluding
     childReference, lhsReference, localReference, forwardReference, forwardAccess, synDecoratedAccessHandler, inhDecoratedAccessHandler,
-    decorateExprWith, newFunction, letp, lexicalLocalReference, matchPrimitiveReal;
+    decorateExprWith, letp, lexicalLocalReference, matchPrimitiveReal;
 propagate flowDefs on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr;
 
 
@@ -255,17 +255,6 @@ top::Expr ::= e::Decorated Expr
 {
   top.flowDeps <- e.flowDeps;
   top.flowDefs <- e.flowDefs;
-}
-
-aspect production newFunction
-top::Expr ::= 'new' '(' e1::Expr ')'
-{
-  -- Emit nothing except the keepDeps, for a vertex node
-  top.flowDeps :=
-    case e1.flowVertexInfo of
-    | hasVertex(vertex) -> vertex.eqVertex
-    | noVertex() -> e1.flowDeps
-    end;
 }
 
 

--- a/grammars/silver/compiler/extension/implicit_monads/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/BuiltInFunctions.sv
@@ -168,19 +168,6 @@ top::Expr ::= 'toString' '(' e::Expr ')'
                        else toStringFunction('toString', '(', e.monadRewritten, ')', location=top.location);
 }
 
-aspect production newFunction
-top::Expr ::= 'new' '(' e::Expr ')'
-{
-  top.merrors := e.merrors;
-  e.mDownSubst = top.mDownSubst;
-  top.mUpSubst = e.mUpSubst;
-  top.mtyperep = e.mtyperep;
-  e.monadicallyUsed = false;
-  top.monadicNames = e.monadicNames;
-  top.monadRewritten = newFunction('new', '(', e.monadRewritten, ')', location=top.location);
-}
-
-
 aspect production terminalConstructor
 top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
 {

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -51,7 +51,7 @@ top::Expr ::= q::Decorated QName _ _
           antiquoteASTExpr(
             Silver_Expr {
               silver:rewrite:anyASTExpr(
-                \ e::$TypeExpr{typerepTypeExpr(decoratedType(finalType(top)), location=builtin)} -> new(e))
+                \ e::$TypeExpr{typerepTypeExpr(decoratedType(finalType(top)), location=builtin)} -> silver:core:new(e))
             }),
           consASTExpr(varASTExpr(q.name), nilASTExpr()),
           nilNamedASTExpr())
@@ -61,7 +61,7 @@ top::Expr ::= q::Decorated QName _ _
       -- The variable is bound in an enclosing let/match
       -- Explicitly undecorate the variable, if appropriate for the final expected type
       if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
-      then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
+      then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(silver:core:new($Expr{top})) })
       else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) })
     end;
 }
@@ -72,7 +72,7 @@ top::Expr ::= q::Decorated QName
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
     if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
-    then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
+    then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(silver:core:new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
 
@@ -82,7 +82,7 @@ top::Expr ::= q::Decorated QName
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
     if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
-    then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
+    then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(silver:core:new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
 
@@ -92,7 +92,7 @@ top::Expr ::= q::Decorated QName
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
     if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
-    then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
+    then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(silver:core:new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
 
@@ -102,7 +102,7 @@ top::Expr ::= q::Decorated QName
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
     if q.lookupValue.typeScheme.isDecorable && !finalType(top).isDecorated
-    then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(new($Expr{top})) })
+    then antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr(silver:core:new($Expr{top})) })
     else antiquoteASTExpr(Silver_Expr { silver:rewrite:anyASTExpr($Expr{top}) });
 }
 
@@ -484,20 +484,6 @@ aspect production toStringFunction
 top::Expr ::= 'toString' '(' e::Expr ')'
 {
   top.transform = toStringASTExpr(e.transform);
-}
-
-aspect production newFunction
-top::Expr ::= 'new' '(' e::Expr ')'
-{
-  top.transform =
-    applyASTExpr(
-      antiquoteASTExpr(
-        Silver_Expr {
-          silver:rewrite:anyASTExpr(
-            \ e::$TypeExpr{typerepTypeExpr(finalType(e), location=builtin)} -> new(e))
-        }),
-      consASTExpr(e.transform, nilASTExpr()),
-      nilNamedASTExpr());
 }
 
 aspect production terminalConstructor

--- a/grammars/silver/compiler/translation/java/core/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/translation/java/core/BuiltInFunctions.sv
@@ -62,14 +62,6 @@ top::Expr ::= 'toString' '(' e::Expr ')'
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
 
-aspect production newFunction
-top::Expr ::= 'new' '(' e::Expr ')'
-{
-  top.translation = s"((${finalType(top).transType})" ++ wrapNewWithOT(top, s"${e.translation}.undecorate()") ++ ")";
-  
-  top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
-}
-
 aspect production terminalConstructor
 top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
 {

--- a/grammars/silver/compiler/translation/java/core/Origins.sv
+++ b/grammars/silver/compiler/translation/java/core/Origins.sv
@@ -118,13 +118,3 @@ String ::= top::Decorated Expr expr::String
   -- The extra (common.Node) cast in the non-generic non-primitive case is sometimes required for reasons I don't fully understand.
 
 }
-
-function wrapNewWithOT
-String ::= top::Decorated Expr expr::String
-{
-  local ty :: Type = finalType(top);
-
-  local directDup :: String = s"((${ty.transType})${expr}).duplicate(${makeOriginContextRef(top)})";
-
-  return if ((!top.config.noRedex) && typeWantsTracking(ty, top.config, top.env)) then directDup else expr;
-}

--- a/grammars/silver/core/Undecorate.sv
+++ b/grammars/silver/core/Undecorate.sv
@@ -1,0 +1,8 @@
+grammar silver:core;
+
+function new
+a ::= x::Decorated a
+{ return error("foreign function"); }
+foreign {
+  "java": return "%x%.undecorate()";
+}


### PR DESCRIPTION
# Changes
This changes `new` from a built-in to a foreign function, as described in #115. 

# Documentation
None yet, this shouldn't have any significant user-facing change to the semantics of `new`, except that it can now be used without being immediately applied (e.g. `map(new, decList)`)