### PR TITLE
Fix for #290

### DIFF
--- a/runtime/java/src/common/CollectionAttribute.java
+++ b/runtime/java/src/common/CollectionAttribute.java
@@ -19,6 +19,7 @@ public abstract class CollectionAttribute implements Lazy {
 	
 	private ArrayList<Lazy> pieces;
 	private Lazy base;
+	public boolean appliedNTFix;
 
 	public CollectionAttribute() {
 		this.pieces = new ArrayList<Lazy>();

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -314,6 +314,19 @@ public class DecoratedNode implements Typed {
 		Lazy l = self.getSynthesized(attribute);
 		if(l != null) {
 			try {
+				if(l instanceof CollectionAttribute) {
+					// This is necessary to ensure collection
+					// attribute equations in aspect default
+					// productions work; see
+					// https://github.com/melt-umn/silver/issues/290
+					CollectionAttribute prodAttr = (CollectionAttribute)l;
+					if(!prodAttr.appliedNTFix) {
+						prodAttr.appliedNTFix = true;
+						CollectionAttribute ntAttr = (CollectionAttribute)self.getDefaultSynthesized(attribute);
+						if(ntAttr != null)
+							prodAttr.getPieces().addAll(ntAttr.getPieces());
+					}
+				}
 				return l.eval(this);
 			} catch(Throwable t) {
 				throw new TraceException("While evaling syn '" + self.getNameOfSynAttr(attribute) + "' in " + getDebugID(), t);

--- a/test/silver_features/Collections.sv
+++ b/test/silver_features/Collections.sv
@@ -186,3 +186,26 @@ equalityTest( colTest3().colFun.isJust, true, Boolean, silver_tests );
 equalityTest( fromMaybe(4, colTest3().colFun), 1, Integer, silver_tests );
 equalityTest( colTest3().colProd.colSyn, "( a  c ) j  k  b ", String, silver_tests );
 
+-- Regression test for #209
+
+nonterminal NT209 with colSyn;
+
+production prod209
+top::NT209 ::=
+{
+  top.colSyn := "foo";
+}
+
+aspect production prod209
+top::NT209 ::=
+{
+  top.colSyn <- "bar";
+}
+
+aspect default production
+top::NT209 ::=
+{
+  top.colSyn <- "baz";
+}
+
+equalityTest(prod209().colSyn, "foobarbaz", String, silver_tests);


### PR DESCRIPTION
# Changes

Fixes #290 by checking for the bad condition (described in thread, but basically an equation existing for a collection attribute in both an `aspect default production` and any other production) and patching it when the attribute is demanded for the first time (per production, not just per node).

# Documentation

Comment pointing to #290, which has a good description of the problem.

# TODOs

- [x] Doing this at runtime is kinda sucky; waiting for Jenks to come back to see if there's a visible perf impact.
- [ ] Was trying to do this in the `postInit()` of the grammar/package that declares the occurrence of the collection attribute on the NT, but ran into the bug in my fix (I think); can do that if it'd be preferred or if this turns out to slow things down.
- [x] Regression test