### PR TITLE
Make the Semigroup Unit instance strict in its arguments.

### DIFF
--- a/grammars/silver/core/Semigroup.sv
+++ b/grammars/silver/core/Semigroup.sv
@@ -35,5 +35,8 @@ instance Semigroup a => Semigroup Maybe<a> {
 }
 
 instance Semigroup Unit {
-  append = \ Unit Unit -> unit();
+  append = \ x::Unit  y::Unit ->
+    case x, y of
+    | unit(), unit() -> unit()
+    end;
 }


### PR DESCRIPTION
# Changes

What it says on the tin.

# Documentation

We don't document strictness, so no documentation changes, I suppose.