### PR TITLE
Fix dropped error messages in string template escapes

### DIFF
--- a/grammars/silver/compiler/extension/templating/StringTemplating.sv
+++ b/grammars/silver/compiler/extension/templating/StringTemplating.sv
@@ -54,6 +54,9 @@ top::Expr ::= a::Expr b::Expr
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
   
   thread downSubst, upSubst on top, a, b, forward;
+  -- These are wrapped in exprRef in the forward, so include their errors here:
+  top.errors <- a.errors;
+  top.errors <- b.errors;
   
   forwards to
     mkStrFunctionInvocation(


### PR DESCRIPTION
# Changes
Fixes #513, errors were getting dropped due to forwarding to `exprRef`.  

# Documentation
None, this is a 2-line bug fix
