### PR TITLE
Add missing error check that production LHSs are actually nonterminals

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionDcl.sv
@@ -10,6 +10,15 @@ aspect production productionLHS
 top::ProductionLHS ::= id::Name '::' t::TypeExpr
 {
   top.errors <- t.errorsKindStar;
+  
+  local checkNT::TypeCheck = checkNonterminal(t.typerep);
+  checkNT.downSubst = emptySubst();
+  checkNT.finalSubst = emptySubst();
+  
+  top.errors <-
+    if checkNT.typeerror
+    then [err(top.location, "Production LHS type must be a nonterminal.  Instead it is of type " ++ checkNT.leftpp)]
+    else [];
 }
 
 aspect production productionRHSElem

--- a/test/csterrors/silver-compile
+++ b/test/csterrors/silver-compile
@@ -8,6 +8,8 @@ silver() { "$SILVER_HOME/support/bin/silver" "$@"; }
 ARGS="$@ --clean --dont-translate"
 
 count=0
+fail=0
+pass=0
 
 # Check to ensure all these builds yield the shown string (as an error)
 function cst_test {
@@ -15,10 +17,12 @@ function cst_test {
     if [[ $? != 0 ]]
     then
         echo -e "\nFailure: $1 did not produce output $2"
-        ((count++))
+        ((fail++))
     else
         echo -n "."
+        ((pass++))
     fi
+    ((count++))
 }
 
 cst_test rhs "B_t"
@@ -27,8 +31,7 @@ cst_test startMissing "nonterm_b:B"
 cst_test prodMod "B_t"
 cst_test mda "nonterm_b:B"
 cst_test missingLHS "nonterm_b:B"
-# terminalLHS doesn't contain a reference to B_t or B
-cst_test terminalLHS "terminalLHS:terminalLHS"
+cst_test terminalLHS "terminalLHS:A_t"
 cst_test terminalSubmit "B_t"
 cst_test terminalDominate "B_t"
 cst_test terminalLexer "lexer_b:B"
@@ -37,7 +40,9 @@ cst_test lexerDominate "B_t"
 cst_test missingSeparator "test:nonterm_b:Mangle_t"
 cst_test multipleSeparators "multipleSeparators:A_t, multipleSeparators:B_t"
 
+echo ""
+echo "$pass out of $count tests passed"
 
 rm -f build.xml
 
-exit $count
+exit $fail

--- a/test/csterrors/silver-compile
+++ b/test/csterrors/silver-compile
@@ -10,24 +10,34 @@ ARGS="$@ --clean --dont-translate"
 count=0
 
 # Check to ensure all these builds yield the shown string (as an error)
+function cst_test {
+    silver $ARGS $1 | grep "$2" > /dev/null
+    if [[ $? != 0 ]]
+    then
+        echo -e "\nFailure: $1 did not produce output $2"
+        ((count++))
+    else
+        echo -n "."
+    fi
+}
 
-silver $ARGS rhs | grep "B_t" > /dev/null || ((count++))
-silver $ARGS disamb | grep "B_t" > /dev/null || ((count++))
-silver $ARGS startMissing | grep "nonterm_b:B" > /dev/null || ((count++))
-silver $ARGS prodMod | grep "B_t" > /dev/null || ((count++))
-silver $ARGS mda | grep "nonterm_b:B" > /dev/null || ((count++))
-silver $ARGS missingLHS | grep "nonterm_b:B" > /dev/null || ((count++))
+cst_test rhs "B_t"
+cst_test disamb "B_t"
+cst_test startMissing "nonterm_b:B"
+cst_test prodMod "B_t"
+cst_test mda "nonterm_b:B"
+cst_test missingLHS "nonterm_b:B"
 # terminalLHS doesn't contain a reference to B_t or B
-silver $ARGS terminalLHS | grep "terminalLHS:terminalLHS" > /dev/null || ((count++))
-silver $ARGS terminalSubmit | grep "B_t" > /dev/null || ((count++))
-silver $ARGS terminalDominate | grep "B_t" > /dev/null || ((count++))
-silver $ARGS terminalLexer | grep "lexer_b:B" > /dev/null || ((count++))
-silver $ARGS lexerSubmit | grep "B_t" > /dev/null || ((count++))
-silver $ARGS lexerDominate | grep "B_t" > /dev/null || ((count++))
-silver $ARGS missingSeparator | grep "test:nonterm_b:Mangle_t" > /dev/null || ((count++))
-silver $ARGS multipleSeparators | grep "multipleSeparators:A_t, multipleSeparators:B_t" > /dev/null || ((count++))
+cst_test terminalLHS "terminalLHS:terminalLHS"
+cst_test terminalSubmit "B_t"
+cst_test terminalDominate "B_t"
+cst_test terminalLexer "lexer_b:B"
+cst_test lexerSubmit "B_t"
+cst_test lexerDominate "B_t"
+cst_test missingSeparator "test:nonterm_b:Mangle_t"
+cst_test multipleSeparators "multipleSeparators:A_t, multipleSeparators:B_t"
 
 
 rm -f build.xml
 
-test $count == 0
+exit $count

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -292,3 +292,10 @@ wrongCode "{silver_features:env2} is not a subset of {silver_features:env1} (ari
 wrongCode "{silver_features:env1} is not a subset of {silver_features:env2} (arising from the use of getEnv1)" {
   global dDisjoint2 :: [String] = getEnv1(decorate mkDExpr() with {env2 = [];});
 }
+
+-------------------------------------- Production LHSs
+wrongCode "Production LHS type must be a nonterminal.  Instead it is of type a" {
+  production varLHS
+  top::a ::=
+  {}
+}


### PR DESCRIPTION
Previously this evidently wasn't being checked at all, and writing a type variable or another type on the LHS would compile without errors to invalid java code.. 
