### PR TITLE
Fix eclipse plugin breakages caused in #497

### DIFF
--- a/grammars/silver/compiler/modification/impide/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/impide/BuildProcess.sv
@@ -71,6 +71,7 @@ top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
       <copy file="$${lang.composed}.jar" tofile="$${ide.proj.plugin.path}/$${lang.composed}.jar"/>
       <copy file="$${sh}/jars/CopperCompiler.jar" tofile="$${ide.proj.plugin.path}/CopperCompiler.jar"/>
       <copy file="$${sh}/jars/SilverRuntime.jar" tofile="$${ide.proj.plugin.path}/SilverRuntime.jar"/>
+      <copy file="$${sh}/jars/commonmark-0.17.1.jar" tofile="$${ide.proj.plugin.path}/commonmark-0.17.1.jar"/>
       <copy file="$${sh}/jars/IDEPluginRuntime.jar" tofile="$${ide.proj.plugin.path}/IDEPluginRuntime.jar"/>
     <!-- 10. Ide resources -->
 ${implode("", map(copyIdeResource, ide.ideResources))}

--- a/resources/ide_skeleton/plugin/META-INF/MANIFEST.MF
+++ b/resources/ide_skeleton/plugin/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-ClassPath: .,
  @LANG_COMPOSED@.jar,
  CopperCompiler.jar,
  SilverRuntime.jar,
+ commonmark-0.17.1.jar,
  IDEPluginRuntime.jar
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/resources/ide_skeleton/plugin/build.properties
+++ b/resources/ide_skeleton/plugin/build.properties
@@ -7,5 +7,6 @@ bin.includes = META-INF/,\
                @LANG_COMPOSED@.jar,\
                CopperCompiler.jar,\
                SilverRuntime.jar,\
+               commonmark-0.17.1.jar,\
                IDEPluginRuntime.jar,\
                plugin.xml

--- a/runtime/imp/main/META-INF/MANIFEST.MF
+++ b/runtime/imp/main/META-INF/MANIFEST.MF
@@ -9,7 +9,9 @@ Export-Package: edu.umn.cs.melt.ide.copper;version="1.0.0",
  edu.umn.cs.melt.ide.silver.misc;version="1.0.0",
  edu.umn.cs.melt.ide.silver.property;version="1.0.0",
  edu.umn.cs.melt.ide.util;version="1.0.0",
- edu.umn.cs.melt.ide.silver.property.ui;version="1.0.0"
+ edu.umn.cs.melt.ide.silver.property.ui;version="1.0.0",
+ org.commonmark.node;version="0.17.1",
+ org.commonmark.parser;version="0.17.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.runtime,

--- a/runtime/imp/main/pom.xml
+++ b/runtime/imp/main/pom.xml
@@ -75,6 +75,13 @@
               <scope>system</scope>
               <systemPath>${basedir}/../../../jars/CopperCompiler.jar</systemPath>
             </extraClasspathElement>
+            <extraClasspathElement>
+              <groupId>org.commonmark</groupId>
+              <artifactId>commonmark</artifactId>
+              <version>0.17.1</version>
+              <scope>system</scope>
+              <systemPath>${basedir}/../../../jars/commonmark-0.17.1.jar</systemPath>
+            </extraClasspathElement>
           </extraClasspathElements>
         </configuration>
       </plugin>

--- a/runtime/java/.classpath
+++ b/runtime/java/.classpath
@@ -5,5 +5,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="var" path="SILVER_HOME/jars/CopperRuntime.jar"/>
 	<classpathentry kind="var" path="SILVER_HOME/generated/bin"/>
+	<classpathentry kind="var" path="SILVER_HOME/jars/commonmark-0.17.1.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/runtime/java/src/common/Markdown.java
+++ b/runtime/java/src/common/Markdown.java
@@ -2,7 +2,6 @@ package common;
 
 import common.javainterop.ConsCellCollection;
 import java.util.ArrayList;
-import java.util.List;
 import org.commonmark.node.AbstractVisitor;
 import org.commonmark.node.FencedCodeBlock;
 import org.commonmark.node.SourceSpan;


### PR DESCRIPTION
# Changes
Fixes to the eclipse IDE plugin generation, was broken by #497 due to the added dependency on commonmark-0.17.1.jar

It's a little unfortunate that this shows up in so many places, especially in the IDE skeleton template, when it should only really be a dependency of the Silver plugin (and not any other hypothetical eclipse plugins for other languages implemented in Silver.)  The issue is that the commonmark library is now effectively a dependency of the Silver runtime, and there doesn't seem to be a way to specify additional classpath dependencies in the current, gross way that we generate the entire eclipse plugin project structure.  This is another example of why trying to generate an entire plugin from a modification to Silver is a mistake, as @tedinski has previously emphasized.  

Note that the entries added in runtime/imp/main/ might not be strictly needed, since I think these are only the deps for _building_ the eclipse IDE runtime?  I'm out of patience with actually testing this, though.  And I suppose having the dependency there is still the right thing to do anyway since commonmark is a dependency of the silver runtime.  

# Documentation
None, this is a bugfix
