### PR TITLE
Avoid forcibly specializing possibly-decorated types in tuple constructors

### DIFF
--- a/grammars/silver/compiler/extension/tuple/Type.sv
+++ b/grammars/silver/compiler/extension/tuple/Type.sv
@@ -36,6 +36,13 @@ top::Type ::= c::Type a::Type
 
 }
 
+-- Avoid specializing possibly-decorated types
+aspect production ntOrDecType
+top::Type ::= nt::Type inhs::Type hidden::Type
+{
+  top.tupleElems = [top];
+}
+
 -- Aspect productions needed to avoid discarding 
 -- the forwarding list type when we extract tupleElems
 aspect production listType


### PR DESCRIPTION
# Changes
Bug fix, there was an equation for `tupleElems` missing on `ntOrDecType`.  We are slightly abusing forwarding here...

# Documentation
Added a comment on the missing aspect prod.