### PR TITLE
Fix issue with type class constraints on functions called in rewrite rules

### DIFF
--- a/grammars/silver/compiler/extension/list/java/Type.sv
+++ b/grammars/silver/compiler/extension/list/java/Type.sv
@@ -14,7 +14,6 @@ top::Type ::=
   top.transCovariantType = "common.ConsCell";
   top.transClassType = "common.ConsCell";
   top.transTypeRep = "new common.BaseTypeRep(\"[]\")";
-  top.transFreshTypeRep = top.transTypeRep;
   top.transTypeName = "List";
 }
 

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -16,7 +16,7 @@ top::Expr ::=
     antiquoteASTExpr(Silver_Expr {
       -- Constrain the type of the wrapped expression to the type that was inferred here,
       -- to allow for any type class constraints to be resolved in the translation.
-      silver:rewrite:anyASTExpr(let val_::$TypeExpr{typerepTypeExpr(top.typerep, location=top.location)} = $Expr{top} in val_ end)
+      silver:rewrite:anyASTExpr(let val_::$TypeExpr{typerepTypeExpr(finalType(top), location=top.location)} = $Expr{top} in val_ end)
     });
   top.decRuleExprs = []; -- Only needed on things resulting from the translation of caseExpr
 }

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -16,7 +16,10 @@ top::Expr ::=
     antiquoteASTExpr(Silver_Expr {
       -- Constrain the type of the wrapped expression to the type that was inferred here,
       -- to allow for any type class constraints to be resolved in the translation.
-      silver:rewrite:anyASTExpr(let val_::$TypeExpr{typerepTypeExpr(finalType(top), location=top.location)} = $Expr{top} in val_ end)
+      silver:rewrite:anyASTExpr(
+        let rewrite_rule_anyAST_val__::$TypeExpr{typerepTypeExpr(finalType(top), location=top.location)} = $Expr{top}
+        in rewrite_rule_anyAST_val__
+        end)
     });
   top.decRuleExprs = []; -- Only needed on things resulting from the translation of caseExpr
 }

--- a/grammars/silver/compiler/modification/ffi/java/Type.sv
+++ b/grammars/silver/compiler/modification/ffi/java/Type.sv
@@ -13,11 +13,7 @@ top::Type ::= fn::String  transType::String  params::[Type]
   top.transClassType = transType;
   top.transTypeRep =
     foldl(
-      \ c::String a::Type -> s"new common.AppTypeRep(${c}, ${decorate a with {skolemTypeReps = top.skolemTypeReps;}.transTypeRep})",
-      s"new common.BaseTypeRep(\"${fn}\")", params);
-  top.transFreshTypeRep =
-    foldl(
-      \ c::String a::Type -> s"new common.AppTypeRep(${c}, ${a.transFreshTypeRep})",
+      \ c::String a::Type -> s"new common.AppTypeRep(${c}, ${transTypeRepWith(a, top.skolemTypeReps)})",
       s"new common.BaseTypeRep(\"${fn}\")", params);
   top.transTypeName = implode("_", substitute(":", "_", fn) :: map(transTypeNameWith(_, top.boundVariables), params));
 }

--- a/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
@@ -17,7 +17,7 @@ top::Expr ::= params::ProductionRHS e::Expr
 {
   local finTy :: Type = finalType(top);
   
-  -- Attempt to solve a context `typeable ${finType}`, from which the runtime TypeRep translation is computed.
+  -- Attempt to solve a context `runtimeTypeable ${finType}`, from which the runtime TypeRep translation is computed.
   -- If the type somehow contains a skolem (e.g. through scoped type variables),
   -- then we will attempt to use the more specific runtime TypeRep from the context,
   -- but will otherwise fall back to rigid skolem constant TypeReps.
@@ -31,13 +31,13 @@ s"""(new common.NodeFactory<${finTy.outputType.transType}>() {
 ${params.lambdaTranslation}
 					return ${e.translation};
 				}
-	
+
 				@Override
 				public final common.TypeRep getType() {
 ${makeTyVarDecls(5, finTy.freeVariables)}
 					return ${context.transTypeableContext};
 				}
-		
+
 				@Override
 				public final String toString() {
 					return "lambda at ${top.grammarName}:${top.location.unparse}";

--- a/grammars/silver/compiler/translation/java/core/ClassDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ClassDcl.sv
@@ -56,7 +56,7 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e:
 	default ${ty.typerep.transCovariantType} ${makeInstanceMemberAccessorName(id.name)}(${contexts.contextParamTrans}) {
 		final common.DecoratedNode context = common.TopNode.singleton;
 		//${e.unparse}
-		return ${e.translation};
+		return ${e.generalizedTranslation};
 	}
 """;
 }

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -32,12 +32,20 @@ inherited attribute invokeArgs :: Decorated AppExprs occurs on Expr;
 inherited attribute invokeNamedArgs :: Decorated AnnoAppExprs occurs on Expr;
 inherited attribute sameProdAsProductionDefinedOn :: Boolean occurs on Expr;
 
+{--
+ - A translation string where skolems in run-time type info should be generalized.
+ - E.g. global id :: (a ::= a) = \ x::a -> x; it is safe and more general for the lambda
+ - to have runtime type (var ::= var) rather than (skolem ::= skolem).
+ -}
+synthesized attribute generalizedTranslation :: String occurs on Expr;
+
 aspect default production
 top::Expr ::=
 {
   top.invokeTranslation =
     -- dynamic method invocation
     s"((${finalType(top).outputType.transType})${top.translation}.invoke(${makeOriginContextRef(top)}, new Object[]{${argsTranslation(top.invokeArgs)}}, ${namedargsTranslation(top.invokeNamedArgs)}))";
+  top.generalizedTranslation = top.translation;
 }
 
 aspect production errorExpr

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -174,7 +174,7 @@ ${contexts.contextInitTrans}
 		@Override
 		public final common.AppTypeRep getType() {
 ${makeTyVarDecls(3, whatSig.typerep.freeVariables)}
-			return ${whatSig.typerep.transFreshTypeRep};
+			return ${transFreshTypeRep(whatSig.typerep)};
 		}
 		
 		@Override

--- a/grammars/silver/compiler/translation/java/core/GlobalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/GlobalDcl.sv
@@ -5,10 +5,10 @@ top::AGDcl ::= 'global' id::Name '::' cl::ConstraintList '=>' t::TypeExpr '=' e:
 {
   top.initValues :=
     if null(cl.contexts) then
-      s"\tpublic static final common.Thunk<${t.typerep.transCovariantType}> global_${id.name} = ${wrapThunkText(e.translation, t.typerep.transCovariantType)};\n"
+      s"\tpublic static final common.Thunk<${t.typerep.transCovariantType}> global_${id.name} = ${wrapThunkText(e.generalizedTranslation, t.typerep.transCovariantType)};\n"
     else s"""
 	public static final common.Thunk<${t.typerep.transCovariantType}> global_${id.name}(${implode(", ", map(\ c::Context -> decorate c with {boundVariables = boundVars;}.contextSigElem, cl.contexts))}){
-		return ${wrapThunkText(e.translation, t.typerep.transCovariantType)};
+		return ${wrapThunkText(e.generalizedTranslation, t.typerep.transCovariantType)};
 	}
 """;
 }

--- a/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
@@ -77,7 +77,7 @@ top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
   top.translation = s"""
 	public ${id.lookupValue.typeScheme.typerep.transCovariantType} ${makeInstanceMemberAccessorName(top.fullName)}(${contexts.contextParamTrans}) {
 		//${e.unparse}
-		return ${e.translation};
+		return ${e.generalizedTranslation};
 	}
 """;
 }

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -349,7 +349,7 @@ String ::= fn::String n::NamedSignatureElement
 {
   return
 s"""try {
-			if (!common.TypeRep.unify(${n.typerep.transFreshTypeRep}, common.Reflection.getType(getChild_${n.elementName}()))) {
+			if (!common.TypeRep.unify(${transFreshTypeRep(n.typerep)}, common.Reflection.getType(getChild_${n.elementName}()))) {
 				throw new common.exceptions.SilverInternalError("Unification failed.");
 			}
 		} catch (common.exceptions.SilverException e) {
@@ -363,7 +363,7 @@ String ::= fn::String numChildren::Integer n::NamedSignatureElement
   return
 s"""Object ${n.childRefElem} = null;
       try {
-        ${n.childRefElem} = common.Reflection.reify(rules, ${n.typerep.transFreshTypeRep}, childASTs[i_${n.elementName}]);
+        ${n.childRefElem} = common.Reflection.reify(rules, ${transFreshTypeRep(n.typerep)}, childASTs[i_${n.elementName}]);
       } catch (common.exceptions.SilverException e) {
         throw new common.exceptions.ChildReifyTraceException("${fn}", "${n.elementName}", ${toString(numChildren)}, i_${n.elementName}, e);
       }
@@ -375,7 +375,7 @@ String ::= fn::String n::NamedSignatureElement
   return
 s"""Object ${n.annoRefElem} = null;
     try {
-      ${n.annoRefElem} = common.Reflection.reify(rules, ${n.typerep.transFreshTypeRep}, annotationASTs[i${n.annoRefElem}]);
+      ${n.annoRefElem} = common.Reflection.reify(rules, ${transFreshTypeRep(n.typerep)}, annotationASTs[i${n.annoRefElem}]);
     } catch (common.exceptions.SilverException e) {
       throw new common.exceptions.AnnotationReifyTraceException("${fn}", "${n.elementName}", e);
     }

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -187,7 +187,7 @@ ${makeTyVarDecls(2, namedSig.typerep.freeVariables)}
         
         ${implode("\n\t\t", map(makeChildUnify(fName, _), namedSig.inputElements))}
         
-        return ${namedSig.outputElement.typerep.transFreshTypeRep};
+        return ${transFreshTypeRep(namedSig.outputElement.typerep)};
     }
 
     static void initProductionAttributeDefinitions() {
@@ -209,7 +209,7 @@ ${body.translation}
             ${makeAnnoIndexDcls(0, namedSig.namedInputElements)}
             ${makeTyVarDecls(2, namedSig.typerep.freeVariables)}
 
-            common.TypeRep givenType = ${namedSig.outputElement.typerep.transFreshTypeRep};
+            common.TypeRep givenType = ${transFreshTypeRep(namedSig.outputElement.typerep)};
             if (!common.TypeRep.unify(resultType, givenType)) {
                 throw new common.exceptions.SilverError("reify is constructing " + resultType.toString() + ", but found " + givenType.toString() + " production ${fName} AST.");
             }
@@ -277,7 +277,7 @@ ${contexts.contextInitTrans}
         @Override
         public final common.AppTypeRep getType() {
 ${makeTyVarDecls(3, namedSig.typerep.freeVariables)}
-			return ${namedSig.typerep.transFreshTypeRep};
+			return ${transFreshTypeRep(namedSig.typerep)};
 		}
 		
 		@Override

--- a/test/silver_features/rewrite/Tests.sv
+++ b/test/silver_features/rewrite/Tests.sv
@@ -43,11 +43,9 @@ global s4::s:Strategy =
 equalityTest(s:rewriteWith(s4, pair(1, 2)), just(pair(2, 1)), Maybe<Pair<Integer Integer>>, silver_tests);
 equalityTest(s:rewriteWith(s4, pair(42, 42)), just(pair(42, 17)), Maybe<Pair<Integer Integer>>, silver_tests);
 
-global isChars::(Boolean ::= [String]) =
-  \ cs::[String] -> all(map(contains(_, ["1", "2", "3", "4", "5", "6", "7", "8", "9"]), cs)); -- TODO: can't use type class functions inside a rule
 global s5::s:Strategy =
   rule on Pair<Integer String> of
-  | pair(n, s) when isChars(explode("", s)) ->
+  | pair(n, s) when all(map(contains(_, ["1", "2", "3", "4", "5", "6", "7", "8", "9"]), explode("", s))) ->
     pair(toInteger(s), toString(n))
   | a -> a
   end;


### PR DESCRIPTION
# Changes
Previously functions in type constraints weren't permitted in rewrite rules since in the translation, the type of the referenced function would be unconstrained, and the constraints would not be resolved successfully.  By inserting let expressions in the transformed expression with the originally inferred types, this can be avoided.  Not sure why I didn't think of this sooner....

# Documentation
This fixes an undocumented bug/missing feature, so this is also a documentation win I guess?  
