### PR TITLE
Adding existing test suites and tutorials to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,8 +79,8 @@ melt.trynode('silver') {
 
   stage("Test") {
     // These test cases and tutorials are run as seperate tasks to allow for parallelism
-    def tests = ["silver_features", "copper_features", "patt", "stdlib", "performance", "csterrors"]
-    def tuts = ["simple/with_all", "simple/with_do_while", "simple/with_repeat_until", "simple/with_implication", "simple/host", "dc", "lambda", "turing", "hello"]
+    def tests = ["silver_features", "copper_features", "patt", "stdlib", "performance", "csterrors", "silver_construction", "origintracking", "implicit_monads"]
+    def tuts = ["simple/with_all", "simple/with_do_while", "simple/with_repeat_until", "simple/with_implication", "simple/host", "dc", "lambda", "turing", "hello", "stlc"]
 
     def tasks = [:]
     tasks << tests.collectEntries { t -> [(t): task_test(t, WS)] }

--- a/tutorials/stlc/silver-compile
+++ b/tutorials/stlc/silver-compile
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+set -eu
+silver() { "../../support/bin/silver" "$@"; }
+
+SRC=..  # cheating a bit. Current directory should be 'stlc'
 GRAMMAR=stlc
 
-silver --clean -I .. $GRAMMAR
+silver -I $SRC $@ $GRAMMAR
 


### PR DESCRIPTION
# Changes
This adds existing test suites and tutorials to the `Jenkinsfile` so Jenkins will run them when doing a build.

# Documentation
This only adds to two existing lists, so there isn't any documentation to add.
