### PR TITLE
Allows code blocks in Literate Silver with an info string of `silver imports` to hoist the code to the top.

### DIFF
--- a/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
+++ b/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
@@ -34,18 +34,35 @@ Since these are the only two extensions allowed by `isValidSilverFile` in `Compi
 
 ## Literate Silver
 
-To get the Silver code blocks, we check that the info string is *exactly* `silver`.
-The CommonMark spec notes that commonly only the first word is used as the language; in the future, we may want to support info strings like `silver test`, `silver wrongCode`, etc.
+The preprocessing for Literate Silver files is just a matter of extracting and concatenating blocks of Silver code.
+The CommonMark spec notes that commonly only the first word is used as the language; all the ones we recognize start with `silver` as a result.
+
+In the future, we may want to support info strings like `silver test`, `silver wrongCode`, etc.
 See [rustdoc](https://doc.rust-lang.org/rustdoc/documentation-tests.html#attributes) for prior art.
+
 
 ```silver
 function extractSilverCodeBlocks
 [String] ::= path::String  markdown::String
 {
+  local allCodeBlocks::[(String, Location, String)] = extractCodeBlocks(path, markdown);
+```
+
+The simple case is blocks whose info string is *exactly* `silver`.
+These are replicated verbatim, after adjusting the line number so locations match.
+
+```silver
   local goodCode::[String] =
     map(\block::(String, Location, String) -> "#line " ++ toString(block.2.line + 1) ++ "\n" ++ block.3,
-        filter(\block::(String, Location, String) -> block.1 == "silver",
-               extractCodeBlocks(path, markdown)));
+        filter(\block::(String, Location, String) -> block.1 == "silver", allCodeBlocks));
+```
+
+An info string of `silver imports` causes the code block to be hoisted to the top; this is useful because imports need to be at the top of the file, but we might want to only show an import later on in a document, to avoid scaring the reader off with a large block of imports at the top.
+
+```silver
+  local importsCode::[String] =
+    map(\block::(String, Location, String) -> "#line " ++ toString(block.2.line + 1) ++ "\n" ++ block.3,
+        filter(\block::(String, Location, String) -> block.1 == "silver imports", allCodeBlocks));
 ```
 
 We also emit warnings for code blocks with no info string.
@@ -54,14 +71,13 @@ We also emit warnings for code blocks with no info string.
   local warnCode::[String] =
     map(\block::(String, Location, String) -> "#line " ++ toString(block.2.line + 1) ++ "\n"
                                            ++ "#warn Code block with no info string; this won't be compiled",
-        filter(\block::(String, Location, String) -> block.1 == "",
-               extractCodeBlocks(path, markdown)));
+        filter(\block::(String, Location, String) -> block.1 == "", allCodeBlocks));
 ```
 
 Since we use `#line` to set the line numbers on the parsed trees, we don't need to do any fancy interleaving or anything before returning all the blocks.
 
 ```silver
-  return goodCode ++ warnCode;
+  return importsCode ++ goodCode ++ warnCode;
 }
 ```
 


### PR DESCRIPTION
# Changes

Found a patch from April sitting amongst the SilvIR stuff...

# Documentation

The code is self-documenting :)

In this case, in a literal sense; next time somebody feels like messing with the website, it'd be nice if `.sv.md` files could end up on it.