### PR TITLE
Refactor to fix MWDA bugs with occurs contexts on globals/instances

### DIFF
--- a/grammars/silver/compiler/definition/core/BlockContext.sv
+++ b/grammars/silver/compiler/definition/core/BlockContext.sv
@@ -138,10 +138,16 @@ top::BlockContext ::= sig::NamedSignature  g::ProductionGraph
 }
 
 abstract production globalExprContext
+top::BlockContext ::= fn::String  ctxs::Contexts  ty::Type  g::ProductionGraph
+{
+  top.fullName = fn;
+  top.signature = globalSignature(fn, ctxs, ty);
+  top.flowGraph = g;
+}
+
+abstract production bogusContext
 top::BlockContext ::= g::ProductionGraph
 {
-  top.fullName = "_NULL_"; -- maybe we should actually error?
-  top.signature = bogusNamedSignature(); -- TODO: do something about this?
-  top.flowGraph = g;
+  forwards to globalExprContext("_NULL_", nilContext(), errorType(), g, sourceGrammar=top.sourceGrammar);
 }
 

--- a/grammars/silver/compiler/definition/core/ClassDcl.sv
+++ b/grammars/silver/compiler/definition/core/ClassDcl.sv
@@ -73,11 +73,11 @@ autocopy attribute constraintEnv::Decorated Env;
 autocopy attribute frameContexts::[Context];  -- Only used for computing frame in members
 
 nonterminal ClassBody with
-  config, grammarName, env, defs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
+  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
 nonterminal ClassBodyItem with
-  config, grammarName, env, defs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
+  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
 
-propagate errors, lexicalTypeVariables, lexicalTyVarKinds on ClassBody, ClassBodyItem;
+propagate flowDefs, errors, lexicalTypeVariables, lexicalTyVarKinds on ClassBody, ClassBodyItem;
 propagate defs on ClassBody;
 
 concrete production consClassBody
@@ -154,8 +154,7 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e:
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
   local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
-  local myFlowGraph :: ProductionGraph = 
-    constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
+  local myFlowGraph :: ProductionGraph = constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
 
   e.frame = globalExprContext(fName, foldContexts(top.frameContexts ++ cl.contexts), ty.typerep, myFlowGraph, sourceGrammar=top.grammarName);
   e.env = occursEnv(cl.occursDefs, newScopeEnv(cl.defs, top.env));

--- a/grammars/silver/compiler/definition/core/ClassDcl.sv
+++ b/grammars/silver/compiler/definition/core/ClassDcl.sv
@@ -57,6 +57,7 @@ top::AGDcl ::= 'class' cl::ConstraintList '=>' id::QNameType var::TypeExpr '{' b
   body.env = occursEnv(cl.occursDefs, newScopeEnv(headDefs, cl.env));
   body.constraintEnv = cl.env;
   body.classHead = instContext(fName, var.typerep);
+  body.frameContexts = supers;
 }
 
 concrete production typeClassDclNoCL
@@ -69,11 +70,12 @@ top::AGDcl ::= 'class' id::QNameType var::TypeExpr '{' body::ClassBody '}'
 
 autocopy attribute classHead::Context;
 autocopy attribute constraintEnv::Decorated Env;
+autocopy attribute frameContexts::[Context];  -- Only used for computing frame in members
 
 nonterminal ClassBody with
-  config, grammarName, env, defs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, compiledGrammars, classMembers;
+  config, grammarName, env, defs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
 nonterminal ClassBodyItem with
-  config, grammarName, env, defs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, compiledGrammars, classMembers;
+  config, grammarName, env, defs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
 
 propagate errors, lexicalTypeVariables, lexicalTyVarKinds on ClassBody, ClassBodyItem;
 propagate defs on ClassBody;
@@ -155,7 +157,7 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e:
   local myFlowGraph :: ProductionGraph = 
     constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
 
-  e.frame = globalExprContext(myFlowGraph, sourceGrammar=top.grammarName);
+  e.frame = globalExprContext(fName, foldContexts(top.frameContexts ++ cl.contexts), ty.typerep, myFlowGraph, sourceGrammar=top.grammarName);
   e.env = occursEnv(cl.occursDefs, newScopeEnv(cl.defs, top.env));
   
   top.defs := [classMemberDef(top.grammarName, top.location, fName, boundVars, top.classHead, cl.contexts, ty.typerep)];

--- a/grammars/silver/compiler/definition/core/GlobalDcl.sv
+++ b/grammars/silver/compiler/definition/core/GlobalDcl.sv
@@ -42,8 +42,7 @@ top::AGDcl ::= 'global' id::Name '::' cl::ConstraintList '=>' t::TypeExpr '=' e:
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
   local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
-  local myFlowGraph :: ProductionGraph = 
-    constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
+  local myFlowGraph :: ProductionGraph = constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
 
   e.frame = globalExprContext(fName, foldContexts(cl.contexts), t.typerep, myFlowGraph, sourceGrammar=top.grammarName);
 }

--- a/grammars/silver/compiler/definition/core/GlobalDcl.sv
+++ b/grammars/silver/compiler/definition/core/GlobalDcl.sv
@@ -24,7 +24,7 @@ top::AGDcl ::= 'global' id::Name '::' cl::ConstraintList '=>' t::TypeExpr '=' e:
   cl.env = newScopeEnv(typeExprDefs, top.env);
   t.env = cl.env;
   -- The expression also requires the constraint list definitions in its env
-  e.env = newScopeEnv(cl.defs, cl.env);
+  e.env = occursEnv(cl.occursDefs, newScopeEnv(cl.defs, cl.env));
 
   top.defs := [globalDef(top.grammarName, id.location, fName, boundVars, cl.contexts, t.typerep)];
 
@@ -45,7 +45,7 @@ top::AGDcl ::= 'global' id::Name '::' cl::ConstraintList '=>' t::TypeExpr '=' e:
   local myFlowGraph :: ProductionGraph = 
     constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
 
-  e.frame = globalExprContext(myFlowGraph, sourceGrammar=top.grammarName);
+  e.frame = globalExprContext(fName, foldContexts(cl.contexts), t.typerep, myFlowGraph, sourceGrammar=top.grammarName);
 }
 
 -- If the global declaration does not have constraints, we unparse appropriately 

--- a/grammars/silver/compiler/definition/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/definition/core/InstanceDcl.sv
@@ -72,11 +72,11 @@ autocopy attribute instanceType::Type;
 inherited attribute expectedClassMembers::[Pair<String Boolean>];
 
 nonterminal InstanceBody with
-  config, grammarName, env, defs, flowEnv, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers;
+  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers;
 nonterminal InstanceBodyItem with
-  config, grammarName, env, defs, flowEnv, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, fullName;
+  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, fullName;
 
-propagate defs, errors on InstanceBody, InstanceBodyItem;
+propagate defs, flowDefs, errors on InstanceBody, InstanceBodyItem;
 
 concrete production consInstanceBody
 top::InstanceBody ::= h::InstanceBodyItem t::InstanceBody
@@ -151,8 +151,7 @@ top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
   local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
-  local myFlowGraph :: ProductionGraph = 
-    constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
+  local myFlowGraph :: ProductionGraph = constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
 
   e.frame = globalExprContext(top.fullName, foldContexts(top.frameContexts), typeScheme.typerep, myFlowGraph, sourceGrammar=top.grammarName);
 }

--- a/grammars/silver/compiler/definition/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/definition/core/InstanceDcl.sv
@@ -56,6 +56,7 @@ top::AGDcl ::= 'instance' cl::ConstraintList '=>' id::QNameType ty::TypeExpr '{'
   body.className = id.lookupType.fullName;
   body.instanceType = ty.typerep; 
   body.expectedClassMembers = if id.lookupType.found then dcl.classMembers else [];
+  body.frameContexts = superContexts.contexts ++ cl.contexts;
 }
 
 concrete production instanceDclNoCL
@@ -71,9 +72,9 @@ autocopy attribute instanceType::Type;
 inherited attribute expectedClassMembers::[Pair<String Boolean>];
 
 nonterminal InstanceBody with
-  config, grammarName, env, defs, flowEnv, location, unparse, errors, compiledGrammars, className, instanceType, expectedClassMembers;
+  config, grammarName, env, defs, flowEnv, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers;
 nonterminal InstanceBodyItem with
-  config, grammarName, env, defs, flowEnv, location, unparse, errors, compiledGrammars, className, instanceType, expectedClassMembers, fullName;
+  config, grammarName, env, defs, flowEnv, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, fullName;
 
 propagate defs, errors on InstanceBody, InstanceBodyItem;
 
@@ -153,5 +154,5 @@ top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
   local myFlowGraph :: ProductionGraph = 
     constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
 
-  e.frame = globalExprContext(myFlowGraph, sourceGrammar=top.grammarName);
+  e.frame = globalExprContext(top.fullName, foldContexts(top.frameContexts), typeScheme.typerep, myFlowGraph, sourceGrammar=top.grammarName);
 }

--- a/grammars/silver/compiler/definition/env/NamedSignature.sv
+++ b/grammars/silver/compiler/definition/env/NamedSignature.sv
@@ -15,12 +15,13 @@ synthesized attribute namedInputElements :: [NamedSignatureElement];
 synthesized attribute inputNames :: [String];
 -- inputTypes comes from the types grammar.
 
-{--
+@{-
  - Represents the signature of a production (or function).
- - @param fn  The full name
- - @param ie  The input elements
- - @param oe  The output element
- - @param np  Named parameters (or annotations)
+ - @param fn   The full name
+ - @param ctxs The type constraint contexts
+ - @param ie   The input elements
+ - @param oe   The output element
+ - @param np   Named parameters (or annotations)
  -}
 abstract production namedSignature
 top::NamedSignature ::= fn::String ctxs::Contexts ie::NamedSignatureElements oe::NamedSignatureElement np::NamedSignatureElements
@@ -41,6 +42,30 @@ top::NamedSignature ::= fn::String ctxs::Contexts ie::NamedSignatureElements oe:
   ie.boundVariables = top.freeVariables;
   oe.boundVariables = top.freeVariables;
   np.boundVariables = top.freeVariables;
+}
+
+@{-
+ - Represents the signature of a global (or class member).
+ - @param fn   The full name
+ - @param ctxs The type constraint contexts
+ - @param ty   The type of the global
+ -}
+abstract production globalSignature
+top::NamedSignature ::= fn::String ctxs::Contexts ty::Type
+{
+  top.fullName = fn;
+  top.contexts = ctxs.contexts;
+  top.inputElements = error("Not a production or function");
+  top.outputElement = error("Not a production or function");
+  top.namedInputElements = error("Not a production or function");
+  top.inputNames = error("Not a production or function");
+  top.inputTypes = ty.inputTypes; -- Does anything actually use this? TODO: eliminate?
+  top.typeScheme = (if null(ctxs.contexts) then polyType else constraintType(_, ctxs.contexts, _))(top.freeVariables, ty);
+  top.freeVariables = setUnionTyVars(ctxs.freeVariables, ty.freeVariables);
+  top.typerep = ty;
+  
+  ctxs.boundVariables = top.freeVariables;
+  ty.boundVariables = top.freeVariables;
 }
 
 {--

--- a/grammars/silver/compiler/definition/origins/BlockContext.sv
+++ b/grammars/silver/compiler/definition/origins/BlockContext.sv
@@ -50,7 +50,7 @@ top::BlockContext ::= sig::NamedSignature  g::ProductionGraph
 }
 
 aspect production globalExprContext
-top::BlockContext ::= g::ProductionGraph
+top::BlockContext ::= _ _ _ _
 {
 	top.originsContextSource = useBogusInfo("GLOBAL_CONTEXT"); --This is a java implementation detail but...
 }

--- a/grammars/silver/compiler/extension/autoattr/Monoid.sv
+++ b/grammars/silver/compiler/extension/autoattr/Monoid.sv
@@ -48,7 +48,7 @@ top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::T
   local myFlowGraph :: ProductionGraph = 
     constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
 
-  e.frame = globalExprContext(myFlowGraph, sourceGrammar=top.grammarName);
+  e.frame = globalExprContext(fName, nilContext(), te.typerep, myFlowGraph, sourceGrammar=top.grammarName);
   
   forwards to
     collectionAttributeDclSyn(

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -31,7 +31,7 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
   local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
   local myFlowGraph :: ProductionGraph = 
     constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
-  e.frame = globalExprContext(myFlowGraph, sourceGrammar=top.grammarName);
+  e.frame = bogusContext(myFlowGraph, sourceGrammar=top.grammarName);
   
   e.recVarNameEnv = recVarNameEnv;
   e.recVarTotalEnv = recVarTotalEnv;

--- a/grammars/silver/compiler/extension/testing/EqualityTest.sv
+++ b/grammars/silver/compiler/extension/testing/EqualityTest.sv
@@ -64,8 +64,8 @@ ag::AGDcl ::= kwd::'equalityTest'
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(ag.grammarName, ag.compiledGrammars)).grammarFlowTypes;
   local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(ag.grammarName, ag.compiledGrammars)).productionFlowGraphs;
 
-  value.frame = globalExprContext(constructAnonymousGraph(value.flowDefs, ag.env, myProds, myFlow), sourceGrammar=ag.grammarName);
-  expected.frame = globalExprContext(constructAnonymousGraph(expected.flowDefs, ag.env, myProds, myFlow), sourceGrammar=ag.grammarName);
+  value.frame = bogusContext(constructAnonymousGraph(value.flowDefs, ag.env, myProds, myFlow), sourceGrammar=ag.grammarName);
+  expected.frame = bogusContext(constructAnonymousGraph(expected.flowDefs, ag.env, myProds, myFlow), sourceGrammar=ag.grammarName);
 
 {- Causes some circularities with the environment. TODO
   forwards to if !errCheck1.typeerror && !errCheck2.typeerror && !errCheck3.typeerror

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -43,7 +43,7 @@ top::NameOrBOperator ::= e::Expr
   local myFlowGraph :: ProductionGraph = 
     constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
 
-  e.frame = globalExprContext(myFlowGraph, sourceGrammar=top.grammarName);
+  e.frame = bogusContext(myFlowGraph, sourceGrammar=top.grammarName);
 }
 
 concrete production plusplusOperator

--- a/grammars/silver/compiler/translation/java/core/BlockContext.sv
+++ b/grammars/silver/compiler/translation/java/core/BlockContext.sv
@@ -43,7 +43,7 @@ top::BlockContext ::= sig::NamedSignature  _
 }
 
 aspect production globalExprContext
-top::BlockContext ::= _
+top::BlockContext ::= _ _ _ _
 {
 }
 

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -63,6 +63,20 @@ top::NamedSignature ::= fn::String ctxs::Contexts ie::NamedSignatureElements oe:
   ie.sigInhOccurs = ctxs.contextInhOccurs;
 }
 
+aspect production globalSignature
+top::NamedSignature ::= fn::String ctxs::Contexts ty::Type
+{
+  top.javaSignature = error("Translation shouldn't be demanded from global signature");
+  top.refInvokeTrans = error("Translation shouldn't be demanded from global signature");
+  top.childTypeVarElems = error("Translation shouldn't be demanded from global signature");
+  top.childStatic = error("Translation shouldn't be demanded from global signature");
+  top.childDecls = error("Translation shouldn't be demanded from global signature");
+
+  top.inhOccursContextTypes = error("Translation shouldn't be demanded from global signature");
+  top.inhOccursIndexDecls := error("Translation shouldn't be demanded from global signature");
+  top.contextInhOccurs := error("Translation shouldn't be demanded from global signature");
+}
+
 propagate contextInhOccurs, inhOccursIndexDecls on Contexts, Context;
 
 aspect production consContext

--- a/test/flow/OccursContext.sv
+++ b/test/flow/OccursContext.sv
@@ -36,11 +36,35 @@ global isEqualGlobal ::
   (Boolean ::= a a) = \ x::a y::a ->
     decorate x with {isEqualTo = y;}.isEqual;
 
+warnCode "Decoration requires inherited attribute for flow:env1." {
 global isEqualGlobalBad ::
   attribute isEqualTo<a> occurs on a,
   attribute isEqual {isEqualTo, env1} occurs on a =>
   (Boolean ::= a a) = \ x::a y::a ->
     decorate x with {isEqualTo = y;}.isEqual;
+}
+
+class Equal1 a {
+  isEqual1 :: (Boolean ::= a a);
+}
+
+warnCode "Decoration requires inherited attribute for flow:env1." {
+instance attribute isEqualTo<a> occurs on a,
+         attribute isEqual {isEqualTo, env1} occurs on a =>
+         Equal1 a {
+  isEqual1 = \ x::a y::a ->
+    decorate x with {isEqualTo = y;}.isEqual;
+}
+}
+
+warnCode "Decoration requires inherited attribute for flow:env1." {
+class attribute isEqualTo<a> occurs on a,
+      attribute isEqual {isEqualTo, env1} occurs on a =>
+      Equal2 a {
+  isEqual2 :: (Boolean ::= a a) = \ x::a y::a ->
+    decorate x with {isEqualTo = y;}.isEqual;
+}
+}
 
 synthesized attribute value::Integer occurs on Expr;
 flowtype value {env1} on Expr;

--- a/test/flow/OccursContext.sv
+++ b/test/flow/OccursContext.sv
@@ -30,6 +30,17 @@ Boolean ::= x::a y::a
 }
 }
 
+global isEqualGlobal ::
+  attribute isEqualTo<a> occurs on a,
+  attribute isEqual {isEqualTo} occurs on a =>
+  (Boolean ::= a a) = \ x::a y::a ->
+    decorate x with {isEqualTo = y;}.isEqual;
+
+global isEqualGlobalBad ::
+  attribute isEqualTo<a> occurs on a,
+  attribute isEqual {isEqualTo, env1} occurs on a =>
+  (Boolean ::= a a) = \ x::a y::a ->
+    decorate x with {isEqualTo = y;}.isEqual;
 
 synthesized attribute value::Integer occurs on Expr;
 flowtype value {env1} on Expr;


### PR DESCRIPTION
# Changes
The bogus `BlockContext`/`NamedSignature` that gets passed down to the expressions in globals and type class/instance members doesn't include their contexts.  This means that flow dependencies introduced by contexts on globals and classes/instances were being ignored.  This PR refactors `NamedSignature` and `BlockContext` to carry the needed context info.  

Also we apparently weren't even checking for missing equations in globals and type classes/instances (?!) so that is fixed here as well.  

# Documentation
This is a bug fix, no docs were needed.  Some tests cases were added to the test suite, though.  
