### PR TITLE
Fixing nOptions and adding documentation

### DIFF
--- a/grammars/silver/util/cmdargs/CmdArgs.sv
+++ b/grammars/silver/util/cmdargs/CmdArgs.sv
@@ -128,11 +128,11 @@ top::Flag ::= n::Integer  ast::(CmdArgs ::= [String] CmdArgs)
       then []
       else drop(n + 1, top.flagInput);
   top.flagModified =
-      if length(top.flagInput) <= n + 1
+      if length(top.flagInput) < n + 1
       then errorCmdArgs(head(top.flagInput) ++ " only has " ++
                         toString(length(top.flagInput)) ++
                         " parameters, when it should have " ++
-                        toString(n - 1))
+                        toString(n))
       else ast(take(n, drop(1, top.flagInput)), top.flagOriginal);
 }
 

--- a/grammars/silver/util/cmdargs/CmdArgs.sv
+++ b/grammars/silver/util/cmdargs/CmdArgs.sv
@@ -1,10 +1,34 @@
 grammar silver:util:cmdargs;
 
+
+@{-
+  - The type of lists of arguments given on the command line
+  -
+  - Define a new production (as a cons cell for the CmdArgs list) for each flag given on the command line:
+  - - For a flag that takes no arguments on the command line, define a production of type (CmdArgs ::= CmdArgs)
+  - - For a flag that takes a single argument, define a production of type (CmdArgs ::= String CmdArgs)
+  - - For a flag that takes more arguments, define a prodution of type (CmdArgs ::= [String] CmdArgs)
+  -}
 nonterminal CmdArgs with cmdRemaining, cmdError;
 
+@{-
+  - The remaining arguments from the commandline after parsing the flags
+  -}
 synthesized attribute cmdRemaining :: [String];
+@{-
+  - The errors from parsing commandline arguments
+  -}
 synthesized attribute cmdError :: Maybe<String>;
 
+
+@{-
+  - Produce a parsed list of arguments using the given flags from the given input
+  -
+  - @param flags  A list of pairs of flag names (starting with hyphens) and the Flag for handling its parsing
+  - @param input  A list of strings, generally the commandline arguments
+  - @return The parsed list of arguments
+  - @warning The flag names in the flags parameter MUST start with a hyphen
+  -}
 function interpretCmdArgs
 CmdArgs ::= flags::[Pair<String Flag>]  input::[String]
 {
@@ -24,9 +48,11 @@ CmdArgs ::= flags::[Pair<String Flag>]  input::[String]
          else here.flagModified;
 }
 
-{--
- - For defining base, default values for any attributes on CmdArgs
- -}
+@{--
+  - For defining base, default values for any attributes on CmdArgs
+  -
+  - @param remaining  Commandline arguments remaining after parsing flags
+  -}
 abstract production endCmdArgs
 top::CmdArgs ::= remaining::[String]
 {
@@ -34,10 +60,12 @@ top::CmdArgs ::= remaining::[String]
   top.cmdError = nothing();
 }
 
-{--
- - Only used when an error is encountered attempting to parse an option.
- - One should always check for .cmdError.isJust BEFORE accessing any other attributes.
- -}
+@{--
+  - Only used when an error is encountered attempting to parse an option.
+  - One should always check for .cmdError.isJust BEFORE accessing any other attributes.
+  -
+  - @param errmsg  Error message
+  -}
 abstract production errorCmdArgs
 top::CmdArgs ::= errmsg::String
 {
@@ -47,9 +75,9 @@ top::CmdArgs ::= errmsg::String
 }
 
 @{--
- - Flags are a representation of what to do with command line flags/options.
- - It should not be necessary to define any new flags.
- -}
+  - Flags are a representation of what to do with command line flags/options.
+  - It should not be necessary to define any new flags.
+  -}
 nonterminal Flag with flagInput, flagOutput, flagOriginal, flagModified;
 
 inherited attribute flagInput::[String];
@@ -60,6 +88,8 @@ synthesized attribute flagModified::CmdArgs;
 @{--
  - In the terminology I've just made up, a 'flag' is a cmd line option
  - with no parameters.
+ -
+ - @param ast  Production for handling this commandline option being given
  -}
 abstract production flag
 top::Flag ::= ast::(CmdArgs ::= CmdArgs)
@@ -71,6 +101,8 @@ top::Flag ::= ast::(CmdArgs ::= CmdArgs)
 @{--
  - In the terminology I've just made up, an 'option' is a cmd line option
  - with one, single parameter.
+ -
+ - @param ast  Production for handling this commandline option being given
  -}
 abstract production option
 top::Flag ::= ast::(CmdArgs ::= String CmdArgs)
@@ -84,13 +116,22 @@ top::Flag ::= ast::(CmdArgs ::= String CmdArgs)
 @{--
  - In the terminology I've just made up, 'nOptions' is a cmd line option
  - with n parameters.
+ -
+ - @param ast  Production for handling this commandline option being given
  -}
 abstract production nOptions
 top::Flag ::= n::Integer  ast::(CmdArgs ::= [String] CmdArgs)
 {
-  top.flagOutput = if length(top.flagInput) <= n then [] else drop(n, top.flagInput);
-  top.flagModified = if length(top.flagInput) <= n
-                     then errorCmdArgs(head(top.flagInput) ++ " only has " ++ toString(length(top.flagInput)-1) ++ " parameters, when it should have " ++ toString(n))
-                     else ast(take(n, top.flagInput), top.flagOriginal);
+  top.flagOutput =
+      if length(top.flagInput) <= n + 1
+      then []
+      else drop(n + 1, top.flagInput);
+  top.flagModified =
+      if length(top.flagInput) <= n + 1
+      then errorCmdArgs(head(top.flagInput) ++ " only has " ++
+                        toString(length(top.flagInput)) ++
+                        " parameters, when it should have " ++
+                        toString(n - 1))
+      else ast(take(n, drop(1, top.flagInput)), top.flagOriginal);
 }
 

--- a/grammars/silver/util/cmdargs/CmdArgs.sv
+++ b/grammars/silver/util/cmdargs/CmdArgs.sv
@@ -117,6 +117,7 @@ top::Flag ::= ast::(CmdArgs ::= String CmdArgs)
  - In the terminology I've just made up, 'nOptions' is a cmd line option
  - with n parameters.
  -
+ - @param n  The number of arguments expected by the flag
  - @param ast  Production for handling this commandline option being given
  -}
 abstract production nOptions


### PR DESCRIPTION
# Changes
The `nOptions` production for `Flag` in `silver:util:cmdargs` was not parsing arguments in the expected way, and was apparently not working at all.  This fixes it so parsing arguments with `interpretCmdArgs([("-flag", nOptions(2, prod))], ["-flag", "a", "b", "c"])` will parse `"a"` and `"b"` as the arguments to `-flag`.  This behavior is in line with the `option` production's behavior.

While I was working on this grammar, I also added doc comments to the grammar in general.

# Documentation
I added doc comments for the declarations in this grammar, which will go onto the website for users of Silver to view.