### PR TITLE
Properly implement matching on decorated polymorphic production children that have occurs-on constraints

### DIFF
--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -222,6 +222,7 @@ Boolean ::= t::Type e::Decorated Env
   return
     case t of
     | skolemType(_) -> !null(searchEnvTree(t.typeName, e.occursTree))
+    | varType(_) -> !null(searchEnvTree(t.typeName, e.occursTree))  -- Can happen when pattern matching on a prod with occurs contexts
     | _ -> t.isNonterminal
     end;
 }


### PR DESCRIPTION
# Changes
See title.  This finishes the implementation of pattern matching on productions with occurs-on constraints, that I had forgotten was still unfinished when #542 was merged.  

# Documentation
This is more of a bug fix; occurs-on constraints will have documentation written soon.
