### PR TITLE
Refactor NamedSignature to use a NamedSignatureElements nonterminal instead of [NamedSignatureElement]

### DIFF
--- a/grammars/silver/compiler/definition/core/AspectDcl.sv
+++ b/grammars/silver/compiler/definition/core/AspectDcl.sv
@@ -98,7 +98,12 @@ top::AspectProductionSignature ::= lhs::AspectProductionLHS '::=' rhs::AspectRHS
 
   propagate defs;
 
-  top.namedSignature = namedSignature(top.signatureName, [], rhs.inputElements, lhs.outputElement, annotationsForNonterminal(lhs.outputElement.typerep, top.env));
+  top.namedSignature =
+    namedSignature(
+      top.signatureName, nilContext(),
+      foldNamedSignatureElements(rhs.inputElements),
+      lhs.outputElement,
+      foldNamedSignatureElements(annotationsForNonterminal(lhs.outputElement.typerep, top.env)));
 
   lhs.realSignature = if null(top.realSignature) then [] else [head(top.realSignature)];
   rhs.realSignature = if null(top.realSignature) then [] else tail(top.realSignature);
@@ -237,8 +242,13 @@ top::AspectFunctionSignature ::= lhs::AspectFunctionLHS '::=' rhs::AspectRHS
 
   propagate defs;
 
-  -- For the moment, functions do not have named parameters (hence, [])
-  top.namedSignature = namedSignature(top.signatureName, [], rhs.inputElements, lhs.outputElement, []);
+  top.namedSignature =
+    namedSignature(
+      top.signatureName, nilContext(),
+      foldNamedSignatureElements(rhs.inputElements),
+      lhs.outputElement,
+      -- For the moment, functions do not have named parameters (hence, nilNamedSignatureElement)
+      nilNamedSignatureElement());
 
   lhs.realSignature = if null(top.realSignature) then [] else [head(top.realSignature)];
   rhs.realSignature = if null(top.realSignature) then [] else tail(top.realSignature);

--- a/grammars/silver/compiler/definition/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/definition/core/FunctionDcl.sv
@@ -52,8 +52,14 @@ top::FunctionSignature ::= cl::ConstraintList '=>' lhs::FunctionLHS '::=' rhs::P
   top.defs := lhs.defs ++ rhs.defs;
   top.constraintDefs = cl.defs;
 
-  -- For the moment, functions do not have named parameters (hence, [])
-  top.namedSignature = namedSignature(top.signatureName, cl.contexts, rhs.inputElements, lhs.outputElement, []);
+  top.namedSignature =
+    namedSignature(
+      top.signatureName,
+      foldContexts(cl.contexts),
+      foldNamedSignatureElements(rhs.inputElements),
+      lhs.outputElement,
+      -- For the moment, functions do not have named parameters (hence, nilNamedSignatureElement)
+      nilNamedSignatureElement());
 }
 
 concrete production functionSignatureNoCL

--- a/grammars/silver/compiler/definition/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/core/ProductionDcl.sv
@@ -79,7 +79,13 @@ top::ProductionSignature ::= cl::ConstraintList '=>' lhs::ProductionLHS '::=' rh
 
   top.defs := lhs.defs ++ rhs.defs;
   top.constraintDefs = cl.defs;
-  top.namedSignature = namedSignature(top.signatureName, cl.contexts, rhs.inputElements, lhs.outputElement, annotationsForNonterminal(lhs.outputElement.typerep, top.env));
+  top.namedSignature =
+    namedSignature(
+      top.signatureName,
+      foldContexts(cl.contexts),
+      foldNamedSignatureElements(rhs.inputElements),
+      lhs.outputElement,
+      foldNamedSignatureElements(annotationsForNonterminal(lhs.outputElement.typerep, top.env)));
 }
 
 concrete production productionSignatureNoCL

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -6,13 +6,19 @@ attribute env occurs on Context;
 
 -- This mostly exists as a convenient way to perform multiple env-dependant operations
 -- on a list of contexts without re-decorating them and repeating context resolution.
-nonterminal Contexts with env, freeVariables, boundVariables;
+nonterminal Contexts with env, contexts, freeVariables, boundVariables;
 abstract production consContext
 top::Contexts ::= h::Context t::Contexts
-{ top.freeVariables = setUnionTyVars(h.freeVariables, t.freeVariables); }
+{
+  top.contexts = h :: t.contexts;
+  top.freeVariables = setUnionTyVars(h.freeVariables, t.freeVariables);
+}
 abstract production nilContext
 top::Contexts ::=
-{ top.freeVariables = []; }
+{
+  top.contexts = [];
+  top.freeVariables = [];
+}
 
 global foldContexts::(Contexts ::= [Context]) = foldr(consContext, nilContext(), _);
 

--- a/grammars/silver/compiler/modification/copper/ParserDcl.sv
+++ b/grammars/silver/compiler/modification/copper/ParserDcl.sv
@@ -29,11 +29,12 @@ top::AGDcl ::= 'parser' n::Name '::' t::TypeExpr '{' m::ParserComponents '}'
   production fName :: String = top.grammarName ++ ":" ++ n.name;
 
   production namedSig :: NamedSignature =
-    namedSignature(fName, [],
-      [namedSignatureElement("stringToParse", stringType()),
-       namedSignatureElement("filenameToReport", stringType())],
+    namedSignature(fName, nilContext(),
+      foldNamedSignatureElements([
+        namedSignatureElement("stringToParse", stringType()),
+        namedSignatureElement("filenameToReport", stringType())]),
       namedSignatureElement("__func__lhs", appType(nonterminalType("silver:core:ParseResult", [starKind()], false), t.typerep)),
-      []);
+      nilNamedSignatureElement());
 
   production spec :: ParserSpec =
     parserSpec(fName, t.typerep.typeName, m.moduleNames, m.customLayout, m.terminalPrefixes, m.grammarTerminalPrefixes, m.syntaxAst, sourceGrammar=top.grammarName, location=top.location);

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -22,9 +22,10 @@ top::AGDcl ::= 'aspect' 'default' 'production'
   top.defs := [];
 
   production namedSig :: NamedSignature = 
-    namedSignature(top.grammarName ++ ":default" ++ te.typerep.typeName, [], [],
+    namedSignature(top.grammarName ++ ":default" ++ te.typerep.typeName,
+      nilContext(), nilNamedSignatureElement(),
       namedSignatureElement(lhs.name, te.typerep),
-      annotationsForNonterminal(te.typerep, top.env));
+      foldNamedSignatureElements(annotationsForNonterminal(te.typerep, top.env)));
 
   propagate errors, flowDefs;
 

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -6,14 +6,20 @@ grammar silver:compiler:translation:java:core;
 synthesized attribute javaSignature :: String occurs on NamedSignature;
 synthesized attribute refInvokeTrans :: String occurs on NamedSignature;
 -- "final ContextName d_contextname"
+synthesized attribute contextSigElems :: [String] occurs on Contexts;
 synthesized attribute contextSigElem :: String occurs on Context;
 -- "final Object c_signame"
+synthesized attribute childSigElems :: [String] occurs on NamedSignatureElements;
+synthesized attribute annoSigElems :: [String] occurs on NamedSignatureElements;
 synthesized attribute childSigElem :: String occurs on NamedSignatureElement;
 synthesized attribute annoSigElem :: String occurs on NamedSignatureElement;
 -- "d_contextname"
+synthesized attribute contextRefElems :: [String] occurs on Contexts;
 synthesized attribute contextRefElem :: String occurs on Context;
 -- "c_signame"
+synthesized attribute childRefElems :: [String] occurs on NamedSignatureElements;
 synthesized attribute childRefElem :: String occurs on NamedSignatureElement;
+synthesized attribute annoRefElems :: [String] occurs on NamedSignatureElements;
 synthesized attribute annoRefElem :: String occurs on NamedSignatureElement;
 -- "inhs[c_signame] = new lazy[]"
 synthesized attribute childStaticElem :: String occurs on NamedSignatureElement;
@@ -26,10 +32,23 @@ synthesized attribute annoNameElem :: String occurs on NamedSignatureElement;
 synthesized attribute annoLookupElem :: String occurs on NamedSignatureElement;
 
 aspect production namedSignature
-top::NamedSignature ::= fn::String contexts::[Context] ie::[NamedSignatureElement] oe::NamedSignatureElement np::[NamedSignatureElement]
+top::NamedSignature ::= fn::String ctxs::Contexts ie::NamedSignatureElements oe::NamedSignatureElement np::NamedSignatureElements
 {
-  top.javaSignature = implode(", ", map(\ c::Context -> decorate c with {boundVariables = top.freeVariables;}.contextSigElem, contexts) ++ map((.childSigElem), ie) ++ map((.annoSigElem), np));
-  top.refInvokeTrans = implode(", ", map(\ c::Context -> decorate c with {boundVariables = top.freeVariables;}.contextRefElem, contexts) ++ map((.childRefElem), ie) ++ map((.annoRefElem), np));
+  top.javaSignature = implode(", ", ctxs.contextSigElems ++ ie.childSigElems ++ np.annoSigElems);
+  top.refInvokeTrans = implode(", ", ctxs.contextRefElems ++ ie.childRefElems ++ np.annoRefElems);
+}
+
+aspect production consContext
+top::Contexts ::= h::Context t::Contexts
+{
+  top.contextSigElems = h.contextSigElem :: t.contextSigElems;
+  top.contextRefElems = h.contextRefElem :: t.contextRefElems;
+}
+aspect production nilContext
+top::Contexts ::=
+{
+  top.contextSigElems = [];
+  top.contextRefElems = [];
 }
 
 aspect production instContext
@@ -52,6 +71,25 @@ top::Context ::= i1::Type i2::Type
   top.contextSigElem = s"final ${top.transType} ${makeInhSubsetName(i1, i2, top.boundVariables)}";
   top.contextRefElem = makeInhSubsetName(i1, i2, top.boundVariables);
 }
+
+aspect production consNamedSignatureElement
+top::NamedSignatureElements ::= h::NamedSignatureElement t::NamedSignatureElements
+{
+  top.childSigElems = h.childSigElem :: t.childSigElems;
+  top.annoSigElems = h.annoSigElem :: t.annoSigElems;
+  top.childRefElems = h.childRefElem :: t.childRefElems;
+  top.annoRefElems = h.annoRefElem :: t.annoRefElems;
+}
+
+aspect production nilNamedSignatureElement
+top::NamedSignatureElements ::=
+{
+  top.childSigElems = [];
+  top.annoSigElems = [];
+  top.childRefElems = [];
+  top.annoRefElems = [];
+}
+
 
 -- TODO: It'd be nice to maybe split these into the ordered parameters and the annotations
 aspect production namedSignatureElement


### PR DESCRIPTION
# Changes
This change is needed for my work on occurs-on constraints, as the translation of polymorphic children/arguments of a production/function depend on the existence of occurs-on constraints for these types.  In practice this requires adding inherited attributes on `NamedSignatureElement`, which is much less painful when dealing with a `NamedSignatureElements` instead of `[NamedSignatureElement]`.  

# Documentation
This is an internal refactoring of the Silver compiler, doesn't require any external documentation.
