### PR TITLE
More cleanup and misc. bug fixes

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
@@ -156,6 +156,12 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
   top.errors <- te.errorsKindStar;
 }
 
+aspect production productionAttributeDcl
+top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
+{
+  top.errors <- te.errorsKindStar;
+}
+
 aspect production localValueDef
 top::ProductionStmt ::= val::Decorated QName  e::Expr
 {

--- a/grammars/silver/compiler/analysis/warnings/Project.sv
+++ b/grammars/silver/compiler/analysis/warnings/Project.sv
@@ -3,17 +3,10 @@ grammar silver:compiler:analysis:warnings;
 imports silver:util:cmdargs;
 imports silver:compiler:driver only parseArgs;
 
-synthesized attribute warnAll :: Boolean occurs on CmdArgs;
-
-aspect production endCmdArgs
-top::CmdArgs ::= l::[String]
-{
-  top.warnAll = false;
-}
 abstract production warnAllFlag
 top::CmdArgs ::= rest::CmdArgs
 {
-  top.warnAll = true;
+  -- This prod should be aspected to turn on all relevant warning flags
   forwards to rest;
 }
 

--- a/grammars/silver/compiler/analysis/warnings/flow/FlowTypeCopyEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/FlowTypeCopyEquation.sv
@@ -26,16 +26,16 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
 
   top.errors <-
     if null(body.errors ++ ns.errors)
-    && (top.config.warnAll || top.config.warnMissingInh || top.config.runMwda)
+    && top.config.warnMissingInh
     -- Must be a forwarding production
     && !null(body.uniqueSignificantExpression)
-    then flatMap(raiseImplicitFwdEqFlowTypes(top.location, lhsNt, fName, _, top.flowEnv, fwdFlowDeps, myFlow, top.config.runMwda), hostSyns)
+    then flatMap(raiseImplicitFwdEqFlowTypes(top.config, top.location, lhsNt, fName, _, top.flowEnv, fwdFlowDeps, myFlow), hostSyns)
     else [];
 }
 
 
 function raiseImplicitFwdEqFlowTypes
-[Message] ::= l::Location  lhsNt::String  prod::String  attr::String  e::FlowEnv  fwdFlowDeps::set:Set<String>  myFlow::EnvTree<FlowType> runMwda::Boolean
+[Message] ::= config::Decorated CmdArgs  l::Location  lhsNt::String  prod::String  attr::String  e::FlowEnv  fwdFlowDeps::set:Set<String>  myFlow::EnvTree<FlowType> 
 {
   -- The flow type for `attr` on `lhsNt`
   local depsForThisAttr :: set:Set<String> = inhDepsForSyn(attr, lhsNt, myFlow);
@@ -46,7 +46,7 @@ function raiseImplicitFwdEqFlowTypes
   | eq :: _ -> []
   | [] ->
       if null(diff) then []
-      else [mwdaWrn(l, s"In production ${prod}, the implicit copy equation for ${attr} (due to forwarding) would exceed the attribute's flow type because the production forward equation depends on ${implode(", ", diff)}", runMwda)]
+      else [mwdaWrn(config, l, s"In production ${prod}, the implicit copy equation for ${attr} (due to forwarding) would exceed the attribute's flow type because the production forward equation depends on ${implode(", ", diff)}")]
   end;
 }
 

--- a/grammars/silver/compiler/analysis/warnings/flow/MwdaFlag.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/MwdaFlag.sv
@@ -1,17 +1,33 @@
 grammar silver:compiler:analysis:warnings:flow;
 
-synthesized attribute runMwda :: Boolean occurs on CmdArgs;
+synthesized attribute errorMwda :: Boolean occurs on CmdArgs;
 
 aspect production endCmdArgs
 top::CmdArgs ::= l::[String]
 {
-  top.runMwda = false;
+  top.errorMwda = false;
 }
 abstract production mwdaFlag
 top::CmdArgs ::= rest::CmdArgs
 {
-  top.runMwda = true;
+  top.errorMwda = true;
+  top.warnMissingInh = true;
+  top.warnMissingSyn = true;
+  top.warnEqdef = true;
+  top.warnOrphaned = true;
+  top.warnFwd = true;
   forwards to rest;
+}
+
+-- Also add these under --warn-all
+aspect production warnAllFlag
+top::CmdArgs ::= rest::CmdArgs
+{
+  top.warnMissingInh = true;
+  top.warnMissingSyn = true;
+  top.warnEqdef = true;
+  top.warnOrphaned = true;
+  top.warnFwd = true;
 }
 
 aspect function parseArgs
@@ -22,10 +38,10 @@ Either<String  Decorated CmdArgs> ::= args::[String]
 }
 
 abstract production mwdaWrn
-top::Message ::= l::Location m::String runMwda::Boolean
+top::Message ::= config::Decorated CmdArgs l::Location m::String
 {
   forwards to
-    if runMwda
+    if config.errorMwda
     then err(l, m)
     else wrn(l, m);
 }

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
@@ -30,15 +30,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur e::
   -- Orphaned equation check
   top.errors <-
     if dl.found && attr.found
-    && (top.config.warnAll || top.config.warnEqdef || top.config.runMwda)
+    && top.config.warnEqdef
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [mwdaWrn(top.location, "Orphaned equation: " ++ attr.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Orphaned equation: " ++ attr.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
     else [];
   
   -- Duplicate equation check
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name ++ " in production " ++ top.frame.fullName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Duplicate equation for " ++ attr.name ++ " in production " ++ top.frame.fullName)]
     else [];
 }
 
@@ -55,15 +55,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
   top.errors <-
     if dl.found && attr.found
-    && (top.config.warnAll || top.config.warnEqdef || top.config.runMwda)
+    && top.config.warnEqdef
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [mwdaWrn(top.location, "Orphaned equation: " ++ attr.name ++ " on " ++ dl.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Orphaned equation: " ++ attr.name ++ " on " ++ dl.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
     -- Now, check for duplicate equations!
     else [];
     
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName)]
     else [];
 }
 
@@ -81,15 +81,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
   -- Orphaned equation check
   top.errors <-
     if dl.found && attr.found
-    && (top.config.warnAll || top.config.warnEqdef || top.config.runMwda)
+    && top.config.warnEqdef
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [mwdaWrn(top.location, "Orphaned equation: " ++ attr.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Orphaned equation: " ++ attr.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
     else [];
   
   -- Duplicate equation check
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name ++ " in production " ++ top.frame.fullName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Duplicate equation for " ++ attr.name ++ " in production " ++ top.frame.fullName)]
     else [];
 }
 aspect production inhBaseColAttributeDef
@@ -105,15 +105,15 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
   top.errors <-
     if dl.found && attr.found
-    && (top.config.warnAll || top.config.warnEqdef || top.config.runMwda)
+    && top.config.warnEqdef
     && !isExportedBy(top.grammarName, exportedBy, top.compiledGrammars)
-    then [mwdaWrn(top.location, "Orphaned equation: " ++ attr.name ++ " on " ++ dl.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Orphaned equation: " ++ attr.name ++ " on " ++ dl.name ++ " (occurs from " ++ attr.dcl.sourceGrammar ++ ") in production " ++ top.frame.fullName)]
     -- Now, check for duplicate equations!
     else [];
     
   top.errors <-
     if length(dl.lookupEqDefLHS) > 1
-    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName)]
     else [];
 }
 
@@ -123,7 +123,7 @@ top::ExprLHSExpr ::= attr::QNameAttrOccur
   -- Duplicate equation check
   top.errors <-
     if attr.attrFound && length(filter(eq(attr.attrDcl.fullName, _), top.allSuppliedInhs)) > 1
-    then [mwdaWrn(top.location, "Duplicate equation for " ++ attr.name, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Duplicate equation for " ++ attr.name)]
     else [];
 }
 

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedOccurs.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedOccurs.sv
@@ -30,9 +30,9 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
 
   top.errors <-
     if nt.lookupType.found && at.lookupAttribute.found
-    && (top.config.warnAll || top.config.warnOrphaned || top.config.runMwda)
+    && top.config.warnOrphaned
     && !isExportedBy(top.grammarName, [nt.lookupType.dcl.sourceGrammar, at.lookupAttribute.dcl.sourceGrammar], top.compiledGrammars)
-    then [mwdaWrn(top.location, "Orphaned occurs declaration: " ++ at.lookupAttribute.fullName ++ " on " ++ nt.lookupType.fullName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Orphaned occurs declaration: " ++ at.lookupAttribute.fullName ++ " on " ++ nt.lookupType.fullName)]
          -- If this is a non-closed NT, or not a synthesized attribute, then we're done.
     else [];
   
@@ -41,7 +41,7 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
     -- For closed nt, either we're exported by only the nt, OR there MUST be a default!
     else if !isExportedBy(top.grammarName, [nt.lookupType.dcl.sourceGrammar], top.compiledGrammars)
          && null(lookupDef(nt.lookupType.fullName, at.lookupAttribute.fullName, top.flowEnv))
-         then [mwdaWrn(top.location, at.lookupAttribute.fullName ++ " cannot occur on " ++ nt.lookupType.fullName ++ " because that nonterminal is closed, and this attribute does not have a default equation.", top.config.runMwda)]
+         then [mwdaWrn(top.config, top.location, at.lookupAttribute.fullName ++ " cannot occur on " ++ nt.lookupType.fullName ++ " because that nonterminal is closed, and this attribute does not have a default equation.")]
          else [];
 }
 

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedProduction.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedProduction.sv
@@ -33,14 +33,14 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
 
   top.errors <-
     if null(body.errors ++ ns.errors)
-    && (top.config.warnAll || top.config.warnFwd || top.config.runMwda)
+    && top.config.warnFwd
     -- If this production does not forward
     && null(body.uniqueSignificantExpression)
     -- AND this is not a closed nonterminal
     && !isClosedNt
     -- AND this production is not exported by the nonterminal definition grammar... even including options
     && !isExportedBy(top.grammarName, [ntDefGram], top.compiledGrammars)
-    then [mwdaWrn(top.location, "Orphaned production: " ++ id.name ++ " on " ++ namedSig.outputElement.typerep.typeName, top.config.runMwda)]
+    then [mwdaWrn(top.config, top.location, "Orphaned production: " ++ id.name ++ " on " ++ namedSig.outputElement.typerep.typeName)]
     else [];
 }
 

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -146,7 +146,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
   top.unparse = "\tlocal attribute " ++ a.unparse ++ "::" ++ te.unparse ++ ";";
 
   production attribute fName :: String;
-  fName = s"${top.frame.fullName}:local:${top.grammarName}:${substitute(".", "_", top.location.filename)}:${toString(top.location.line)}:${toString(top.location.column)}:" ++ a.name;
+  fName = s"${top.frame.fullName}:local:${top.grammarName}:${implode("_", filter(isAlpha, explode(".", top.location.filename)))}:${toString(top.location.line)}:${toString(top.location.column)}:" ++ a.name;
 
   top.defs := [localDef(top.grammarName, a.location, fName, te.typerep)];
 

--- a/grammars/silver/compiler/definition/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/core/ProductionDcl.sv
@@ -69,7 +69,7 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
   local attribute prodAtts :: [Def];
   prodAtts = defsFromPADcls(getProdAttrs(fName, top.env), namedSig);
 
-  body.env = occursEnv(ns.occursDefs, newScopeEnv(body.defs ++ sigDefs ++ ns.constraintDefs, newScopeEnv(prodAtts, top.env)));
+  body.env = occursEnv(ns.occursDefs, newScopeEnv(body.defs ++ sigDefs ++ ns.constraintDefs ++ prodAtts, top.env));
   body.frame = productionContext(namedSig, myFlowGraph, sourceGrammar=top.grammarName); -- graph from flow:env
 }
 

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -86,7 +86,7 @@ top::FlowSpec ::= attr::FlowSpecId  '{' inhs::FlowSpecInhs '}'
 
   top.errors <-
     if !attr.found ||
-       !(top.config.warnAll || top.config.warnMissingInh) || -- we don't want to compute flow graphs unless told to
+       !top.config.warnMissingInh || -- we don't want to compute flow graphs unless told to
        isExportedBy(attr.authorityGrammar, [hackGramFromFName(top.onNt.typeName)], top.compiledGrammars) ||
        null(missingFt)
     then []

--- a/grammars/silver/compiler/extension/implicit_monads/Case.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Case.sv
@@ -518,7 +518,7 @@ Expr ::= exprs::[Expr] names::[String] loc::Location base::Expr
              if isMonad(ety, env) && fst(monadsMatch(ety, em, sub))
              then buildApplication(
                     monadBind(loc),
-                              [if isDecorated(ety)
+                              [if ety.isDecorated
                                then mkStrFunctionInvocation(loc, "silver:core:new", [head(exprs)])
                                else head(exprs),
                                buildLambda(head(names), monadInnerType(ety, loc), subcall, loc)],

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -247,7 +247,7 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   -- fun >>= \ bind_name -> lambda_fun(args, bind_name)
   local bind_fun_in::Expr =
         Silver_Expr {
-          bind($Expr {if isDecorated(ne.mtyperep) then mkStrFunctionInvocation(top.location, "silver:core:new", [ne.monadRewritten]) else ne.monadRewritten},
+          bind($Expr {if ne.mtyperep.isDecorated then mkStrFunctionInvocation(top.location, "silver:core:new", [ne.monadRewritten]) else ne.monadRewritten},
                $Expr {buildLambda(bind_name, monadInnerType(ne.mtyperep, top.location), applicationExpr(lambda_fun, '(', expanded_name_args, ')', location=top.location), top.location) })
         };
   local expanded_name_args::AppExprs =
@@ -475,7 +475,7 @@ top::Expr ::= e::Expr '.' q::QNameAttrOccur
                      else e.monadicNames;
 
   local eUnDec::Expr =
-        if isDecorated(e.mtyperep)
+        if e.mtyperep.isDecorated
         then Silver_Expr{ silver:core:new($Expr {e.monadRewritten}) }
         else e.monadRewritten;
   local noMonad::Expr = access(e.monadRewritten, '.', q, location=top.location);
@@ -805,7 +805,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
                        productionRHSNil(location=top.location),
                        location=top.location);
   local eUnDec::Expr =
-        if isDecorated(e.mtyperep)
+        if e.mtyperep.isDecorated
         then Silver_Expr {new($Expr {e.monadRewritten})}
         else e.monadRewritten;
   top.monadRewritten =
@@ -942,11 +942,11 @@ top::Expr ::= e1::Expr '&&' e2::Expr
   top.monadicNames = e1.monadicNames ++ e2.monadicNames;
 
   local e1UnDec::Expr =
-        if isDecorated(e1.mtyperep)
+        if e1.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e1.monadRewritten})}
         else e1.monadRewritten;
   local e2UnDec::Expr =
-        if isDecorated(e2.mtyperep)
+        if e2.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e2.monadRewritten})}
         else e2.monadRewritten;
   --e1 >>= ( (\x y -> if x then y else Return(false))(_, e2) )
@@ -1028,11 +1028,11 @@ top::Expr ::= e1::Expr '||' e2::Expr
   e2.expectedMonad = top.expectedMonad;
 
   local e1UnDec::Expr =
-        if isDecorated(e1.mtyperep)
+        if e1.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e1.monadRewritten})}
         else e1.monadRewritten;
   local e2UnDec::Expr =
-        if isDecorated(e2.mtyperep)
+        if e2.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e2.monadRewritten})}
         else e2.monadRewritten;
   --e1 >>= ( (\x y -> if x then Return(true) else y)(_, e2) )
@@ -1095,7 +1095,7 @@ top::Expr ::= '!' e::Expr
   e.expectedMonad = top.expectedMonad;
 
   local eUnDec::Expr =
-        if isDecorated(e.mtyperep)
+        if e.mtyperep.isDecorated
         then Silver_Expr {silver:core:new($Expr {e.monadRewritten})}
         else e.monadRewritten;
   top.monadRewritten =
@@ -1213,7 +1213,7 @@ top::Expr ::= 'if' e1::Expr 'then' e2::Expr 'else' e3::Expr
   local e3Type::Type = performSubstitution(e3.mtyperep, top.finalSubst);
   --
   local e1UnDec::Expr =
-        if isDecorated(e1.mtyperep)
+        if e1.mtyperep.isDecorated
         then Silver_Expr {silver:core:new($Expr {e1.monadRewritten})}
         else e1.monadRewritten;
   --We assume that if e2 or e3 are monads, they are the same as e1 if that is a
@@ -1319,11 +1319,11 @@ top::Expr ::= e1::Expr '+' e2::Expr
   top.monadicNames = e1.monadicNames ++ e2.monadicNames;
 
   local e1UnDec::Expr =
-        if isDecorated(e1.mtyperep)
+        if e1.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e1.monadRewritten})}
         else e1.monadRewritten;
   local e2UnDec::Expr =
-        if isDecorated(e2.mtyperep)
+        if e2.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e2.monadRewritten})}
         else e2.monadRewritten;
   --e1 >>= ( (\x y -> y >>= \z -> Return(x + z))(_, e2) )
@@ -1412,11 +1412,11 @@ top::Expr ::= e1::Expr '-' e2::Expr
   top.monadicNames = e1.monadicNames ++ e2.monadicNames;
 
   local e1UnDec::Expr =
-        if isDecorated(e1.mtyperep)
+        if e1.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e1.monadRewritten})}
         else e1.monadRewritten;
   local e2UnDec::Expr =
-        if isDecorated(e2.mtyperep)
+        if e2.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e2.monadRewritten})}
         else e2.monadRewritten;
   --e1 >>= ( (\x y -> y >>= \z -> Return(x - z))(_, e2) )
@@ -1505,11 +1505,11 @@ top::Expr ::= e1::Expr '*' e2::Expr
   top.monadicNames = e1.monadicNames ++ e2.monadicNames;
 
   local e1UnDec::Expr =
-        if isDecorated(e1.mtyperep)
+        if e1.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e1.monadRewritten})}
         else e1.monadRewritten;
   local e2UnDec::Expr =
-        if isDecorated(e2.mtyperep)
+        if e2.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e2.monadRewritten})}
         else e2.monadRewritten;
   --e1 >>= ( (\x y -> y >>= \z -> Return(x * z))(_, e2) )
@@ -1598,11 +1598,11 @@ top::Expr ::= e1::Expr '/' e2::Expr
   top.monadicNames = e1.monadicNames ++ e2.monadicNames;
 
   local e1UnDec::Expr =
-        if isDecorated(e1.mtyperep)
+        if e1.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e1.monadRewritten})}
         else e1.monadRewritten;
   local e2UnDec::Expr =
-        if isDecorated(e2.mtyperep)
+        if e2.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e2.monadRewritten})}
         else e2.monadRewritten;
   --e1 >>= ( (\x y -> y >>= \z -> Return(x / z))(_, e2) )
@@ -1691,11 +1691,11 @@ top::Expr ::= e1::Expr '%' e2::Expr
   top.monadicNames = e1.monadicNames ++ e2.monadicNames;
 
   local e1UnDec::Expr =
-        if isDecorated(e1.mtyperep)
+        if e1.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e1.monadRewritten})}
         else e1.monadRewritten;
   local e2UnDec::Expr =
-        if isDecorated(e2.mtyperep)
+        if e2.mtyperep.isDecorated
         then Silver_Expr {silver:core:new( $Expr {e2.monadRewritten})}
         else e2.monadRewritten;
   --e1 >>= ( (\x y -> y >>= \z -> Return(x % z))(_, e2) )
@@ -1755,7 +1755,7 @@ top::Expr ::= '-' e::Expr
   propagate mDownSubst, mUpSubst;
 
   local eUnDec::Expr =
-        if isDecorated(e.mtyperep)
+        if e.mtyperep.isDecorated
         then Silver_Expr {silver:core:new($Expr {e.monadRewritten})}
         else e.monadRewritten;
   top.monadRewritten =

--- a/grammars/silver/compiler/extension/implicit_monads/Util.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Util.sv
@@ -65,20 +65,7 @@ Boolean ::= ty::Type env::Decorated Env
 function dropDecorated
 Type ::= ty::Type
 {
-  return case ty of
-         | decoratedType(t, _) -> t
-         | listType(t) -> listType(t)
-         | t -> t
-         end;
-}
-
-function isDecorated
-Boolean ::= ty::Type
-{
-  return case ty of
-         | decoratedType(t, _) -> true
-         | t -> false
-         end;
+  return if ty.isDecorated then ty.decoratedType else ty;
 }
 
 

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -117,10 +117,9 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] complete::Boolean failExpr::Exp
   top.errors <-
       case completenessCounterExample of
       | just(lst) when complete ->
-        [mwdaWrn(top.location,
+        [mwdaWrn(top.config, top.location,
                  "This pattern-matching is not exhaustive.  Here is an example of a " ++
-                   "case that is not matched:  " ++ implode(", ", map((.unparse), lst)),
-                 top.config.runMwda)]
+                   "case that is not matched:  " ++ implode(", ", map((.unparse), lst)))]
       | _ -> []
       end;
 

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -200,7 +200,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr 'with
   top.productionAttributes := [localColDef(top.grammarName, a.location, fName, te.typerep, q.operation)];
 
   production attribute fName :: String;
-  fName = top.frame.fullName ++ ":local:" ++ a.name;
+  fName = top.frame.fullName ++ ":local:" ++ top.grammarName ++ ":" ++ a.name;
 
   top.defs := [];
 

--- a/grammars/silver/compiler/translation/java/core/DclInfo.sv
+++ b/grammars/silver/compiler/translation/java/core/DclInfo.sv
@@ -94,9 +94,6 @@ top::ValueDclInfo ::=
 aspect production localDcl
 top::ValueDclInfo ::= fn::String ty::Type
 {
-  -- TODO: BUG: See https://github.com/melt-umn/silver/issues/52
-  -- This is the kind of nasty hack that we might fix with a FullName type, instead of hacking on 'fn'
-  -- Also, this choice of name is actually buggy! Can cause java compiler errors with name collisions.
   local attribute li :: Integer;
   li = lastIndexOf(":local:", fn);
   top.attrOccursIndexName = makeIdName(substring(li+7, length(fn), fn) ++ "__ON__" ++ substring(0,li,fn));


### PR DESCRIPTION
# Changes
* Fix issues with name collisions between locals with the same name causing bogus flow errors and invalid translations.  Note that Ted suggested introducing a `FullName` type to use for full names instead of `String`s as a part of fixing this, in #52.  I'm not sure I understand how that would significantly improve the current state of affairs, honestly.  So I'm deferring that to a future refactor if needed.  
* Give production attributes their own host production instead of trying to make them forward into locals
* Cleanup to how we handle various error reporting flags in the MWDA
* Some minor cleanup in the implicit monads extension, use the existing `.isDecorated` attribute on types instead of declaring a new function that does the same thing.  

# Documentation
These are all internal code changes and cleanups that shouldn't change the compiler behaviour, aside from some bug fixes.  I added comments in a few places.  