### PR TITLE
Don't crash when a convinience aspect has an invalid pattern type

### DIFF
--- a/grammars/silver/compiler/extension/convenienceaspects/AbstractSyntax.sv
+++ b/grammars/silver/compiler/extension/convenienceaspects/AbstractSyntax.sv
@@ -359,7 +359,7 @@ Pair<AGDcl [Message]> ::= rules::[MatchRule] aspectLHS::ConvAspectLHS aspectAttr
       [])
     | _ ->
       pair(
-        error("Patterns in aspect convenience syntax should be productions,wildcards, or varpatterns only"),
+        emptyAGDcl(location=location),
         [err(location,"Patterns in aspect convenience syntax should be productions,wildcards, or varpatterns only")])
     end;
 }


### PR DESCRIPTION
# Changes
When a convenience aspect has an invalid type of pattern, forward to an empty `AGDcl` instead of to `error()` to avoid an unneeded fatal crash.

# Documentation
None, this is a bug fix.
