### PR TITLE
Literate Silver

### DIFF
--- a/grammars/silver/compiler/definition/core/Terminals.sv
+++ b/grammars/silver/compiler/definition/core/Terminals.sv
@@ -113,9 +113,9 @@ ignore terminal LocationTag_t /#line -?[0-9]+/
   action {
     line = toInteger(substring(6, length(lexeme), lexeme));
   };
-ignore terminal WarnTag_t /#warn [^\n]+/
+ignore terminal WarnTag_t /#warn [^\r\n]+/
   action {
-    print "WARNING: substring(6, length(lexeme), lexeme);
+    print "WARNING:" ++ substring(6, length(lexeme), lexeme);
   };
 
 terminal IdLower_t /[a-z][A-Za-z0-9\_]*/ lexer classes {IDENTIFIER};

--- a/grammars/silver/compiler/definition/core/Terminals.sv
+++ b/grammars/silver/compiler/definition/core/Terminals.sv
@@ -113,6 +113,10 @@ ignore terminal LocationTag_t /#line -?[0-9]+/
   action {
     line = toInteger(substring(6, length(lexeme), lexeme));
   };
+ignore terminal WarnTag_t /#warn [^\n]+/
+  action {
+    print "WARNING: substring(6, length(lexeme), lexeme);
+  };
 
 terminal IdLower_t /[a-z][A-Za-z0-9\_]*/ lexer classes {IDENTIFIER};
 terminal IdUpper_t /[A-Z][A-Za-z0-9\_]*/ lexer classes {IDENTIFIER};

--- a/grammars/silver/compiler/definition/core/Terminals.sv
+++ b/grammars/silver/compiler/definition/core/Terminals.sv
@@ -109,6 +109,11 @@ ignore terminal Comments /([\-][\-].*)/ lexer classes {COMMENT};
 
 ignore terminal WhiteSpace /[\r\n\t\ ]+/;
 
+ignore terminal LocationTag_t /#line -?[0-9]+/
+  action {
+    line = toInteger(substring(6, length(lexeme), lexeme));
+  };
+
 terminal IdLower_t /[a-z][A-Za-z0-9\_]*/ lexer classes {IDENTIFIER};
 terminal IdUpper_t /[A-Z][A-Za-z0-9\_]*/ lexer classes {IDENTIFIER};
 

--- a/grammars/silver/compiler/driver/CompileFiles.sv
+++ b/grammars/silver/compiler/driver/CompileFiles.sv
@@ -13,9 +13,10 @@ IOVal<Pair<[Root] [ParseError]>> ::= svParser::SVParser  gpath::String  files::[
 {
   local file :: String = head(files);
   
-  -- Print the path we're reading, and read the file.
-  local text :: IOVal<String> =
+  local rawText :: IOVal<String> =
     readFile(gpath ++ file, ioin);
+  local text :: IOVal<String> =
+    ioval(rawText.io, transformFile(file, rawText.iovalue));
 
   -- This is where a .sv file actually gets parsed:
   local r :: ParseResult<Root> = svParser(text.iovalue, file);
@@ -32,4 +33,3 @@ IOVal<Pair<[Root] [ParseError]>> ::= svParser::SVParser  gpath::String  files::[
              ioval(recurse.io, pair(recurse.iovalue.fst, errval :: recurse.iovalue.snd))
          end;
 }
-

--- a/grammars/silver/compiler/driver/CompileGrammar.sv
+++ b/grammars/silver/compiler/driver/CompileGrammar.sv
@@ -68,7 +68,7 @@ Grammar ::= l::[Root]
 function isValidSilverFile
 Boolean ::= f::String
 {
-  return endsWith(".sv", f) && !startsWith(".", f);
+  return any(map(endsWith(_, f), [".sv", ".sv.md"])) && !startsWith(".", f);
 }
 function listSilverFiles
 IOVal<[String]> ::= dir::String  ioin::IO

--- a/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
+++ b/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
@@ -49,7 +49,7 @@ function extractSilverCodeBlocks
 ```
 
 We do the actual extraction with the [commonmark-java](https://github.com/commonmark/commonmark-java) library.
-Tragically, foreign functions seem not to support multiline strings, so the code it generates is fairly hard to read.
+The actual conversion is in `Markdown.java` in the runtime; see there for the fine details.
 
 ```silver
 function extractCodeBlocks
@@ -57,8 +57,6 @@ function extractCodeBlocks
 {
   return [];
 } foreign {
-  "java" : return "(new common.Lazy() { public Object eval(common.DecoratedNode context) { java.util.ArrayList<silver.core.Ppair> out = new java.util.ArrayList<silver.core.Ppair>(); org.commonmark.parser.Parser.builder().includeSourceSpans(org.commonmark.parser.IncludeSourceSpans.BLOCKS).build().parse(%markdown%.toString()).accept(new org.commonmark.node.AbstractVisitor() { public void visit(org.commonmark.node.FencedCodeBlock node) { java.util.List<org.commonmark.node.SourceSpan> spans = node.getSourceSpans(); out.add(silver.core.Ppair.rtConstruct(null, new common.StringCatter(node.getInfo()), silver.core.Ppair.rtConstruct(null, new Integer(spans.isEmpty() ? -1 : spans.get(0).getLineIndex()), new common.StringCatter(node.getLiteral())))); } }); return common.javainterop.ConsCellCollection.fromIterator(out.iterator()); } }).eval(null)";
+  "java" : return "common.Markdown.extractCodeBlocks(%markdown%.toString())";
 }
 ```
-
-Indented more reasonably, this is:

--- a/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
+++ b/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
@@ -1,0 +1,85 @@
+This file implements the helpers for literate programming in Silver, and serves as a test-case for it as well.
+
+## Pre-processing
+
+The transformFile function here implements whatever preprocessing needs to be done on a certain file.
+
+```silver
+function transformFile
+String ::= path::String  contents::String
+{
+  return
+```
+
+If the file is a normal Silver file, we return the contents unchanged.
+
+```silver
+    if endsWith(".sv", path)
+    then contents
+```
+
+If it's a Literate Silver file instead, we extract the relevant code blocks, then join them with newlines.
+
+```silver
+    else if endsWith(".sv.md", path)
+    then implode("\n", extractSilverCodeBlocks(contents))
+```
+
+Since these are the only two extensions allowed by `isValidSilverFile` in `CompileGrammar.sv`, they're the only two we need to handle.
+
+```silver
+    else error("Unknown filetype for " ++ path);
+}
+```
+
+## Literate Silver
+
+To get the Silver code blocks, we check that the info string is *exactly* `silver`.
+The CommonMark spec notes that commonly only the first word is used as the language; in the future, we may want to support info strings like `silver test`, `silver wrongCode`, etc.
+See [rustdoc](https://doc.rust-lang.org/rustdoc/documentation-tests.html#attributes) for prior art.
+
+```silver
+function extractSilverCodeBlocks
+[String] ::= markdown::String
+{
+  return map(\block::(String, Integer, String) -> block.3,
+             filter(\block::(String, Integer, String) -> block.1 == "silver",
+                    extractCodeBlocks(markdown)));
+}
+```
+
+We do the actual extraction with the [commonmark-java](https://github.com/commonmark/commonmark-java) library.
+Tragically, foreign functions seem not to support multiline strings, so the code it generates is fairly hard to read.
+
+```silver
+function extractCodeBlocks
+[(String, Integer, String)] ::= markdown::String
+{
+  return [];
+} foreign {
+  "java" : return "(new common.Lazy() { public Object eval(common.DecoratedNode context) { java.util.ArrayList<silver.core.Ppair> out = new java.util.ArrayList<silver.core.Ppair>(); org.commonmark.parser.Parser.builder().build().parse(%markdown%.toString()).accept(new org.commonmark.node.AbstractVisitor() { public void visit(org.commonmark.node.FencedCodeBlock node) { out.add(silver.core.Ppair.rtConstruct(null, new common.StringCatter(node.getInfo()), silver.core.Ppair.rtConstruct(null, new Integer(0), new common.StringCatter(node.getLiteral())))); } }); return common.javainterop.ConsCellCollection.fromIterator(out.iterator()); } }).eval(null)";
+}
+```
+
+Indented more reasonably, this is:
+
+```java
+(new common.Lazy() {
+  public Object eval(common.DecoratedNode context) {
+    java.util.ArrayList<silver.core.Ppair> out = new java.util.ArrayList<silver.core.Ppair>();
+    org.commonmark.parser.Parser.builder()
+      .build()
+      .parse(%markdown%.toString())
+      .accept(new org.commonmark.node.AbstractVisitor() {
+        public void visit(org.commonmark.node.FencedCodeBlock node) {
+          out.add(silver.core.Ppair.rtConstruct(null,
+            new common.StringCatter(node.getInfo()),
+            silver.core.Ppair.rtConstruct(null,
+              new Integer(0),
+              new common.StringCatter(node.getLiteral()))));
+        }
+      });
+  return common.javainterop.ConsCellCollection.fromIterator(out.iterator());
+  }
+}).eval(null)
+```

--- a/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
+++ b/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
@@ -62,26 +62,3 @@ function extractCodeBlocks
 ```
 
 Indented more reasonably, this is:
-
-```java
-(new common.Lazy() {
-  public Object eval(common.DecoratedNode context) {
-    java.util.ArrayList<silver.core.Ppair> out = new java.util.ArrayList<silver.core.Ppair>();
-    org.commonmark.parser.Parser.builder()
-      .includeSourceSpans(org.commonmark.parser.IncludeSourceSpans.BLOCKS)
-      .build()
-      .parse(%markdown%.toString())
-      .accept(new org.commonmark.node.AbstractVisitor() {
-        public void visit(org.commonmark.node.FencedCodeBlock node) {
-	  java.util.List<org.commonmark.node.SourceSpan> spans = node.getSourceSpans();
-          out.add(silver.core.Ppair.rtConstruct(null,
-            new common.StringCatter(node.getInfo()),
-            silver.core.Ppair.rtConstruct(null,
-              new Integer(spans.isEmpty() ? -1 : spans.get(0).getLineIndex()),
-              new common.StringCatter(node.getLiteral()))));
-        }
-      });
-  return common.javainterop.ConsCellCollection.fromIterator(out.iterator());
-  }
-}).eval(null)
-```

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -99,10 +99,10 @@ top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
   extraGrammarsDeps := ["init"];
   
   production attribute classpathCompiler :: [String] with ++;
-  classpathCompiler := [];
+  classpathCompiler := ["${sh}/jars/commonmark-0.17.1.jar"];
   
   production attribute classpathRuntime :: [String] with ++;
-  classpathRuntime := ["${sh}/jars/SilverRuntime.jar"];
+  classpathRuntime := ["${sh}/jars/commonmark-0.17.1.jar", "${sh}/jars/SilverRuntime.jar"];
   
   -- The --XRTjar hack
   classpathRuntime <- top.config.includeRTJars;

--- a/grammars/silver/core/Monoid.sv
+++ b/grammars/silver/core/Monoid.sv
@@ -24,6 +24,10 @@ instance Plus m => Monoid m<a> {
   mempty = empty;
 }
 
+instance Monoid a, Monoid b => Monoid (a, b) {
+  mempty = (mempty, mempty);
+}
+
 instance Monoid String {
   mempty = "";
 }

--- a/grammars/silver/core/Semigroup.sv
+++ b/grammars/silver/core/Semigroup.sv
@@ -17,6 +17,10 @@ instance Alt m => Semigroup m<a> {
   append = alt;
 }
 
+instance Semigroup a, Semigroup b => Semigroup (a, b) {
+  append = \x::(a, b) y::(a, b) -> (append(x.1, y.1), append(x.2, y.2));
+}
+
 instance Semigroup String {
   append = stringAppend;
 }

--- a/runtime/java/build.xml
+++ b/runtime/java/build.xml
@@ -10,6 +10,7 @@
 
   <path id='compile.classpath'>
     <fileset dir='../../jars' includes='CopperCompiler.jar' />
+    <fileset dir='../../jars' includes='commonmark-0.17.1.jar' />
   </path>
 
   <target name='init'>

--- a/runtime/java/src/common/Markdown.java
+++ b/runtime/java/src/common/Markdown.java
@@ -1,0 +1,38 @@
+package common;
+
+import common.javainterop.ConsCellCollection;
+import java.util.ArrayList;
+import java.util.List;
+import org.commonmark.node.AbstractVisitor;
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.SourceSpan;
+import org.commonmark.parser.IncludeSourceSpans;
+import org.commonmark.parser.Parser;
+import silver.core.Ppair;
+
+/**
+ * The Markdown class contains some utilities that are too groty to put inline
+ * in the compiler.
+ *
+ * @author remexre
+ */
+public final class Markdown {
+  public static ConsCell extractCodeBlocks(String markdown) {
+    ArrayList<Ppair> out = new ArrayList<Ppair>();
+    Parser.builder()
+        .includeSourceSpans(IncludeSourceSpans.BLOCKS)
+        .build()
+        .parse(markdown)
+        .accept(new AbstractVisitor() {
+          public void visit(FencedCodeBlock node) {
+            List<SourceSpan> spans = node.getSourceSpans();
+            out.add(Ppair.rtConstruct(
+                null, new StringCatter(node.getInfo()),
+                Ppair.rtConstruct(null,
+                                  new Integer(spans.get(0).getLineIndex()),
+                                  new StringCatter(node.getLiteral()))));
+          }
+        });
+    return ConsCellCollection.fromIterator(out.iterator());
+  }
+}

--- a/runtime/java/src/common/Markdown.java
+++ b/runtime/java/src/common/Markdown.java
@@ -8,6 +8,7 @@ import org.commonmark.node.FencedCodeBlock;
 import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.IncludeSourceSpans;
 import org.commonmark.parser.Parser;
+import silver.core.Ploc;
 import silver.core.Ppair;
 
 /**
@@ -17,7 +18,7 @@ import silver.core.Ppair;
  * @author remexre
  */
 public final class Markdown {
-  public static ConsCell extractCodeBlocks(String markdown) {
+  public static ConsCell extractCodeBlocks(String path, String markdown) {
     ArrayList<Ppair> out = new ArrayList<Ppair>();
     Parser.builder()
         .includeSourceSpans(IncludeSourceSpans.BLOCKS)
@@ -25,11 +26,17 @@ public final class Markdown {
         .parse(markdown)
         .accept(new AbstractVisitor() {
           public void visit(FencedCodeBlock node) {
-            List<SourceSpan> spans = node.getSourceSpans();
+            SourceSpan span = node.getSourceSpans().get(0);
+
+            // TODO: SourceSpan only provides line/column, but it provides a
+            // length in UTF-16 code units; do we have a utility for this?
+            Ploc location = Ploc.rtConstruct(
+                null, path, span.getLineIndex(), span.getColumnIndex(),
+                span.getLineIndex(), span.getColumnIndex(), 0, 0);
+
             out.add(Ppair.rtConstruct(
                 null, new StringCatter(node.getInfo()),
-                Ppair.rtConstruct(null,
-                                  new Integer(spans.get(0).getLineIndex()),
+                Ppair.rtConstruct(null, location,
                                   new StringCatter(node.getLiteral()))));
           }
         });


### PR DESCRIPTION
# Changes

Silver now build `.sv.md` files found in a grammar.
Code blocks that have an info string of (exactly) `silver` have the code blocks extracted and concatenated as a preprocessing step.

# Documentation

- `CompileLiterateFile.sv.md` acts as an example, testcase, and documentation of use.
- I'll probably add some user documentation to the website once locations are fixed.
- I don't think developer documentation on the website is needed, as the implementation is fairly straightforward (excepting the literal lexical reading of `extractCodeBlocks`...)

# Questions

- Should this intersect with docgen in any way?
- Multi-line foreigns?

# TODOs

- [x] Preserve locations with a `#line` directive
- [x] Website documentation
- [x] Warn about fenced code blocks without an info string