### PR TITLE
Fix #589, don't crash on circular type alias decls

### DIFF
--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:definition:env;
 
 imports silver:compiler:definition:type;
+imports silver:compiler:definition:type:syntax only mentionedAliases;
 imports silver:regex;
 
 -- Some of these nonterminals are closed, but the dispatch attributes are
@@ -130,7 +131,7 @@ top::ValueDclInfo ::= fn::String
   top.typeScheme = monoType(terminalIdType());
 }
 
-closed nonterminal TypeDclInfo with sourceGrammar, sourceLocation, fullName, typeScheme, kindrep, givenNonterminalType, isType, isTypeAlias, isClass, classMembers, givenInstanceType, superContexts;
+closed nonterminal TypeDclInfo with sourceGrammar, sourceLocation, fullName, typeScheme, kindrep, givenNonterminalType, isType, isTypeAlias, mentionedAliases, isClass, classMembers, givenInstanceType, superContexts;
 
 aspect default production
 top::TypeDclInfo ::=
@@ -138,6 +139,7 @@ top::TypeDclInfo ::=
   top.kindrep = starKind();
   top.isType = false;
   top.isTypeAlias = false;
+  top.mentionedAliases := [];
   top.isClass = false;
   top.classMembers = [];
   top.superContexts = [];
@@ -172,12 +174,13 @@ top::TypeDclInfo ::= fn::String isAspect::Boolean tv::TyVar
   top.isType = true;
 }
 abstract production typeAliasDcl
-top::TypeDclInfo ::= fn::String bound::[TyVar] ty::Type
+top::TypeDclInfo ::= fn::String mentionedAliases::[String] bound::[TyVar] ty::Type
 {
   top.fullName = fn;
 
   top.isType = null(bound);
   top.isTypeAlias = true;
+  top.mentionedAliases := mentionedAliases;
   top.typeScheme = if null(bound) then monoType(ty) else polyType(bound, ty);
   top.kindrep = foldr(arrowKind, ty.kindrep, map((.kindrep), bound)); 
 }

--- a/grammars/silver/compiler/definition/env/Defs.sv
+++ b/grammars/silver/compiler/definition/env/Defs.sv
@@ -176,9 +176,9 @@ Def ::= sg::String  sl::Location  fn::String  tv::TyVar
   return typeDef(defaultEnvItem(lexTyVarDcl(fn,true,tv,sourceGrammar=sg,sourceLocation=sl)));
 }
 function typeAliasDef
-Def ::= sg::String sl::Location fn::String bound::[TyVar] ty::Type
+Def ::= sg::String sl::Location fn::String mentionedAliases::[String] bound::[TyVar] ty::Type
 {
-  return typeDef(defaultEnvItem(typeAliasDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
+  return typeDef(defaultEnvItem(typeAliasDcl(fn,mentionedAliases,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
 }
 function synDef
 Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -33,6 +33,7 @@ synthesized attribute envBindingTyVars :: Decorated Env;
 
 monoid attribute errorsKindStar::[Message];
 
+-- The set of full names of type aliases that are mentioned by/transitively depended on by this type expression.
 monoid attribute mentionedAliases :: [String];
 
 

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -5,12 +5,12 @@ imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:flow:syntax;
 
-nonterminal TypeExpr  with config, location, grammarName, errors, env, flowEnv, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, errorsKindStar, freeVariables, onNt, errorsInhSet, typerepInhSet;
-nonterminal Signature with config, location, grammarName, errors, env, flowEnv, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds;
-nonterminal SignatureLHS with config, location, grammarName, errors, env, flowEnv, unparse, maybeType, lexicalTypeVariables, lexicalTyVarKinds;
-nonterminal TypeExprs with config, location, grammarName, errors, env, unparse, flowEnv, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, appArgKinds, appLexicalTyVarKinds, errorsTyVars, errorsKindStar, freeVariables;
-nonterminal BracketedTypeExprs with config, location, grammarName, errors, env, flowEnv, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, appArgKinds, appLexicalTyVarKinds, errorsTyVars, freeVariables, envBindingTyVars, initialEnv;
-nonterminal BracketedOptTypeExprs with config, location, grammarName, errors, env, flowEnv, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, appArgKinds, appLexicalTyVarKinds, errorsTyVars, freeVariables, envBindingTyVars, initialEnv;
+nonterminal TypeExpr  with config, location, grammarName, errors, env, flowEnv, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, errorsKindStar, freeVariables, mentionedAliases, onNt, errorsInhSet, typerepInhSet;
+nonterminal Signature with config, location, grammarName, errors, env, flowEnv, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds, mentionedAliases;
+nonterminal SignatureLHS with config, location, grammarName, errors, env, flowEnv, unparse, maybeType, lexicalTypeVariables, lexicalTyVarKinds, mentionedAliases;
+nonterminal TypeExprs with config, location, grammarName, errors, env, unparse, flowEnv, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, appArgKinds, appLexicalTyVarKinds, errorsTyVars, errorsKindStar, freeVariables, mentionedAliases;
+nonterminal BracketedTypeExprs with config, location, grammarName, errors, env, flowEnv, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, appArgKinds, appLexicalTyVarKinds, errorsTyVars, freeVariables, mentionedAliases, envBindingTyVars, initialEnv;
+nonterminal BracketedOptTypeExprs with config, location, grammarName, errors, env, flowEnv, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, appArgKinds, appLexicalTyVarKinds, errorsTyVars, freeVariables, mentionedAliases, envBindingTyVars, initialEnv;
 
 synthesized attribute maybeType :: Maybe<Type>;
 synthesized attribute types :: [Type];
@@ -33,6 +33,9 @@ synthesized attribute envBindingTyVars :: Decorated Env;
 
 monoid attribute errorsKindStar::[Message];
 
+monoid attribute mentionedAliases :: [String];
+
+
 synthesized attribute errorsInhSet::[Message];
 synthesized attribute typerepInhSet::Type;
 
@@ -53,6 +56,7 @@ propagate lexicalTypeVariables, lexicalTyVarKinds on TypeExpr, Signature, Signat
 propagate appLexicalTyVarKinds on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate errorsTyVars on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate errorsKindStar on TypeExprs;
+propagate mentionedAliases on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 
 function addNewLexicalTyVars
 [Def] ::= gn::String sl::Location lk::[Pair<String Kind>] l::[String]
@@ -160,6 +164,11 @@ top::TypeExpr ::= q::QNameType
 {
   top.unparse = q.unparse;
 
+  top.mentionedAliases <-
+    if q.lookupType.dcl.isTypeAlias
+    then q.lookupType.fullName :: q.lookupType.dcl.mentionedAliases
+    else [];
+
   top.errors <- q.lookupType.errors;
   top.errors <-
     if !q.lookupType.found || q.lookupType.dcl.isType then []
@@ -219,12 +228,14 @@ top::TypeExpr ::= ty::TypeExpr tl::BracketedTypeExprs
 }
 
 abstract production aliasAppTypeExpr
-top::TypeExpr ::= q::Decorated QNameType with {env} tl::BracketedTypeExprs
+top::TypeExpr ::= q::Decorated QNameType with {env}  tl::BracketedTypeExprs
 {
   top.unparse = q.unparse ++ tl.unparse;
 
   production ts::PolyType = q.lookupType.typeScheme;
   top.typerep = performRenaming(ts.typerep, zipVarsAndTypesIntoSubstitution(ts.boundVars, tl.types));
+
+  top.mentionedAliases <- q.lookupType.fullName :: q.lookupType.dcl.mentionedAliases;
 
   local tlCount::Integer = length(tl.types) + tl.missingCount;
   top.errors <-
@@ -243,6 +254,8 @@ top::TypeExpr ::= ty::Decorated TypeExpr tl::BracketedTypeExprs
   top.unparse = ty.unparse ++ tl.unparse;
 
   top.typerep = appTypes(ty.typerep, tl.types);
+
+  top.mentionedAliases <- ty.mentionedAliases;
 
   top.errors <- ty.errors;
 

--- a/grammars/silver/compiler/modification/ffi/TypeDcl.sv
+++ b/grammars/silver/compiler/modification/ffi/TypeDcl.sv
@@ -38,7 +38,7 @@ top::AGDcl ::= 'type' id::Name tl::BracketedOptTypeExprs 'foreign' '=' trans::St
   -- Strip quotes
   local transType :: String = substring(1, length(trans.lexeme) - 1, trans.lexeme);
 
-  top.defs := [typeAliasDef(top.grammarName, id.location, fName, tl.freeVariables, foreignType(fName, transType, tl.types))];
+  top.defs := [typeAliasDef(top.grammarName, id.location, fName, [], tl.freeVariables, foreignType(fName, transType, tl.types))];
 
   propagate errors, flowDefs;
   top.errors <- tl.errorsTyVars;

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -147,6 +147,16 @@ wrongCode "repeats type variable names" {
  type TypeTwo<a a> = Integer;
 }
 
+wrongCode "Definition of silver_features:RecAliasFoo is self-referential" {
+  type RecAliasFoo = RecAliasBar;
+  type RecAliasBar = RecAliasFoo;
+}
+
+wrongCode "Definition of silver_features:RecAliasBaz is self-referential" {
+  type RecAliasBaz<a> = RecAliasQux<a>;
+  type RecAliasQux<a> = Either<a RecAliasBaz<Integer>>;
+}
+
 ----------------------------------------- toString implementations
 
 equalityTest(toString("foo"), "foo",   String, silver_tests);


### PR DESCRIPTION
# Changes
Raise an error message instead of crashing when a type alias has a circular definition

# Documentation
Not needed, this is a bug fix.