### PR TITLE
Bugfix/tuple selector typechecking

### DIFF
--- a/grammars/silver/compiler/extension/tuple/Tuple.sv
+++ b/grammars/silver/compiler/extension/tuple/Tuple.sv
@@ -56,7 +56,8 @@ top::Expr ::= tuple::Expr '.' a::IntConst
   -- will be 1, so we must pattern match to get at the 
   -- underlying tupleType and compute correct length of 
   -- its tupleElems
-  local len::Integer = case tuple.typerep of
+  local ty :: Type = performSubstitution(tuple.typerep, tuple.upSubst);
+  local len::Integer = case ty of
     | decoratedType(t, _) -> length(t.tupleElems)
     | t -> length(t.tupleElems)
     end;

--- a/test/silver_features/Tuple.sv
+++ b/test/silver_features/Tuple.sv
@@ -245,3 +245,20 @@ c ::= tuple::(a,b,c,d,e)
 }
 equalityTest(thirdOfFive((1,2,"three", 4, "five")), "three", String, silver_tests);
 equalityTest(thirdOfFive((1,2,3,"four", "five")), 3, Integer, silver_tests);
+
+global lst::[(Integer, Integer)] = [(0, 1), (1, 2), (2, 3)];
+global x::Integer = head(lst).1;
+
+equalityTest(x, 0, Integer, silver_tests);
+
+function id
+a ::= a::a
+{
+  return a;
+}
+
+global y::Integer = id((1, 3)).1;
+global z::String = id(("hello", "this", "is", "test")).4;
+
+equalityTest(y, 1, Integer, silver_tests);
+equalityTest(z, "test", String, silver_tests);


### PR DESCRIPTION
# Changes
This should close the issue Dawn noted in #486 where tuple access selectors used on calls of polymorphic functions were not typechecking correctly. I just added a single line to apply tuple.upSubst to tuple.typerep before computing the len in the selector production.

# Documentation
I did not add documentation because I just added a single line to the tuple selector production and some tests to show that the issue should be resolved now.