### PR TITLE
Ensures tuple selector does not hide child errors

### DIFF
--- a/grammars/silver/compiler/extension/tuple/Tuple.sv
+++ b/grammars/silver/compiler/extension/tuple/Tuple.sv
@@ -51,6 +51,7 @@ top::Expr ::= tuple::Expr '.' a::IntConst
   local accessIndex::Integer = toInteger(a.lexeme);
 
   top.unparse = tuple.unparse ++ "." ++ a.lexeme;
+  top.errors <- tuple.errors;
 
   -- If tuple is decorated, the length of its tupleElems 
   -- will be 1, so we must pattern match to get at the 
@@ -63,7 +64,7 @@ top::Expr ::= tuple::Expr '.' a::IntConst
     end;
   
   forwards to if (accessIndex > len || accessIndex < 1) then
-      errorExpr(tuple.errors ++ [err(top.location, "Invalid tuple selector index.")], location=top.location)
+      errorExpr([err(top.location, "Invalid tuple selector index.")], location=top.location)
     -- exprRef prevents exponential type checking
     else select(exprRef(tuple, location=top.location), 1, accessIndex, len);
 

--- a/test/silver_features/Tuple.sv
+++ b/test/silver_features/Tuple.sv
@@ -237,6 +237,18 @@ wrongCode "Invalid tuple selector index." {
 equalityTest((3, 2).2, 2, Integer, silver_tests);
 equalityTest(("one", 2).1, "one", String, silver_tests);
 
+-- tests that tuple selectors do not hide child errors
+
+wrongCode "Undeclared value 'random'" {
+
+function fun
+String ::=
+{
+  return random.1;
+}
+
+}
+
 -- polymorphism
 function thirdOfFive
 c ::= tuple::(a,b,c,d,e)


### PR DESCRIPTION
# Changes

Adds a line to collect tuple.errors in top.errors, which explicitly includes the tuple errors since exprRef on line 69 of tuple/Tuple.sv assumes tuple has already been checked for errors and suppresses them. Adds Dawn's example from the original issue to the test file to show that the bug is fixed.

There are some concerns here with adding this explicit synthesized equation on the forwarding production, but Lucas said there will be upcoming changes with exprRef and changes in behavior can be dealt with then.

Resolves #503 

# Documentation
I did not add documentation since I only added one line.  Should I add a note about the concerns regarding the error collection as a comment?
