### PR TITLE
Allows interface files with the same timestamp as the grammar.

### DIFF
--- a/grammars/silver/compiler/driver/CompileInterface.sv
+++ b/grammars/silver/compiler/driver/CompileInterface.sv
@@ -49,7 +49,7 @@ IOVal<Maybe<RootSpec>> ::= grammarName::String  silverHostGen::[String]  grammar
     if !gen.iovalue.isJust then
       -- Didn't find one. Stop short, return nothing.
       ioval(gen.io, nothing())
-    else if modTime.iovalue <= grammarTime then
+    else if modTime.iovalue < grammarTime then
       -- Interface file is too old, stop short, return nothing.
       ioval(modTime.io, nothing())
     else if ir.isLeft || !null(ir.fromRight.interfaceErrors) then


### PR DESCRIPTION
Maybe Silver just got really really fast. :)

More relevantly to my usecase, in cases where timestamps got wiped out
to the same value (e.g. distributing artifacts in archives that don't
preserve metadata, normalization by Nix before hashing, etc.), we still
want to treat the interface files as valid.

I feel like there's an issue for this somewhere, but... not seeing it.
(I've definitely written this exact patch before though.)