### PR TITLE
Fixes environment call in convenience aspects.

### DIFF
--- a/grammars/silver/compiler/extension/convenienceaspects/AbstractSyntax.sv
+++ b/grammars/silver/compiler/extension/convenienceaspects/AbstractSyntax.sv
@@ -162,7 +162,7 @@ Pair<AGDcl [Message]> ::= rules::[MatchRule] aspectLHS::ConvAspectLHS aspectAttr
 {
 
   local lookupProdInputTypes::([Type] ::= String) = \prodName::String ->
-      case (getValueDclInScope(prodName,env)) of
+      case (getValueDcl(prodName,env)) of
       | [] -> []
       | dcl:: _ ->
         let dcl :: Decorated DclInfo with {givenNonterminalType} =


### PR DESCRIPTION
When looking up productions, It was using getValueDclInScope, but should
have been using getValueDcl.

-------

# Changes
Changes call to getValueDclInScope to getValueDcl for looking up productions

# Documentation
As this is a bugfix, there is no documentation as of yet. Documentation tags for the
comments already written is coming in another separate pull request.