### PR TITLE
Build docs in silver build, fix nesting bug

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ melt.trynode('silver') {
                            "/melt-umn/lambda-calculus", "/melt-umn/rewriting-regex-matching", "/melt-umn/rewriting-optimization-demo",
                            "/internal/ring"]
     // Specific other jobs to build
-    def specific_jobs = ["/internal/matlab/master", "/internal/metaII/master", "/internal/simple/master"]
+    def specific_jobs = ["/internal/matlab/master", "/internal/metaII/master", "/internal/simple/master", "/melt-umn/melt-website/master"]
     // AbleP is now downstream from Silver-AbleC, so we don't need to build it here: "/melt-umn/ableP/master"
 
     def tasks = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,8 @@ melt.trynode('silver') {
     sh "./deep-rebuild"
     // Clean (but leave generated files)
     sh "./deep-clean -delete"
+    // Generate docs
+    sh "./make-docs"
     // Package
     sh "rm -rf silver-latest* || true" // Robustness to past failures
     sh "./make-dist latest"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ melt.trynode('silver') {
                            "/melt-umn/lambda-calculus", "/melt-umn/rewriting-regex-matching", "/melt-umn/rewriting-optimization-demo",
                            "/internal/ring"]
     // Specific other jobs to build
-    def specific_jobs = ["/internal/matlab/master", "/internal/metaII/master", "/internal/simple/master", "/melt-umn/melt-website/master"]
+    def specific_jobs = ["/internal/matlab/master", "/internal/metaII/master", "/internal/simple/master"]
     // AbleP is now downstream from Silver-AbleC, so we don't need to build it here: "/melt-umn/ableP/master"
 
     def tasks = [:]
@@ -132,6 +132,10 @@ melt.trynode('silver') {
       // --delete-excluded  Remove files from dest that we're excluding
       // NOTE: we exclude generated, which means there's no generated dir in the custom
       // location, which means if you don't set it, things should blow up.
+
+      sh "rsync -a --delete generated/doc/ ${silver.SILVER_WORKSPACE}/../custom-silver-doc/"
+
+      parallel [melt.buildJob("/melt-umn/website/master")]
 
       sh "cp silver-latest.tar.gz ${melt.ARTIFACTS}/"
       sh "cp jars/*.jar ${melt.ARTIFACTS}/"

--- a/build-everything
+++ b/build-everything
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-for grammar in $(find grammars -name '*.sv' | sed 's#grammars/\(.*\)/.*\.sv#\1#' | sort | uniq | sed 's#/#:#g'); do
-	java -Xss8M -Xmx2000M -jar jars/silver.compiler.composed.Default.jar --clean $grammar
-done

--- a/deep-clean
+++ b/deep-clean
@@ -34,5 +34,5 @@ find ./runtime/imp/main/src/ide $1
 find ./runtime/imp/main/target $1
 
 if [ "$2" == "all" ]; then
-  rm -rf generated/src/* generated/bin/* runtime/java/bin/* generated/ide/*
+  rm -rf generated/src/* generated/bin/* runtime/java/bin/* generated/ide/* generated/doc/*
 fi

--- a/grammars/silver/compiler/extension/doc/core/doclang/DclComment.sv
+++ b/grammars/silver/compiler/extension/doc/core/doclang/DclComment.sv
@@ -419,7 +419,7 @@ top::DclCommentPart ::= '@@'
     top.body = "@";
 }
 
-@@{- Most of the complexity in terminals here is to allow bullet point lists. Be careful :) -}
+@@{- Most of the complexity in terminals here is to allow bullet point lists and nested comments. Be careful :) -}
 
 terminal InitialIgnore_t /@+\{\-[ \t]*\-*[ \t]*([ \t]*\-*[ \t]*\r?\n)*[ \t]*\-*[ \t]*/;
 terminal FinalIgnore_t /[\- \r\n]*\-\}/ dominates {CommentContent_t};
@@ -428,7 +428,7 @@ terminal EmptyDclComment_t /@+{\-[ \-]*\-}/;
 terminal EmptyLines_t /\r?\n([ \t]*\-*[ \t]*\r?\n)+[ \t]*\-*[ \t]*/;
 terminal Newline_t /\r?\n[ \t]*\-*[ \t]*/;
 
-terminal CommentContent_t /([^@\r\n])+/;
+terminal CommentContent_t /([^@\r\n\-]|\-[^\r\n\}]|\-\}.)+/;
 
 terminal EscapedAt_t '@@';
 

--- a/grammars/silver/core/ParseResult.sv
+++ b/grammars/silver/core/ParseResult.sv
@@ -36,6 +36,7 @@ nonterminal ParseResult<a> with parseSuccess, parseError, parseErrors, parseTree
  - Parse failure constructor.
  -
  - @param e  The error string reported by the parser.
+ - @param terminals TODO
  -}
 abstract production parseFailed
 top::ParseResult<a> ::= e::ParseError terminals::[TerminalDescriptor]
@@ -51,6 +52,7 @@ top::ParseResult<a> ::= e::ParseError terminals::[TerminalDescriptor]
  - Parse success constructor.
  -
  - @param t  The syntax tree returned by the parser.
+ - @param terminals TODO
  -}
 abstract production parseSucceeded
 top::ParseResult<a> ::= t::a terminals::[TerminalDescriptor]

--- a/make-docs
+++ b/make-docs
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+
+if [ $0 != "./make-docs" ]; then
+  echo "Run as ./make-docs"
+  exit 1
+fi
+
+: ${DOCGRAMMAR="silver:compiler:extension:doc:extra"}
+
+rm -rf ./generated/doc
+
+./support/bin/silver-custom ./build/silver.compiler.composed.Default.jar --dont-translate --doc --clean --warn-error $DOCGRAMMAR
+

--- a/make-docs
+++ b/make-docs
@@ -11,5 +11,5 @@ fi
 
 rm -rf ./generated/doc
 
-./support/bin/silver-custom ./build/silver.compiler.composed.Default.jar --dont-translate --doc --clean --warn-error $DOCGRAMMAR
+./support/bin/silver --dont-translate --doc --clean --warn-error $DOCGRAMMAR
 


### PR DESCRIPTION
Fixes (again?) parse issue with nested comments.

Makes building docs part of the build process, and fails it if there is a doc warning.
