### PR TITLE
Copper API

### DIFF
--- a/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
@@ -119,7 +119,7 @@ ${s2.lexerClassRefDcls}
     parserClassAuxCode, parserInitCode, preambleCode,
     copper:grammar_(s2.containingGrammar, s2.copperGrammarElements));
 
-  top.xmlCopper = unsafeTracePrint(xmlCopper, hackUnparse(top.copperParser));
+  top.xmlCopper = unsafeTrace(xmlCopper, copper:compileParserBean(top.copperParser, unsafeIO()));
   local xmlCopper::String =
 s"""<?xml version="1.0" encoding="UTF-8"?>
 

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
@@ -115,8 +115,8 @@ ${s2.lexerClassRefDcls}
   local preambleCode::String = "import java.util.ArrayList;\nimport java.util.List;\n";
 
   top.copperParser = copper:parserBean(makeCopperName(parsername), parsername,
-    s2.containingGrammar, head(startFound).copperElementReference, startLayoutCopper,
-    parserClassAuxCode, parserInitCode, preambleCode, []);
+    head(startFound).copperElementReference, startLayoutCopper,
+    parserClassAuxCode, parserInitCode, preambleCode, s2.copperGrammar);
 
   top.xmlCopper = unsafeTracePrint(xmlCopper, hackUnparse(top.copperParser));
   local xmlCopper::String =

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
@@ -116,7 +116,8 @@ ${s2.lexerClassRefDcls}
 
   top.copperParser = copper:parserBean(makeCopperName(parsername), parsername,
     head(startFound).copperElementReference, startLayoutCopper,
-    parserClassAuxCode, parserInitCode, preambleCode, s2.copperGrammar);
+    parserClassAuxCode, parserInitCode, preambleCode,
+    copper:grammar_(s2.containingGrammar, s2.copperGrammarElements));
 
   top.xmlCopper = unsafeTracePrint(xmlCopper, hackUnparse(top.copperParser));
   local xmlCopper::String =

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -40,7 +40,8 @@ aspect default production
 top::SyntaxLexerClassModifier ::=
 {
   -- Empty values as defaults
-  propagate cstErrors, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, prefixSeperator;
+  propagate cstErrors, superClassContribs, disambiguationClasses, dominatesXML,
+    submitsXML, dominates_, submits_, prefixSeperator;
 }
 
 {--
@@ -75,7 +76,7 @@ top::SyntaxLexerClassModifier ::= sub::[String]
                            "this grammar was not included in this parser. (Referenced from submit clause for lexer class)"], --TODO: come up with a way to reference a given lexer class (line numbers would be great)
                    zipWith(pair, sub, subRefs)); 
   
-  top.submits_ := map(error("TODO"), map(head, subRefs));
+  top.submits_ := map((.copperElementReference), map(head, subRefs));
 
   top.submitsXML := implode("", map(xmlCopperRef, map(head, subRefs)));
 }
@@ -94,7 +95,7 @@ top::SyntaxLexerClassModifier ::= dom::[String]
                            "this grammar was not included in this parser. (Referenced from dominates clause for lexer class)"],
                    zipWith(pair, dom, domRefs));
 
-  top.dominates_ := map(error("TODO"), map(head, domRefs));
+  top.dominates_ := map((.copperElementReference), map(head, domRefs));
 
   top.dominatesXML := implode("", map(xmlCopperRef, map(head, domRefs)));
 }

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -10,9 +10,9 @@ autocopy attribute className :: String;
 {--
  - Modifiers for lexer classes.
  -}
-nonterminal SyntaxLexerClassModifiers with cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, prefixSeperator, containingGrammar;
+nonterminal SyntaxLexerClassModifiers with cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, prefixSeperator, containingGrammar, dominates_, submits_;
 
-propagate cstErrors, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, prefixSeperator
+propagate cstErrors, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, prefixSeperator, dominates_, submits_
   on SyntaxLexerClassModifiers;
 
 abstract production consLexerClassMod
@@ -33,7 +33,7 @@ top::SyntaxLexerClassModifiers ::=
 {--
  - Modifiers for lexer classes.
  -}
-closed nonterminal SyntaxLexerClassModifier with cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, prefixSeperator, containingGrammar;
+closed nonterminal SyntaxLexerClassModifier with cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, dominatesXML, submitsXML, prefixSeperator, containingGrammar, dominates_, submits_;
 
 {- We default ALL attributes, so we can focus only on those that are interesting in each case... -}
 aspect default production
@@ -74,6 +74,9 @@ top::SyntaxLexerClassModifier ::= sub::[String]
                      else ["Terminal / Lexer Class " ++ a.fst ++ " was referenced but " ++
                            "this grammar was not included in this parser. (Referenced from submit clause for lexer class)"], --TODO: come up with a way to reference a given lexer class (line numbers would be great)
                    zipWith(pair, sub, subRefs)); 
+  
+  top.submits_ := map(error("TODO"), map(head, subRefs));
+
   top.submitsXML := implode("", map(xmlCopperRef, map(head, subRefs)));
 }
 {--
@@ -90,6 +93,9 @@ top::SyntaxLexerClassModifier ::= dom::[String]
                      else ["Terminal / Lexer Class " ++ a.fst ++ " was referenced but " ++
                            "this grammar was not included in this parser. (Referenced from dominates clause for lexer class)"],
                    zipWith(pair, dom, domRefs));
+
+  top.dominates_ := map(error("TODO"), map(head, subRefs));
+
   top.dominatesXML := implode("", map(xmlCopperRef, map(head, domRefs)));
 }
 

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -94,7 +94,7 @@ top::SyntaxLexerClassModifier ::= dom::[String]
                            "this grammar was not included in this parser. (Referenced from dominates clause for lexer class)"],
                    zipWith(pair, dom, domRefs));
 
-  top.dominates_ := map(error("TODO"), map(head, subRefs));
+  top.dominates_ := map(error("TODO"), map(head, domRefs));
 
   top.dominatesXML := implode("", map(xmlCopperRef, map(head, domRefs)));
 }

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Regex.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Regex.sv
@@ -1,9 +1,16 @@
 grammar silver:compiler:definition:concrete_syntax:ast;
 
 imports silver:core hiding empty, alt;
+import silver:compiler:definition:concrete_syntax:copper as copper;
 
 -- Translation of regex to Copper XML format.
 attribute xmlCopper occurs on Regex;
+
+-- Translation of regex to Copper grammar beans.
+synthesized attribute copperRegex::copper:Regex occurs on Regex, RegexSeq, RegexRepetition, RegexItem, RegexCharSet, RegexCharSetItem, RegexChar;
+synthesized attribute copperRegexAlts::[copper:Regex] occurs on Regex, RegexSeq, RegexRepetition, RegexItem, RegexCharSet, RegexCharSetItem, RegexChar;
+synthesized attribute copperRegexSeqs::[copper:Regex] occurs on Regex, RegexSeq, RegexRepetition, RegexItem, RegexCharSet, RegexCharSetItem, RegexChar;
+synthesized attribute copperRegexCharSet::copper:CharSet occurs on Regex, RegexSeq, RegexRepetition, RegexItem, RegexCharSet, RegexCharSetItem, RegexChar;
 
 {--
  - Used to prevent unneeded nesting of the same operator. (choices, sequences)
@@ -20,6 +27,9 @@ attribute setXML occurs on Regex;
 aspect default production
 top::Regex ::=
 {
+  top.copperRegexAlts = [top.copperRegex];
+  top.copperRegexSeqs = [top.copperRegex];
+  implicit top.copperRegexCharSet =;
   top.altXML = top.xmlCopper;
   top.seqXML = top.xmlCopper;
   implicit top.setXML =;

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Regex.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Regex.sv
@@ -103,12 +103,14 @@ top::Regex ::=
 aspect production alt
 top::Regex ::= r1::Regex r2::Regex
 {
-  top.copperRegex = case top.copperRegexCharSet of
+  top.copperRegex =
+    case top.copperRegexCharSet of
     | just(cs) -> copper:characterSetRegex(cs)
     | nothing() -> copper:choiceRegex(top.copperRegexAlts)
     end;
-  top.copperRegexAlts = case top.copperRegexCharSet of
-    | just(cs) -> [top.copperRegex]
+  top.copperRegexAlts =
+    case top.copperRegexCharSet of
+    | just(_) -> [top.copperRegex]
     | nothing() -> r1.copperRegexAlts ++ r2.copperRegexAlts
     end;
   top.copperRegexCharSet = copper:unionCharSets(r1.copperRegexCharSet, r2.copperRegexCharSet);
@@ -118,7 +120,11 @@ top::Regex ::= r1::Regex r2::Regex
     | just(sx) -> "<CharacterSet>" ++ sx ++ "</CharacterSet>"
     | nothing() -> "<Choice>" ++ r1.altXML ++ r2.altXML ++ "</Choice>"
     end;
-  top.altXML = r1.altXML ++ r2.altXML;
+  top.altXML =
+    case top.setXML of
+    | just(_) -> top.xmlCopper
+    | nothing() -> r1.altXML ++ r2.altXML
+    end;
   top.setXML = r1.setXML ++ r2.setXML;
 }
 aspect production seq

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Regex.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Regex.sv
@@ -111,7 +111,7 @@ top::Regex ::= r1::Regex r2::Regex
     | just(cs) -> [top.copperRegex]
     | nothing() -> r1.copperRegexAlts ++ r2.copperRegexAlts
     end;
-  top.copperRegexCharSet = unionCharSets(r1.copperRegexCharSet, r2.copperRegexCharSet);
+  top.copperRegexCharSet = copper:unionCharSets(r1.copperRegexCharSet, r2.copperRegexCharSet);
 
   top.xmlCopper =
     case top.setXML of

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -51,13 +51,14 @@ monoid attribute prettyNamesAccum::[Pair<String String>];
 autocopy attribute prettyNames::tm:Map<String String>;
 
 synthesized attribute copperElementReference::copper:ElementReference;
+synthesized attribute copperGrammar::copper:Grammar;
 synthesized attribute copperGrammarElement::copper:GrammarElement;
 synthesized attribute copperGrammarElements::[copper:GrammarElement];
 
 {--
  - An abstract syntax tree for representing concrete syntax.
  -}
-nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, layoutContribs, layoutTerms, xmlCopper, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElements;
+nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, layoutContribs, layoutTerms, xmlCopper, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammar, copperGrammarElements;
 
 propagate cstDcls, cstErrors, cstProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, superClassContribs, parserAttributeAspectContribs, lexerClassRefDcls, layoutContribs, prettyNamesAccum
   on Syntax;

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -50,6 +50,7 @@ autocopy attribute componentGrammarMarkingTerminals :: EnvTree<[String]>;
 monoid attribute prettyNamesAccum::[Pair<String String>];
 autocopy attribute prettyNames::tm:Map<String String>;
 
+synthesized attribute copperElementReference::copper:ElementReference;
 synthesized attribute copperGrammarElement::copper:GrammarElement;
 synthesized attribute copperGrammarElements::[copper:GrammarElement];
 
@@ -80,7 +81,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, xmlCopper, classDomContribsXML, classSubContribsXML, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElement;
+nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, xmlCopper, classDomContribsXML, classSubContribsXML, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElement;
 
 synthesized attribute sortKey :: String;
 
@@ -124,6 +125,7 @@ top::SyntaxDcl ::= t::Type subdcls::Syntax exportedProds::[String] exportedLayou
   top.hasCustomLayout = modifiers.customLayout.isJust;
   top.layoutContribs := map(pair(t.typeName, _), fromMaybe(exportedLayoutTerms, modifiers.customLayout));
 
+  top.copperElementReference = copper:elementReference(makeCopperName(t.typeName), top.containingGrammar);
   top.copperGrammarElement = copper:nonterminal_(makeCopperName(t.typeName),
     t.typeName, makeNTName(t.typeName));
 
@@ -177,6 +179,7 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
     | _ -> prettyName ++ " (" ++ n ++ ")"
     end;
 
+  top.copperElementReference = copper:elementReference(makeCopperName(n), top.containingGrammar);
   top.copperGrammarElement = copper:terminal_(makeCopperName(n),
     disambiguatedPrettyName, regex.copperRegex, modifiers.opPrecedence.isJust,
     error("precedence"), modifiers.opAssociation.isJust,
@@ -289,6 +292,8 @@ top::SyntaxDcl ::= ns::NamedSignature  modifiers::SyntaxProductionModifiers
                                "new silver.core.PparsedOriginInfo(common.OriginsUtil.SET_FROM_PARSER_OIT, common.Terminal.createSpan(_children, virtualLocation, (int)_pos.getPos()), common.ConsCell.nil)"  ++ commaIfArgsOrAnnos
                                else "";
 
+  top.copperElementReference = copper:elementReference(makeCopperName(ns.fullName), top.containingGrammar);
+
   top.xmlCopper =
     "  <Production id=\"" ++ makeCopperName(ns.fullName) ++ "\">\n" ++
     (if modifiers.productionPrecedence.isJust then
@@ -384,6 +389,7 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
   top.lexerClassRefDcls :=
     s"    protected common.ConsCell ${makeCopperName(n)} = ${termsInit};\n";
 
+  top.copperElementReference = copper:elementReference(makeCopperName(n), top.containingGrammar);
   top.copperGrammarElement = copper:terminalClass(makeCopperName(n));
   
   top.xmlCopper =
@@ -459,6 +465,8 @@ top::SyntaxDcl ::= n::String terms::[String] applicableToSubsets::Boolean acode:
     zipWith(pair, terms, trefs));
 
   top.cstNormalize := [top];
+
+  top.copperElementReference = copper:elementReference(makeCopperName(n), top.containingGrammar);
 
   top.xmlCopper =
     "  <DisambiguationFunction id=\"" ++ makeCopperName(n) ++ "\" applicableToSubsets=\"" ++ toString(applicableToSubsets) ++ "\">\n" ++

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -51,14 +51,12 @@ monoid attribute prettyNamesAccum::[Pair<String String>];
 autocopy attribute prettyNames::tm:Map<String String>;
 
 synthesized attribute copperElementReference::copper:ElementReference;
-synthesized attribute copperGrammar::copper:Grammar;
-synthesized attribute copperGrammarElement::copper:GrammarElement;
 synthesized attribute copperGrammarElements::[copper:GrammarElement];
 
 {--
  - An abstract syntax tree for representing concrete syntax.
  -}
-nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, layoutContribs, layoutTerms, xmlCopper, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammar, copperGrammarElements;
+nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, layoutContribs, layoutTerms, xmlCopper, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElements;
 
 propagate cstDcls, cstErrors, cstProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, superClassContribs, parserAttributeAspectContribs, lexerClassRefDcls, layoutContribs, prettyNamesAccum
   on Syntax;
@@ -74,7 +72,7 @@ top::Syntax ::=
 abstract production consSyntax
 top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {
-  top.copperGrammarElements = s1.copperGrammarElement :: s2.copperGrammarElements;
+  top.copperGrammarElements = s1.copperGrammarElements ++ s2.copperGrammarElements;
 
   top.xmlCopper = s1.xmlCopper ++ s2.xmlCopper;
 }
@@ -82,7 +80,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, xmlCopper, classDomContribsXML, classSubContribsXML, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElement;
+nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, xmlCopper, classDomContribsXML, classSubContribsXML, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElements;
 
 synthesized attribute sortKey :: String;
 
@@ -127,8 +125,8 @@ top::SyntaxDcl ::= t::Type subdcls::Syntax exportedProds::[String] exportedLayou
   top.layoutContribs := map(pair(t.typeName, _), fromMaybe(exportedLayoutTerms, modifiers.customLayout));
 
   top.copperElementReference = copper:elementReference(makeCopperName(t.typeName), top.containingGrammar);
-  top.copperGrammarElement = copper:nonterminal_(makeCopperName(t.typeName),
-    t.typeName, makeNTName(t.typeName));
+  top.copperGrammarElements = [copper:nonterminal_(makeCopperName(t.typeName),
+    t.typeName, makeNTName(t.typeName))];
 
   top.xmlCopper =
     "\n  <Nonterminal id=\"" ++ makeCopperName(t.typeName) ++ "\">\n" ++
@@ -181,13 +179,13 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
     end;
 
   top.copperElementReference = copper:elementReference(makeCopperName(n), top.containingGrammar);
-  top.copperGrammarElement = copper:terminal_(makeCopperName(n),
+  top.copperGrammarElements = [copper:terminal_(makeCopperName(n),
     disambiguatedPrettyName, regex.copperRegex, modifiers.opPrecedence.isJust,
-    error("precedence"), modifiers.opAssociation.isJust,
-    error("associativity"), makeTerminalName(n), 
+    modifiers.opPrecedence.fromJust, modifiers.opAssociation.isJust,
+    fromMaybe("", modifiers.opAssociation), makeTerminalName(n), 
     "RESULT = new " ++ makeTerminalName(n) ++ "(lexeme,virtualLocation,(int)getStartRealLocation().getPos(),(int)getEndRealLocation().getPos());tokenList.add(RESULT);\n" ++ modifiers.acode,
     modifiers.lexerClasses,
-    !null(pfx), error("TODO pfx"), modifiers.submits_, modifiers.dominates_);
+    !null(pfx), error("TODO pfx"), modifiers.submits_, modifiers.dominates_)];
 
   top.xmlCopper =
     "  <Terminal id=\"" ++ makeCopperName(n) ++ "\">\n" ++
@@ -294,6 +292,7 @@ top::SyntaxDcl ::= ns::NamedSignature  modifiers::SyntaxProductionModifiers
                                else "";
 
   top.copperElementReference = copper:elementReference(makeCopperName(ns.fullName), top.containingGrammar);
+  top.copperGrammarElements = error("TODO Production copperGrammarElements");
 
   top.xmlCopper =
     "  <Production id=\"" ++ makeCopperName(ns.fullName) ++ "\">\n" ++
@@ -391,7 +390,7 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
     s"    protected common.ConsCell ${makeCopperName(n)} = ${termsInit};\n";
 
   top.copperElementReference = copper:elementReference(makeCopperName(n), top.containingGrammar);
-  top.copperGrammarElement = copper:terminalClass(makeCopperName(n));
+  top.copperGrammarElements = [copper:terminalClass(makeCopperName(n))];
   
   top.xmlCopper =
     "  <TerminalClass id=\"" ++ makeCopperName(n) ++ "\" />\n";
@@ -410,6 +409,8 @@ top::SyntaxDcl ::= n::String ty::Type acode::String
                    else ["Name conflict with parser attribute " ++ n];
 
   top.cstNormalize := [top];
+
+  top.copperGrammarElements = error("TODO ParserAttribute copperGrammarElements");
 
   top.xmlCopper =
     "  <ParserAttribute id=\"" ++ makeCopperName(n) ++ "\">\n" ++
@@ -468,6 +469,11 @@ top::SyntaxDcl ::= n::String terms::[String] applicableToSubsets::Boolean acode:
   top.cstNormalize := [top];
 
   top.copperElementReference = copper:elementReference(makeCopperName(n), top.containingGrammar);
+  local members::[copper:ElementReference] =
+    map(\dcl::[Decorated SyntaxDcl] -> head(dcl).copperElementReference,
+        trefs);
+  top.copperGrammarElements = [copper:disambiguationFunction(makeCopperName(n), acode, members,
+    applicableToSubsets)];
 
   top.xmlCopper =
     "  <DisambiguationFunction id=\"" ++ makeCopperName(n) ++ "\" applicableToSubsets=\"" ++ toString(applicableToSubsets) ++ "\">\n" ++

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -32,8 +32,8 @@ monoid attribute allMarkingTerminals :: [String];
 monoid attribute allProductions :: [Decorated SyntaxDcl];
 monoid attribute allNonterminals :: [Decorated SyntaxDcl];
 monoid attribute disambiguationClasses :: [Decorated SyntaxDcl];
-synthesized attribute classDomContribs :: String;
-synthesized attribute classSubContribs :: String;
+synthesized attribute classDomContribsXML :: String;
+synthesized attribute classSubContribsXML :: String;
 autocopy attribute containingGrammar :: String;
 monoid attribute lexerClassRefDcls :: String;
 synthesized attribute exportedProds :: [String];
@@ -80,7 +80,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, xmlCopper, classDomContribs, classSubContribs, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElement;
+nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, xmlCopper, classDomContribsXML, classSubContribsXML, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElement;
 
 synthesized attribute sortKey :: String;
 
@@ -91,8 +91,8 @@ top::SyntaxDcl ::=
 {
   -- Empty values as defaults
   propagate cstProds, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, superClassContribs, parserAttributeAspectContribs, lexerClassRefDcls, layoutContribs, prettyNamesAccum;
-  top.classDomContribs = error("Internal compiler error: should only ever be demanded of lexer classes");
-  top.classSubContribs = error("Internal compiler error: should only ever be demanded of lexer classes");
+  top.classDomContribsXML = error("Internal compiler error: should only ever be demanded of lexer classes");
+  top.classSubContribsXML = error("Internal compiler error: should only ever be demanded of lexer classes");
   top.exportedProds = error("Internal compiler error: should only ever be demanded of nonterminals");
   top.hasCustomLayout = false;
 }
@@ -368,8 +368,8 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
 
   -- TODO: these attributes are on all SyntaxDcls, but only have meaning for this production
   -- that's UUUUGLY.
-  top.classDomContribs = modifiers.dominatesXML;
-  top.classSubContribs = modifiers.submitsXML;
+  top.classDomContribsXML = modifiers.dominatesXML;
+  top.classSubContribsXML = modifiers.submitsXML;
 
   top.cstNormalize := [top];
   top.superClassContribs := modifiers.superClassContribs;

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -124,7 +124,7 @@ top::SyntaxDcl ::= t::Type subdcls::Syntax exportedProds::[String] exportedLayou
   top.hasCustomLayout = modifiers.customLayout.isJust;
   top.layoutContribs := map(pair(t.typeName, _), fromMaybe(exportedLayoutTerms, modifiers.customLayout));
 
-  top.copperElementReference = copper:elementReference(makeCopperName(t.typeName), top.containingGrammar);
+  top.copperElementReference = copper:elementReference(top.containingGrammar, makeCopperName(t.typeName));
   top.copperGrammarElements = [copper:nonterminal_(makeCopperName(t.typeName),
     t.typeName, makeNTName(t.typeName))];
 
@@ -178,7 +178,7 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
     | _ -> prettyName ++ " (" ++ n ++ ")"
     end;
 
-  top.copperElementReference = copper:elementReference(makeCopperName(n), top.containingGrammar);
+  top.copperElementReference = copper:elementReference(top.containingGrammar, makeCopperName(n));
   top.copperGrammarElements = [copper:terminal_(makeCopperName(n),
     disambiguatedPrettyName, regex.copperRegex, modifiers.opPrecedence.isJust,
     modifiers.opPrecedence.fromJust, modifiers.opAssociation.isJust,
@@ -291,7 +291,7 @@ top::SyntaxDcl ::= ns::NamedSignature  modifiers::SyntaxProductionModifiers
                                "new silver.core.PparsedOriginInfo(common.OriginsUtil.SET_FROM_PARSER_OIT, common.Terminal.createSpan(_children, virtualLocation, (int)_pos.getPos()), common.ConsCell.nil)"  ++ commaIfArgsOrAnnos
                                else "";
 
-  top.copperElementReference = copper:elementReference(makeCopperName(ns.fullName), top.containingGrammar);
+  top.copperElementReference = copper:elementReference(top.containingGrammar, makeCopperName(ns.fullName));
   top.copperGrammarElements = error("TODO Production copperGrammarElements");
 
   top.xmlCopper =
@@ -389,7 +389,7 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
   top.lexerClassRefDcls :=
     s"    protected common.ConsCell ${makeCopperName(n)} = ${termsInit};\n";
 
-  top.copperElementReference = copper:elementReference(makeCopperName(n), top.containingGrammar);
+  top.copperElementReference = copper:elementReference(top.containingGrammar, makeCopperName(n));
   top.copperGrammarElements = [copper:terminalClass(makeCopperName(n))];
   
   top.xmlCopper =
@@ -468,7 +468,7 @@ top::SyntaxDcl ::= n::String terms::[String] applicableToSubsets::Boolean acode:
 
   top.cstNormalize := [top];
 
-  top.copperElementReference = copper:elementReference(makeCopperName(n), top.containingGrammar);
+  top.copperElementReference = copper:elementReference(top.containingGrammar, makeCopperName(n));
   local members::[copper:ElementReference] =
     map(\dcl::[Decorated SyntaxDcl] -> head(dcl).copperElementReference,
         trefs);

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -34,6 +34,8 @@ monoid attribute allNonterminals :: [Decorated SyntaxDcl];
 monoid attribute disambiguationClasses :: [Decorated SyntaxDcl];
 synthesized attribute classDomContribsXML :: String;
 synthesized attribute classSubContribsXML :: String;
+synthesized attribute domContribs :: [copper:ElementReference];
+synthesized attribute subContribs :: [copper:ElementReference];
 autocopy attribute containingGrammar :: String;
 monoid attribute lexerClassRefDcls :: String;
 synthesized attribute exportedProds :: [String];
@@ -80,7 +82,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, xmlCopper, classDomContribsXML, classSubContribsXML, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElements;
+nonterminal SyntaxDcl with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, xmlCopper, classDomContribsXML, classSubContribsXML, domContribs, subContribs, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElements;
 
 synthesized attribute sortKey :: String;
 
@@ -93,6 +95,8 @@ top::SyntaxDcl ::=
   propagate cstProds, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allNonterminals, disambiguationClasses, classTerminalContribs, superClassContribs, parserAttributeAspectContribs, lexerClassRefDcls, layoutContribs, prettyNamesAccum;
   top.classDomContribsXML = error("Internal compiler error: should only ever be demanded of lexer classes");
   top.classSubContribsXML = error("Internal compiler error: should only ever be demanded of lexer classes");
+  top.domContribs = error("Internal compiler error: should only ever be demanded of lexer classes or terminals");
+  top.subContribs = error("Internal compiler error: should only ever be demanded of lexer classes or terminals");
   top.exportedProds = error("Internal compiler error: should only ever be demanded of nonterminals");
   top.hasCustomLayout = false;
 }
@@ -177,6 +181,9 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
     | 1 -> prettyName
     | _ -> prettyName ++ " (" ++ n ++ ")"
     end;
+
+  top.domContribs = [top.copperElementReference];
+  top.subContribs = [top.copperElementReference];
 
   top.copperElementReference = copper:elementReference(top.containingGrammar, makeCopperName(n));
   top.copperGrammarElements = [copper:terminal_(makeCopperName(n),
@@ -379,6 +386,8 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
   -- that's UUUUGLY.
   top.classDomContribsXML = modifiers.dominatesXML;
   top.classSubContribsXML = modifiers.submitsXML;
+  top.domContribs = modifiers.dominates_;
+  top.subContribs = modifiers.submits_;
 
   top.cstNormalize := [top];
   top.superClassContribs := modifiers.superClassContribs;

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -49,18 +49,21 @@ top::SyntaxTerminalModifiers ::=
 {--
  - Modifiers for terminals.
  -}
-closed nonterminal SyntaxTerminalModifier with cstEnv, cstErrors, classTerminalContribs, superClasses, subClasses, dominatesXML,
-  submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, prefixSeperator, prefixSeperatorToApply, componentGrammarMarkingTerminals,
-  marking, terminalName, prettyName;
+closed nonterminal SyntaxTerminalModifier with cstEnv, cstErrors,
+  classTerminalContribs, superClasses, subClasses, dominatesXML, submitsXML,
+  dominates_, submits_, ignored, acode, lexerclassesXML, opPrecedence,
+  opAssociation, prefixSeperator, prefixSeperatorToApply,
+  componentGrammarMarkingTerminals, marking, terminalName, prettyName;
 
 {- We default ALL attributes, so we can focus only on those that are interesting in each case... -}
 aspect default production
 top::SyntaxTerminalModifier ::=
 {
   -- Empty values as defaults
-  propagate cstErrors, classTerminalContribs, dominatesXML,
-    submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, prefixSeperator, prefixSeperatorToApply,
-    marking, prettyName;
+  propagate cstErrors, classTerminalContribs, dominatesXML, submitsXML,
+    dominates_, submits_, ignored, acode, lexerclassesXML, opPrecedence,
+    opAssociation, prefixSeperator, prefixSeperatorToApply, marking,
+    prettyName;
 }
 
 {--
@@ -127,7 +130,8 @@ top::SyntaxTerminalModifier ::= cls::[String]
   top.submitsXML := implode("", map((.classSubContribsXML), allClsRefs));
   top.lexerclassesXML := implode("", map(xmlCopperRef, allClsRefs));
 
-  -- top.dominates_ := 
+  top.dominates_ := flatMap((.domContribs), allClsRefs);
+  top.submits_ := flatMap((.subContribs), allClsRefs);
   
   local termSeps :: [Maybe<String>] = map((.prefixSeperator), allClsRefs);
   top.prefixSeperator := foldr(orElse, nothing(), termSeps);
@@ -151,6 +155,7 @@ top::SyntaxTerminalModifier ::= sub::[String]
                            "this grammar was not included in this parser. (Referenced from submit clause on terminal " ++ top.terminalName ++ ")"],
                    zipWith(pair, sub, subRefs)); 
   top.submitsXML := implode("", map(xmlCopperRef, map(head, subRefs)));
+  top.submits_ := flatMap((.subContribs), map(head, subRefs));
 }
 {--
  - The dominates list for the terminal. Either lexer classes or terminals.
@@ -167,6 +172,7 @@ top::SyntaxTerminalModifier ::= dom::[String]
                            "this grammar was not included in this parser. (Referenced from dominates clause on terminal " ++ top.terminalName ++ ")"],
                    zipWith(pair, dom, domRefs)); 
   top.dominatesXML := implode("", map(xmlCopperRef, map(head, domRefs)));
+  top.dominates_ := flatMap((.domContribs), map(head, domRefs));
 }
 {--
  - The action to take whenever this terminal is SHIFTed.

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -1,5 +1,7 @@
 grammar silver:compiler:definition:concrete_syntax:ast;
 
+import silver:compiler:definition:concrete_syntax:copper as copper;
+
 monoid attribute dominatesXML :: String;
 monoid attribute submitsXML :: String;
 monoid attribute lexerclassesXML :: String;
@@ -13,9 +15,9 @@ monoid attribute prefixSeperatorToApply :: Maybe<String> with nothing(), orElse;
 monoid attribute prettyName :: Maybe<String> with nothing(), orElse;
 autocopy attribute terminalName :: String;
 
-monoid attribute dominates_ :: [String] with [], ++;
-monoid attribute submits_ :: [String] with [], ++;
-monoid attribute lexerClasses :: [String] with [], ++;
+monoid attribute dominates_ :: [copper:ElementReference] with [], ++;
+monoid attribute submits_ :: [copper:ElementReference] with [], ++;
+monoid attribute lexerClasses :: [copper:ElementReference] with [], ++;
 
 {--
  - Modifiers for terminals.
@@ -121,9 +123,11 @@ top::SyntaxTerminalModifier ::= cls::[String]
                    zipWith(pair, allCls, allClsRefsL)); 
   top.classTerminalContribs := map(pair(_, top.terminalName), allCls);
   -- We "translate away" lexer classes dom/sub, by moving that info to the terminals (here)
-  top.dominatesXML := implode("", map((.classDomContribs), allClsRefs));
-  top.submitsXML := implode("", map((.classSubContribs), allClsRefs));
+  top.dominatesXML := implode("", map((.classDomContribsXML), allClsRefs));
+  top.submitsXML := implode("", map((.classSubContribsXML), allClsRefs));
   top.lexerclassesXML := implode("", map(xmlCopperRef, allClsRefs));
+
+  -- top.dominates_ := 
   
   local termSeps :: [Maybe<String>] = map((.prefixSeperator), allClsRefs);
   top.prefixSeperator := foldr(orElse, nothing(), termSeps);

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -13,16 +13,20 @@ monoid attribute prefixSeperatorToApply :: Maybe<String> with nothing(), orElse;
 monoid attribute prettyName :: Maybe<String> with nothing(), orElse;
 autocopy attribute terminalName :: String;
 
+monoid attribute dominates_ :: [String] with [], ++;
+monoid attribute submits_ :: [String] with [], ++;
+monoid attribute lexerClasses :: [String] with [], ++;
+
 {--
  - Modifiers for terminals.
  -}
 nonterminal SyntaxTerminalModifiers with cstEnv, cstErrors, classTerminalContribs, superClasses, subClasses, dominatesXML,
   submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, prefixSeperator, prefixSeperatorToApply, componentGrammarMarkingTerminals,
-  marking, terminalName, prettyName;
+  marking, terminalName, prettyName, dominates_, submits_, lexerClasses;
 
 propagate cstErrors, classTerminalContribs, dominatesXML,
     submitsXML, ignored, acode, lexerclassesXML, opPrecedence, opAssociation, prefixSeperator, prefixSeperatorToApply,
-    marking, prettyName
+    marking, prettyName, dominates_, submits_, lexerClasses
   on SyntaxTerminalModifiers;
 
 abstract production consTerminalMod

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/ElementReference.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/ElementReference.sv
@@ -9,6 +9,6 @@ function elementReference
 ElementReference ::= grammarName::String  name::String
 {
   return error("copper FFI function");
-} {- foreign {
+} foreign {
   "java" : return "common.CopperUtil.makeElementReference(%grammarName%.toString(), %name%.toString())";
-} -}
+}

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/ElementReference.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/ElementReference.sv
@@ -1,0 +1,14 @@
+grammar silver:compiler:definition:concrete_syntax:copper;
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference
+type ElementReference foreign;
+
+-- We don't bother passing Silver Locations through, since all the relevant
+-- checks Copper does should already have been performed.
+function elementReference
+ElementReference ::= grammarName::String  name::String
+{
+  return error("copper FFI function");
+} foreign {
+  "java" : return "common.CopperUtil.makeElementReference(%grammarName%.toString(), %name%.toString())";
+}

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/ElementReference.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/ElementReference.sv
@@ -9,6 +9,6 @@ function elementReference
 ElementReference ::= grammarName::String  name::String
 {
   return error("copper FFI function");
-} foreign {
+} {- foreign {
   "java" : return "common.CopperUtil.makeElementReference(%grammarName%.toString(), %name%.toString())";
-}
+} -}

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
@@ -27,6 +27,15 @@ GrammarElement ::= id::String  pp::String  type_::String
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ParserAttribute
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Production
+function production_
+GrammarElement ::= id::String  hasPrecedence::Boolean  precedence_::Integer
+    hasOperator::Boolean  operator_::String  code::String  lhs::ElementReference
+    rhs::[ElementReference]
+{
+  return error("copper FFI function");
+} foreign {
+  "java" : return "common.CopperUtil.makeProduction(%id%.toString(), %hasPrecedence% ? %precedence_% : null, %hasOperator% ? %operator_%.toString() : null, %code%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%lhs%, new common.javainterop.ConsCellCollection(%rhs%))";
+}
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Terminal
 function terminal_

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
@@ -5,7 +5,14 @@ type GrammarElement foreign;
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.DisambiguationFunction
 
--- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.GrammarSymbol
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Nonterminal
+function nonterminal_
+GrammarElement ::= id::String  pp::String  type_::String
+{
+  return error("copper FFI function");
+} foreign {
+  "java" : return "common.CopperUtil.makeNonTerminal(%id%.toString(), %pp%.toString(), %type_%.toString())";
+}
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.OperatorClass
 
@@ -13,4 +20,23 @@ type GrammarElement foreign;
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Production
 
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Terminal
+function terminal_
+GrammarElement ::= id::String  pp::String  regex::Regex  hasPrecedence::Boolean
+    precedence_::Integer  hasAssociativity::Boolean associativity::String
+    type_::String  code::String  classes_::[String] hasPrefix::Boolean
+    prefix_::String submits_::[String]  dominates_::[String]
+{
+  return error("copper FFI function");
+} {- foreign {
+  "java" : return "common.CopperUtil.makeTerminalClass(%id%.toString())";
+} -}
+
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.TerminalClass
+function terminalClass
+GrammarElement ::= id::String
+{
+  return error("copper FFI function");
+} foreign {
+  "java" : return "common.CopperUtil.makeTerminalClass(%id%.toString())";
+}

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
@@ -1,0 +1,16 @@
+grammar silver:compiler:definition:concrete_syntax:copper;
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.GrammarElement
+type GrammarElement foreign;
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.DisambiguationFunction
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.GrammarSymbol
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.OperatorClass
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ParserAttribute
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Production
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.TerminalClass

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
@@ -4,15 +4,23 @@ grammar silver:compiler:definition:concrete_syntax:copper;
 type GrammarElement foreign;
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.DisambiguationFunction
+function disambiguationFunction
+GrammarElement ::= id::String  code::String  members::[ElementReference]
+    applicableToSubsets::Boolean
+{
+  return error("copper FFI function");
+} foreign {
+  "java" : return "common.CopperUtil.makeDisambiguationFunction(%id%.toString(), %code%.toString(), new common.javainterop.ConsCellCollection(%members%), %applicableToSubsets%)";
+}
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Nonterminal
 function nonterminal_
 GrammarElement ::= id::String  pp::String  type_::String
 {
   return error("copper FFI function");
-} {- foreign {
+} foreign {
   "java" : return "common.CopperUtil.makeNonTerminal(%id%.toString(), %pp%.toString(), %type_%.toString())";
-} -}
+}
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.OperatorClass
 
@@ -28,15 +36,15 @@ GrammarElement ::= id::String  pp::String  regex::Regex  hasPrecedence::Boolean
     prefix_::ElementReference submits_::[ElementReference]  dominates_::[ElementReference]
 {
   return error("copper FFI function");
-} {- foreign {
-  "java" : return "common.CopperUtil.makeTerminalClass(%id%.toString())";
-} -}
+} foreign {
+  "java" : return "common.CopperUtil.makeTerminal(%id%.toString(), %pp%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex)%regex%, %hasPrecedence% ? %precedence_% : null, %hasAssociativity% ? %associativity%.toString() : null, %type_%.toString(), %code%.toString(), new common.javainterop.ConsCellCollection(%classes_%), %hasPrefix% ? (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%prefix_% : null, new common.javainterop.ConsCellCollection(%submits_%), new common.javainterop.ConsCellCollection(%dominates_%))";
+}
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.TerminalClass
 function terminalClass
 GrammarElement ::= id::String
 {
   return error("copper FFI function");
-} {- foreign {
+} foreign {
   "java" : return "common.CopperUtil.makeTerminalClass(%id%.toString())";
-} -}
+}

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
@@ -10,9 +10,9 @@ function nonterminal_
 GrammarElement ::= id::String  pp::String  type_::String
 {
   return error("copper FFI function");
-} foreign {
+} {- foreign {
   "java" : return "common.CopperUtil.makeNonTerminal(%id%.toString(), %pp%.toString(), %type_%.toString())";
-}
+} -}
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.OperatorClass
 
@@ -37,6 +37,6 @@ function terminalClass
 GrammarElement ::= id::String
 {
   return error("copper FFI function");
-} foreign {
+} {- foreign {
   "java" : return "common.CopperUtil.makeTerminalClass(%id%.toString())";
-}
+} -}

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
@@ -24,8 +24,8 @@ GrammarElement ::= id::String  pp::String  type_::String
 function terminal_
 GrammarElement ::= id::String  pp::String  regex::Regex  hasPrecedence::Boolean
     precedence_::Integer  hasAssociativity::Boolean associativity::String
-    type_::String  code::String  classes_::[String] hasPrefix::Boolean
-    prefix_::String submits_::[String]  dominates_::[String]
+    type_::String  code::String  classes_::[ElementReference] hasPrefix::Boolean
+    prefix_::ElementReference submits_::[ElementReference]  dominates_::[ElementReference]
 {
   return error("copper FFI function");
 } {- foreign {

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
@@ -4,14 +4,13 @@ grammar silver:compiler:definition:concrete_syntax:copper;
 type ParserBean foreign;
 
 function parserBean
-ParserBean ::= id::String  name::String  grammarName::String
-     startSymbol::ElementReference  startLayout::[ElementReference]
-     parserClassAuxCode::String  parserInitCode::String  preambleCode::String
-     grammars::[Grammar]
+ParserBean ::= id::String  name::String  startSymbol::ElementReference
+     startLayout::[ElementReference]  parserClassAuxCode::String
+     parserInitCode::String  preambleCode::String  grammar_::Grammar
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "common.CopperUtil.makeParserBean(%id%.toString(), %name%.toString(), %grammarName%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference>(new common.javainterop.ConsCellCollection(%startLayout%)), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar>(new common.javainterop.ConsCellCollection(%grammars%)))";
+  "java" : return "common.CopperUtil.makeParserBean(%id%.toString(), %name%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new common.javainterop.ConsCellCollection(%startLayout%), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)(%grammar_%))";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
@@ -10,7 +10,7 @@ ParserBean ::= id::String  name::String  startSymbol::ElementReference
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "common.CopperUtil.makeParserBean(%id%.toString(), %name%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new common.javainterop.ConsCellCollection(%startLayout%), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)(%grammar_%))";
+  "java" : return "common.CopperUtil.makeParserBean(%id%.toString(), %name%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new common.javainterop.ConsCellCollection(%startLayout%), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)%grammar_%)";
 }
 
 function compileParserBean

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
@@ -1,0 +1,22 @@
+grammar silver:compiler:definition:concrete_syntax:copper;
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ParserBean
+type ParserBean foreign;
+
+function parserBean
+ParserBean ::= id::String  name::String  grammarName::String
+     startSymbol::ElementReference  startLayout::[ElementReference]
+     parserClassAuxCode::String  parserInitCode::String  preambleCode::String
+     grammars::[Grammar]
+{
+  return error("copper FFI function");
+}
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar
+type Grammar foreign;
+
+function grammar_
+Grammar ::= id::String  name::String  x
+{
+  return error("copper FFI function");
+}

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
@@ -10,13 +10,15 @@ ParserBean ::= id::String  name::String  grammarName::String
      grammars::[Grammar]
 {
   return error("copper FFI function");
+} foreign {
+  "java" : return "common.CopperUtil.makeParserBean(%id%.toString(), %name%.toString(), %grammarName%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference>(new common.javainterop.ConsCellCollection(%startLayout%)), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar>(new common.javainterop.ConsCellCollection(%grammars%)))";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar
 type Grammar foreign;
 
 function grammar_
-Grammar ::= id::String  name::String  x
+Grammar ::= id::String  name::String
 {
   return error("copper FFI function");
 }

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
@@ -17,7 +17,10 @@ ParserBean ::= id::String  name::String  startSymbol::ElementReference
 type Grammar foreign;
 
 function grammar_
-Grammar ::= id::String  name::String
+Grammar ::= id::String  copperGrammarElements::[GrammarElement]
+-- TODO: setGrammarLayout?
 {
   return error("copper FFI function");
+} foreign {
+  "java": return "common.CopperUtil.makeGrammar(%id%.toString(), new common.javainterop.ConsCellCollection(%copperGrammarElements%))";
 }

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
@@ -13,6 +13,14 @@ ParserBean ::= id::String  name::String  startSymbol::ElementReference
   "java" : return "common.CopperUtil.makeParserBean(%id%.toString(), %name%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new common.javainterop.ConsCellCollection(%startLayout%), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)(%grammar_%))";
 }
 
+function compileParserBean
+IO ::= parser_::ParserBean  io::IO
+{
+  return error("copper FFI function");
+} foreign {
+  "java": return "common.CopperUtil.compile((edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ParserBean)%parser_%, %io%)";
+}
+
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar
 type Grammar foreign;
 

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Regex.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Regex.sv
@@ -41,7 +41,7 @@ Regex ::= r::Regex
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CharacterSetRegex
 function characterSetRegex
-Regex ::=
+Regex ::= cs::CharSet
 {
   return error("copper FFI function");
 } foreign {
@@ -50,3 +50,20 @@ Regex ::=
 }
 
 nonterminal CharSet;
+
+-- This should always be called with a single-char string.
+abstract production singleChar
+top::CharSet ::= c::String
+{}
+
+abstract production invertCharSet
+top::CharSet ::= inner::CharSet
+{}
+
+abstract production charRange
+top::CharSet ::= lower::String upper::String
+{}
+
+abstract production unionCharSets
+top::CharSet ::= l::CharSet  r::CharSet
+{}

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Regex.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Regex.sv
@@ -9,7 +9,7 @@ Regex ::=
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.EmptyStringRegex()";
+  "java": return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.EmptyStringRegex()";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ChoiceRegex
@@ -18,7 +18,7 @@ Regex ::= subexps::[Regex]
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ChoiceRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection(%subexps%)))";
+  "java": return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ChoiceRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection(%subexps%)))";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ConcatenationRegex
@@ -27,7 +27,7 @@ Regex ::= subexps::[Regex]
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ConcatenationRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection(%subexps%)))";
+  "java": return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ConcatenationRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection(%subexps%)))";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.KleeneStarRegex
@@ -36,7 +36,7 @@ Regex ::= r::Regex
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.KleeneStarRegex((edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex) %r%)";
+  "java": return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.KleeneStarRegex((edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex) %r%)";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CharacterSetRegex
@@ -45,25 +45,41 @@ Regex ::= cs::CharSet
 {
   return error("copper FFI function");
 } foreign {
-  -- "java" : return "common.rawlib.RawTreeSet.isEmpty((java.util.TreeSet<Object>)%s%)";
-  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CharacterSetRegex()"; -- TODO
+  "java": return "%cs%";
 }
 
-nonterminal CharSet;
+-- common.copperutil.CharSet
+type CharSet foreign;
 
 -- This should always be called with a single-char string.
-abstract production singleChar
-top::CharSet ::= c::String
-{}
+function singleChar
+CharSet ::= c::String
+{
+  return error("copper FFI function");
+} foreign {
+  "java": return "common.CopperUtil.makeSingleChar(%c%.toString())";
+}
 
-abstract production invertCharSet
-top::CharSet ::= inner::CharSet
-{}
+function invertCharSet
+CharSet ::= inner::CharSet
+{
+  return error("copper FFI function");
+} foreign {
+  "java": return "((edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CharacterSetRegex)%inner%).invert()";
+}
 
-abstract production charRange
-top::CharSet ::= lower::String upper::String
-{}
+function charRange
+CharSet ::= lower::String  upper::String
+{
+  return error("copper FFI function");
+} foreign {
+  "java": return "common.CopperUtil.makeCharRange(%lower%.toString(), %upper%.toString())";
+}
 
-abstract production unionCharSets
-top::CharSet ::= l::CharSet  r::CharSet
-{}
+function unionCharSets
+CharSet ::= l::CharSet  r::CharSet
+{
+  return error("copper FFI function");
+} foreign {
+  "java": return "edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CharacterSetRegex.union((edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CharacterSetRegex)%l%, (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CharacterSetRegex)%r%)";
+}

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Regex.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Regex.sv
@@ -1,0 +1,52 @@
+grammar silver:compiler:definition:concrete_syntax:copper;
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex
+type Regex foreign;
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.EmptyStringRegex
+function emptyStringRegex
+Regex ::=
+{
+  return error("copper FFI function");
+} foreign {
+  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.EmptyStringRegex()";
+}
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ChoiceRegex
+function choiceRegex
+Regex ::= subexps::[Regex]
+{
+  return error("copper FFI function");
+} foreign {
+  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ChoiceRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection(%subexps%)))";
+}
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ConcatenationRegex
+function concatenationRegex
+Regex ::= subexps::[Regex]
+{
+  return error("copper FFI function");
+} foreign {
+  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ConcatenationRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection(%subexps%)))";
+}
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.KleeneStarRegex
+function kleeneStarRegex
+Regex ::= r::Regex
+{
+  return error("copper FFI function");
+} foreign {
+  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.KleeneStarRegex((edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex) %r%)";
+}
+
+-- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CharacterSetRegex
+function characterSetRegex
+Regex ::=
+{
+  return error("copper FFI function");
+} foreign {
+  -- "java" : return "common.rawlib.RawTreeSet.isEmpty((java.util.TreeSet<Object>)%s%)";
+  "java" : return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CharacterSetRegex()"; -- TODO
+}
+
+nonterminal CharSet;

--- a/grammars/silver/compiler/modification/impide/cstast/Syntax.sv
+++ b/grammars/silver/compiler/modification/impide/cstast/Syntax.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:modification:impide:cstast;
 
 --import (see grammar-wide import in cstast.sv)
+import silver:compiler:definition:concrete_syntax:copper as copper;
 
 monoid attribute fontList :: [Pair<String Font>];
 monoid attribute classFontList :: [Pair<String String>];
@@ -28,6 +29,7 @@ top::SyntaxDcl ::= fontName::String fnt::Font -- TODO: we probably? need to fact
   top.cstDcls := [pair(fontName, top)];
   top.cstNormalize := [top];
   
+  top.copperGrammarElements = [];
   top.xmlCopper = "";
 }
 

--- a/runtime/java/src/common/CopperUtil.java
+++ b/runtime/java/src/common/CopperUtil.java
@@ -1,13 +1,27 @@
 package common;
 
 import edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.*;
+import edu.umn.cs.melt.copper.runtime.engines.semantics.VirtualLocation;
+import edu.umn.cs.melt.copper.runtime.io.Location;
 import java.text.ParseException;
 import java.util.List;
 
 public final class CopperUtil {
+  private static Location LOCATION = new VirtualLocation("<silver>", -1, -1);
+
+  public static CopperElementReference makeElementReference(String grammarName,
+                                                            String name) {
+    try {
+      return CopperElementReference.ref(CopperElementName.newName(grammarName),
+                                        name, LOCATION);
+    } catch (ParseException exc) {
+      throw new RuntimeException(exc);
+    }
+  }
+
   public static NonTerminal makeNonTerminal(String id, String pp,
                                             String type_) {
-    return null;
+    throw new RuntimeException("TODO CopperUtil.makeNonTerminal");
   }
 
   public static Terminal makeTerminal(String id, String pp, Regex regex,
@@ -16,7 +30,7 @@ public final class CopperUtil {
                                       List<StringCatter> classes, String prefix,
                                       List<StringCatter> submits,
                                       List<StringCatter> dominates) {
-    return null;
+    throw new RuntimeException("TODO CopperUtil.makeTerminal");
   }
 
   public static TerminalClass makeTerminalClass(String id) {

--- a/runtime/java/src/common/CopperUtil.java
+++ b/runtime/java/src/common/CopperUtil.java
@@ -10,83 +10,141 @@ import java.util.HashSet;
 import java.util.Set;
 
 public final class CopperUtil {
-  private static Location LOCATION = new VirtualLocation("<silver>", -1, -1);
+    private static Location LOCATION = new VirtualLocation("<silver>", -1, -1);
 
-  public static CopperElementReference makeElementReference(String grammarName,
-                                                            String name) {
-    try {
-      return CopperElementReference.ref(CopperElementName.newName(grammarName),
-                                        name, LOCATION);
-    } catch (ParseException exc) {
-      throw new RuntimeException(exc);
+    public static DisambiguationFunction makeDisambiguationFunction(String id,
+            String code, ConsCellCollection<CopperElementReference> members, Boolean applicableToSubsets) {
+        try {
+            DisambiguationFunction f = new DisambiguationFunction();
+            f.setName(id);
+            f.setCode(code);
+            Set<CopperElementReference> memberSet =
+                new HashSet<CopperElementReference>();
+            members.iterator().forEachRemaining(memberSet::add);
+            f.setMembers(memberSet);
+            f.setApplicableToSubsets(applicableToSubsets);
+            return f;
+        } catch (ParseException exc) {
+            throw new RuntimeException(exc);
+        }
     }
-  }
 
-  public static NonTerminal makeNonTerminal(String id, String pp,
-                                            String type_) {
-    throw new RuntimeException("TODO CopperUtil.makeNonTerminal");
-  }
-
-  public static ParserBean
-  makeParserBean(String id, String pp, CopperElementReference startSymbol,
-                 ConsCellCollection<CopperElementReference> startLayout,
-                 String parserClassAuxCode, String parserInitCode,
-                 String preambleCode, Grammar grammar) {
-    try {
-      System.err.println("bruh 36");
-      ParserBean parserBean = new ParserBean();
-      System.err.println("bruh 38");
-      parserBean.setName(id);
-      System.err.println("bruh 40");
-      parserBean.setDisplayName(pp);
-      System.err.println("bruh 42");
-      parserBean.setUnitary(true);
-      System.err.println("bruh 44");
-      parserBean.addGrammar(grammar);
-      System.err.println("bruh 46");
-      parserBean.setStartSymbol(startSymbol);
-      System.err.println("bruh 48");
-
-      Set<CopperElementReference> startLayoutSet =
-          new HashSet<CopperElementReference>();
-      System.err.println("bruh 52");
-      System.out.println(startLayout);
-      System.err.println("bruh 54");
-      System.out.println(startLayoutSet);
-      System.err.println("bruh 56");
-      startLayout.iterator().forEachRemaining(startLayoutSet::add);
-      System.err.println("bruh 58");
-      System.out.println(startLayout);
-      System.err.println("bruh 60");
-      System.out.println(startLayoutSet);
-      System.err.println("bruh 62");
-      parserBean.setStartLayout(startLayoutSet);
-      System.err.println("bruh 64");
-
-      throw new RuntimeException("TODO CopperUtil.makeParserBean");
-    } catch (CopperException exc) {
-      throw new RuntimeException(exc);
-    } catch (ParseException exc) {
-      throw new RuntimeException(exc);
+    public static CopperElementReference makeElementReference(String grammarName,
+            String name) {
+        try {
+            return CopperElementReference.ref(CopperElementName.newName(grammarName),
+                                              name, LOCATION);
+        } catch (ParseException exc) {
+            throw new RuntimeException(exc);
+        }
     }
-  }
 
-  public static Terminal
-  makeTerminal(String id, String pp, Regex regex, Integer precedence,
-               Object associativity, String type_, String code,
-               ConsCellCollection<StringCatter> classes, String prefix,
-               ConsCellCollection<StringCatter> submits,
-               ConsCellCollection<StringCatter> dominates) {
-    throw new RuntimeException("TODO CopperUtil.makeTerminal");
-  }
-
-  public static TerminalClass makeTerminalClass(String id) {
-    TerminalClass out = new TerminalClass();
-    try {
-      out.setName(id);
-    } catch (ParseException exc) {
-      throw new RuntimeException(exc);
+    public static Grammar makeGrammar(String id, ConsCellCollection<GrammarElement> grammarElements) {
+        try {
+            Grammar grammar = new Grammar();
+            grammar.setName(id);
+            grammarElements.iterator().forEachRemaining((ele) ->  {
+                try {
+                    grammar.addGrammarElement(ele);
+                } catch(CopperException exc) {
+                    throw new RuntimeException(exc);
+                }
+            });
+            return grammar;
+        } catch (ParseException exc) {
+            throw new RuntimeException(exc);
+        }
     }
-    return out;
-  }
+
+    public static NonTerminal makeNonTerminal(String id, String pp,
+            String type_) {
+        try {
+            NonTerminal nt = new NonTerminal();
+            nt.setName(id);
+            nt.setDisplayName(pp);
+            nt.setReturnType(type_);
+            return nt;
+        } catch (ParseException exc) {
+            throw new RuntimeException(exc);
+        }
+    }
+
+    public static ParserBean
+    makeParserBean(String id, String pp, CopperElementReference startSymbol,
+                   ConsCellCollection<CopperElementReference> startLayout,
+                   String parserClassAuxCode, String parserInitCode,
+                   String preambleCode, Grammar grammar) {
+        try {
+            ParserBean parserBean = new ParserBean();
+            parserBean.setName(id);
+            parserBean.setDisplayName(pp);
+            parserBean.setUnitary(true);
+            parserBean.setStartSymbol(startSymbol);
+
+            Set<CopperElementReference> startLayoutSet =
+                new HashSet<CopperElementReference>();
+            startLayout.iterator().forEachRemaining(startLayoutSet::add);
+            parserBean.setStartLayout(startLayoutSet);
+
+            // TODO: parserClassAuxCode
+            // TODO: parserInitCode
+            // TODO: preambleCode
+
+            parserBean.addGrammar(grammar);
+            return parserBean;
+        } catch (CopperException exc) {
+            throw new RuntimeException(exc);
+        } catch (ParseException exc) {
+            throw new RuntimeException(exc);
+        }
+    }
+
+    public static edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Terminal
+    makeTerminal(String id, String pp, Regex regex, Integer precedence,
+                 String associativity, String type_, String code,
+                 ConsCellCollection<CopperElementReference> classes,
+                 CopperElementReference prefix,
+                 ConsCellCollection<CopperElementReference> submits,
+                 ConsCellCollection<CopperElementReference> dominates) {
+        try {
+            edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Terminal terminal =
+                new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Terminal();
+            terminal.setName(id);
+            terminal.setDisplayName(pp);
+            terminal.setRegex(regex);
+            // TODO: operatorClass?
+            terminal.setOperatorPrecedence(precedence);
+            if(associativity!= null) {
+                switch(associativity) {
+                case "left":
+                    terminal.setOperatorAssociativity(OperatorAssociativity.LEFT);
+                    break;
+                case "right":
+                    terminal.setOperatorAssociativity(OperatorAssociativity.RIGHT);
+                    break;
+                default:
+                    throw new RuntimeException("associativity = " + associativity);
+                }
+            }
+            // TODO: type_
+            // TODO: code
+            // TODO: classes
+            // TODO: prefix
+            // TODO: submits
+            // TODO: dominates
+            return terminal;
+        } catch (ParseException exc) {
+            throw new RuntimeException(exc);
+        }
+    }
+
+    public static TerminalClass makeTerminalClass(String id) {
+        TerminalClass out = new TerminalClass();
+        try {
+            out.setName(id);
+        } catch (ParseException exc) {
+            throw new RuntimeException(exc);
+        }
+        return out;
+    }
 }

--- a/runtime/java/src/common/CopperUtil.java
+++ b/runtime/java/src/common/CopperUtil.java
@@ -1,0 +1,31 @@
+package common;
+
+import edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.*;
+import java.text.ParseException;
+import java.util.List;
+
+public final class CopperUtil {
+  public static NonTerminal makeNonTerminal(String id, String pp,
+                                            String type_) {
+    return null;
+  }
+
+  public static Terminal makeTerminal(String id, String pp, Regex regex,
+                                      Integer precedence, Object associativity,
+                                      String type_, String code,
+                                      List<StringCatter> classes, String prefix,
+                                      List<StringCatter> submits,
+                                      List<StringCatter> dominates) {
+    return null;
+  }
+
+  public static TerminalClass makeTerminalClass(String id) {
+    TerminalClass out = new TerminalClass();
+    try {
+      out.setName(id);
+    } catch (ParseException exc) {
+      throw new RuntimeException(exc);
+    }
+    return out;
+  }
+}

--- a/runtime/java/src/common/CopperUtil.java
+++ b/runtime/java/src/common/CopperUtil.java
@@ -2,6 +2,8 @@ package common;
 
 import common.javainterop.ConsCellCollection;
 import edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.*;
+import edu.umn.cs.melt.copper.main.ParserCompiler;
+import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.engines.semantics.VirtualLocation;
 import edu.umn.cs.melt.copper.runtime.io.Location;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
@@ -12,8 +14,20 @@ import java.util.Set;
 public final class CopperUtil {
     private static Location LOCATION = new VirtualLocation("<silver>", -1, -1);
 
-    public static DisambiguationFunction makeDisambiguationFunction(String id,
-            String code, ConsCellCollection<CopperElementReference> members, Boolean applicableToSubsets) {
+    public static IOToken compile(ParserBean parser, IOToken tok) {
+        ParserCompilerParameters params = new ParserCompilerParameters();
+        try {
+            ParserCompiler.compile(parser, params);
+        } catch(CopperException exc) {
+            throw new RuntimeException(exc);
+        }
+        return tok;
+    }
+
+    public static DisambiguationFunction
+    makeDisambiguationFunction(String id, String code,
+                               ConsCellCollection<CopperElementReference> members,
+                               Boolean applicableToSubsets) {
         try {
             DisambiguationFunction f = new DisambiguationFunction();
             f.setName(id);
@@ -31,6 +45,7 @@ public final class CopperUtil {
 
     public static CopperElementReference makeElementReference(String grammarName,
             String name) {
+        System.out.println("element reference " + grammarName + " " + name);
         try {
             return CopperElementReference.ref(CopperElementName.newName(grammarName),
                                               name, LOCATION);
@@ -76,6 +91,7 @@ public final class CopperUtil {
                    String preambleCode, Grammar grammar) {
         try {
             ParserBean parserBean = new ParserBean();
+            parserBean.setLocation(LOCATION);
             parserBean.setName(id);
             parserBean.setDisplayName(pp);
             parserBean.setUnitary(true);

--- a/runtime/java/src/common/CopperUtil.java
+++ b/runtime/java/src/common/CopperUtil.java
@@ -24,6 +24,15 @@ public final class CopperUtil {
     throw new RuntimeException("TODO CopperUtil.makeNonTerminal");
   }
 
+  public static ParserBean
+  makeParserBean(String id, String pp, String grammarName,
+                 CopperElementReference startSymbol,
+                 List<CopperElementReference> startLayout,
+                 String parserClassAuxCode, String parserInitCode,
+                 String preambleCode, List<Grammar> grammars) {
+    throw new RuntimeException("TODO CopperUtil.makeParserBean");
+  }
+
   public static Terminal makeTerminal(String id, String pp, Regex regex,
                                       Integer precedence, Object associativity,
                                       String type_, String code,

--- a/runtime/java/src/common/CopperUtil.java
+++ b/runtime/java/src/common/CopperUtil.java
@@ -1,10 +1,13 @@
 package common;
 
+import common.javainterop.ConsCellCollection;
 import edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.*;
 import edu.umn.cs.melt.copper.runtime.engines.semantics.VirtualLocation;
 import edu.umn.cs.melt.copper.runtime.io.Location;
+import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 import java.text.ParseException;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 public final class CopperUtil {
   private static Location LOCATION = new VirtualLocation("<silver>", -1, -1);
@@ -25,20 +28,55 @@ public final class CopperUtil {
   }
 
   public static ParserBean
-  makeParserBean(String id, String pp, String grammarName,
-                 CopperElementReference startSymbol,
-                 List<CopperElementReference> startLayout,
+  makeParserBean(String id, String pp, CopperElementReference startSymbol,
+                 ConsCellCollection<CopperElementReference> startLayout,
                  String parserClassAuxCode, String parserInitCode,
-                 String preambleCode, List<Grammar> grammars) {
-    throw new RuntimeException("TODO CopperUtil.makeParserBean");
+                 String preambleCode, Grammar grammar) {
+    try {
+      System.err.println("bruh 36");
+      ParserBean parserBean = new ParserBean();
+      System.err.println("bruh 38");
+      parserBean.setName(id);
+      System.err.println("bruh 40");
+      parserBean.setDisplayName(pp);
+      System.err.println("bruh 42");
+      parserBean.setUnitary(true);
+      System.err.println("bruh 44");
+      parserBean.addGrammar(grammar);
+      System.err.println("bruh 46");
+      parserBean.setStartSymbol(startSymbol);
+      System.err.println("bruh 48");
+
+      Set<CopperElementReference> startLayoutSet =
+          new HashSet<CopperElementReference>();
+      System.err.println("bruh 52");
+      System.out.println(startLayout);
+      System.err.println("bruh 54");
+      System.out.println(startLayoutSet);
+      System.err.println("bruh 56");
+      startLayout.iterator().forEachRemaining(startLayoutSet::add);
+      System.err.println("bruh 58");
+      System.out.println(startLayout);
+      System.err.println("bruh 60");
+      System.out.println(startLayoutSet);
+      System.err.println("bruh 62");
+      parserBean.setStartLayout(startLayoutSet);
+      System.err.println("bruh 64");
+
+      throw new RuntimeException("TODO CopperUtil.makeParserBean");
+    } catch (CopperException exc) {
+      throw new RuntimeException(exc);
+    } catch (ParseException exc) {
+      throw new RuntimeException(exc);
+    }
   }
 
-  public static Terminal makeTerminal(String id, String pp, Regex regex,
-                                      Integer precedence, Object associativity,
-                                      String type_, String code,
-                                      List<StringCatter> classes, String prefix,
-                                      List<StringCatter> submits,
-                                      List<StringCatter> dominates) {
+  public static Terminal
+  makeTerminal(String id, String pp, Regex regex, Integer precedence,
+               Object associativity, String type_, String code,
+               ConsCellCollection<StringCatter> classes, String prefix,
+               ConsCellCollection<StringCatter> submits,
+               ConsCellCollection<StringCatter> dominates) {
     throw new RuntimeException("TODO CopperUtil.makeTerminal");
   }
 

--- a/runtime/java/src/common/CopperUtil.java
+++ b/runtime/java/src/common/CopperUtil.java
@@ -24,6 +24,18 @@ public final class CopperUtil {
         return tok;
     }
 
+    public static CharacterSetRegex makeCharRange(String lo, String hi) {
+        CharacterSetRegex re = new CharacterSetRegex();
+        re.addRange(lo.charAt(0), hi.charAt(0));
+        return re;
+    }
+
+    public static CharacterSetRegex makeSingleChar(String ch) {
+        CharacterSetRegex re = new CharacterSetRegex();
+        re.addLooseChar(ch.charAt(0));
+        return re;
+    }
+
     public static DisambiguationFunction
     makeDisambiguationFunction(String id, String code,
                                ConsCellCollection<CopperElementReference> members,
@@ -45,7 +57,6 @@ public final class CopperUtil {
 
     public static CopperElementReference makeElementReference(String grammarName,
             String name) {
-        System.out.println("element reference " + grammarName + " " + name);
         try {
             return CopperElementReference.ref(CopperElementName.newName(grammarName),
                                               name, LOCATION);

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -324,7 +324,7 @@ public final class Util {
 		} else if(o instanceof ConsCell) {
 			hackyhackyUnparseList((ConsCell)o, sb);
 		} else {
-			sb.append("<OBJ>");
+			sb.append("<OBJ " + o.toString() + ">");
 		}
 	}
 	private static void hackyhackyUnparseNode(Node n, StringBuilder sb) {


### PR DESCRIPTION
# Changes

Changes Copper integration to use the Copper API. Before merging, will also remove the Ant requirement (which will hopefully get SubstrateVM working, #512!).

# Documentation

- [ ] Remove Ant dependency from docs, once Ant dependency is actually gone.

# TODOs

- [ ] Remove Ant
- [ ] Stop XML escaping terminal pretty-prints