### PR TITLE
Fix #506, freshen looked-up signatures with skolems when type checking aspects

### DIFF
--- a/grammars/silver/compiler/definition/env/NamedSignature.sv
+++ b/grammars/silver/compiler/definition/env/NamedSignature.sv
@@ -141,11 +141,12 @@ Integer ::= s::String l::[NamedSignatureElement] z::Integer
 attribute substitution, flatRenamed occurs on NamedSignature, Contexts, NamedSignatureElements, NamedSignatureElement;
 propagate flatRenamed on NamedSignature, Contexts, NamedSignatureElements, NamedSignatureElement;
 
--- Freshens all the signature's types
+-- "Freshens" all the signature's type variables with new skolem constants,
+-- to avoid type vars from interface files clashing with new ones from genInt()
 function freshenNamedSignature
 NamedSignature ::= ns::NamedSignature
 {
-  ns.substitution = zipVarsIntoSubstitution(ns.freeVariables, ns.typeScheme.boundVars);
+  ns.substitution = zipVarsAndTypesIntoSubstitution(ns.freeVariables, map(skolemType, ns.typeScheme.boundVars));
   return ns.flatRenamed;
 }
 

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -299,3 +299,9 @@ wrongCode "Production LHS type must be a nonterminal.  Instead it is of type a" 
   top::a ::=
   {}
 }
+
+wrongCode "Type incorrect in aspect signature. Expected: silver:core:Maybe<a>  Got: silver:core:Maybe<String>" {
+  aspect production just
+  top::Maybe<String> ::= x::String
+  {}
+}


### PR DESCRIPTION
# Changes
Apparently we are freshening the signature looked up from the environment before unifying it with the given one from the aspect, so a more specific type given in the aspect signature can (incorrectly!) unify with the freshened signature, rather than giving an error.

It looks like the freshening that caused this bug was introduced in https://github.com/melt-umn/silver/commit/e13cd86f1334afd9cb6c2cf13503cc88ee8b2eac, which has the commit message `Fix remaining buggy direct uses of parameterized types from environment.`  IIRC this was because type variables from interface files could potentially clash with type vars created by `genInt()` in a different run of the Silver compiler.  I guess the fix is to "freshen" with new Skolem constants instead of flexible type variables.  

# Documentation
None, internal bug fix
