### PR TITLE
Support .ag file extension as an alternative to .sv

### DIFF
--- a/grammars/silver/compiler/driver/CompileGrammar.sv
+++ b/grammars/silver/compiler/driver/CompileGrammar.sv
@@ -68,7 +68,7 @@ Grammar ::= l::[Root]
 function isValidSilverFile
 Boolean ::= f::String
 {
-  return any(map(endsWith(_, f), [".sv", ".sv.md"])) && !startsWith(".", f);
+  return any(map(endsWith(_, f), allowedSilverFileExtensions)) && !startsWith(".", f);
 }
 function listSilverFiles
 IOVal<[String]> ::= dir::String  ioin::IO

--- a/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
+++ b/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
@@ -14,18 +14,18 @@ String ::= path::String  contents::String
 If the file is a normal Silver file, we return the contents unchanged.
 
 ```silver
-    if endsWith(".sv", path)
+    if endsWith(".sv", path) || endsWith(".ag", path)
     then contents
 ```
 
 If it's a Literate Silver file instead, we extract the relevant code blocks, then join them with newlines.
 
 ```silver
-    else if endsWith(".sv.md", path)
+    else if endsWith(".sv.md", path) || endsWith(".ag.md", path)
     then implode("\n", extractSilverCodeBlocks(path, contents))
 ```
 
-Since these are the only two extensions allowed by `isValidSilverFile` in `CompileGrammar.sv`, they're the only two we need to handle.
+Since these are the only extensions allowed by `isValidSilverFile` in `CompileGrammar.sv`, they're the only two we need to handle.
 
 ```silver
     else error("Unknown filetype for " ++ path);

--- a/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
+++ b/grammars/silver/compiler/driver/CompileLiterateFile.sv.md
@@ -25,7 +25,7 @@ If it's a Literate Silver file instead, we extract the relevant code blocks, the
     then implode("\n", extractSilverCodeBlocks(path, contents))
 ```
 
-Since these are the only extensions allowed by `isValidSilverFile` in `CompileGrammar.sv`, they're the only two we need to handle.
+Since these are the only extensions allowed by `isValidSilverFile` in `CompileGrammar.sv`, they're the only ones we need to handle.
 
 ```silver
     else error("Unknown filetype for " ++ path);

--- a/grammars/silver/compiler/driver/util/Util.sv
+++ b/grammars/silver/compiler/driver/util/Util.sv
@@ -3,6 +3,7 @@ grammar silver:compiler:driver:util;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
 
+-- Note that CompileLiterateFile.sv.md needs to be updated too if this changes.
 global allowedSilverFileExtensions::[String] = [".sv", ".ag", ".sv.md", ".ag.md"];
 
 {--

--- a/grammars/silver/compiler/driver/util/Util.sv
+++ b/grammars/silver/compiler/driver/util/Util.sv
@@ -3,6 +3,8 @@ grammar silver:compiler:driver:util;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
 
+global allowedSilverFileExtensions::[String] = [".sv", ".ag", ".sv.md", ".ag.md"];
+
 {--
  - Turns a grammar name into a path, including trailing slash.
  -}

--- a/grammars/silver/compiler/extension/doc/core/RootSpec.sv
+++ b/grammars/silver/compiler/extension/doc/core/RootSpec.sv
@@ -25,6 +25,15 @@ top::RootSpec ::= g::Grammar  _ _ _ _
   g.downDocConfig = g.upDocConfig;
 }
 
+function silverToMdFilename
+String ::= fileName::String
+{
+  return foldr(
+    \ ext::String file::String ->
+      if endsWith(file, ext) then substitute(ext, ".md", file) else file,
+    fileName, allowedSilverFileExtensions);
+}
+
 @{- 
  - Turn the files in a grammar into zero or more single-file docs pages, and collect the rest of the docs
  - (possibly zero) into the index file.
@@ -35,8 +44,8 @@ function toSplitFiles
   return case g of
        | consGrammar(this, rest) ->
            if getSplit(this.localDocConfig) then toSplitFiles(rest, grammarConf, forIndex, formatFile(
-             substitute(".sv", ".md", this.location.filename),
-             getFileTitle(this.localDocConfig, substitute(".sv", "", this.location.filename)),
+             silverToMdFilename(this.location.filename),
+             getFileTitle(this.localDocConfig, silverToMdFilename(this.location.filename)),
              getFileWeight(this.localDocConfig), true,
              s"In grammar `${g.grammarName}` file `${this.location.filename}`: "++(if getToc(this.localDocConfig) then "{{< toc >}}" else ""), 
              this.docs) ++ soFar) else toSplitFiles(rest, grammarConf, forIndex ++ this.docs, soFar)

--- a/support/emacs/silver-mode/silver-mode.el
+++ b/support/emacs/silver-mode/silver-mode.el
@@ -1,6 +1,7 @@
 (defvar silver-mode-hook nil)
 
 (add-to-list 'auto-mode-alist '("\\.sv\\'" . silver-mode))
+(add-to-list 'auto-mode-alist '("\\.ag\\'" . silver-mode))
 
 (defun silver-comment-dwim (arg)
 "Comment or uncomment current line or region in a smart way but with silver's -- syntax

--- a/support/vim/ftdetect/sv.vim
+++ b/support/vim/ftdetect/sv.vim
@@ -1,1 +1,2 @@
 au BufRead,BufNewFile *.sv set filetype=sv
+au BufRead,BufNewFile *.ag set filetype=sv


### PR DESCRIPTION
# Changes
This permits .ag as an alternative file extension to .sv - .sv conflicts with System Verilog, which poses some unavoidable issues for a certain use case of Silver.  Message me privately if you want more details.  

I updated the vim and emacs plugins to recognize both extensions, but the gedit plugin install script is broken for modern versions of that editor, so I'm leaving that one alone for now.  

# Documentation
None yet.  As best I can tell we never say that "sv is the canonical file extension for Silver" in any existing documentation, so nothing is out of date per-se, but we may want to add something?  