### PR TITLE
Adding functions to read until a certain string is reached

### DIFF
--- a/grammars/silver/util/subprocess/Subprocess.sv
+++ b/grammars/silver/util/subprocess/Subprocess.sv
@@ -73,6 +73,25 @@ IOVal<String> ::= p::ProcessHandle i::IO
 
 
 {--
+ - Read everything in the stdout from a subprocess until reaching the string "ending".
+ - The ending string is included in the output.  If the process never outputs the
+ - ending string to stdout, this function never returns.
+ -
+ - @param p  The process from which to read
+ - @param ending  The string to end on
+ - @param i  The IO token
+ - @return  The line which was read
+-}
+function readUntilFromProcess
+IOVal<String> ::= p::ProcessHandle ending::String i::IO
+{
+  return error("Not Yet Implemented:  readLineFromProcess");
+} foreign {
+  "java" : return "%p%.readUntilFromProcess(%i%, %ending%)";
+}
+
+
+{--
  - Read a line of output from stderr of a subprocess
  -
  - @param p  The process from which to read
@@ -102,6 +121,25 @@ IOVal<String> ::= p::ProcessHandle i::IO
   return error("Not Yet Implemented:  readLineFromProcess");
 } foreign {
   "java" : return "%p%.readErrAllFromProcess(%i%)";
+}
+
+
+{--
+ - Read everything in the stderr from a subprocess until reaching the string "ending".
+ - The ending string is included in the output.  If the process never outputs the
+ - ending string to stderr, this function never returns.
+ -
+ - @param p  The process from which to read
+ - @param ending  The string to end on
+ - @param i  The IO token
+ - @return  The line which was read
+-}
+function readErrUntilFromProcess
+IOVal<String> ::= p::ProcessHandle ending::String i::IO
+{
+  return error("Not Yet Implemented:  readLineFromProcess");
+} foreign {
+  "java" : return "%p%.readErrUntilFromProcess(%i%, %ending%)";
 }
 
 


### PR DESCRIPTION
# Changes
This adds a function to read everything from `stdout` of a subprocess until reaching a given string, which is useful when interacting with a REPL to know when the output of one command is finished.  A corresponding function for `stderr` is added to keep `stdout` and `stderr` symmetric.

This also cleans up the Java code for subprocesses by reorganizing and pulling duplicated code out into functions.

# Documentation
I added general comments in the Java code to explain what the functions are doing.  I added doc comments to the new Silver subprocess functions so users know what to expect from them.

I did not add anything to the website for users because there is nothing to say about it beyond what the doc comments say.  I did not add anything for Silver developers because it does not change anything beyond the library.
