### PR TITLE
Use subset constraints when determining inherited attributes available on references for MWDA

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/Context.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Context.sv
@@ -61,14 +61,12 @@ top::Context ::= i1::Type i2::Type
     then map(
       \ tv::TyVar -> err(top.contextLoc, s"Ambiguous type variable ${findAbbrevFor(tv, top.freeVariables)} (arising from ${top.contextSource}) prevents the constraint ${prettyContext(top)} from being solved."),
       i1.freeFlexibleVars ++ i2.freeFlexibleVars)
-    else case i1, i2 of
-    | skolemType(a1), skolemType(a2) when a1 == a2 -> []
-    | _, _ ->
+    else
       case getMaxInhSetMembers([], i1, top.env), getMinInhSetMembers([], i2, top.env) of
-      | just(inhs1), inhs2 when all(map(contains(_, inhs2), inhs1)) -> []
+      | (just(inhs1), _), (inhs2, _) when all(map(contains(_, inhs2), inhs1)) -> []
+      | (_, tvs1), (_, tvs2) when any(map(contains(_, tvs2), tvs1)) -> []
       | _, _ -> [err(top.contextLoc, s"${prettyTypeWith(i1, top.freeVariables)} is not a subset of ${prettyTypeWith(i2, top.freeVariables)} (arising from ${top.contextSource})")]
-      end
-    end;
+      end;
 
   top.upSubst = top.downSubst; -- No effect on decoratedness
 }

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -419,7 +419,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 
   local finalTy :: Type = performSubstitution(e.typerep, e.upSubst);
   local diff :: [String] =
-    set:toList(set:removeAll(getInhSetMembers([], finalTy, top.env),  -- blessed inhs for a reference
+    set:toList(set:removeAll(getMinInhSetMembers([], finalTy, top.env),  -- blessed inhs for a reference
       inhDepsForSyn(q.attrDcl.fullName, finalTy.typeName, myFlow))); -- needed inhs
   
   -- CASE 1: References. This check is necessary and won't be caught elsewhere.
@@ -495,7 +495,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
       | hasVertex(_) -> [] -- no check to make, as it was done transitively
       -- without a vertex, we're accessing from a reference, and so...
       | noVertex() ->
-          if contains(q.attrDcl.fullName, getInhSetMembers([], finalTy, top.env))
+          if contains(q.attrDcl.fullName, getMinInhSetMembers([], finalTy, top.env))
           then []
           else [mwdaWrn(top.location, "Access of inherited attribute " ++ q.name ++ " on reference of type " ++ prettyType(finalTy) ++ " is not permitted", top.config.runMwda)]
       end
@@ -519,7 +519,7 @@ top::Expr ::= '(' '.' q::QName ')'
   -- undecorated accesses: flow type for attribute has to be empty
   -- decorated accesses: FT has to be subset of refset
   local acceptable :: [String] =
-    if inputType.isDecorated then getInhSetMembers([], inputType, top.env) else [];
+    if inputType.isDecorated then getMinInhSetMembers([], inputType, top.env) else [];
 
   top.errors <- 
     if q.lookupAttribute.found
@@ -563,7 +563,7 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
 
   -- Subtract the ref set from our deps
   local diff :: [String] =
-    set:toList(set:removeAll(getInhSetMembers([], e.typerep, top.env), set:add(inhDeps, set:empty())));
+    set:toList(set:removeAll(getMinInhSetMembers([], e.typerep, top.env), set:add(inhDeps, set:empty())));
 
   top.errors <-
     if null(e.errors)

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -419,7 +419,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 
   local finalTy :: Type = performSubstitution(e.typerep, e.upSubst);
   local diff :: [String] =
-    set:toList(set:removeAll(getMinInhSetMembers([], finalTy, top.env),  -- blessed inhs for a reference
+    set:toList(set:removeAll(getMinInhSetMembers([], finalTy, top.env).fst,  -- blessed inhs for a reference
       inhDepsForSyn(q.attrDcl.fullName, finalTy.typeName, myFlow))); -- needed inhs
   
   -- CASE 1: References. This check is necessary and won't be caught elsewhere.
@@ -495,7 +495,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
       | hasVertex(_) -> [] -- no check to make, as it was done transitively
       -- without a vertex, we're accessing from a reference, and so...
       | noVertex() ->
-          if contains(q.attrDcl.fullName, getMinInhSetMembers([], finalTy, top.env))
+          if contains(q.attrDcl.fullName, getMinInhSetMembers([], finalTy, top.env).fst)
           then []
           else [mwdaWrn(top.location, "Access of inherited attribute " ++ q.name ++ " on reference of type " ++ prettyType(finalTy) ++ " is not permitted", top.config.runMwda)]
       end
@@ -519,7 +519,7 @@ top::Expr ::= '(' '.' q::QName ')'
   -- undecorated accesses: flow type for attribute has to be empty
   -- decorated accesses: FT has to be subset of refset
   local acceptable :: [String] =
-    if inputType.isDecorated then getMinInhSetMembers([], inputType, top.env) else [];
+    if inputType.isDecorated then getMinInhSetMembers([], inputType, top.env).fst else [];
 
   top.errors <- 
     if q.lookupAttribute.found
@@ -563,7 +563,7 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
 
   -- Subtract the ref set from our deps
   local diff :: [String] =
-    set:toList(set:removeAll(getMinInhSetMembers([], e.typerep, top.env), set:add(inhDeps, set:empty())));
+    set:toList(set:removeAll(getMinInhSetMembers([], e.typerep, top.env).fst, set:add(inhDeps, set:empty())));
 
   top.errors <-
     if null(e.errors)

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -419,7 +419,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 
   local finalTy :: Type = performSubstitution(e.typerep, e.upSubst);
   local diff :: [String] =
-    set:toList(set:removeAll(finalTy.inhSetMembers,  -- blessed inhs for a reference
+    set:toList(set:removeAll(getInhSetMembers([], finalTy, top.env),  -- blessed inhs for a reference
       inhDepsForSyn(q.attrDcl.fullName, finalTy.typeName, myFlow))); -- needed inhs
   
   -- CASE 1: References. This check is necessary and won't be caught elsewhere.
@@ -495,7 +495,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
       | hasVertex(_) -> [] -- no check to make, as it was done transitively
       -- without a vertex, we're accessing from a reference, and so...
       | noVertex() ->
-          if contains(q.attrDcl.fullName, finalTy.inhSetMembers)
+          if contains(q.attrDcl.fullName, getInhSetMembers([], finalTy, top.env))
           then []
           else [mwdaWrn(top.location, "Access of inherited attribute " ++ q.name ++ " on reference of type " ++ prettyType(finalTy) ++ " is not permitted", top.config.runMwda)]
       end
@@ -519,7 +519,7 @@ top::Expr ::= '(' '.' q::QName ')'
   -- undecorated accesses: flow type for attribute has to be empty
   -- decorated accesses: FT has to be subset of refset
   local acceptable :: [String] =
-    if inputType.isDecorated then inputType.inhSetMembers else [];
+    if inputType.isDecorated then getInhSetMembers([], inputType, top.env) else [];
 
   top.errors <- 
     if q.lookupAttribute.found
@@ -563,7 +563,7 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
 
   -- Subtract the ref set from our deps
   local diff :: [String] =
-    set:toList(set:removeAll(e.typerep.inhSetMembers, set:add(inhDeps, set:empty())));
+    set:toList(set:removeAll(getInhSetMembers([], e.typerep, top.env), set:add(inhDeps, set:empty())));
 
   top.errors <-
     if null(e.errors)

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -68,15 +68,16 @@ top::Context ::= t::Type
   top.contextClassName = nothing();
 
   top.resolved =
-    if t.isTypeable
-    then [typeableDcl(t, sourceGrammar="silver:core", sourceLocation=txtLoc("<builtin>"))]
-    else
-      filter(
-        \ d::DclInfo -> !unifyDirectional(d.typeScheme.typerep, t).failure && !d.typeScheme.typerep.isError,
-        searchEnvTree("typeable", top.env.instTree));
+    filter(
+      \ d::DclInfo -> !unifyDirectional(d.typeScheme.typerep, t).failure && !d.typeScheme.typerep.isError,
+      searchEnvTree("typeable", top.env.instTree));
 
   production resolvedDcl::DclInfo = head(top.resolved); -- resolvedDcl.typeScheme should not bind any type variables!
-  production requiredContexts::Contexts = foldContexts(resolvedDcl.typeScheme.contexts);
+  production requiredContexts::Contexts =
+    foldContexts(
+      if null(top.resolved)
+      then map(compose(typeableContext, skolemType), t.freeSkolemVars)
+      else resolvedDcl.typeScheme.contexts);
   requiredContexts.env = top.env;
 }
 

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -96,18 +96,11 @@ top::Context ::= i1::Type i2::Type
   top.contextClassName = nothing();
 
   top.resolved =
-    case i1, i2 of
-    | skolemType(a1), skolemType(a2) when a1 == a2 -> 
-      [inhSubsetDcl(i1, i2, sourceGrammar="silver:core", sourceLocation=txtLoc("<builtin>"))]
-    | inhSetType(inhs1), inhSetType(inhs2) when all(map(contains(_, inhs2), inhs1)) -> 
-      [inhSubsetDcl(i1, i2, sourceGrammar="silver:core", sourceLocation=txtLoc("<builtin>"))]
-    | _, _ ->
-      filter(
-        \ d::DclInfo ->
-          !unifyDirectional(d.typeScheme.monoType, i1).failure && !d.typeScheme.monoType.isError &&
-          !unifyDirectional(d.typerep2, i2).failure && !d.typerep2.isError,
-        searchEnvTree("subset", top.env.instTree))
-    end;
+    filter(
+      \ d::DclInfo ->
+        !unifyDirectional(d.typeScheme.monoType, i1).failure && !d.typeScheme.monoType.isError &&
+        !unifyDirectional(d.typerep2, i2).failure && !d.typerep2.isError,
+      searchEnvTree("subset", top.env.instTree));
 }
 
 -- Invariant: This should be called when a and b are unifyable

--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -407,15 +407,6 @@ top::DclInfo ::= i1::Type i2::Type ns::NamedSignature
   top.typeScheme = monoType(i1);
   top.typerep2 = i2;
 }
--- This doesn't appear in the environment, but is instead "looked up" on the type
-abstract production inhSubsetDcl
-top::DclInfo ::= i1::Type i2::Type
-{
-  top.fullName = "subset";
-
-  top.typeScheme = monoType(i1);
-  top.typerep2 = i2;
-}
 
 -- TODO: this should probably go elsewhere?
 function determineAttributeType

--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -377,18 +377,6 @@ top::DclInfo ::= baseDcl::DclInfo
   
   top.typeScheme = baseDcl.typeScheme;
 }
--- This doesn't appear in the environment, but is instead "looked up" on the type
-abstract production typeableDcl
-top::DclInfo ::= ty::Type
-{
-  top.fullName = "typeable";
-
-  top.typeScheme =
-    case ty of
-    | varType(_) -> monoType(ty) -- Don't require an instance for flexible type variables, leave these flexible at runtime
-    | _ -> constraintType([], map(compose(typeableContext, skolemType), ty.freeVariables), ty)
-    end;
-}
 
 -- inhSubset instances
 abstract production inhSubsetInstConstraintDcl

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -309,7 +309,7 @@ function getMaxInhSetMembers
   
   local recurse::[(Maybe<[String]>, [TyVar])] =
     map(
-      \ d::DclInfo -> getMaxInhSetMembers(t.freeVariables ++ seen, d.typeScheme.monoType, e),
+      \ d::DclInfo -> getMaxInhSetMembers(t.freeVariables ++ seen, d.typerep2, e),
       c.resolved);
   
   return

--- a/grammars/silver/compiler/definition/env/NamedSignature.sv
+++ b/grammars/silver/compiler/definition/env/NamedSignature.sv
@@ -33,8 +33,8 @@ top::NamedSignature ::= fn::String ctxs::[Context] ie::[NamedSignatureElement] o
   top.inputNames = map((.elementName), ie);
   top.inputTypes = map((.typerep), ie); -- Does anything actually use this? TODO: eliminate?
   local typerep::Type = appTypes(functionType(length(ie), map((.elementShortName), np)), top.inputTypes ++ map((.typerep), np) ++ [oe.typerep]);
-  top.typeScheme = (if null(ctxs) then polyType else constraintType(_, ctxs, _))(typerep.freeVariables, typerep);
-  top.freeVariables = typerep.freeVariables;
+  top.typeScheme = (if null(ctxs) then polyType else constraintType(_, ctxs, _))(top.freeVariables, typerep);
+  top.freeVariables = setUnionTyVarsAll(typerep.freeVariables :: map((.freeVariables), ctxs));
   top.typerep = typerep; -- TODO: Only used by unifyNamedSignature.  Would be nice to eliminate, somehow.
 }
 

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -30,7 +30,7 @@ propagate flowDefs on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoApp
 function depsForTakingRef
 [FlowVertex] ::= env::Decorated Env f::VertexType  t::Type
 {
-  return map(f.inhVertex, getMinInhSetMembers([], t, env));
+  return map(f.inhVertex, getMinInhSetMembers([], t, env).fst);
 }
 
 aspect default production

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -30,7 +30,7 @@ propagate flowDefs on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoApp
 function depsForTakingRef
 [FlowVertex] ::= env::Decorated Env f::VertexType  t::Type
 {
-  return map(f.inhVertex, getInhSetMembers([], t, env));
+  return map(f.inhVertex, getMinInhSetMembers([], t, env));
 }
 
 aspect default production

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -28,9 +28,9 @@ propagate flowDeps on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoApp
 propagate flowDefs on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr;
 
 function depsForTakingRef
-[FlowVertex] ::= f::VertexType  t::Type
+[FlowVertex] ::= env::Decorated Env f::VertexType  t::Type
 {
-  return map(f.inhVertex, t.inhSetMembers);  
+  return map(f.inhVertex, getInhSetMembers([], t, env));
 }
 
 aspect default production
@@ -50,7 +50,7 @@ top::Expr ::= q::Decorated QName
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.flowDeps :=
     if q.lookupValue.typeScheme.isDecorable && !finalTy.isDecorable
-    then depsForTakingRef(rhsVertexType(q.lookupValue.fullName), finalTy)
+    then depsForTakingRef(top.env, rhsVertexType(q.lookupValue.fullName), finalTy)
     else [];
   top.flowVertexInfo = 
     if q.lookupValue.typeScheme.isDecorable && !finalTy.isDecorable
@@ -64,7 +64,7 @@ top::Expr ::= q::Decorated QName
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.flowDeps :=
     if !finalTy.isDecorable
-    then depsForTakingRef(lhsVertexType, finalTy)
+    then depsForTakingRef(top.env, lhsVertexType, finalTy)
     else [];
   top.flowVertexInfo = 
     if !finalTy.isDecorable
@@ -78,7 +78,7 @@ top::Expr ::= q::Decorated QName
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.flowDeps := [localEqVertex(q.lookupValue.fullName)] ++
     if q.lookupValue.typeScheme.isDecorable && !finalTy.isDecorable
-    then depsForTakingRef(localVertexType(q.lookupValue.fullName), finalTy)
+    then depsForTakingRef(top.env, localVertexType(q.lookupValue.fullName), finalTy)
     else [];
     
   top.flowVertexInfo =
@@ -93,7 +93,7 @@ top::Expr ::= q::Decorated QName
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.flowDeps := [forwardEqVertex()]++
     if !finalTy.isDecorable
-    then depsForTakingRef(forwardVertexType, finalTy)
+    then depsForTakingRef(top.env, forwardVertexType, finalTy)
     else [];
     
   top.flowVertexInfo =
@@ -202,7 +202,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
   -- Finally, our standard flow deps mimic those of a local: "taking a reference"
   -- This are of course ignored when treated specially.
   top.flowDeps := [anonEqVertex(inh.decorationVertex)] ++
-    depsForTakingRef(anonVertexType(inh.decorationVertex), performSubstitution(top.typerep, top.finalSubst));
+    depsForTakingRef(top.env, anonVertexType(inh.decorationVertex), performSubstitution(top.typerep, top.finalSubst));
 }
 
 autocopy attribute decorationVertex :: String occurs on ExprInhs, ExprInh;

--- a/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
@@ -132,7 +132,7 @@ top::VarBinder ::= n::Name
     else noVertex();
   local deps :: [FlowVertex] =
     if top.bindingType.isDecorable
-    then depsForTakingRef(anonVertexType(fName), performSubstitution(ty, top.finalSubst))
+    then depsForTakingRef(top.env, anonVertexType(fName), performSubstitution(ty, top.finalSubst))
     else [];
 
   top.defs <- [lexicalLocalDef(top.grammarName, n.location, fName, ty, vt, deps)];

--- a/grammars/silver/compiler/translation/java/type/Context.sv
+++ b/grammars/silver/compiler/translation/java/type/Context.sv
@@ -168,11 +168,6 @@ top::DclInfo ::= i1::Type i2::Type fnsig::NamedSignature
 {
   top.transContext = "null";
 }
-aspect production inhSubsetDcl
-top::DclInfo ::= i1::Type i2::Type
-{
-  top.transContext = "null";
-}
 
 function makeConstraintDictName
 String ::= s::String t::Type tvs::[TyVar]

--- a/grammars/silver/compiler/translation/java/type/Context.sv
+++ b/grammars/silver/compiler/translation/java/type/Context.sv
@@ -58,12 +58,14 @@ top::Context ::= t::Type
 {
   top.transType = "common.TypeRep";
   
+  t.skolemTypeReps = zipWith(pair, t.freeVariables, requiredContexts.transTypeableContexts);
   resolvedDcl.transContextDeps = requiredContexts.transTypeableContexts;
   top.transTypeableContext =
     case top.resolved, t of
     -- We might need translate this context even when resolution fails;
     -- in that case fall back to a rigid skolem constant.
     | [], skolemType(tv) -> s"new common.BaseTypeRep(\"b${toString(tv.extractTyVarRep)}\")"
+    | [], _ -> t.transTypeRep
     | _, _ -> resolvedDcl.transContext
     end;
   top.transContext =
@@ -151,12 +153,6 @@ top::DclInfo ::= baseDcl::DclInfo
 {
   baseDcl.transContextDeps = top.transContextDeps;
   top.transContext = baseDcl.transContext ++ ".getType()";
-}
-aspect production typeableDcl
-top::DclInfo ::= ty::Type
-{
-  ty.skolemTypeReps = zipWith(pair, ty.freeVariables, top.transContextDeps);
-  top.transContext = ty.transTypeRep;
 }
 aspect production inhSubsetInstConstraintDcl
 top::DclInfo ::= i1::Type i2::Type tvs::[TyVar]

--- a/test/silver_features/TypeClasses.sv
+++ b/test/silver_features/TypeClasses.sv
@@ -384,3 +384,30 @@ global sCaseRes::[String] =
   end;
 equalityTest(sCaseRes, ["2"], [String], silver_tests);
 
+function transitiveSubset
+i1 subset i2, i2 subset i3, i3 subset i4 => Decorated a with i1 ::= x::Decorated a with i4
+{
+  return partialUndecorate(x);
+}
+
+function transitiveSubset2
+i1 subset {env1}, {env1, env2} subset i2 => Decorated a with i1 ::= x::Decorated a with i2
+{
+  return partialUndecorate(x);
+}
+
+wrongCode "i3 is not a subset of i2 (arising from the use of partialUndecorate)" {
+  function transitiveSubsetBad
+  i1 subset i2, i2 subset i3, i3 subset i4 => Decorated a with i3 ::= x::Decorated a with i2
+  {
+    return partialUndecorate(x);
+  }
+}
+
+wrongCode "i1 is not a subset of i2 (arising from the use of partialUndecorate)" {
+  function transitiveSubsetBad2
+  i1 subset {env1, env2}, {env1} subset i2 => Decorated a with i1 ::= x::Decorated a with i2
+  {
+    return partialUndecorate(x);
+  }
+}

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -197,13 +197,53 @@ global d8 :: Decorated DExpr with {env1} = partialUndecorate(decorate mkDExpr() 
 global d9 :: Decorated DExpr with {env1} = partialUndecorate(decorate mkDExpr() with {env1 = [];});
 
 function getEnv1
-{env1} subset i => [String] ::= x::Decorated DExpr with i 
+{env1} subset i => [String] ::= x::Decorated DExpr with i
 {
   return let y::Decorated DExpr with {env1} = partialUndecorate(x) in y.env1 end;
 }
-
 global d10 :: [String] = getEnv1(decorate mkDExpr() with {env1 = []; env2 = [];});
 global d11 :: [String] = getEnv1(decorate mkDExpr() with {env1 = [];});
+
+function getEnv1Direct
+{env1} subset i => [String] ::= x::Decorated DExpr with i
+{
+  return x.env1;
+}
+global d12 :: [String] = getEnv1Direct(decorate mkDExpr() with {env1 = []; env2 = [];});
+global d13 :: [String] = getEnv1Direct(decorate mkDExpr() with {env1 = [];});
+
+function getEnv1Chained
+{env1} subset i1, i1 subset i2 => [String] ::= Decorated DExpr with i1  x::Decorated DExpr with i2
+{
+  return x.env1;
+}
+
+global d14 :: [String] = getEnv1Chained(decorate mkDExpr() with {env1 = []; env2 = [];}, decorate mkDExpr() with {env1 = []; env2 = [];});
+global d15 :: [String] = getEnv1Chained(decorate mkDExpr() with {env1 = [];}, decorate mkDExpr() with {env1 = []; env2 = [];});
+global d16 :: [String] = getEnv1Chained(decorate mkDExpr() with {env1 = [];}, decorate mkDExpr() with {env1 = [];});
+
+function getEnv1Cycle
+{env1} subset i1, i1 subset i2, i2 subset i1 => [String] ::= Decorated DExpr with i1  x::Decorated DExpr with i2
+{
+  return x.env1;
+}
+
+global d17 :: [String] = getEnv1Cycle(decorate mkDExpr() with {env1 = []; env2 = [];}, decorate mkDExpr() with {env1 = []; env2 = [];});
+global d18 :: [String] = getEnv1Cycle(decorate mkDExpr() with {env1 = [];}, decorate mkDExpr() with {env1 = [];});
+
+wrongCode "{silver_features:env1, :env2} is not a subset of {silver_features:env1} (arising from the use of getEnv1Cycle)" {
+  global dBad :: [String] = getEnv1Cycle(decorate mkDExpr() with {env1 = [];}, decorate mkDExpr() with {env1 = []; env2 = [];});
+}
+
+function getEnv1ChainedAmb
+{env1} subset i1, i1 subset i2 => [String] ::= x::Decorated DExpr with i2
+{
+  return x.env1;
+}
+
+wrongCode "Ambiguous type variable a (arising from the use of getEnv1ChainedAmb) prevents the constraint a subset {silver_features:env1, :env2} from being solved." {
+  global dAmb :: [String] = getEnv1ChainedAmb(decorate mkDExpr() with {env1 = []; env2 = [];});
+}
 
 wrongCode "type Decorated silver_features:DExpr with {silver_features:env1, :env2} has initialization expression with type Decorated silver_features:DExpr with {silver_features:env1}" {
   global dBad :: Decorated DExpr with {env1, env2} = decorate mkDExpr() with {env1 = [];};


### PR DESCRIPTION
# Changes
Now use `InhSet` type `subset` constraints in the MWDA for determining what is available on references.  For example, the MWDA will no longer complain about this:
```
inherited attribute env::Env occurs on Expr;
function getEnv
{env} subset i => Env ::= e::Decorated Expr with i
{
  return e.env;
}
```
Previously `Decorated Expr with i` was treated like `Decorated Expr with {}` by the flow analysis - the only operations possible were to undecorate or access a synthesized attribute with an empty flow type.

Also handles resolving `subset` instance resolution more generally: for example if there are contexts i1 subset {env1}, {env1, env2} subset i2` then we can now automatically solve the constraint `i1 subset i2`.  

# Documentation
Writing this up as a part of my WPE paper, will adapt for website eventually.
