### PR TITLE
Attempt to use the type variable names given in the code in pretty-printing types

### DIFF
--- a/grammars/silver/compiler/definition/core/ClassDcl.sv
+++ b/grammars/silver/compiler/definition/core/ClassDcl.sv
@@ -104,7 +104,7 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr ';'
   
   production fName :: String = top.grammarName ++ ":" ++ id.name;
   production boundVars :: [TyVar] =
-    setUnionTyVars(top.classHead.freeVariables, ty.typerep.freeVariables);
+    setUnionTyVarsAll(top.classHead.freeVariables :: map((.freeVariables), cl.contexts) ++ [ty.typerep.freeVariables]);
   top.classMembers = [pair(fName, false)];
   
   cl.constraintPos =
@@ -135,7 +135,7 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e:
   
   production fName :: String = top.grammarName ++ ":" ++ id.name;
   production boundVars :: [TyVar] =
-    setUnionTyVars(top.classHead.freeVariables, ty.typerep.freeVariables);
+    setUnionTyVarsAll(top.classHead.freeVariables :: map((.freeVariables), cl.contexts) ++ [ty.typerep.freeVariables]);
   top.classMembers = [pair(fName, true)];
   
   cl.constraintPos =

--- a/grammars/silver/compiler/definition/type/Type.sv
+++ b/grammars/silver/compiler/definition/type/Type.sv
@@ -291,10 +291,22 @@ top::TyVar ::= k::Kind i::Integer
   top.extractTyVarRep = i;
 }
 
+abstract production tyVarNamed
+top::TyVar ::= k::Kind i::Integer n::String
+{
+  forwards to tyVar(k, i);
+}
+
 function freshTyVar
 TyVar ::= k::Kind
 {
   return tyVar(k, genInt());
+}
+
+function freshTyVarNamed
+TyVar ::= k::Kind n::String
+{
+  return tyVarNamed(k, genInt(), n);
 }
 
 function freshType

--- a/grammars/silver/compiler/definition/type/syntax/AspectDcl.sv
+++ b/grammars/silver/compiler/definition/type/syntax/AspectDcl.sv
@@ -8,9 +8,7 @@ flowtype lexicalTypeVariables {deterministicCount, realSignature, env} on Aspect
 function addNewLexicalTyVars_ActuallyVariables
 [Def] ::= gn::String sl::Location lk::[Pair<String Kind>] l::[String]
 {
-  return if null(l) then []
-         else aspectLexTyVarDef(gn, sl, head(l), freshTyVar(fromMaybe(starKind(), lookup(head(l), lk)))) ::
-                  addNewLexicalTyVars_ActuallyVariables(gn, sl, lk, tail(l));
+  return map(\ n::String -> aspectLexTyVarDef(gn, sl, n, freshTyVarNamed(fromMaybe(starKind(), lookup(n, lk)), n)), l);
 }
 
 -- This binds variables that appear in the signature to type variables, rather than skolem constants

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -41,15 +41,10 @@ propagate lexicalTypeVariables, lexicalTyVarKinds on TypeExpr, Signature, Signat
 propagate appLexicalTyVarKinds on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate errorsTyVars on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 
--- TODO: This function should go away because it doesn't do location correctly.
--- But for now, we'll use it. It might be easier to get rid of once we know exactly
--- how ty vars end up in the environment.
 function addNewLexicalTyVars
 [Def] ::= gn::String sl::Location lk::[Pair<String Kind>] l::[String]
 {
-  return if null(l) then []
-         else lexTyVarDef(gn, sl, head(l), freshTyVar(fromMaybe(starKind(), lookup(head(l), lk)))) ::
-                  addNewLexicalTyVars(gn, sl, lk, tail(l));
+  return map(\ n::String -> lexTyVarDef(gn, sl, n, freshTyVarNamed(fromMaybe(starKind(), lookup(n, lk)), n)), l);
 }
 
 aspect default production

--- a/grammars/silver/compiler/translation/java/core/ClassDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ClassDcl.sv
@@ -41,7 +41,7 @@ aspect production constraintClassBodyItem
 top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr ';'
 {
   local contexts::Contexts = foldContexts(cl.contexts);
-  contexts.boundVariables = ty.freeVariables;
+  contexts.boundVariables = boundVars;
 
   top.translation = s"\t${ty.typerep.transCovariantType} ${makeInstanceMemberAccessorName(id.name)}(${contexts.contextParamTrans});";
 }
@@ -50,7 +50,7 @@ aspect production defaultConstraintClassBodyItem
 top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e::Expr ';'
 {
   local contexts::Contexts = foldContexts(cl.contexts);
-  contexts.boundVariables = ty.freeVariables;
+  contexts.boundVariables = boundVars;
 
   top.translation = s"""
 	default ${ty.typerep.transCovariantType} ${makeInstanceMemberAccessorName(id.name)}(${contexts.contextParamTrans}) {

--- a/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
@@ -72,7 +72,7 @@ aspect production instanceBodyItem
 top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
 {
   local contexts::Contexts = foldContexts(memberContexts);
-  contexts.boundVariables = top.instanceType.freeVariables;
+  contexts.boundVariables = boundVars;
 
   top.translation = s"""
 	public ${id.lookupValue.typeScheme.typerep.transCovariantType} ${makeInstanceMemberAccessorName(top.fullName)}(${contexts.contextParamTrans}) {

--- a/grammars/silver/compiler/translation/java/type/Type.sv
+++ b/grammars/silver/compiler/translation/java/type/Type.sv
@@ -50,7 +50,7 @@ top::Type ::= tv::TyVar
   top.transClassType = "Object";
   top.transTypeRep = s"freshTypeVar_${toString(tv.extractTyVarRep)}";
   top.transFreshTypeRep = top.transTypeRep;
-  top.transTypeName = findAbbrevFor(tv, top.boundVariables);
+  top.transTypeName = "a" ++ toString(positionOf(tv, top.boundVariables));
 }
 
 aspect production skolemType
@@ -59,7 +59,7 @@ top::Type ::= tv::TyVar
   top.transClassType = "Object";
   top.transTypeRep = lookup(tv, top.skolemTypeReps).fromJust;
   top.transFreshTypeRep = s"freshTypeVar_${toString(tv.extractTyVarRep)}";
-  top.transTypeName = findAbbrevFor(tv, top.boundVariables);
+  top.transTypeName = "a" ++ toString(positionOf(tv, top.boundVariables));
 }
 
 aspect production appType

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -1,6 +1,6 @@
 import silver:testing;
 
-------------------------------------- Number of parameters to type constructors
+------------------------------------- Number/kinds of parameters to type constructors
 terminal ATerminalType 'doesnotmatter';
 
 wrongCode "ATerminalType has kind *, but there are 1 type arguments supplied here" {
@@ -75,6 +75,20 @@ wrongCode "[] has kind * -> *, but there are 2 type arguments supplied here" {
 }
 wrongCode "[Integer] has kind *, but there are 1 type arguments supplied here" {
   global badCtrList2::[Integer]<Integer> = [1, 2, 3];
+}
+
+-------------------------------------- Type variables are named properly in error messages
+wrongCode "(bar, baz)" {
+  global foo::(bar, baz) = 42;
+}
+wrongCode "(b, a)" {
+  global foo::(b, a) = 42;
+}
+wrongCode "(a1, a)" {
+  global foo::(a1, a) = 42;
+}
+wrongCode "(a, b) has initialization expression with type (silver:core:Pair<c a> ::= c a)" {
+  global foo::(a, b) = pair(_, _);
 }
 
 -------------------------------------- Type Decls
@@ -221,7 +235,7 @@ wrongCode "type Decorated silver_features:DExpr with {silver_features:env1} has 
   global dBad :: Decorated DExpr with {env1} = let res :: Decorated DExpr with {env2} = error("") in res end;
 }
 
-wrongCode "Expected return type is Decorated silver_features:DExpr with {silver_features:env1}, but the expression has actual type Decorated silver_features:DExpr with a" {
+wrongCode "Expected return type is Decorated silver_features:DExpr with {silver_features:env1}, but the expression has actual type Decorated silver_features:DExpr with i" {
   function decBad
   Decorated DExpr with {env1} ::= x::Decorated DExpr with i
   {


### PR DESCRIPTION
# Changes
Finally got fed up with confusing errors and decided to fix this -
```
global foo::(b, a) = 42;
```
would previously give an error mentioning the type `(a, b)`.  This changes things so that the pretty-printed type matches what is written.  That this is especially helpful in reporting error messages involving non trivial type class instances using type variables `a`, `b`, `c`, ..., where often the same var names are used in error messages, but in a different order.

# Documentation
None, this is mostly fixing a usability "bug" with error messages.
