### PR TITLE
Adding subprocess grammar to be built with website documentation

### DIFF
--- a/grammars/silver/compiler/extension/doc/extra/Main.sv
+++ b/grammars/silver/compiler/extension/doc/extra/Main.sv
@@ -46,6 +46,7 @@ import silver:util:treemap;
 import silver:util:graph;
 import silver:util:treemap;
 import silver:util:treeset;
+import silver:util:subprocess;
 
 import silver:xml;
 


### PR DESCRIPTION
# Changes
This adds an import of the `silver:util:subprocess` grammar to the documentation grammar for the website so the documentation will be built for and show up on the website.

# Documentation
This is a one-line change to generate documentation, and thus does not require any documentation itself.