### PR TITLE
Bump up stack space for running test suites in testing driver

### DIFF
--- a/grammars/silver/testing/bin/TestSpecLang.sv
+++ b/grammars/silver/testing/bin/TestSpecLang.sv
@@ -91,7 +91,7 @@ ts::Run ::= 'test' 'suite' jar::Jar_t
  local testSuiteResults :: IOVal<Integer> 
    = system ("cd " ++ ts.testFileDir ++ ";" ++
              "rm -f " ++ ts.testFileName ++ ".output ; " ++ 
-             " java -Xss6M -jar " ++ jar.lexeme ++
+             " java -Xss10M -jar " ++ jar.lexeme ++
              " >& " ++ ts.testFileName ++ ".output" ,
              msgBefore ) ;
 


### PR DESCRIPTION
# Changes
Bump up stack space for running test suites in testing driver.  Previously the default was 6 MB, but the `silver_tests` suite seems to sometimes require slightly more than this (I have manually been running it with 8M and haven't gotten any stack overflows)

# Documentation
This is an internal fix.