### PR TITLE
Fixes incorrect `unification attribute ... occurs on ...;' behavior.

### DIFF
--- a/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
@@ -66,7 +66,7 @@ top::AGDcl ::= 'unification' 'attribute' inh::Name i::TypeExpr ',' synPartial::N
       appendAGDcl(
         makeOccursDclsHelp($1.location, qNameWithTL(qNameId(inh, location=inh.location), botlNone(location=top.location)), qs.qnames),
         appendAGDcl(
-          makeOccursDclsHelp($1.location, qNameWithTL(qNameId(inh, location=inh.location), botlNone(location=top.location)), qs.qnames),
+          makeOccursDclsHelp($1.location, qNameWithTL(qNameId(synPartial, location=synPartial.location), botlNone(location=top.location)), qs.qnames),
           makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
           location=top.location),
         location=top.location),


### PR DESCRIPTION
# Changes

Previously, code like:

    nonterminal Repr;
    unification attribute foo {}, bar, baz occurs on Repr;

would result in:

    definition.sv.md:16:22: error: Attribute 'foo' already occurs on 'Repr'.
    definition.sv.md:16:22: error: Attribute 'foo' already occurs on 'Repr'.

# Documentation

As far as I can tell (grepping Silver and ableC) nobody actually *uses* unification attributes, so... no user-visible change -> no doc update required 🙃