### PR TITLE
Archive per-commit artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,7 @@ melt.trynode('silver') {
     sh "./make-dist latest"
     // Upon succeeding at initial build, archive for future builds
     archiveArtifacts(artifacts: "jars/*.jar", fingerprint: true)
+    melt.archiveCommitArtifacts("jars/*.jar")
   }
 
   stage("Test") {


### PR DESCRIPTION
# Changes
Minor Jenkinsfile tweak to save all per-commit jars seperately, as requested by @remexre 

