### PR TITLE
Bump up stack space given to ant task, fixing javac stack overflows

### DIFF
--- a/deep-rebuild
+++ b/deep-rebuild
@@ -4,6 +4,7 @@ set -eu
 
 export SILVER_HOME=$(pwd)
 JVM_ARGS="-Xss16M -Xmx4G -jar ../jars/silver.compiler.composed.Default.jar"
+export ANT_OPTS=-Xss10M
 
 # just run this script, no parameters or options.
 # One new option: --newcore, for when the core FFI stuff has to change in tandem with the runtime

--- a/self-compile
+++ b/self-compile
@@ -9,6 +9,8 @@ SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx4G -Xss16M"}
   # -XX:+PrintCompilation -verbose:gc -XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:-PrintGC
 SV_BUILD_TARGET=${SV_BUILD_TARGET:-"silver:compiler:composed:Default"}
 
+export ANT_OPTS=-Xss10M
+
 mkdir -p build
 cd build
 


### PR DESCRIPTION
Fixes the occasional crashes seen running `./self-compile` without `--clean`.  

I haven't seen these crashes when building any Silver projects besides the Silver compiler itself, but if needed the same could be done in the `support/bin/silver` script.  