### PR TITLE
Fixing flow errors and related cleanup, part 2

### DIFF
--- a/grammars/silver/compiler/definition/core/GrammarParts.sv
+++ b/grammars/silver/compiler/definition/core/GrammarParts.sv
@@ -9,7 +9,7 @@ nonterminal Grammar with
   declaredName, moduleNames, exportedGrammars, optionalGrammars, condBuild,
   defs, occursDefs, importedDefs, importedOccursDefs, grammarErrors, jarName;
 
-flowtype Grammar = decorate {config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, grammarName, env, globalImports, grammarDependencies};
+flowtype Grammar = decorate {config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, grammarName, env, flowEnv, globalImports, grammarDependencies};
 
 {--
 - A list of grammars that this grammar depends upon,

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -33,8 +33,15 @@ synthesized attribute envBindingTyVars :: Decorated Env;
 
 monoid attribute errorsKindStar::[Message];
 
+-- Better error checking and type information if this type expression is an inherited attribute set
+-- for a particular nonterminal (e.g. the {env} in Decorated Expr with {env}).
+-- We can check that the attributes actually occur on the nonterminal,
+-- and also can interpret {decorate} or {forward} since we can look up those flow types.
+-- The nonterminal type is specified by the attribute onNt, which should only be used by these attributes.
 synthesized attribute errorsInhSet::[Message];
 synthesized attribute typerepInhSet::Type;
+flowtype errorsInhSet {decorate, onNt} on TypeExpr;
+flowtype typerepInhSet {decorate, onNt} on TypeExpr;
 
 flowtype TypeExpr =
   decorate {grammarName, env, flowEnv}, forward {decorate},
@@ -45,8 +52,6 @@ flowtype TypeExpr =
 flowtype typerep {grammarName, env, flowEnv} on TypeExpr, Signature;
 flowtype maybeType {grammarName, env, flowEnv} on SignatureLHS;
 flowtype types {grammarName, env, flowEnv} on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
-
-flowtype typerepInhSet {decorate, onNt} on TypeExpr;
 
 propagate errors on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs excluding refTypeExpr;
 propagate lexicalTypeVariables, lexicalTyVarKinds on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;

--- a/grammars/silver/compiler/extension/attrsection/AttrSection.sv.md
+++ b/grammars/silver/compiler/extension/attrsection/AttrSection.sv.md
@@ -6,6 +6,8 @@ imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
 imports silver:compiler:modification:lambda_fn;
+
+import silver:util:treeset as ts;
 ```
 
 Attribute sections are a shorthand syntax for a lambda function that simply access an attribute on their argument. 

--- a/grammars/silver/compiler/extension/easyterminal/TerminalDcl.sv
+++ b/grammars/silver/compiler/extension/easyterminal/TerminalDcl.sv
@@ -8,6 +8,8 @@ import silver:compiler:definition:concrete_syntax;
 
 import silver:regex only Regex, regexLiteral;
 
+import silver:util:treeset as ts;
+
 terminal Terminal_t /\'[^\'\r\n]*\'/ lexer classes {LITERAL};
 
 -- TODO: refactor this to actually create two separate terminal declarations, one regular regex, one single quote.

--- a/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
@@ -337,7 +337,7 @@ top::PatternList ::=
 
 synthesized attribute namedPatternList::[Pair<String Decorated Pattern>];
 
-nonterminal NamedPatternList with location, config, unparse, env, errors, patternVars, patternVarEnv, namedPatternList;
+nonterminal NamedPatternList with location, config, unparse, frame, env, errors, patternVars, patternVarEnv, namedPatternList;
 
 concrete production namedPatternList_one
 top::NamedPatternList ::= p::NamedPattern
@@ -370,7 +370,7 @@ top::NamedPatternList ::=
   top.namedPatternList = [];
 }
 
-nonterminal NamedPattern with location, config, unparse, env, errors, patternVars, patternVarEnv, namedPatternList;
+nonterminal NamedPattern with location, config, unparse, frame, env, errors, patternVars, patternVarEnv, namedPatternList;
 
 concrete production namedPattern
 top::NamedPattern ::= qn::QName '=' p::Pattern

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -7,7 +7,7 @@ autocopy attribute boundVars::[Pair<String Boolean>] occurs on Expr, Exprs, Expr
 
 attribute transform<ASTExpr> occurs on Expr;
 
-synthesized attribute decRuleExprs::[Pair<String Decorated Expr>] occurs on Expr, AssignExpr, PrimPatterns, PrimPattern;
+synthesized attribute decRuleExprs::[(String, Decorated Expr with {decorate, boundVars})] occurs on Expr, AssignExpr, PrimPatterns, PrimPattern;
 
 aspect default production
 top::Expr ::=

--- a/grammars/silver/compiler/extension/rewriting/Pattern.sv
+++ b/grammars/silver/compiler/extension/rewriting/Pattern.sv
@@ -33,11 +33,11 @@ attribute transform<Strategy> occurs on MRuleList, MatchRule;
 synthesized attribute isPolymorphic :: Boolean occurs on MRuleList, MatchRule, PatternList, Pattern, NamedPatternList, NamedPattern;
 inherited attribute typeHasUniversalVars :: Boolean occurs on Pattern;
 inherited attribute typesHaveUniversalVars :: [Boolean] occurs on PatternList;
-autocopy attribute namedTypesHaveUniversalVars :: [Pair<String Boolean>] occurs on NamedPatternList, NamedPattern;
+autocopy attribute namedTypesHaveUniversalVars :: [(String, Boolean)] occurs on NamedPatternList, NamedPattern;
 
 synthesized attribute wrappedMatchRuleList :: [AbstractMatchRule] occurs on MRuleList, MatchRule;
 
-autocopy attribute decRuleExprsIn::[Pair<String Decorated Expr>] occurs on MRuleList, MatchRule;
+autocopy attribute decRuleExprsIn::[(String, Decorated Expr with {decorate, boundVars})] occurs on MRuleList, MatchRule;
 inherited attribute ruleIndex::Integer occurs on MRuleList, MatchRule;
 
 aspect production mRuleList_one

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -7,6 +7,9 @@ abstract production strategyAttributeDcl
 top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] recVarTotalEnv::[Pair<String Boolean>] e::StrategyExpr
 {
   top.unparse = (if isTotal then "" else "partial ") ++ "strategy attribute " ++ a.unparse ++ "=" ++ e.unparse ++ ";";
+  top.occursDefs := [];
+  top.specDefs := [];
+  top.refDefs := [];
 
   production attribute fName :: String;
   fName = top.grammarName ++ ":" ++ a.name;
@@ -35,6 +38,7 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
   
   e.recVarNameEnv = recVarNameEnv;
   e.recVarTotalEnv = recVarTotalEnv;
+  e.recVarTotalNoEnvEnv = recVarTotalEnv;
   e.outerAttr = just(a.name);
   
   local fwrd::AGDcl =
@@ -49,21 +53,15 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
                sourceGrammar=top.grammarName, sourceLocation=a.location)))],
         location=top.location),
       map(
-        \ d::Pair<String Decorated StrategyExpr> ->
+        \ d::Pair<String LiftedStrategy> ->
           strategyAttributeDcl(
-            d.snd.isTotal, name(d.fst, top.location), d.snd.recVarNameEnv, d.snd.recVarTotalEnv, new(d.snd),
+            d.snd.isTotalNoEnv, name(d.fst, top.location), d.snd.recVarNameEnv, d.snd.recVarTotalNoEnvEnv, new(d.snd),
             location=top.location),
-        decorate e with {
-          env = emptyEnv(); -- Forward (and thus lifting) cannot depend on top.env to avoid circular dependency
-          config = e.config; grammarName = e.grammarName; recVarNameEnv = recVarNameEnv; recVarTotalEnv = recVarTotalEnv; outerAttr = e.outerAttr;
-        }.liftedStrategies));
+        e.liftedStrategies));
   
   -- Uncomment for debugging
   --forwards to unsafeTrace(fwrd, print(a.name ++ " = " ++ e.unparse ++ "; lifted  " ++ implode(",  ", map(fst, e.liftedStrategies)) ++ "\n\n", unsafeIO()));
-  
-  -- Flow errors here due to exceeding the allowable host forward flow type.
-  -- I'm not actually sure where we depend on flowEnv, config or compiledGrammars.
-  -- This could be fixed by seeding the host flow type or tracking down those dependencies and substituting dummy values.
+
   forwards to fwrd;
 }
 
@@ -149,6 +147,7 @@ top::ProductionStmt ::= attr::Decorated QName
   e2.recVarTotalEnv = e.recVarTotalEnv;
   e2.outerAttr = e.outerAttr;
   e2.inlinedStrategies = e.inlinedStrategies;
+  e2.flowEnv = top.flowEnv;
   
   -- Can't do this with forwarding to avoid circular dependency of
   -- forward -> dcl.containsErrors -> dcl.flowEnv -> forward.flowDefs

--- a/grammars/silver/compiler/extension/templating/StringTemplating.sv
+++ b/grammars/silver/compiler/extension/templating/StringTemplating.sv
@@ -9,6 +9,8 @@ imports silver:compiler:translation:java:core;
 
 exports silver:compiler:extension:templating:syntax;
 
+import silver:util:treeset as ts;
+
 terminal Template_kwd   's"""' lexer classes {LITERAL};
 terminal SLTemplate_kwd 's"'   lexer classes {LITERAL};
 
@@ -46,6 +48,9 @@ layout {}
 production stringAppendCall
 top::Expr ::= a::Expr b::Expr
 {
+  top.unparse = s"${a.unparse} ++ ${b.unparse}";
+  propagate freeVars;
+
   -- TODO: We really need eagerness analysis in Silver.
   -- Otherwise the translation for a large string template block contains
   -- new common.Thunk<Object>(new common.Thunk.Evaluable() { public final Object eval() { return ((common.StringCatter)silver.core.PstringAppend.invoke(${a.translation}, ${b.translation}); } })

--- a/grammars/silver/compiler/extension/treegen/Arbitrary.sv
+++ b/grammars/silver/compiler/extension/treegen/Arbitrary.sv
@@ -1,5 +1,7 @@
 grammar silver:compiler:extension:treegen;
 
+-- TODO: Rework this to use type classes
+
 terminal Derive_t 'derive' lexer classes {KEYWORD};
 
 terminal Arbitrary_t 'Arbitrary' lexer classes {KEYWORD};
@@ -8,6 +10,9 @@ terminal Arbitrary_t 'Arbitrary' lexer classes {KEYWORD};
 concrete production deriveagdcl
 top::AGDcl ::= 'derive' 'Arbitrary' 'on' names::QNames ';'
 {
+  top.unparse = s"derive Arbitrary on ${names.unparse};";
+  top.moduleNames := [];
+
   forwards to 
     foldr(
       appendAGDcl(_, _, location=top.location),

--- a/grammars/silver/compiler/extension/treegen/Eq.sv
+++ b/grammars/silver/compiler/extension/treegen/Eq.sv
@@ -1,5 +1,7 @@
 grammar silver:compiler:extension:treegen;
 
+-- TODO: Remove this noew that we have an Eq type class
+
 import silver:compiler:modification:let_fix;
 import silver:compiler:extension:patternmatching;
 import silver:compiler:modification:primitivepattern;
@@ -10,8 +12,10 @@ terminal Eq_t 'Eq' lexer classes {KEYWORD};
 concrete production deriveEqagdcl
 top::AGDcl ::= 'derive' 'Eq' 'on' names::QNames ';'
 {
+  top.unparse = s"derive Eq on ${names.unparse};";
   -- bug: stupid hack. Find some other way to fix this, maybe?
   top.flowDefs := [];
+  top.moduleNames := [];
 
   forwards to 
     foldr(

--- a/grammars/silver/compiler/extension/treegen/TestFor.sv
+++ b/grammars/silver/compiler/extension/treegen/TestFor.sv
@@ -7,6 +7,7 @@ terminal TestFor_T 'testFor';
 concrete production testforagdcl
 top::AGDcl ::= 'testFor' testSuite::Name ':' n::Name '::' id::QName ',' e::Expr ';'
 {
+  top.unparse = s"testFor ${testSuite.unparse} : ${n.unparse} :: ${id.unparse}, ${e.unparse};";
   top.defs := [];
   top.moduleNames := [];
   top.flowDefs := [];

--- a/grammars/silver/compiler/extension/treegen/Type.sv
+++ b/grammars/silver/compiler/extension/treegen/Type.sv
@@ -56,6 +56,11 @@ top::Type ::=
 {
   top.idNameForGenArb = "String";
 }
+aspect production terminalIdType
+top::Type ::=
+{
+  top.idNameForGenArb = "TerminalId";
+}
 aspect production nonterminalType
 top::Type ::= fn::String _ _
 {
@@ -70,6 +75,12 @@ aspect production decoratedType
 top::Type ::= te::Type _
 {
   top.idNameForGenArb = "Decorated" ++ te.idNameForGenArb;
+}
+aspect production inhSetType
+top::Type ::= _
+{
+  -- err, shouldn't happen?
+  top.idNameForGenArb = "INH_SET";
 }
 aspect production ntOrDecType
 top::Type ::= _ _ _

--- a/grammars/silver/core/Undecorate.sv
+++ b/grammars/silver/core/Undecorate.sv
@@ -7,7 +7,7 @@ foreign {
   "java": return "common.OriginsUtil.duplicatePoly(%x%.undecorate(), originCtx)";
 }
 
-function partialUndecorate
+function castRef
 i1 subset i2 => Decorated a with i1 ::= x::Decorated a with i2
 { return error("foreign function"); }
 foreign {

--- a/test/silver_features/TypeClasses.sv
+++ b/test/silver_features/TypeClasses.sv
@@ -393,35 +393,35 @@ i1 subset i2 => top::SNT ::= x::Decorated a with i2  f::([String] ::= Decorated 
 
 global sCaseRes::[String] =
   case sProd(decorate mkDExpr() with {env1 = ["a"]; env2 = ["2"];}, \ x::Decorated DExpr with {env2} -> x.env2) of
-  | sProd(x, f) -> f(partialUndecorate(x))
+  | sProd(x, f) -> f(castRef(x))
   end;
 equalityTest(sCaseRes, ["2"], [String], silver_tests);
 
 function transitiveSubset
 i1 subset i2, i2 subset i3, i3 subset i4 => Decorated a with i1 ::= x::Decorated a with i4
 {
-  return partialUndecorate(x);
+  return castRef(x);
 }
 
 function transitiveSubset2
 i1 subset {env1}, {env1, env2} subset i2 => Decorated a with i1 ::= x::Decorated a with i2
 {
-  return partialUndecorate(x);
+  return castRef(x);
 }
 
-wrongCode "i3 is not a subset of i2 (arising from the use of partialUndecorate)" {
+wrongCode "i3 is not a subset of i2 (arising from the use of castRef)" {
   function transitiveSubsetBad
   i1 subset i2, i2 subset i3, i3 subset i4 => Decorated a with i3 ::= x::Decorated a with i2
   {
-    return partialUndecorate(x);
+    return castRef(x);
   }
 }
 
-wrongCode "i1 is not a subset of i2 (arising from the use of partialUndecorate)" {
+wrongCode "i1 is not a subset of i2 (arising from the use of castRef)" {
   function transitiveSubsetBad2
   i1 subset {env1, env2}, {env1} subset i2 => Decorated a with i1 ::= x::Decorated a with i2
   {
-    return partialUndecorate(x);
+    return castRef(x);
   }
 }
 

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -217,13 +217,13 @@ global d6 :: Decorated DExpr with {decorate, env2} = decorate mkDExpr() with {en
 type Inhs1 = {env1};
 global d7 :: Decorated DExpr with Inhs1 = decorate mkDExpr() with {env1 = [];};
 
-global d8 :: Decorated DExpr with {env1} = partialUndecorate(decorate mkDExpr() with {env1 = []; env2 = [];});
-global d9 :: Decorated DExpr with {env1} = partialUndecorate(decorate mkDExpr() with {env1 = [];});
+global d8 :: Decorated DExpr with {env1} = castRef(decorate mkDExpr() with {env1 = []; env2 = [];});
+global d9 :: Decorated DExpr with {env1} = castRef(decorate mkDExpr() with {env1 = [];});
 
 function getEnv1
 {env1} subset i => [String] ::= x::Decorated DExpr with i
 {
-  return let y::Decorated DExpr with {env1} = partialUndecorate(x) in y.env1 end;
+  return let y::Decorated DExpr with {env1} = castRef(x) in y.env1 end;
 }
 global d10 :: [String] = getEnv1(decorate mkDExpr() with {env1 = []; env2 = [];});
 global d11 :: [String] = getEnv1(decorate mkDExpr() with {env1 = [];});
@@ -293,11 +293,11 @@ wrongCode "Expected return type is Decorated silver_features:DExpr with {silver_
   }
 }
 
-wrongCode "{silver_features:env1, :env2} is not a subset of {silver_features:env1} (arising from the use of partialUndecorate)" {
-  global dSuper :: Decorated DExpr with {env1, env2} = partialUndecorate(decorate mkDExpr() with {env1 = [];});
+wrongCode "{silver_features:env1, :env2} is not a subset of {silver_features:env1} (arising from the use of castRef)" {
+  global dSuper :: Decorated DExpr with {env1, env2} = castRef(decorate mkDExpr() with {env1 = [];});
 }
-wrongCode "{silver_features:env2} is not a subset of {silver_features:env1} (arising from the use of partialUndecorate)" {
-  global dDisjoint :: Decorated DExpr with {env2} = partialUndecorate(decorate mkDExpr() with {env1 = [];});
+wrongCode "{silver_features:env2} is not a subset of {silver_features:env1} (arising from the use of castRef)" {
+  global dDisjoint :: Decorated DExpr with {env2} = castRef(decorate mkDExpr() with {env1 = [];});
 }
 wrongCode "{silver_features:env1} is not a subset of {silver_features:env2} (arising from the use of getEnv1)" {
   global dDisjoint2 :: [String] = getEnv1(decorate mkDExpr() with {env2 = [];});


### PR DESCRIPTION
# Changes
This continues #585 by fixing more flow errors in the Silver compiler.  A number of the fixes here are addressing equations  that exceed their allowed flow types.  This includes a cleanup of the strategy attributes extension, where some attributes had to be duplicated adding less-precise versions that don't depend on `env`.  

Also included in this pull request are some mostly-unrelated cleanups that I salvaged from feature/inhset-collection-type-const, which is probably being abandoned.  This includes making some of the attributes used in constructing a `FlowEnv` from `FlowDefs` into monoid attributes, and renaming the `partialUndecorate` function to `castRef` (which is a better name, since this is really performing a type-safe cast from one reference type to another, no actual "undecoration" is happening.)  

# Documentation
This is an internal cleanup aside from renaming `partialUndecorate`, which is reflected in the generated documentation