### PR TITLE
Fix to MWDA handling of taking references

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ melt.trynode('silver') {
 
   stage("Test") {
     // These test cases and tutorials are run as seperate tasks to allow for parallelism
-    def tests = ["silver_features", "copper_features", "patt", "stdlib", "performance", "csterrors", "silver_construction", "origintracking", "implicit_monads"]
+    def tests = ["silver_features", "copper_features", "patt", "flow", "stdlib", "performance", "csterrors", "silver_construction", "origintracking", "implicit_monads"]
     def tuts = ["simple/with_all", "simple/with_do_while", "simple/with_repeat_until", "simple/with_implication", "simple/host", "dc", "lambda", "turing", "hello", "stlc"]
 
     def tasks = [:]

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -410,7 +410,7 @@ top::Expr ::= q::Decorated QName
     if (top.config.warnAll || top.config.warnMissingInh || top.config.runMwda)
     && q.lookupValue.typeScheme.isDecorable
     then if refSet.isJust then []
-         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)} as the reference set is not bounded", top.config.runMwda)]
+         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)}, as the reference set is not bounded.", top.config.runMwda)]
     else [];
 }
 aspect production lhsReference
@@ -420,7 +420,7 @@ top::Expr ::= q::Decorated QName
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh || top.config.runMwda)
     then if refSet.isJust then []
-         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)} as the reference set is not bounded", top.config.runMwda)]
+         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)}, as the reference set is not bounded.", top.config.runMwda)]
     else [];
 }
 aspect production localReference
@@ -431,7 +431,7 @@ top::Expr ::= q::Decorated QName
     if (top.config.warnAll || top.config.warnMissingInh || top.config.runMwda)
     && q.lookupValue.typeScheme.isDecorable
     then if refSet.isJust then []
-         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)} as the reference set is not bounded", top.config.runMwda)]
+         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)}, as the reference set is not bounded.", top.config.runMwda)]
     else [];
 }
 aspect production forwardReference
@@ -441,7 +441,7 @@ top::Expr ::= q::Decorated QName
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh || top.config.runMwda)
     then if refSet.isJust then []
-         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)} as the reference set is not bounded", top.config.runMwda)]
+         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)}, as the reference set is not bounded.", top.config.runMwda)]
     else [];
 }
 
@@ -636,12 +636,12 @@ autocopy attribute receivedDeps :: [FlowVertex] occurs on VarBinders, VarBinder,
 aspect production varVarBinder
 top::VarBinder ::= n::Name
 {
-  -- MWDA check that we're not taking an unbounded reference
+  -- Check that we're not taking an unbounded reference
   top.errors <-
     if (top.config.warnAll || top.config.warnMissingInh || top.config.runMwda)
     && top.bindingType.isDecorable
     then if refSet.isJust then []
-         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)} as the reference set is not bounded", top.config.runMwda)]
+         else [mwdaWrn(top.location, s"Cannot take a reference of type ${prettyType(finalTy)}, as the reference set is not bounded.", top.config.runMwda)]
     else [];
 
   -- fName is our invented vertex name for the pattern variable

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
@@ -117,6 +117,16 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     else [];
 }
 
+aspect production exprLhsExpr
+top::ExprLHSExpr ::= attr::QNameAttrOccur
+{
+  -- Duplicate equation check
+  top.errors <-
+    if attr.attrFound && length(filter(eq(attr.attrDcl.fullName, _), top.allSuppliedInhs)) > 1
+    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name, top.config.runMwda)]
+    else [];
+}
+
 
 --- For our DefLHSs:
 

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -9,11 +9,11 @@ nonterminal Exprs with
   config, grammarName, env, location, unparse, errors, freeVars, frame, compiledGrammars, exprs, rawExprs, isRoot, originRules;
 
 nonterminal ExprInhs with
-  config, grammarName, env, location, unparse, errors, freeVars, frame, compiledGrammars, decoratingnt, suppliedInhs, isRoot, originRules;
+  config, grammarName, env, location, unparse, errors, freeVars, frame, compiledGrammars, decoratingnt, suppliedInhs, allSuppliedInhs, isRoot, originRules;
 nonterminal ExprInh with
-  config, grammarName, env, location, unparse, errors, freeVars, frame, compiledGrammars, decoratingnt, suppliedInhs, isRoot, originRules;
+  config, grammarName, env, location, unparse, errors, freeVars, frame, compiledGrammars, decoratingnt, suppliedInhs, allSuppliedInhs, isRoot, originRules;
 nonterminal ExprLHSExpr with
-  config, grammarName, env, location, unparse, errors, freeVars, name, typerep, decoratingnt, suppliedInhs, isRoot, originRules;
+  config, grammarName, env, location, unparse, errors, freeVars, name, typerep, decoratingnt, suppliedInhs, allSuppliedInhs, isRoot, originRules;
 
 flowtype freeVars {} on Expr, Exprs, ExprInhs, ExprInh, ExprLHSExpr;
 
@@ -27,6 +27,7 @@ autocopy attribute decoratingnt :: Type;
  - The inherited attributes being supplied in a decorate expression
  -}
 synthesized attribute suppliedInhs :: [String];
+autocopy attribute allSuppliedInhs :: [String];
 {--
  - A list of decorated expressions from an Exprs.
  -}
@@ -549,10 +550,11 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
 {
   top.unparse = "decorate " ++ e.unparse ++ " with {" ++ inh.unparse ++ "}";
 
-  top.typerep = decoratedType(performSubstitution(e.typerep, e.upSubst), inhSetType(sort(inh.suppliedInhs))); -- .decoratedForm?
+  top.typerep = decoratedType(performSubstitution(e.typerep, e.upSubst), inhSetType(sort(nub(inh.suppliedInhs)))); -- .decoratedForm?
   e.isRoot = false;
   
   inh.decoratingnt = performSubstitution(e.typerep, e.upSubst);
+  inh.allSuppliedInhs = inh.suppliedInhs;
 }
 
 abstract production exprInhsEmpty

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -296,6 +296,7 @@ function getMinInhSetMembers
   return
     case t of
     | skolemType(tv) when contains(tv, seen) -> ([], [])
+    | varType(_) -> ([], [])  -- If an InhSet is unspecialized after type checking, assume it is empty
     | _ -> (sort(unions(t.inhSetMembers :: map(fst, recurse))), unions(t.freeVariables :: map(snd, recurse))) 
     end;
 }
@@ -325,6 +326,7 @@ function getMaxInhSetMembers
   return
     case t of
     | skolemType(tv) when contains(tv, seen) -> (nothing(), [])
+    | varType(_) -> (just([]), [])  -- If an InhSet is unspecialized after type checking, assume it is empty
     | inhSetType(inhs) -> (just(inhs), [])
     | _ -> (map(sort, foldr(
         \ inhs1::Maybe<[String]> inhs2::Maybe<[String]> -> alt(lift2(intersect, inhs1, inhs2), alt(inhs1, inhs2)),

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -300,6 +300,16 @@ function getMinInhSetMembers
     end;
 }
 
+function getMinRefSet
+[String] ::= t::Type e::Decorated Env
+{
+  return
+    case t of
+    | decoratedType(_, i) -> getMinInhSetMembers([], i, e).fst
+    | _ -> []
+    end;
+}
+
 -- Try to compute an upper bound on the members of an InhSet type, including transitive ones arising from subset constraints
 function getMaxInhSetMembers
 (Maybe<[String]>, [TyVar]) ::= seen::[TyVar] t::Type e::Decorated Env
@@ -320,6 +330,16 @@ function getMaxInhSetMembers
         \ inhs1::Maybe<[String]> inhs2::Maybe<[String]> -> alt(lift2(intersect, inhs1, inhs2), alt(inhs1, inhs2)),
         empty, map(fst, recurse))),
       unions(t.freeVariables :: map(snd, recurse)))
+    end;
+}
+
+function getMaxRefSet
+Maybe<[String]> ::= t::Type e::Decorated Env
+{
+  return
+    case t of
+    | decoratedType(_, i) -> getMaxInhSetMembers([], i, e).fst
+    | _ -> just([])
     end;
 }
  

--- a/grammars/silver/compiler/definition/type/Type.sv
+++ b/grammars/silver/compiler/definition/type/Type.sv
@@ -236,7 +236,7 @@ top::Type ::= te::Type i::Type
  - It represents a nonterminal that is *either* decorated or undecorated
  - (e.g. when referencing a child) but has not yet been specialized.
  - @param nt  MUST be a 'nonterminalType'
- - @param inhs  The inh set that we're decorated with if we never specialize - MUST have kind InhSet
+ - @param inhs  The inh set that we're decorated with - MUST have kind InhSet
  - @param hidden  One of: (a) a type variable (b) 'nt' (c) 'decoratedType(inhs, nt)'
  -                representing state: unspecialized, undecorated, or decorated.
  -}

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -126,12 +126,12 @@ top::TypeExpr ::= InhSetLCurly_t inhs::FlowSpecInhs '}'
 {
   top.unparse = s"{${inhs.unparse}}";
   
-  top.typerep = inhSetType(sort(inhs.inhList));
+  top.typerep = inhSetType(sort(nub(inhs.inhList)));
   inhs.onNt = errorType();
 
   -- When we are in a refTypeExpr where we know the nonterminal type,
   -- decorate the inhSetTypeExpr with onNt for better errors and lookup disambiguation.
-  -- TODO: Make this Decorated FlowSpecInhs and only redecorate with onNt
+  -- TODO: Make this ref(inhs)
   production ntInhs::FlowSpecInhs = inhs;
   ntInhs.config = top.config;
   ntInhs.grammarName = top.grammarName;

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -803,8 +803,8 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
                    e.mtyperep,
                    decoratedType(
                      performSubstitution(monadInnerType(e.mtyperep, top.location), e.mUpSubst),
-                     inhSetType(sort(inh.suppliedInhs))))
-                 else decoratedType(performSubstitution(e.mtyperep, e.mUpSubst), inhSetType(sort(inh.suppliedInhs)));
+                     inhSetType(sort(nub(inh.suppliedInhs)))))
+                 else decoratedType(performSubstitution(e.mtyperep, e.mUpSubst), inhSetType(sort(nub(inh.suppliedInhs))));
 
   local newname::String = "__sv_bind_" ++ toString(genInt());
   local params::ProductionRHS =

--- a/test/flow/References.sv
+++ b/test/flow/References.sv
@@ -29,7 +29,7 @@ Decorated Expr with {env1} ::= x::Expr
   return x;
 }
 
-warnCode "Equation has transitive dependency for any inherited attribute on child x, caused by taking an unbounded reference." {
+warnCode "Cannot take a reference of type Decorated flow:Expr with i, as the reference set is not bounded." {
   function getRefUnbounded
   Decorated Expr with i ::= x::Expr
   {
@@ -65,7 +65,7 @@ wrongCode "Expected return type is Decorated flow:Expr with i, but the expressio
 
 synthesized attribute getRefWith<a (i :: InhSet)>::Decorated a with i;
 nonterminal RExpr<(i :: InhSet)> with env1, env2, getRefWith<RExpr<i> i>;
-warnCode "Equation has transitive dependency for any inherited attribute, caused by taking an unbounded reference to the production LHS." {
+warnCode "Cannot take a reference of type Decorated flow:RExpr<i> with i, as the reference set is not bounded." {
   production mkRExprUnbounded
   top::RExpr<i> ::=
   {

--- a/test/flow/References.sv
+++ b/test/flow/References.sv
@@ -1,0 +1,88 @@
+grammar flow;
+
+inherited attribute env1::[String];
+inherited attribute env2::[String];
+nonterminal Expr with env1, env2;
+flowtype Expr = decorate {env1};
+
+production zero
+top::Expr ::=
+{}
+
+function getRef
+Decorated Expr ::= x::Expr
+{
+  x.env1 = [];
+  return x;
+}
+
+warnCode "Equation has transitive dependency on child x's inherited attribute for flow:env1 but this equation appears to be missing." {
+  function getRefEnv1Missing
+  Decorated Expr with {env1} ::= x::Expr
+  { return x; }
+}
+
+function getRefEnv1
+Decorated Expr with {env1} ::= x::Expr
+{
+  x.env1 = [];
+  return x;
+}
+
+warnCode "Equation has transitive dependency for any inherited attribute on child x, caused by taking an unbounded reference." {
+  function getRefUnbounded
+  Decorated Expr with i ::= x::Expr
+  {
+    x.env1 = [];
+    return x;
+  }
+}
+
+function getRefBoundedEnv1
+i subset {env1} => Decorated Expr with i ::= x::Expr
+{
+  x.env1 = [];
+  return x;
+}
+
+-- This would be flow error, but is caught by type checking first
+wrongCode "Expected return type is Decorated flow:Expr with i, but the expression has actual type Decorated flow:Expr with {flow:env1}" {
+  function getDecRefUnbounded
+  Decorated Expr with i ::= x::Expr
+  {
+    return decorate x with {env1=[];};
+  }
+}
+
+-- This would be OK, but is caught by type checking anyway
+wrongCode "Expected return type is Decorated flow:Expr with i, but the expression has actual type Decorated flow:Expr with {flow:env1}" {
+  function getDecRefUnbounded
+  i subset {env1} => Decorated Expr with i ::= x::Expr
+  {
+    return decorate x with {env1=[];};
+  }
+}
+
+synthesized attribute getRefWith<a (i :: InhSet)>::Decorated a with i;
+nonterminal RExpr<(i :: InhSet)> with env1, env2, getRefWith<RExpr<i> i>;
+warnCode "Equation has transitive dependency for any inherited attribute, caused by taking an unbounded reference to the production LHS." {
+  production mkRExprUnbounded
+  top::RExpr<i> ::=
+  {
+    top.getRefWith = top;
+  }
+}
+
+production mkRExprBounded
+i subset {env1} => top::RExpr<i> ::=
+{
+  top.getRefWith = top;
+}
+
+function getRExprRefWithEnv1
+Decorated RExpr<{env1}> with {env1} ::=
+{
+  local a::RExpr<{env1}> = mkRExprBounded();
+  a.env1 = [];
+  return a.getRefWith;
+}

--- a/test/flow/References.sv
+++ b/test/flow/References.sv
@@ -86,3 +86,7 @@ Decorated RExpr<{env1}> with {env1} ::=
   a.env1 = [];
   return a.getRefWith;
 }
+
+warnCode "Duplicate equation for env1" {
+  global decDuplicate::Decorated Expr with {env1, env2} = decorate zero() with {env1 = []; env2 = []; env1 = ["a"];};
+}

--- a/test/flow/build.test
+++ b/test/flow/build.test
@@ -1,0 +1,1 @@
+run: ./silver-compile --clean

--- a/test/flow/silver-compile
+++ b/test/flow/silver-compile
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+silver() { "../../support/bin/silver" "$@"; }
+
+SRC=..
+GRAMMAR=flow
+
+silver -I $SRC --warn-all --dont-translate $@ $GRAMMAR
+


### PR DESCRIPTION
# Changes
Turns out that there was a bug in #489 - we should be checking that the *maximum* possible set of inherited attributes that could be demanded from a reference are in fact available, rather than the minimum set.  In fact there are some cases where we don't know what attributes are demanded from a reference (and thus we say the reference is "unbounded"), for example
```
inherited attribute env1::[String];
inherited attribute env2::[String];
nonterminal Expr with env1, env2;
...
function getRefUnbounded
Decorated Expr with i ::= x::Expr
{
  x.env1 = [];
  return x;
}
```
Here we are claiming to return a reference to `x` that can have any set of `i` inherited attributes.  This should be some sort of flow error, as accessing an attribute that needs anything other than `env` on the result of `getRefUnbounded(...)` would be missing an equation.  

Note that something like this is okay, since the function can only be used in a way where the result has at most `{env1}`:
```
function getRefBounded
i subset {env1} => Decorated Expr with i ::= x::Expr
{
  x.env1 = [];
  return x;
}
```

The fix for this is fairly straightforward, and can reuse the same logic added in #489 for intelligently solving `subset` constraints, to raise an error when we are unable to determine a maximum set of attributes corresponding to an `InhSet` type used in taking a reference.  

# Documentation
Will be written up in my WPE paper, will eventually make it to the website.