### PR TITLE
Refactor involving various automatic attributes

### DIFF
--- a/grammars/silver/compiler/definition/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/definition/core/InstanceDcl.sv
@@ -12,7 +12,8 @@ top::AGDcl ::= 'instance' cl::ConstraintList '=>' id::QNameType ty::TypeExpr '{'
   production dcl::DclInfo = id.lookupType.dcl;
   dcl.givenInstanceType = ty.typerep;
   
-  production superContexts::Contexts = foldContexts(if id.lookupType.found then dcl.superContexts else []);
+  production superContexts::Contexts =
+    foldContexts(if id.lookupType.found && !foldContexts(cl.contexts).isTypeError then dcl.superContexts else []);
   superContexts.env = body.env;
   
   top.defs := [instDef(top.grammarName, id.location, fName, boundVars, cl.contexts, ty.typerep)];

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -55,6 +55,7 @@ top::Context ::= cls::String t::Type
   -- so we can't allow this to match an instance for the undecorated type.
   production decT::Type =
     case t of
+    | ntOrDecType(nt, varType(_), _) -> decoratedType(nt, inhSetType([]))
     | ntOrDecType(nt, inhs, _) -> decoratedType(nt, inhs)
     | _ -> t
     end;

--- a/grammars/silver/compiler/definition/flow/ast/Vertex.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Vertex.sv
@@ -5,10 +5,8 @@ grammar silver:compiler:definition:flow:ast;
  -
  - See VertexType for some extra information organizing these vertexes somewhat.
  -}
-nonterminal FlowVertex with vertexComparisonKey;
-
--- It's kinda hard to implement a comparison of a type like this, so we serialize to string and compare that.
-synthesized attribute vertexComparisonKey :: String;
+nonterminal FlowVertex with compareTo, isEqual, compareKey, compare;
+propagate compareTo, isEqual, compareKey, compare on FlowVertex;
 
 {--
  - A vertex representing a synthesized attribute on the nonterminal being constructed by this production.
@@ -17,9 +15,7 @@ synthesized attribute vertexComparisonKey :: String;
  -}
 abstract production lhsSynVertex
 top::FlowVertex ::= attrName::String
-{
-  top.vertexComparisonKey = "lhsSynV(" ++ (attrName) ++ ")";
-}
+{}
 
 {--
  - A vertex representing an inherited attribute on the nonterminal being constructed by this production.
@@ -31,9 +27,7 @@ top::FlowVertex ::= attrName::String
  -}
 abstract production lhsInhVertex
 top::FlowVertex ::= attrName::String
-{
-  top.vertexComparisonKey = "lhsInhV(" ++ (attrName) ++ ")";
-}
+{}
 
 -- TODO: we should do the above syn/inh separation for everything below too.
 
@@ -45,9 +39,7 @@ top::FlowVertex ::= attrName::String
  -}
 abstract production rhsVertex
 top::FlowVertex ::= sigName::String  attrName::String
-{
-  top.vertexComparisonKey = "rhsV(" ++ (sigName) ++ ", " ++ (attrName) ++ ")";
-}
+{}
 
 {--
  - A vertex representing a local equation. i.e. forward, local attribute, production
@@ -59,9 +51,7 @@ top::FlowVertex ::= sigName::String  attrName::String
  -}
 abstract production localEqVertex
 top::FlowVertex ::= fName::String
-{
-  top.vertexComparisonKey = "localEqV(" ++ (fName) ++ ")";
-}
+{}
 
 {--
  - A vertex representing an attribute on a local equation. i.e. forward, local
@@ -73,9 +63,7 @@ top::FlowVertex ::= fName::String
  -}
 abstract production localVertex
 top::FlowVertex ::= fName::String  attrName::String
-{
-  top.vertexComparisonKey = "localV(" ++ (fName) ++ ", " ++ (attrName) ++ ")";
-}
+{}
 
 -- TODO: we should distinguish these!
 
@@ -101,9 +89,7 @@ FlowVertex ::= attrName::String
  -}
 abstract production anonEqVertex
 top::FlowVertex ::= fName::String
-{
-  top.vertexComparisonKey = "anonEqV(" ++ (fName) ++ ")";
-}
+{}
 
 {--
  - A vertex representing an attribute on an anonymous equation.
@@ -114,28 +100,4 @@ top::FlowVertex ::= fName::String
  -}
 abstract production anonVertex
 top::FlowVertex ::= fName::String  attrName::String
-{
-  top.vertexComparisonKey = "anonV(" ++ (fName) ++ ", " ++ (attrName) ++ ")";
-}
-
---------------------------------------------------------------------------------
-
--- TODO: Replace with propagated equality/ordering attributes
-instance Eq FlowVertex {
-  eq = \ a::FlowVertex  b::FlowVertex -> case a, b of
-    | lhsSynVertex(a1), lhsSynVertex(a2) -> a1 == a2
-    | lhsInhVertex(a1), lhsInhVertex(a2) -> a1 == a2
-    | rhsVertex(s1, a1), rhsVertex(s2, a2) -> s1 == s2 && a1 == a2
-    | localEqVertex(f1), localEqVertex(f2) -> f1 == f2
-    | localVertex(f1, a1), localVertex(f2, a2) -> f1 == f2 && a1 == a2
-    | anonEqVertex(f1), anonEqVertex(f2) -> f1 == f2
-    | anonVertex(f1, a1), anonVertex(f2, a2) -> f1 == f2 && a1 == a2
-    | _, _ -> false
-    end;
-}
-
-instance Ord FlowVertex {
-  compare = \ a::FlowVertex b::FlowVertex ->
-    compare(a.vertexComparisonKey, b.vertexComparisonKey);
-}
-
+{}

--- a/grammars/silver/compiler/definition/type/Kind.sv
+++ b/grammars/silver/compiler/definition/type/Kind.sv
@@ -28,11 +28,5 @@ top::Kind ::= k1::Kind k2::Kind
   top.argKinds = k1 :: k2.argKinds;
 }
 
-
--- TODO: Replace with default instance
-instance Eq Kind {
-  eq = \ k1::Kind k2::Kind -> decorate k1 with {compareTo = decorate k2 with {};}.isEqual;
-}
-
 global constructorKind::(Kind ::= Integer) = \ arity::Integer ->
   foldr(arrowKind, starKind(), repeat(starKind(), arity));

--- a/grammars/silver/compiler/definition/type/Kind.sv
+++ b/grammars/silver/compiler/definition/type/Kind.sv
@@ -3,8 +3,8 @@ grammar silver:compiler:definition:type;
 synthesized attribute baseKind::Kind;
 synthesized attribute argKinds::[Kind];
 
-nonterminal Kind with isEqualTo, isEqual, baseKind, argKinds;
-propagate isEqualTo, isEqual on Kind;
+nonterminal Kind with compareTo, isEqual, baseKind, argKinds;
+propagate compareTo, isEqual on Kind;
 
 aspect default production
 top::Kind ::=
@@ -31,7 +31,7 @@ top::Kind ::= k1::Kind k2::Kind
 
 -- TODO: Replace with default instance
 instance Eq Kind {
-  eq = \ k1::Kind k2::Kind -> decorate k1 with {isEqualTo = k2;}.isEqual;
+  eq = \ k1::Kind k2::Kind -> decorate k1 with {compareTo = k2;}.isEqual;
 }
 
 global constructorKind::(Kind ::= Integer) = \ arity::Integer ->

--- a/grammars/silver/compiler/definition/type/Kind.sv
+++ b/grammars/silver/compiler/definition/type/Kind.sv
@@ -31,7 +31,7 @@ top::Kind ::= k1::Kind k2::Kind
 
 -- TODO: Replace with default instance
 instance Eq Kind {
-  eq = \ k1::Kind k2::Kind -> decorate k1 with {compareTo = k2;}.isEqual;
+  eq = \ k1::Kind k2::Kind -> decorate k1 with {compareTo = decorate k2 with {};}.isEqual;
 }
 
 global constructorKind::(Kind ::= Integer) = \ arity::Integer ->

--- a/grammars/silver/compiler/definition/type/Type.sv
+++ b/grammars/silver/compiler/definition/type/Type.sv
@@ -297,7 +297,8 @@ top::Type ::= params::Integer namedParams::[String]
 
 --------------------------------------------------------------------------------
 
-nonterminal TyVar with kindrep;
+nonterminal TyVar with kindrep, compareTo, isEqual;
+propagate compareTo, isEqual on TyVar;
 
 -- In essence, this should be 'private' to this file.
 synthesized attribute extractTyVarRep :: Integer occurs on TyVar;
@@ -344,9 +345,3 @@ Type ::=
 {
   return varType(freshTyVar(inhSetKind()));
 }
-
--- TODO: Replace with propagated default instance
-instance Eq TyVar {
-  eq = \ tv1::TyVar tv2::TyVar -> tv1.kindrep == tv2.kindrep && tv1.extractTyVarRep == tv2.extractTyVarRep;
-}
-

--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -68,7 +68,7 @@ top::DclInfo ::= fn::String tyVar::TyVar
   top.propagateDispatcher = propagateDestruct(_, location=_);
 }
 
-abstract production equalitySynDcl
+abstract production equalityDcl
 top::DclInfo ::= inh::String syn::String
 {
   top.fullName = syn;
@@ -81,6 +81,21 @@ top::DclInfo ::= inh::String syn::String
   top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
   top.propagateDispatcher = propagateEquality(inh, _, location=_);
+}
+
+abstract production orderingDcl
+top::DclInfo ::= inh::String syn::String
+{
+  top.fullName = syn;
+
+  top.typeScheme = monoType(intType());
+  top.isSynthesized = true;
+  
+  top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
+  top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
+  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
+  top.propagateDispatcher = propagateOrdering(inh, _, location=_);
 }
 
 abstract production unificationInhDcl

--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -55,18 +55,19 @@ top::DclInfo ::= fn::String bound::[TyVar] ty::Type empty::Expr append::Operatio
 }
 
 abstract production destructDcl
-top::DclInfo ::= fn::String inhs::[String]
+top::DclInfo ::= fn::String
 {
   top.fullName = fn;
 
   production tyVar::TyVar = freshTyVar(starKind());
-  top.typeScheme = polyType([tyVar], decoratedType(varType(tyVar), inhSetType(inhs)));
+  production inhsTyVar::TyVar = freshTyVar(inhSetKind());
+  top.typeScheme = polyType([tyVar, inhsTyVar], decoratedType(varType(tyVar), varType(inhsTyVar)));
   top.isInherited = true;
   
   top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _); -- TODO: should probably be an error handler! access inh from undecorated?
   top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_); -- Allow normal inh equations
-  top.attributionDispatcher = functorAttributionDcl(_, _, _, _, location=_); -- Same as functor
+  top.attributionDispatcher = destructAttributionDcl(_, _, _, _, location=_);
   top.propagateDispatcher = propagateDestruct(_, location=_);
 }
 

--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -18,10 +18,11 @@ top::DclInfo ::= fn::String bound::[TyVar] ty::Type
 }
 
 abstract production functorDcl
-top::DclInfo ::= fn::String tyVar::TyVar
+top::DclInfo ::= fn::String
 {
   top.fullName = fn;
 
+  production tyVar::TyVar = freshTyVar(starKind());
   top.typeScheme = polyType([tyVar], varType(tyVar));
   top.isSynthesized = true;
   
@@ -54,11 +55,12 @@ top::DclInfo ::= fn::String bound::[TyVar] ty::Type empty::Expr append::Operatio
 }
 
 abstract production destructDcl
-top::DclInfo ::= fn::String tyVar::TyVar
+top::DclInfo ::= fn::String inhs::[String]
 {
   top.fullName = fn;
 
-  top.typeScheme = polyType([tyVar], varType(tyVar));
+  production tyVar::TyVar = freshTyVar(starKind());
+  top.typeScheme = polyType([tyVar], decoratedType(varType(tyVar), inhSetType(inhs)));
   top.isInherited = true;
   
   top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);

--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -83,8 +83,23 @@ top::DclInfo ::= inh::String syn::String
   top.propagateDispatcher = propagateEquality(inh, _, location=_);
 }
 
+abstract production orderingKeyDcl
+top::DclInfo ::= syn::String
+{
+  top.fullName = syn;
+
+  top.typeScheme = monoType(stringType());
+  top.isSynthesized = true;
+  
+  top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
+  top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
+  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
+  top.propagateDispatcher = propagateOrderingKey(_, location=_);
+}
+
 abstract production orderingDcl
-top::DclInfo ::= inh::String syn::String
+top::DclInfo ::= inh::String keySyn::String syn::String
 {
   top.fullName = syn;
 
@@ -95,7 +110,7 @@ top::DclInfo ::= inh::String syn::String
   top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
   top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
-  top.propagateDispatcher = propagateOrdering(inh, _, location=_);
+  top.propagateDispatcher = propagateOrdering(inh, keySyn, _, location=_);
 }
 
 abstract production unificationInhDcl

--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -53,7 +53,7 @@ top::DclInfo ::= fn::String bound::[TyVar] ty::Type empty::Expr append::Operatio
   top.propagateDispatcher = propagateMonoid(_, location=_);
 }
 
-abstract production equalityInhDcl
+abstract production destructDcl
 top::DclInfo ::= fn::String tyVar::TyVar
 {
   top.fullName = fn;
@@ -65,7 +65,7 @@ top::DclInfo ::= fn::String tyVar::TyVar
   top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _); -- TODO: should probably be an error handler! access inh from undecorated?
   top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_); -- Allow normal inh equations
   top.attributionDispatcher = functorAttributionDcl(_, _, _, _, location=_); -- Same as functor
-  top.propagateDispatcher = propagateEqualityInh(_, location=_);
+  top.propagateDispatcher = propagateDestruct(_, location=_);
 }
 
 abstract production equalitySynDcl
@@ -80,7 +80,7 @@ top::DclInfo ::= inh::String syn::String
   top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
   top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
-  top.propagateDispatcher = propagateEqualitySyn(inh, _, location=_);
+  top.propagateDispatcher = propagateEquality(inh, _, location=_);
 }
 
 abstract production unificationInhDcl
@@ -95,7 +95,7 @@ top::DclInfo ::= fn::String tyVar::TyVar inhs::[String]
   top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _); -- TODO: should probably be an error handler! access inh from undecorated?
   top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_); -- Allow normal inh equations
   top.attributionDispatcher = unificationInhAttributionDcl(_, _, _, _, location=_); -- Same as functor, except decorated
-  top.propagateDispatcher = propagateEqualityInh(_, location=_);
+  top.propagateDispatcher = propagateDestruct(_, location=_);
 }
 
 abstract production unificationSynPartialDcl

--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -115,22 +115,7 @@ top::DclInfo ::= inh::String keySyn::String syn::String
   top.propagateDispatcher = propagateOrdering(inh, keySyn, _, location=_);
 }
 
-abstract production unificationInhDcl
-top::DclInfo ::= fn::String tyVar::TyVar inhs::[String]
-{
-  top.fullName = fn;
-
-  top.typeScheme = polyType([tyVar], decoratedType(varType(tyVar), inhSetType(sort(nub(fn :: inhs)))));
-  top.isInherited = true;
-  
-  top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
-  top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _); -- TODO: should probably be an error handler! access inh from undecorated?
-  top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_); -- Allow normal inh equations
-  top.attributionDispatcher = unificationInhAttributionDcl(_, _, _, _, location=_); -- Same as functor, except decorated
-  top.propagateDispatcher = propagateDestruct(_, location=_);
-}
-
-abstract production unificationSynPartialDcl
+abstract production unificationPartialDcl
 top::DclInfo ::= inh::String synPartial::String syn::String
 {
   top.fullName = synPartial;
@@ -145,7 +130,7 @@ top::DclInfo ::= inh::String synPartial::String syn::String
   top.propagateDispatcher = propagateUnificationSynPartial(inh, _, syn, location=_);
 }
 
-abstract production unificationSynDcl
+abstract production unificationDcl
 top::DclInfo ::= inh::String synPartial::String syn::String
 {
   top.fullName = syn;

--- a/grammars/silver/compiler/extension/autoattr/Destruct.sv
+++ b/grammars/silver/compiler/extension/autoattr/Destruct.sv
@@ -1,9 +1,9 @@
 grammar silver:compiler:extension:autoattr;
 
 concrete production destructAttributeDcl
-top::AGDcl ::= 'destruct' 'attribute' inh::Name ';'
+top::AGDcl ::= 'destruct' 'attribute' inh::Name 'with' i::TypeExpr ';'
 {
-  top.unparse = s"destruct attribute ${inh.unparse};";
+  top.unparse = s"destruct attribute ${inh.unparse} with ${i.unparse};";
   top.moduleNames := [];
 
   production attribute inhFName :: String;
@@ -13,10 +13,11 @@ top::AGDcl ::= 'destruct' 'attribute' inh::Name ';'
     if length(getAttrDclAll(inhFName, top.env)) > 1
     then [err(inh.location, "Attribute '" ++ inhFName ++ "' is already bound.")]
     else [];
+  top.errors <- i.errors;
   
   forwards to
     defsAGDcl(
-      [attrDef(defaultEnvItem(destructDcl(inhFName, freshTyVar(starKind()), sourceGrammar=top.grammarName, sourceLocation=inh.location)))],
+      [attrDef(defaultEnvItem(destructDcl(inhFName, i.typerep.inhSetMembers, sourceGrammar=top.grammarName, sourceLocation=inh.location)))],
       location=top.location);
 }
 

--- a/grammars/silver/compiler/extension/autoattr/Destruct.sv
+++ b/grammars/silver/compiler/extension/autoattr/Destruct.sv
@@ -1,0 +1,67 @@
+grammar silver:compiler:extension:autoattr;
+
+concrete production destructAttributeDcl
+top::AGDcl ::= 'destruct' 'attribute' inh::Name ';'
+{
+  top.unparse = s"destruct attribute ${inh.unparse};";
+  top.moduleNames := [];
+
+  production attribute inhFName :: String;
+  inhFName = top.grammarName ++ ":" ++ inh.name;
+  
+  top.errors <-
+    if length(getAttrDclAll(inhFName, top.env)) > 1
+    then [err(inh.location, "Attribute '" ++ inhFName ++ "' is already bound.")]
+    else [];
+  
+  forwards to
+    defsAGDcl(
+      [attrDef(defaultEnvItem(destructDcl(inhFName, freshTyVar(starKind()), sourceGrammar=top.grammarName, sourceLocation=inh.location)))],
+      location=top.location);
+}
+
+{--
+ - Propagate a destruct inherited attribute on the enclosing production
+ - @param attr  The name of the attribute to propagate
+ -}
+abstract production propagateDestruct
+top::ProductionStmt ::= attr::Decorated QName
+{
+  top.unparse = s"propagate ${attr.unparse};";
+  
+  local numChildren::Integer = length(top.frame.signature.inputElements);
+  forwards to
+    foldr(
+      productionStmtAppend(_, _, location=top.location),
+      errorProductionStmt([], location=top.location), -- No emptyProductionStmt?
+      map(
+        \ ie::Pair<Integer NamedSignatureElement> ->
+          Silver_ProductionStmt {
+            $name{ie.snd.elementName}.$QName{new(attr)} =
+              case $name{top.frame.signature.outputElement.elementName}.$QName{new(attr)} of
+              | $Pattern{
+                  prodAppPattern(
+                    qName(top.location, top.frame.signature.fullName),
+                    '(',
+                    foldr(
+                      patternList_more(_, ',', _, location=top.location),
+                      patternList_nil(location=top.location),
+                      repeat(wildcPattern('_', location=top.location), ie.fst) ++
+                      Silver_Pattern { a } ::
+                      repeat(wildcPattern('_', location=top.location), numChildren - (ie.fst + 1)) ),
+                    ')',
+                    location=top.location)} -> a
+              | a ->
+                error(
+                  "Destruct attribute " ++ $Expr{stringConst(terminal(String_t, s"\"${attr.name}\"", top.location), location=top.location)} ++
+                  " demanded on child " ++ $Expr{stringConst(terminal(String_t, s"\"${ie.snd.elementName}\"", top.location), location=top.location)} ++
+                  " of production " ++ $Expr{stringConst(terminal(String_t, s"\"${top.frame.signature.fullName}\"", top.location), location=top.location)} ++
+                  " when given value " ++ silver:core:hackUnparse(a) ++ " does not match.")
+              end;
+          },
+        filter(
+          \ ie::Pair<Integer NamedSignatureElement> ->
+            !null(getOccursDcl(attr.lookupAttribute.dcl.fullName, ie.snd.typerep.typeName, top.env)),
+          zipWith(pair, range(0, numChildren), top.frame.signature.inputElements))));
+}
+

--- a/grammars/silver/compiler/extension/autoattr/Equality.sv
+++ b/grammars/silver/compiler/extension/autoattr/Equality.sv
@@ -1,13 +1,13 @@
 grammar silver:compiler:extension:autoattr;
 
 concrete production equalityAttributeDcl
-top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::Name ';'
+top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::QName ';'
 {
   top.unparse = s"equality attribute ${syn.unparse} with ${inh.unparse};";
   top.moduleNames := [];
 
   production attribute inhFName :: String;
-  inhFName = top.grammarName ++ ":" ++ inh.name;
+  inhFName = inh.lookupAttribute.fullName;
   production attribute synFName :: String;
   synFName = top.grammarName ++ ":" ++ syn.name;
   

--- a/grammars/silver/compiler/extension/autoattr/Equality.sv
+++ b/grammars/silver/compiler/extension/autoattr/Equality.sv
@@ -1,9 +1,9 @@
 grammar silver:compiler:extension:autoattr;
 
 concrete production equalityAttributeDcl
-top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
+top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::Name ';'
 {
-  top.unparse = s"equality attribute ${inh.unparse}, ${syn.unparse};";
+  top.unparse = s"equality attribute ${syn.unparse} with ${inh.unparse};";
   top.moduleNames := [];
 
   production attribute inhFName :: String;
@@ -12,71 +12,21 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
   synFName = top.grammarName ++ ":" ++ syn.name;
   
   top.errors <-
-    if length(getAttrDclAll(inhFName, top.env)) > 1
-    then [err(inh.location, "Attribute '" ++ inhFName ++ "' is already bound.")]
-    else [];
-  top.errors <-
     if length(getAttrDclAll(synFName, top.env)) > 1
     then [err(syn.location, "Attribute '" ++ synFName ++ "' is already bound.")]
     else [];
   
   forwards to
     defsAGDcl(
-      [attrDef(defaultEnvItem(equalityInhDcl(inhFName, freshTyVar(starKind()), sourceGrammar=top.grammarName, sourceLocation=inh.location))),
-       attrDef(defaultEnvItem(equalitySynDcl(inhFName, synFName, sourceGrammar=top.grammarName, sourceLocation=syn.location)))],
+      [attrDef(defaultEnvItem(equalitySynDcl(inhFName, synFName, sourceGrammar=top.grammarName, sourceLocation=syn.location)))],
       location=top.location);
-}
-
-{--
- - Propagate a equality inherited attribute on the enclosing production
- - @param attr  The name of the attribute to propagate
- -}
-abstract production propagateEqualityInh
-top::ProductionStmt ::= attr::Decorated QName
-{
-  top.unparse = s"propagate ${attr.unparse};";
-  
-  local numChildren::Integer = length(top.frame.signature.inputElements);
-  forwards to
-    foldr(
-      productionStmtAppend(_, _, location=top.location),
-      errorProductionStmt([], location=top.location), -- No emptyProductionStmt?
-      map(
-        \ ie::Pair<Integer NamedSignatureElement> ->
-          Silver_ProductionStmt {
-            $name{ie.snd.elementName}.$QName{new(attr)} =
-              case $name{top.frame.signature.outputElement.elementName}.$QName{new(attr)} of
-              | $Pattern{
-                  prodAppPattern(
-                    qName(top.location, top.frame.signature.fullName),
-                    '(',
-                    foldr(
-                      patternList_more(_, ',', _, location=top.location),
-                      patternList_nil(location=top.location),
-                      repeat(wildcPattern('_', location=top.location), ie.fst) ++
-                      Silver_Pattern { a } ::
-                      repeat(wildcPattern('_', location=top.location), numChildren - (ie.fst + 1)) ),
-                    ')',
-                    location=top.location)} -> a
-              | a ->
-                error(
-                  "Attribute " ++ $Expr{stringConst(terminal(String_t, s"\"${attr.name}\"", top.location), location=top.location)} ++
-                  " demanded on child " ++ $Expr{stringConst(terminal(String_t, s"\"${ie.snd.elementName}\"", top.location), location=top.location)} ++
-                  " of production " ++ $Expr{stringConst(terminal(String_t, s"\"${top.frame.signature.fullName}\"", top.location), location=top.location)} ++
-                  " when given value " ++ silver:core:hackUnparse(a) ++ " does not match.")
-              end;
-          },
-        filter(
-          \ ie::Pair<Integer NamedSignatureElement> ->
-            !null(getOccursDcl(attr.lookupAttribute.dcl.fullName, ie.snd.typerep.typeName, top.env)),
-          zipWith(pair, range(0, numChildren), top.frame.signature.inputElements))));
 }
 
 {--
  - Propagate a equality synthesized attribute on the enclosing production
  - @param attr  The name of the attribute to propagate
  -}
-abstract production propagateEqualitySyn
+abstract production propagateEquality
 top::ProductionStmt ::= inh::String syn::Decorated QName
 {
   top.unparse = s"propagate ${syn.unparse};";

--- a/grammars/silver/compiler/extension/autoattr/Functor.sv
+++ b/grammars/silver/compiler/extension/autoattr/Functor.sv
@@ -16,7 +16,7 @@ top::AGDcl ::= 'functor' 'attribute' a::Name ';'
   
   forwards to
     defsAGDcl(
-      [attrDef(defaultEnvItem(functorDcl(fName, freshTyVar(starKind()), sourceGrammar=top.grammarName, sourceLocation=a.location)))],
+      [attrDef(defaultEnvItem(functorDcl(fName, sourceGrammar=top.grammarName, sourceLocation=a.location)))],
       location=top.location);
 }
 

--- a/grammars/silver/compiler/extension/autoattr/Terminals.sv
+++ b/grammars/silver/compiler/extension/autoattr/Terminals.sv
@@ -8,5 +8,6 @@ terminal Functor_kwd     'functor'     lexer classes {KEYWORD};
 terminal Monoid_kwd      'monoid'      lexer classes {KEYWORD};
 terminal Destruct_kwd    'destruct'    lexer classes {KEYWORD};
 terminal Equality_kwd    'equality'    lexer classes {KEYWORD};
+terminal Ordering_kwd    'ordering'    lexer classes {KEYWORD};
 terminal Unification_kwd 'unification' lexer classes {KEYWORD};
 terminal Threaded_kwd    'threaded'    lexer classes {KEYWORD};

--- a/grammars/silver/compiler/extension/autoattr/Terminals.sv
+++ b/grammars/silver/compiler/extension/autoattr/Terminals.sv
@@ -6,6 +6,7 @@ terminal Thread_kwd    'thread'    lexer classes {KEYWORD,RESERVED};
 
 terminal Functor_kwd     'functor'     lexer classes {KEYWORD};
 terminal Monoid_kwd      'monoid'      lexer classes {KEYWORD};
+terminal Destruct_kwd    'destruct'    lexer classes {KEYWORD};
 terminal Equality_kwd    'equality'    lexer classes {KEYWORD};
 terminal Unification_kwd 'unification' lexer classes {KEYWORD};
 terminal Threaded_kwd    'threaded'    lexer classes {KEYWORD};

--- a/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
@@ -54,7 +54,7 @@ top::AGDcl ::= 'destruct' 'attribute' a::Name 'occurs' 'on' qs::QNames ';'
 }
 
 concrete production equalityAttributeDclMultiple
-top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::Name 'occurs' 'on' qs::QNames ';'
+top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::QName 'occurs' 'on' qs::QNames ';'
 {
   top.unparse = "equality attribute " ++ syn.name ++ " with " ++ inh.unparse ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
@@ -65,12 +65,12 @@ top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::Name 'occurs' 'on' q
 }
 
 concrete production orderingAttributeDclMultiple
-top::AGDcl ::= 'ordering' 'attribute' syn::Name 'with' inh::Name 'occurs' 'on' qs::QNames ';'
+top::AGDcl ::= 'ordering' 'attribute' keySyn::Name ',' syn::Name 'with' inh::QName 'occurs' 'on' qs::QNames ';'
 {
-  top.unparse = "ordering attribute " ++ syn.name ++ " with " ++ inh.unparse ++ " occurs on " ++ qs.unparse ++ ";";
+  top.unparse = "ordering attribute " ++ keySyn.name ++ ", " ++ syn.name ++ " with " ++ inh.unparse ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      orderingAttributeDcl($1, $2, syn, $4, inh, $9, location=top.location),
+      orderingAttributeDcl($1, $2, keySyn, $4, syn, $6, inh, $11, location=top.location),
       makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
       location=top.location);
 }
@@ -83,7 +83,7 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
   forwards to
     appendAGDcl(
       destructAttributeDcl('destruct', $2, inh, $6, location=top.location),
-      equalityAttributeDcl($1, $2, syn, 'with', inh, $6, location=top.location),
+      equalityAttributeDcl($1, $2, syn, 'with', qNameId(inh, location=top.location), $6, location=top.location),
       location=top.location);
 }
 concrete production destructEqualityAttributeDclMultiple
@@ -93,27 +93,27 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name 'occurs' 'on' qs::
   forwards to
     appendAGDcl(
       destructAttributeDclMultiple('destruct', $2, inh, $6, $7, qs, $9, location=top.location),
-      equalityAttributeDclMultiple($1, $2, syn, 'with', inh, $6, $7, qs, $9, location=top.location),
+      equalityAttributeDclMultiple($1, $2, syn, 'with', qNameId(inh, location=top.location), $6, $7, qs, $9, location=top.location),
       location=top.location);
 }
 concrete production destructOrderingAttributeDcl
-top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' syn::Name ';'
+top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' keySyn::Name ',' syn::Name ';'
 {
-  top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ syn.name ++ ";";
+  top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ keySyn.name ++ ", " ++ syn.name ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDcl('destruct', $2, inh, $6, location=top.location),
-      orderingAttributeDcl($1, $2, syn, 'with', inh, $6, location=top.location),
+      destructAttributeDcl('destruct', $2, inh, $8, location=top.location),
+      orderingAttributeDcl($1, $2, keySyn, $6, syn, 'with', qNameId(inh, location=top.location), $8, location=top.location),
       location=top.location);
 }
 concrete production destructOrderingAttributeDclMultiple
-top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' syn::Name 'occurs' 'on' qs::QNames ';'
+top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' keySyn::Name ',' syn::Name 'occurs' 'on' qs::QNames ';'
 {
-  top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
+  top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ keySyn.name ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDclMultiple('destruct', $2, inh, $6, $7, qs, $9, location=top.location),
-      orderingAttributeDclMultiple($1, $2, syn, 'with', inh, $6, $7, qs, $9, location=top.location),
+      destructAttributeDclMultiple('destruct', $2, inh, $8, $9, qs, $11, location=top.location),
+      orderingAttributeDclMultiple($1, $2, keySyn, $6, syn, 'with', qNameId(inh, location=top.location), $8, $9, qs, $11, location=top.location),
       location=top.location);
 }
 

--- a/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
@@ -71,7 +71,10 @@ top::AGDcl ::= 'ordering' 'attribute' keySyn::Name ',' syn::Name 'with' inh::QNa
   forwards to
     appendAGDcl(
       orderingAttributeDcl($1, $2, keySyn, $4, syn, $6, inh, $11, location=top.location),
-      makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
+      appendAGDcl(
+        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(keySyn, location=syn.location), botlNone(location=top.location)), qs.qnames),
+        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
+        location=top.location),
       location=top.location);
 }
 
@@ -118,18 +121,15 @@ top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' keySyn::Name ',' syn::Name '
 }
 
 concrete production unificationAttributeDclMultiple
-top::AGDcl ::= 'unification' 'attribute' inh::Name i::TypeExpr ',' synPartial::Name ',' syn::Name 'occurs' 'on' qs::QNames ';'
+top::AGDcl ::= 'unification' 'attribute' synPartial::Name ',' syn::Name 'with' inh::QName 'occurs' 'on' qs::QNames ';'
 {
-  top.unparse = "equality attribute " ++ inh.unparse ++ " " ++ i.unparse ++ ", " ++ synPartial.name ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
+  top.unparse = "unification attribute " ++ synPartial.name ++ ", " ++ syn.name ++ " with " ++ inh.unparse ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      unificationAttributeDcl($1, $2, inh, i, $5, syn, $7, synPartial, $12, location=top.location),
+      unificationAttributeDcl($1, $2, synPartial, ',', syn, 'with', inh, ';', location=top.location),
       appendAGDcl(
-        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(inh, location=inh.location), botlNone(location=top.location)), qs.qnames),
-        appendAGDcl(
-          makeOccursDclsHelp($1.location, qNameWithTL(qNameId(synPartial, location=synPartial.location), botlNone(location=top.location)), qs.qnames),
-          makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
-          location=top.location),
+        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(synPartial, location=synPartial.location), botlNone(location=top.location)), qs.qnames),
+        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
         location=top.location),
       location=top.location);
 }

--- a/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
@@ -42,17 +42,47 @@ top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::T
       location=top.location);
 }
 
+concrete production destructAttributeDclMultiple
+top::AGDcl ::= 'destruct' 'attribute' a::Name 'occurs' 'on' qs::QNames ';'
+{
+  top.unparse = "destruct attribute " ++ a.name ++ " occurs on " ++ qs.unparse ++ ";";
+  forwards to
+    appendAGDcl(
+      destructAttributeDcl($1, $2, a, $7, location=a.location),
+      makeOccursDclsHelp($1.location, qNameWithTL(qNameId(a, location=a.location), botlNone(location=top.location)), qs.qnames),
+      location=top.location);
+}
+
 concrete production equalityAttributeDclMultiple
+top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::Name 'occurs' 'on' qs::QNames ';'
+{
+  top.unparse = "equality attribute " ++ syn.name ++ " with " ++ inh.unparse ++ " occurs on " ++ qs.unparse ++ ";";
+  forwards to
+    appendAGDcl(
+      equalityAttributeDcl($1, $2, syn, $4, inh, $9, location=top.location),
+      makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
+      location=top.location);
+}
+
+-- Deprecate?  Eric suggested keeping this: https://github.com/melt-umn/silver/issues/431#issuecomment-760552226
+concrete production destructEqualityAttributeDcl
+top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
+{
+  top.unparse = "equality attribute " ++ inh.unparse ++ ", " ++ syn.name ++ ";";
+  forwards to
+    appendAGDcl(
+      destructAttributeDcl('destruct', $2, inh, $6, location=top.location),
+      equalityAttributeDcl($1, $2, syn, 'with', inh, $6, location=top.location),
+      location=top.location);
+}
+concrete production destructEqualityAttributeDclMultiple
 top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name 'occurs' 'on' qs::QNames ';'
 {
   top.unparse = "equality attribute " ++ inh.unparse ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      equalityAttributeDcl($1, $2, inh, $4, syn, $9, location=top.location),
-      appendAGDcl(
-        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(inh, location=inh.location), botlNone(location=top.location)), qs.qnames),
-        makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
-        location=top.location),
+      destructAttributeDclMultiple('destruct', $2, inh, $6, $7, qs, $9, location=top.location),
+      equalityAttributeDclMultiple($1, $2, syn, 'with', inh, $6, $7, qs, $9, location=top.location),
       location=top.location);
 }
 

--- a/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
@@ -43,12 +43,12 @@ top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::T
 }
 
 concrete production destructAttributeDclMultiple
-top::AGDcl ::= 'destruct' 'attribute' a::Name 'occurs' 'on' qs::QNames ';'
+top::AGDcl ::= 'destruct' 'attribute' a::Name 'with' i::TypeExpr 'occurs' 'on' qs::QNames ';'
 {
   top.unparse = "destruct attribute " ++ a.name ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDcl($1, $2, a, $7, location=a.location),
+      destructAttributeDcl($1, $2, a, $4, i, $9, location=a.location),
       makeOccursDclsHelp($1.location, qNameWithTL(qNameId(a, location=a.location), botlNone(location=top.location)), qs.qnames),
       location=top.location);
 }
@@ -82,7 +82,7 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
   top.unparse = "equality attribute " ++ inh.unparse ++ ", " ++ syn.name ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDcl('destruct', $2, inh, $6, location=top.location),
+      destructAttributeDcl('destruct', $2, inh, 'with', typerepTypeExpr(inhSetType([]), location=top.location), $6, location=top.location),
       equalityAttributeDcl($1, $2, syn, 'with', qNameId(inh, location=top.location), $6, location=top.location),
       location=top.location);
 }
@@ -92,7 +92,7 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name 'occurs' 'on' qs::
   top.unparse = "equality attribute " ++ inh.unparse ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDclMultiple('destruct', $2, inh, $6, $7, qs, $9, location=top.location),
+      destructAttributeDclMultiple('destruct', $2, inh, 'with', typerepTypeExpr(inhSetType([]), location=top.location), $6, $7, qs, $9, location=top.location),
       equalityAttributeDclMultiple($1, $2, syn, 'with', qNameId(inh, location=top.location), $6, $7, qs, $9, location=top.location),
       location=top.location);
 }
@@ -102,7 +102,7 @@ top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' keySyn::Name ',' syn::Name '
   top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ keySyn.name ++ ", " ++ syn.name ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDcl('destruct', $2, inh, $8, location=top.location),
+      destructAttributeDcl('destruct', $2, inh, 'with', typerepTypeExpr(inhSetType([]), location=top.location), $8, location=top.location),
       orderingAttributeDcl($1, $2, keySyn, $6, syn, 'with', qNameId(inh, location=top.location), $8, location=top.location),
       location=top.location);
 }
@@ -112,7 +112,7 @@ top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' keySyn::Name ',' syn::Name '
   top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ keySyn.name ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDclMultiple('destruct', $2, inh, $8, $9, qs, $11, location=top.location),
+      destructAttributeDclMultiple('destruct', $2, inh, 'with', typerepTypeExpr(inhSetType([]), location=top.location), $8, $9, qs, $11, location=top.location),
       orderingAttributeDclMultiple($1, $2, keySyn, $6, syn, 'with', qNameId(inh, location=top.location), $8, $9, qs, $11, location=top.location),
       location=top.location);
 }

--- a/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
@@ -43,12 +43,12 @@ top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::T
 }
 
 concrete production destructAttributeDclMultiple
-top::AGDcl ::= 'destruct' 'attribute' a::Name 'with' i::TypeExpr 'occurs' 'on' qs::QNames ';'
+top::AGDcl ::= 'destruct' 'attribute' a::Name 'occurs' 'on' qs::QNames ';'
 {
   top.unparse = "destruct attribute " ++ a.name ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDcl($1, $2, a, $4, i, $9, location=a.location),
+      destructAttributeDcl($1, $2, a, ';', location=a.location),
       makeOccursDclsHelp($1.location, qNameWithTL(qNameId(a, location=a.location), botlNone(location=top.location)), qs.qnames),
       location=top.location);
 }
@@ -85,7 +85,7 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
   top.unparse = "equality attribute " ++ inh.unparse ++ ", " ++ syn.name ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDcl('destruct', $2, inh, 'with', typerepTypeExpr(inhSetType([]), location=top.location), $6, location=top.location),
+      destructAttributeDcl('destruct', $2, inh, $6, location=top.location),
       equalityAttributeDcl($1, $2, syn, 'with', qNameId(inh, location=top.location), $6, location=top.location),
       location=top.location);
 }
@@ -95,7 +95,7 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name 'occurs' 'on' qs::
   top.unparse = "equality attribute " ++ inh.unparse ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDclMultiple('destruct', $2, inh, 'with', typerepTypeExpr(inhSetType([]), location=top.location), $6, $7, qs, $9, location=top.location),
+      destructAttributeDclMultiple('destruct', $2, inh, $6, $7, qs, $9, location=top.location),
       equalityAttributeDclMultiple($1, $2, syn, 'with', qNameId(inh, location=top.location), $6, $7, qs, $9, location=top.location),
       location=top.location);
 }
@@ -105,7 +105,7 @@ top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' keySyn::Name ',' syn::Name '
   top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ keySyn.name ++ ", " ++ syn.name ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDcl('destruct', $2, inh, 'with', typerepTypeExpr(inhSetType([]), location=top.location), $8, location=top.location),
+      destructAttributeDcl('destruct', $2, inh, $8, location=top.location),
       orderingAttributeDcl($1, $2, keySyn, $6, syn, 'with', qNameId(inh, location=top.location), $8, location=top.location),
       location=top.location);
 }
@@ -115,7 +115,7 @@ top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' keySyn::Name ',' syn::Name '
   top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ keySyn.name ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      destructAttributeDclMultiple('destruct', $2, inh, 'with', typerepTypeExpr(inhSetType([]), location=top.location), $8, $9, qs, $11, location=top.location),
+      destructAttributeDclMultiple('destruct', $2, inh, $8, $9, qs, $11, location=top.location),
       orderingAttributeDclMultiple($1, $2, keySyn, $6, syn, 'with', qNameId(inh, location=top.location), $8, $9, qs, $11, location=top.location),
       location=top.location);
 }

--- a/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
@@ -64,6 +64,17 @@ top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::Name 'occurs' 'on' q
       location=top.location);
 }
 
+concrete production orderingAttributeDclMultiple
+top::AGDcl ::= 'ordering' 'attribute' syn::Name 'with' inh::Name 'occurs' 'on' qs::QNames ';'
+{
+  top.unparse = "ordering attribute " ++ syn.name ++ " with " ++ inh.unparse ++ " occurs on " ++ qs.unparse ++ ";";
+  forwards to
+    appendAGDcl(
+      orderingAttributeDcl($1, $2, syn, $4, inh, $9, location=top.location),
+      makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),
+      location=top.location);
+}
+
 -- Deprecate?  Eric suggested keeping this: https://github.com/melt-umn/silver/issues/431#issuecomment-760552226
 concrete production destructEqualityAttributeDcl
 top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
@@ -83,6 +94,26 @@ top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name 'occurs' 'on' qs::
     appendAGDcl(
       destructAttributeDclMultiple('destruct', $2, inh, $6, $7, qs, $9, location=top.location),
       equalityAttributeDclMultiple($1, $2, syn, 'with', inh, $6, $7, qs, $9, location=top.location),
+      location=top.location);
+}
+concrete production destructOrderingAttributeDcl
+top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' syn::Name ';'
+{
+  top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ syn.name ++ ";";
+  forwards to
+    appendAGDcl(
+      destructAttributeDcl('destruct', $2, inh, $6, location=top.location),
+      orderingAttributeDcl($1, $2, syn, 'with', inh, $6, location=top.location),
+      location=top.location);
+}
+concrete production destructOrderingAttributeDclMultiple
+top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' syn::Name 'occurs' 'on' qs::QNames ';'
+{
+  top.unparse = "ordering attribute " ++ inh.unparse ++ ", " ++ syn.name ++ " occurs on " ++ qs.unparse ++ ";";
+  forwards to
+    appendAGDcl(
+      destructAttributeDclMultiple('destruct', $2, inh, $6, $7, qs, $9, location=top.location),
+      orderingAttributeDclMultiple($1, $2, syn, 'with', inh, $6, $7, qs, $9, location=top.location),
       location=top.location);
 }
 

--- a/grammars/silver/compiler/extension/doc/core/AGDcl.sv
+++ b/grammars/silver/compiler/extension/doc/core/AGDcl.sv
@@ -123,11 +123,20 @@ top::AGDcl ::= 'annotation' a::QName tl::BracketedOptTypeExprs '::' te::TypeExpr
 }
 
 aspect production equalityAttributeDcl
-top::AGDcl ::= 'equality' 'attribute' inh::Name ',' syn::Name ';'
+top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::QName ';'
 {
-  top.docForName = inh.name++" and "++syn.name++" (equality pair)";
-  top.docUnparse = s"`equality attribute ${inh.name}, ${syn.name}`";
-  top.docDcls := [pair(inh.name, docDclInfo(inh.name, top.location, top.grammarName)),
+  top.docForName = syn.name;
+  top.docUnparse = s"`equality attribute ${syn.name} with ${inh.name}`";
+  top.docDcls := [pair(syn.name, docDclInfo(syn.name, top.location, top.grammarName))];
+  top.docs := [mkUndocumentedItem(top.docForName, top)];
+}
+
+aspect production orderingAttributeDcl
+top::AGDcl ::= 'ordering' 'attribute' keySyn::Name ',' syn::Name 'with' inh::QName ';'
+{
+  top.docForName = keySyn.name++" and "++syn.name++" (ordering pair)";
+  top.docUnparse = s"`ordering attribute ${keySyn.name}, ${syn.name} with ${inh.name}`";
+  top.docDcls := [pair(keySyn.name, docDclInfo(keySyn.name, top.location, top.grammarName)),
                   pair(syn.name, docDclInfo(syn.name, top.location, top.grammarName))];
   top.docs := [mkUndocumentedItem(top.docForName, top)];
 }

--- a/grammars/silver/core/Eq.sv
+++ b/grammars/silver/core/Eq.sv
@@ -32,6 +32,11 @@ instance attribute compareTo<a> occurs on a,
   eq = \ x::a y::a -> decorate x with {compareTo = decorate y with {};}.isEqual;
 }
 
+instance typeError "Equality is not supported for Decorated types"
+         => Eq Decorated a with i {
+  eq = error("type error");
+}
+
 instance Eq Integer {
   eq = eqInteger;
   neq = neqInteger;

--- a/grammars/silver/core/Eq.sv
+++ b/grammars/silver/core/Eq.sv
@@ -23,10 +23,15 @@ class Eq a {
   neq :: (Boolean ::= a a) = \ x::a y::a -> !(x == y);
 }
 
-equality attribute isEqualTo, isEqual;
+equality attribute compareTo, isEqual;
+{-
+destruct attribute compareTo;
+equality attribute isEqual with compareTo;
+-}
+
 {- TODO: once we have occurence constraints...
-instance isEqual {isEqualTo} occurs on a => Eq a {
-  eq = \ x::a y::a -> decorate x with {isEqualTo = y;}.isEqual;
+instance isEqual {compareTo} occurs on a => Eq a {
+  eq = \ x::a y::a -> decorate x with {compareTo = y;}.isEqual;
 }
 Do something similar for Ord.
 -}

--- a/grammars/silver/core/Eq.sv
+++ b/grammars/silver/core/Eq.sv
@@ -23,18 +23,14 @@ class Eq a {
   neq :: (Boolean ::= a a) = \ x::a y::a -> !(x == y);
 }
 
-equality attribute compareTo, isEqual;
-{-
-destruct attribute compareTo;
+destruct attribute compareTo with {};
 equality attribute isEqual with compareTo;
--}
 
-{- TODO: once we have occurence constraints...
-instance isEqual {compareTo} occurs on a => Eq a {
-  eq = \ x::a y::a -> decorate x with {compareTo = y;}.isEqual;
+instance attribute compareTo<a> occurs on a,
+         attribute isEqual {compareTo} occurs on a
+         => Eq a {
+  eq = \ x::a y::a -> decorate x with {compareTo = decorate y with {};}.isEqual;
 }
-Do something similar for Ord.
--}
 
 instance Eq Integer {
   eq = eqInteger;

--- a/grammars/silver/core/Eq.sv
+++ b/grammars/silver/core/Eq.sv
@@ -23,10 +23,10 @@ class Eq a {
   neq :: (Boolean ::= a a) = \ x::a y::a -> !(x == y);
 }
 
-destruct attribute compareTo with {};
+destruct attribute compareTo;
 equality attribute isEqual with compareTo;
 
-instance attribute compareTo<a> occurs on a,
+instance attribute compareTo<a {}> occurs on a,
          attribute isEqual {compareTo} occurs on a
          => Eq a {
   eq = \ x::a y::a -> decorate x with {compareTo = decorate y with {};}.isEqual;

--- a/grammars/silver/core/Ord.sv
+++ b/grammars/silver/core/Ord.sv
@@ -39,8 +39,6 @@ class Eq a => Ord a {
   min :: (a ::= a a) = \ x::a y::a -> if x >= y then y else x;
 }
 
-ordering attribute compare with compareTo;
-
 instance Ord Integer {
   compare = \ x::Integer y::Integer -> x - y;
   lt = ltInteger;

--- a/grammars/silver/core/Ord.sv
+++ b/grammars/silver/core/Ord.sv
@@ -39,6 +39,8 @@ class Eq a => Ord a {
   min :: (a ::= a a) = \ x::a y::a -> if x >= y then y else x;
 }
 
+ordering attribute compare with compareTo;
+
 instance Ord Integer {
   compare = \ x::Integer y::Integer -> x - y;
   lt = ltInteger;

--- a/grammars/silver/core/Ord.sv
+++ b/grammars/silver/core/Ord.sv
@@ -41,7 +41,7 @@ class Eq a => Ord a {
 
 ordering attribute compareKey, compare with compareTo;
 
-instance attribute compareTo<a> occurs on a,
+instance attribute compareTo<a {}> occurs on a,
          attribute isEqual {compareTo} occurs on a, -- Needed by Eq superclass
          attribute compareKey {compareTo} occurs on a,
          attribute compare {compareTo} occurs on a

--- a/grammars/silver/core/Ord.sv
+++ b/grammars/silver/core/Ord.sv
@@ -39,6 +39,21 @@ class Eq a => Ord a {
   min :: (a ::= a a) = \ x::a y::a -> if x >= y then y else x;
 }
 
+ordering attribute compareKey, compare with compareTo;
+
+instance attribute compareTo<a> occurs on a,
+         attribute isEqual {compareTo} occurs on a, -- Needed by Eq superclass
+         attribute compareKey {compareTo} occurs on a,
+         attribute compare {compareTo} occurs on a
+         => Ord a {
+  compare = \ x::a y::a -> decorate x with {compareTo = decorate y with {};}.compare;
+}
+
+instance typeError "Comparison is not supported for Decorated types"
+         => Ord Decorated a with i {
+  compare = error("type error");
+}
+
 instance Ord Integer {
   compare = \ x::Integer y::Integer -> x - y;
   lt = ltInteger;

--- a/grammars/silver/core/Ord.sv
+++ b/grammars/silver/core/Ord.sv
@@ -242,7 +242,7 @@ Boolean ::= x::TerminalId y::TerminalId
 instance Ord a => Ord [a] {
   lte = \ x::[a] y::[a] ->
     case x, y of
-    | h1::t1, h2::t2 -> h1 <= h2 && t1 <= t2
+    | h1::t1, h2::t2 -> if h1 == h2 then t1 <= t2 else h1 < h2
     | [], _ -> true
     | _, _ -> false
     end;

--- a/grammars/silver/regex/AbstractSyntax.sv
+++ b/grammars/silver/regex/AbstractSyntax.sv
@@ -10,9 +10,9 @@ synthesized attribute seqPP::Document;
 synthesized attribute basePP::Document;
 implicit synthesized attribute classPP::Maybe<Document>;
 
-nonterminal Regex with pp, altPP, seqPP, basePP, classPP, isEqualTo, isEqual;
+nonterminal Regex with pp, altPP, seqPP, basePP, classPP, compareTo, isEqual;
 
-propagate isEqual, isEqualTo on Regex;
+propagate isEqual, compareTo on Regex;
 
 aspect default production
 top::Regex ::=

--- a/grammars/silver/regex/Matching.sv
+++ b/grammars/silver/regex/Matching.sv
@@ -17,7 +17,7 @@ strategy attribute simpl =
     | alt(r, empty()) -> r
     | alt(epsilon(), r) when r.nullable -> r
     | alt(r, epsilon()) when r.nullable -> r
-    | alt(r1, r2) when decorate r1 with { compareTo = r2; }.isEqual -> r1
+    | alt(r1, r2) when r1 == r2 -> r1
     | star(empty()) -> epsilon()
     | star(epsilon()) -> epsilon()
     end)

--- a/grammars/silver/regex/Matching.sv
+++ b/grammars/silver/regex/Matching.sv
@@ -17,7 +17,7 @@ strategy attribute simpl =
     | alt(r, empty()) -> r
     | alt(epsilon(), r) when r.nullable -> r
     | alt(r, epsilon()) when r.nullable -> r
-    | alt(r1, r2) when decorate r1 with { isEqualTo = r2; }.isEqual -> r1
+    | alt(r1, r2) when decorate r1 with { compareTo = r2; }.isEqual -> r1
     | star(empty()) -> epsilon()
     | star(epsilon()) -> epsilon()
     end)

--- a/test/flow/OccursContext.sv
+++ b/test/flow/OccursContext.sv
@@ -11,7 +11,7 @@ top::Expr ::=
 { top.isEqual = false; }
 
 function isEqual
-attribute compareTo<a> occurs on a,
+attribute compareTo<a {}> occurs on a,
 attribute isEqual {compareTo} occurs on a =>
 Boolean ::= x::a y::a
 {

--- a/test/flow/OccursContext.sv
+++ b/test/flow/OccursContext.sv
@@ -1,31 +1,31 @@
 grammar flow;
 
-attribute isEqual, isEqualTo occurs on Expr;
-flowtype isEqual {isEqualTo} on Expr;
+attribute isEqual, compareTo occurs on Expr;
+flowtype isEqual {compareTo} on Expr;
 aspect production zero top::Expr ::=
-{ propagate isEqual, isEqualTo; }
+{ propagate isEqual, compareTo; }
 aspect production succ top::Expr ::= _
-{ propagate isEqual, isEqualTo; }
+{ propagate isEqual, compareTo; }
 aspect default production
 top::Expr ::=
 { top.isEqual = false; }
 
 function isEqual
-attribute isEqualTo<a> occurs on a,
-attribute isEqual {isEqualTo} occurs on a =>
+attribute compareTo<a> occurs on a,
+attribute isEqual {compareTo} occurs on a =>
 Boolean ::= x::a y::a
 {
-  x.isEqualTo = y;
+  x.compareTo = y;
   return x.isEqual;
 }
 
 warnCode "Equation has transitive dependency on child x's inherited attribute for flow:env1 but this equation appears to be missing." {
 function isEqualBad
-attribute isEqualTo<a> occurs on a,
-attribute isEqual {isEqualTo, env1} occurs on a =>
+attribute compareTo<a> occurs on a,
+attribute isEqual {compareTo, env1} occurs on a =>
 Boolean ::= x::a y::a
 {
-  x.isEqualTo = y;
+  x.compareTo = y;
   return x.isEqual;
 }
 }

--- a/test/silver_features/EqualityAttr.sv
+++ b/test/silver_features/EqualityAttr.sv
@@ -1,30 +1,30 @@
 grammar silver_features;
 
-nonterminal EqExpr with compareTo, isEqual;
+nonterminal EqExpr with compareTo, isEqual, compare;
 
 abstract production addEqExpr
 top::EqExpr ::= e1::EqExpr e2::EqExpr
 {
-  propagate compareTo, isEqual;
+  propagate compareTo, isEqual, compare;
 }
 
 abstract production intEqExpr
 top::EqExpr ::= i::Integer
 {
-  propagate compareTo, isEqual;
+  propagate compareTo, isEqual, compare;
 }
 
 abstract production appEqExpr
 top::EqExpr ::= n::String e::EqExpr
 {
-  propagate compareTo, isEqual;
+  propagate compareTo, isEqual, compare;
 }
 
-{- TODO: This gives an error in generated code
+{- TODO: This should give an error, but the error is in generated code at the moment so we can't test for it
 abstract production polyEqExpr
 Eq a => top::EqExpr ::= x::a
 {
-  propagate compareTo, isEqual;
+  propagate compareTo, isEqual, compare;
 }
 -}
 

--- a/test/silver_features/EqualityAttr.sv
+++ b/test/silver_features/EqualityAttr.sv
@@ -1,30 +1,30 @@
 grammar silver_features;
 
-nonterminal EqExpr with isEqualTo, isEqual;
+nonterminal EqExpr with compareTo, isEqual;
 
 abstract production addEqExpr
 top::EqExpr ::= e1::EqExpr e2::EqExpr
 {
-  propagate isEqualTo, isEqual;
+  propagate compareTo, isEqual;
 }
 
 abstract production intEqExpr
 top::EqExpr ::= i::Integer
 {
-  propagate isEqualTo, isEqual;
+  propagate compareTo, isEqual;
 }
 
 abstract production appEqExpr
 top::EqExpr ::= n::String e::EqExpr
 {
-  propagate isEqualTo, isEqual;
+  propagate compareTo, isEqual;
 }
 
 {- TODO: This gives an error in generated code
 abstract production polyEqExpr
 Eq a => top::EqExpr ::= x::a
 {
-  propagate isEqualTo, isEqual;
+  propagate compareTo, isEqual;
 }
 -}
 
@@ -32,12 +32,12 @@ global ee1::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("abc", intEqExpr(5)));
 global ee2::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("c", intEqExpr(5)));
 global ee3::EqExpr = addEqExpr(appEqExpr("c", intEqExpr(5)), intEqExpr(42));
 
-equalityTest(decorate ee1 with {isEqualTo = ee1;}.isEqual, true, Boolean, silver_tests);
-equalityTest(decorate ee1 with {isEqualTo = ee2;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee1 with {isEqualTo = ee3;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee2 with {isEqualTo = ee1;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee2 with {isEqualTo = ee2;}.isEqual, true, Boolean, silver_tests);
-equalityTest(decorate ee2 with {isEqualTo = ee3;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee3 with {isEqualTo = ee1;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee3 with {isEqualTo = ee2;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee3 with {isEqualTo = ee3;}.isEqual, true, Boolean, silver_tests);
+equalityTest(decorate ee1 with {compareTo = ee1;}.isEqual, true, Boolean, silver_tests);
+equalityTest(decorate ee1 with {compareTo = ee2;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee1 with {compareTo = ee3;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee2 with {compareTo = ee1;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee2 with {compareTo = ee2;}.isEqual, true, Boolean, silver_tests);
+equalityTest(decorate ee2 with {compareTo = ee3;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee3 with {compareTo = ee1;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee3 with {compareTo = ee2;}.isEqual, false, Boolean, silver_tests);
+equalityTest(decorate ee3 with {compareTo = ee3;}.isEqual, true, Boolean, silver_tests);

--- a/test/silver_features/EqualityAttr.sv
+++ b/test/silver_features/EqualityAttr.sv
@@ -1,8 +1,5 @@
 grammar silver_features;
 
--- TODO: Move to silver:core
-ordering attribute compareKey, compare with compareTo;
-
 nonterminal EqExpr with compareTo, isEqual, compareKey, compare;
 
 abstract production addEqExpr
@@ -35,23 +32,22 @@ global ee1::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("abc", intEqExpr(5)));
 global ee2::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("c", intEqExpr(5)));
 global ee3::EqExpr = addEqExpr(appEqExpr("c", intEqExpr(5)), intEqExpr(42));
 
--- TODO: Change to use ==/< operators
-equalityTest(decorate ee1 with {compareTo = ee1;}.isEqual, true, Boolean, silver_tests);
-equalityTest(decorate ee1 with {compareTo = ee2;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee1 with {compareTo = ee3;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee2 with {compareTo = ee1;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee2 with {compareTo = ee2;}.isEqual, true, Boolean, silver_tests);
-equalityTest(decorate ee2 with {compareTo = ee3;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee3 with {compareTo = ee1;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee3 with {compareTo = ee2;}.isEqual, false, Boolean, silver_tests);
-equalityTest(decorate ee3 with {compareTo = ee3;}.isEqual, true, Boolean, silver_tests);
+equalityTest(ee1 == ee1, true, Boolean, silver_tests);
+equalityTest(ee1 == ee2, false, Boolean, silver_tests);
+equalityTest(ee1 == ee3, false, Boolean, silver_tests);
+equalityTest(ee2 == ee1, false, Boolean, silver_tests);
+equalityTest(ee2 == ee2, true, Boolean, silver_tests);
+equalityTest(ee2 == ee3, false, Boolean, silver_tests);
+equalityTest(ee3 == ee1, false, Boolean, silver_tests);
+equalityTest(ee3 == ee2, false, Boolean, silver_tests);
+equalityTest(ee3 == ee3, true, Boolean, silver_tests);
 
-equalityTest(decorate ee1 with {compareTo = ee1;}.compare < 0, false, Boolean, silver_tests);
-equalityTest(decorate ee1 with {compareTo = ee2;}.compare < 0, true, Boolean, silver_tests);
-equalityTest(decorate ee1 with {compareTo = ee3;}.compare < 0, false, Boolean, silver_tests);
-equalityTest(decorate ee2 with {compareTo = ee1;}.compare < 0, false, Boolean, silver_tests);
-equalityTest(decorate ee2 with {compareTo = ee2;}.compare < 0, false, Boolean, silver_tests);
-equalityTest(decorate ee2 with {compareTo = ee3;}.compare < 0, false, Boolean, silver_tests);
-equalityTest(decorate ee3 with {compareTo = ee1;}.compare < 0, true, Boolean, silver_tests);
-equalityTest(decorate ee3 with {compareTo = ee2;}.compare < 0, true, Boolean, silver_tests);
-equalityTest(decorate ee3 with {compareTo = ee3;}.compare < 0, false, Boolean, silver_tests);
+equalityTest(ee1 < ee1, false, Boolean, silver_tests);
+equalityTest(ee1 < ee2, true, Boolean, silver_tests);
+equalityTest(ee1 < ee3, false, Boolean, silver_tests);
+equalityTest(ee2 < ee1, false, Boolean, silver_tests);
+equalityTest(ee2 < ee2, false, Boolean, silver_tests);
+equalityTest(ee2 < ee3, false, Boolean, silver_tests);
+equalityTest(ee3 < ee1, true, Boolean, silver_tests);
+equalityTest(ee3 < ee2, true, Boolean, silver_tests);
+equalityTest(ee3 < ee3, false, Boolean, silver_tests);

--- a/test/silver_features/EqualityAttr.sv
+++ b/test/silver_features/EqualityAttr.sv
@@ -1,23 +1,26 @@
 grammar silver_features;
 
-nonterminal EqExpr with compareTo, isEqual, compare;
+-- TODO: Move to silver:core
+ordering attribute compareKey, compare with compareTo;
+
+nonterminal EqExpr with compareTo, isEqual, compareKey, compare;
 
 abstract production addEqExpr
 top::EqExpr ::= e1::EqExpr e2::EqExpr
 {
-  propagate compareTo, isEqual, compare;
+  propagate compareTo, isEqual, compareKey, compare;
 }
 
 abstract production intEqExpr
 top::EqExpr ::= i::Integer
 {
-  propagate compareTo, isEqual, compare;
+  propagate compareTo, isEqual, compareKey, compare;
 }
 
 abstract production appEqExpr
 top::EqExpr ::= n::String e::EqExpr
 {
-  propagate compareTo, isEqual, compare;
+  propagate compareTo, isEqual, compareKey, compare;
 }
 
 {- TODO: This should give an error, but the error is in generated code at the moment so we can't test for it
@@ -32,6 +35,7 @@ global ee1::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("abc", intEqExpr(5)));
 global ee2::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("c", intEqExpr(5)));
 global ee3::EqExpr = addEqExpr(appEqExpr("c", intEqExpr(5)), intEqExpr(42));
 
+-- TODO: Change to use ==/< operators
 equalityTest(decorate ee1 with {compareTo = ee1;}.isEqual, true, Boolean, silver_tests);
 equalityTest(decorate ee1 with {compareTo = ee2;}.isEqual, false, Boolean, silver_tests);
 equalityTest(decorate ee1 with {compareTo = ee3;}.isEqual, false, Boolean, silver_tests);
@@ -41,3 +45,13 @@ equalityTest(decorate ee2 with {compareTo = ee3;}.isEqual, false, Boolean, silve
 equalityTest(decorate ee3 with {compareTo = ee1;}.isEqual, false, Boolean, silver_tests);
 equalityTest(decorate ee3 with {compareTo = ee2;}.isEqual, false, Boolean, silver_tests);
 equalityTest(decorate ee3 with {compareTo = ee3;}.isEqual, true, Boolean, silver_tests);
+
+equalityTest(decorate ee1 with {compareTo = ee1;}.compare < 0, false, Boolean, silver_tests);
+equalityTest(decorate ee1 with {compareTo = ee2;}.compare < 0, true, Boolean, silver_tests);
+equalityTest(decorate ee1 with {compareTo = ee3;}.compare < 0, false, Boolean, silver_tests);
+equalityTest(decorate ee2 with {compareTo = ee1;}.compare < 0, false, Boolean, silver_tests);
+equalityTest(decorate ee2 with {compareTo = ee2;}.compare < 0, false, Boolean, silver_tests);
+equalityTest(decorate ee2 with {compareTo = ee3;}.compare < 0, false, Boolean, silver_tests);
+equalityTest(decorate ee3 with {compareTo = ee1;}.compare < 0, true, Boolean, silver_tests);
+equalityTest(decorate ee3 with {compareTo = ee2;}.compare < 0, true, Boolean, silver_tests);
+equalityTest(decorate ee3 with {compareTo = ee3;}.compare < 0, false, Boolean, silver_tests);

--- a/test/silver_features/EqualityAttr.sv
+++ b/test/silver_features/EqualityAttr.sv
@@ -28,26 +28,55 @@ Eq a => top::EqExpr ::= x::a
 }
 -}
 
+abstract production seqEqExpr
+top::EqExpr ::= es::[EqExpr]
+{
+  propagate compareTo, isEqual, compareKey, compare;
+}
+
 global ee1::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("abc", intEqExpr(5)));
 global ee2::EqExpr = addEqExpr(intEqExpr(42), appEqExpr("c", intEqExpr(5)));
 global ee3::EqExpr = addEqExpr(appEqExpr("c", intEqExpr(5)), intEqExpr(42));
+global ee4::EqExpr = seqEqExpr([ee1, ee2, ee3]);
+global ee5::EqExpr = seqEqExpr([ee3, ee2, ee1]);
 
 equalityTest(ee1 == ee1, true, Boolean, silver_tests);
 equalityTest(ee1 == ee2, false, Boolean, silver_tests);
 equalityTest(ee1 == ee3, false, Boolean, silver_tests);
+equalityTest(ee1 == ee4, false, Boolean, silver_tests);
 equalityTest(ee2 == ee1, false, Boolean, silver_tests);
 equalityTest(ee2 == ee2, true, Boolean, silver_tests);
 equalityTest(ee2 == ee3, false, Boolean, silver_tests);
+equalityTest(ee2 == ee4, false, Boolean, silver_tests);
 equalityTest(ee3 == ee1, false, Boolean, silver_tests);
 equalityTest(ee3 == ee2, false, Boolean, silver_tests);
 equalityTest(ee3 == ee3, true, Boolean, silver_tests);
+equalityTest(ee3 == ee4, false, Boolean, silver_tests);
+equalityTest(ee4 == ee1, false, Boolean, silver_tests);
+equalityTest(ee4 == ee2, false, Boolean, silver_tests);
+equalityTest(ee4 == ee3, false, Boolean, silver_tests);
+equalityTest(ee4 == ee4, true, Boolean, silver_tests);
+equalityTest(ee4 == ee5, false, Boolean, silver_tests);
+equalityTest([ee1, ee2, ee3] == [ee1, ee2, ee3], true, Boolean, silver_tests);
+equalityTest([ee1, ee2, ee3] == [ee3, ee2, ee1], false, Boolean, silver_tests);
 
 equalityTest(ee1 < ee1, false, Boolean, silver_tests);
 equalityTest(ee1 < ee2, true, Boolean, silver_tests);
 equalityTest(ee1 < ee3, false, Boolean, silver_tests);
+equalityTest(ee1 < ee4, true, Boolean, silver_tests);
 equalityTest(ee2 < ee1, false, Boolean, silver_tests);
 equalityTest(ee2 < ee2, false, Boolean, silver_tests);
 equalityTest(ee2 < ee3, false, Boolean, silver_tests);
+equalityTest(ee2 < ee4, true, Boolean, silver_tests);
 equalityTest(ee3 < ee1, true, Boolean, silver_tests);
 equalityTest(ee3 < ee2, true, Boolean, silver_tests);
 equalityTest(ee3 < ee3, false, Boolean, silver_tests);
+equalityTest(ee3 < ee4, true, Boolean, silver_tests);
+equalityTest(ee4 < ee1, false, Boolean, silver_tests);
+equalityTest(ee4 < ee2, false, Boolean, silver_tests);
+equalityTest(ee4 < ee3, false, Boolean, silver_tests);
+equalityTest(ee4 < ee4, false, Boolean, silver_tests);
+equalityTest(ee4 < ee5, false, Boolean, silver_tests);
+equalityTest(ee5 < ee4, true, Boolean, silver_tests);
+equalityTest([ee1, ee2, ee3] < [ee1, ee2, ee3], false, Boolean, silver_tests);
+equalityTest([ee3, ee2, ee1] < [ee1, ee2, ee3], true, Boolean, silver_tests);

--- a/test/silver_features/OccursContext.sv
+++ b/test/silver_features/OccursContext.sv
@@ -121,7 +121,7 @@ equalityTest(ocEq(ocEqPair(ee1, ee2), ocEqPair(ee1, ee3)), false, Boolean, silve
 wrongCode "Could not find an instance for attribute silver:core:isEqual {silver:core:compareTo} occurs on String (arising from the use of ocEqPair)" {
   global err::OCEqPair<EqExpr String> = ocEqPair(ee1, "abc");
 }
-wrongCode "Could not find an instance for attribute silver:core:compareTo<String> occurs on String (arising from the use of ocEqPair)" {
+wrongCode "Could not find an instance for attribute silver:core:compareTo<String {}> occurs on String (arising from the use of ocEqPair)" {
   global err::OCEqPair<EqExpr String> = ocEqPair(ee1, "abc");
 }
 

--- a/test/silver_features/OccursContext.sv
+++ b/test/silver_features/OccursContext.sv
@@ -4,7 +4,7 @@ inherited attribute extraInh1::String occurs on EqExpr;
 inherited attribute extraInh2::Integer occurs on EqExpr;
 
 function eqA
-attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a =>
+attribute compareTo<a {}> occurs on a, attribute isEqual {compareTo} occurs on a =>
 Boolean ::= x::a y::a
 {
   x.compareTo = y;
@@ -22,7 +22,7 @@ equalityTest(eqA(ee3, ee2), false, Boolean, silver_tests);
 equalityTest(eqA(ee3, ee3), true, Boolean, silver_tests);
 
 function eqB
-attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a =>
+attribute compareTo<a {}> occurs on a, attribute isEqual {compareTo} occurs on a =>
 Boolean ::= x::a y::a
 {
   production z::a = x;
@@ -42,7 +42,7 @@ equalityTest(eqB(ee3, ee2), false, Boolean, silver_tests);
 equalityTest(eqB(ee3, ee3), true, Boolean, silver_tests);
 
 function eqC
-attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a =>
+attribute compareTo<a {}> occurs on a, attribute isEqual {compareTo} occurs on a =>
 Boolean ::= x::(a ::= ) y::(a ::= )
 {
   production z::a = x();
@@ -75,7 +75,7 @@ instance OCEq String
   ocEq = \ x::String y::String -> x == y;
 }
 
-instance attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a => OCEq a {
+instance attribute compareTo<a {}> occurs on a, attribute isEqual {compareTo} occurs on a => OCEq a {
   ocEq = \ x::a y::a -> decorate x with {compareTo = decorate y with {};}.isEqual; 
 }
 
@@ -91,8 +91,8 @@ equalityTest(ocEq(ee3, ee3), true, Boolean, silver_tests);
 
 nonterminal OCEqPair<a b> with compareTo, isEqual;
 production ocEqPair
-attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a,
-attribute compareTo<b> occurs on b, attribute isEqual {compareTo} occurs on b =>
+attribute compareTo<a {}> occurs on a, attribute isEqual {compareTo} occurs on a,
+attribute compareTo<b {}> occurs on b, attribute isEqual {compareTo} occurs on b =>
 top::OCEqPair<a b> ::= x::a y::b
 {
   propagate compareTo, isEqual;

--- a/test/silver_features/OccursContext.sv
+++ b/test/silver_features/OccursContext.sv
@@ -4,10 +4,10 @@ inherited attribute extraInh1::String occurs on EqExpr;
 inherited attribute extraInh2::Integer occurs on EqExpr;
 
 function eqA
-attribute isEqualTo<a> occurs on a, attribute isEqual {isEqualTo} occurs on a =>
+attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a =>
 Boolean ::= x::a y::a
 {
-  x.isEqualTo = y;
+  x.compareTo = y;
   return x.isEqual;
 }
 
@@ -22,12 +22,12 @@ equalityTest(eqA(ee3, ee2), false, Boolean, silver_tests);
 equalityTest(eqA(ee3, ee3), true, Boolean, silver_tests);
 
 function eqB
-attribute isEqualTo<a> occurs on a, attribute isEqual {isEqualTo} occurs on a =>
+attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a =>
 Boolean ::= x::a y::a
 {
   production z::a = x;
   production w::a = z;
-  w.isEqualTo = y;
+  w.compareTo = y;
   return w.isEqual;
 }
 
@@ -42,12 +42,12 @@ equalityTest(eqB(ee3, ee2), false, Boolean, silver_tests);
 equalityTest(eqB(ee3, ee3), true, Boolean, silver_tests);
 
 function eqC
-attribute isEqualTo<a> occurs on a, attribute isEqual {isEqualTo} occurs on a =>
+attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a =>
 Boolean ::= x::(a ::= ) y::(a ::= )
 {
   production z::a = x();
   production w::a = y();
-  w.isEqualTo = z;
+  w.compareTo = z;
   return w.isEqual;
 }
 
@@ -75,8 +75,8 @@ instance OCEq String
   ocEq = \ x::String y::String -> x == y;
 }
 
-instance attribute isEqualTo<a> occurs on a, attribute isEqual {isEqualTo} occurs on a => OCEq a {
-  ocEq = \ x::a y::a -> decorate x with {isEqualTo = y;}.isEqual; 
+instance attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a => OCEq a {
+  ocEq = \ x::a y::a -> decorate x with {compareTo = y;}.isEqual; 
 }
 
 equalityTest(ocEq(ee1, ee1), true, Boolean, silver_tests);
@@ -89,32 +89,32 @@ equalityTest(ocEq(ee3, ee1), false, Boolean, silver_tests);
 equalityTest(ocEq(ee3, ee2), false, Boolean, silver_tests);
 equalityTest(ocEq(ee3, ee3), true, Boolean, silver_tests);
 
-nonterminal OCEqPair<a b> with isEqualTo, isEqual;
+nonterminal OCEqPair<a b> with compareTo, isEqual;
 production ocEqPair
-attribute isEqualTo<a> occurs on a, attribute isEqual {isEqualTo} occurs on a,
-attribute isEqualTo<b> occurs on b, attribute isEqual {isEqualTo} occurs on b =>
+attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a,
+attribute compareTo<b> occurs on b, attribute isEqual {compareTo} occurs on b =>
 top::OCEqPair<a b> ::= x::a y::b
 {
-  propagate isEqualTo, isEqual;
+  propagate compareTo, isEqual;
 {-
-  x.isEqualTo = case top.isEqualTo of ocEqPair(a, _) -> a end;
-  y.isEqualTo = case top.isEqualTo of ocEqPair(_, a) -> a end;
+  x.compareTo = case top.compareTo of ocEqPair(a, _) -> a end;
+  y.compareTo = case top.compareTo of ocEqPair(_, a) -> a end;
   top.isEqual = x.isEqual && y.isEqual;
   -}
 }
 
-equalityTest(decorate ocEqPair(ee1, ee2) with {isEqualTo = ocEqPair(ee1, ee2);}.isEqual, true, Boolean, silver_tests);
+equalityTest(decorate ocEqPair(ee1, ee2) with {compareTo = ocEqPair(ee1, ee2);}.isEqual, true, Boolean, silver_tests);
 
 -- Not supported: decorated match on polymorphic child
--- equalityTest(case decorate ocEqPair(ee1, ee2) with {isEqualTo = ocEqPair(ee1, ee2);} of ocEqPair(x, y) -> x.isEqual && y.isEqual end, true, Boolean, silver_tests);
+-- equalityTest(case decorate ocEqPair(ee1, ee2) with {compareTo = ocEqPair(ee1, ee2);} of ocEqPair(x, y) -> x.isEqual && y.isEqual end, true, Boolean, silver_tests);
 
 equalityTest(ocEq(ocEqPair(ee1, ee2), ocEqPair(ee1, ee2)), true, Boolean, silver_tests);
 equalityTest(ocEq(ocEqPair(ee1, ee2), ocEqPair(ee1, ee3)), false, Boolean, silver_tests);
 
-wrongCode "Could not find an instance for attribute silver:core:isEqual {silver:core:isEqualTo} occurs on String (arising from the use of ocEqPair)" {
+wrongCode "Could not find an instance for attribute silver:core:isEqual {silver:core:compareTo} occurs on String (arising from the use of ocEqPair)" {
   global err::OCEqPair<EqExpr String> = ocEqPair(ee1, "abc");
 }
-wrongCode "Could not find an instance for attribute silver:core:isEqualTo<String> occurs on String (arising from the use of ocEqPair)" {
+wrongCode "Could not find an instance for attribute silver:core:compareTo<String> occurs on String (arising from the use of ocEqPair)" {
   global err::OCEqPair<EqExpr String> = ocEqPair(ee1, "abc");
 }
 
@@ -125,7 +125,7 @@ top::OCEqPair<a b> ::= x::a y::b
   top.isEqual2 = x.isEqual && y.isEqual;
 }
 
-equalityTest(decorate ocEqPair(ee1, ee2) with {isEqualTo = ocEqPair(ee1, ee2);}.isEqual2, true, Boolean, silver_tests);
+equalityTest(decorate ocEqPair(ee1, ee2) with {compareTo = ocEqPair(ee1, ee2);}.isEqual2, true, Boolean, silver_tests);
 
 synthesized attribute prodName::String;
 nonterminal OCExpr with prodName;

--- a/test/silver_features/OccursContext.sv
+++ b/test/silver_features/OccursContext.sv
@@ -76,7 +76,7 @@ instance OCEq String
 }
 
 instance attribute compareTo<a> occurs on a, attribute isEqual {compareTo} occurs on a => OCEq a {
-  ocEq = \ x::a y::a -> decorate x with {compareTo = y;}.isEqual; 
+  ocEq = \ x::a y::a -> decorate x with {compareTo = decorate y with {};}.isEqual; 
 }
 
 equalityTest(ocEq(ee1, ee1), true, Boolean, silver_tests);
@@ -103,7 +103,7 @@ top::OCEqPair<a b> ::= x::a y::b
   -}
 }
 
-equalityTest(decorate ocEqPair(ee1, ee2) with {compareTo = ocEqPair(ee1, ee2);}.isEqual, true, Boolean, silver_tests);
+equalityTest(decorate ocEqPair(ee1, ee2) with {compareTo = decorate ocEqPair(ee1, ee2) with {};}.isEqual, true, Boolean, silver_tests);
 
 -- Not supported: decorated match on polymorphic child
 -- equalityTest(case decorate ocEqPair(ee1, ee2) with {compareTo = ocEqPair(ee1, ee2);} of ocEqPair(x, y) -> x.isEqual && y.isEqual end, true, Boolean, silver_tests);
@@ -125,7 +125,7 @@ top::OCEqPair<a b> ::= x::a y::b
   top.isEqual2 = x.isEqual && y.isEqual;
 }
 
-equalityTest(decorate ocEqPair(ee1, ee2) with {compareTo = ocEqPair(ee1, ee2);}.isEqual2, true, Boolean, silver_tests);
+equalityTest(decorate ocEqPair(ee1, ee2) with {compareTo = decorate ocEqPair(ee1, ee2) with {};}.isEqual2, true, Boolean, silver_tests);
 
 synthesized attribute prodName::String;
 nonterminal OCExpr with prodName;

--- a/test/silver_features/Strategy.sv
+++ b/test/silver_features/Strategy.sv
@@ -36,15 +36,6 @@ top::SStmt ::= n::String e::SExpr
 attribute compareTo, isEqual occurs on SExpr, SStmt;
 propagate compareTo, isEqual on SExpr, SStmt;
 
--- TODO: Remove these once default instance exists
-instance Eq SExpr {
-  eq = \ a::SExpr b::SExpr -> decorate a with {compareTo = b;}.isEqual;
-}
-instance Eq SStmt {
-  eq = \ a::SStmt b::SStmt -> decorate a with {compareTo = b;}.isEqual;
-}
-
-
 equalityTest(
   addSExpr(constSExpr(42), constSExpr(0)).elimPlusZero,
   constSExpr(42),

--- a/test/silver_features/Strategy.sv
+++ b/test/silver_features/Strategy.sv
@@ -33,15 +33,15 @@ top::SStmt ::= n::String e::SExpr
   propagate elimPlusZero;
 }
 
-attribute isEqualTo, isEqual occurs on SExpr, SStmt;
-propagate isEqualTo, isEqual on SExpr, SStmt;
+attribute compareTo, isEqual occurs on SExpr, SStmt;
+propagate compareTo, isEqual on SExpr, SStmt;
 
 -- TODO: Remove these once default instance exists
 instance Eq SExpr {
-  eq = \ a::SExpr b::SExpr -> decorate a with {isEqualTo = b;}.isEqual;
+  eq = \ a::SExpr b::SExpr -> decorate a with {compareTo = b;}.isEqual;
 }
 instance Eq SStmt {
-  eq = \ a::SStmt b::SStmt -> decorate a with {isEqualTo = b;}.isEqual;
+  eq = \ a::SStmt b::SStmt -> decorate a with {compareTo = b;}.isEqual;
 }
 
 

--- a/test/silver_features/TypeClasses.sv
+++ b/test/silver_features/TypeClasses.sv
@@ -73,8 +73,9 @@ MyEq a => [a] ::= x::a xs::[a]
 }
 equalityTest(myRemove(3, [1, 2, 3, 4]), [1, 2, 4], [Integer], silver_tests);
 
-equality attribute isEqTo, isEq;
-nonterminal EqPair<a b> with fst<a>, snd<b>, isEqTo, isEq;
+inherited attribute isEqTo<a>::a;
+synthesized attribute isEq::Boolean;
+nonterminal EqPair<a b> with fst<a>, snd<b>, isEqTo<EqPair<a b>>, isEq;
 production eqPair
 MyEq a, MyEq b => top::EqPair<a b> ::= x::a y::b
 {

--- a/test/silver_features/rewrite/Tests.sv
+++ b/test/silver_features/rewrite/Tests.sv
@@ -81,14 +81,10 @@ top::Foo ::= n::Integer
 {}
 
 propagate compareTo, isEqual on Foo;
--- TODO: Remove this instance once default exists
-instance Eq Foo {
-  eq = \ f1::Foo f2::Foo -> decorate f1 with {compareTo = f2;}.isEqual;
-}
 
 global s8::s:Strategy =
   rule on [Foo] of
-  | f1 :: f2 :: rest when decorate f1 with {compareTo = f2;}.isEqual -> f1 :: rest 
+  | f1 :: f2 :: rest when decorate f1 with {compareTo = decorate f2 with {};}.isEqual -> f1 :: rest 
   end;
 
 equalityTest(s:rewriteWith(s8, [foo(1), foo(2), foo(3)]), nothing(), Maybe<[Foo]>, silver_tests);

--- a/test/silver_features/rewrite/Tests.sv
+++ b/test/silver_features/rewrite/Tests.sv
@@ -75,20 +75,20 @@ global s7::s:Strategy =
 equalityTest(s:rewriteWith(s7, pair(123, 456)), just(pair(456, 123)), Maybe<Pair<Integer Integer>>, silver_tests);
 equalityTest(s:rewriteWith(s7, pair(123, "hello")), nothing(), Maybe<Pair<Integer String>>, silver_tests);
 
-nonterminal Foo with isEqual, isEqualTo;
+nonterminal Foo with isEqual, compareTo;
 abstract production foo
 top::Foo ::= n::Integer
 {}
 
-propagate isEqualTo, isEqual on Foo;
+propagate compareTo, isEqual on Foo;
 -- TODO: Remove this instance once default exists
 instance Eq Foo {
-  eq = \ f1::Foo f2::Foo -> decorate f1 with {isEqualTo = f2;}.isEqual;
+  eq = \ f1::Foo f2::Foo -> decorate f1 with {compareTo = f2;}.isEqual;
 }
 
 global s8::s:Strategy =
   rule on [Foo] of
-  | f1 :: f2 :: rest when decorate f1 with {isEqualTo = f2;}.isEqual -> f1 :: rest 
+  | f1 :: f2 :: rest when decorate f1 with {compareTo = f2;}.isEqual -> f1 :: rest 
   end;
 
 equalityTest(s:rewriteWith(s8, [foo(1), foo(2), foo(3)]), nothing(), Maybe<[Foo]>, silver_tests);


### PR DESCRIPTION
# Changes
Fixes #431 

* Separates "destruct" attributes that were a part of equality attributes into something that can be propagated separately
* Destruct attributes are now decorated
* Implemented ordering attributes
* Rename `isEqualTo` to `compareTo`, shared with `compare`/`compareKey` ordering attribute pair
* Added default instances for `Eq` and `Ord` using equality and ordering attributes
* Removed instances for the above that are now obsoleted by these default instances
* the unfinished prototype of "unification attributes" was simplified to also reuse destruct attributes

# Documentation
Currently being written for the website, will make a separate pull request for that when ready.
