### PR TITLE
Implement a RandomGen monad

### DIFF
--- a/grammars/silver/core/IO.sv
+++ b/grammars/silver/core/IO.sv
@@ -454,7 +454,7 @@ Integer ::=
 
 @{--
  - Generates a random number between [0, 1).
- - @deprecated This function is impure!  Consider using the RandomGen monad.
+ - This function is impure!  Consider using the RandomGen monad.
  -}
 function genRand
 Float ::=

--- a/grammars/silver/core/IO.sv
+++ b/grammars/silver/core/IO.sv
@@ -440,6 +440,7 @@ IO ::=
 @{--
  - Generate an integer unique to this run of this process.  Starts from 0 and just
  - counts up each call.
+ - Warning: This function is impure!
  -
  - @return  An integer unique to this process.
  -}
@@ -452,7 +453,8 @@ Integer ::=
 }
 
 @{--
- - Generates a random number between [0, 1)
+ - Generates a random number between [0, 1).
+ - @deprecated This function is impure!  Consider using the RandomGen monad.
  -}
 function genRand
 Float ::=

--- a/grammars/silver/core/Random.sv
+++ b/grammars/silver/core/Random.sv
@@ -20,7 +20,7 @@ instance Random Boolean {
 }
 
 @{-
-Types for which random values can be generated, uniformly distributed over some range.
+Types for which random values can be generated, uniformly distributed over some closed range [min, max].
 
 Note that this is not a subclass of Ord since we may have instances for partial orders.
 
@@ -33,11 +33,15 @@ class Random a => RandomRange a {
 }
 
 instance RandomRange Integer {
-  randomRange = \ min::Integer max::Integer -> map(\ i::Integer -> i % (max - min) + min, random);
+  randomRange = \ min::Integer max::Integer ->
+    if min > max then error(s"Empty Integer range [${toString(min)}, ${toString(max)}]")
+    else map(\ i::Integer -> i % (max - min + 1) + min, random);
 }
 
 instance RandomRange Float {
-  randomRange = \ min::Float max::Float -> map(\ f::Float -> f * (max - min) + min, random);
+  randomRange = \ min::Float max::Float ->
+    if min > max then error(s"Empty Float range [${toString(min)}, ${toString(max)}]")
+    else map(\ f::Float -> f * (max - min) + min, random);
 }
 
 instance RandomRange Boolean {
@@ -45,7 +49,7 @@ instance RandomRange Boolean {
     case min, max of
     | false, false -> pure(false)
     | false, true -> random
-    | true, false -> error("Invalid range")
+    | true, false -> error("Empty Boolean range")
     | true, true -> pure(true)
     end;
 }

--- a/grammars/silver/core/Random.sv
+++ b/grammars/silver/core/Random.sv
@@ -101,7 +101,7 @@ instance Monad RandomGen {}
 
 @{-
   Run a RandomGen computation, using an arbitrary seed.
-  Warning: this function is nondeterministic (may vary between runs) and thus impure -
+  Warning: this function is nondeterministic (may vary between runs) and thus impure;
   use at your own risk!
   
   @param r  The computation to run
@@ -117,7 +117,7 @@ a ::= r::RandomGen<a>
 
 @{-
   Run a RandomGen computation, using an arbitrary seed.
-  Warning: this function is nondeterministic (may vary between runs) and thus impure -
+  Warning: this function is nondeterministic (may vary between runs) and thus impure;
   use at your own risk!
 
   @param seed  The initial seed value for the random number generator

--- a/grammars/silver/core/Random.sv
+++ b/grammars/silver/core/Random.sv
@@ -39,13 +39,8 @@ class Random a => RandomRange a {
 }
 
 instance RandomRange Integer {
-  randomRange = \ min::Integer max::Integer ->
-    if min > max then error(s"Empty Integer range [${toString(min)}, ${toString(max)}]")
-    -- TODO: Using modulo here isn't actually uniform for big ranges.
-    -- The right method is something like
-    -- do { x = the low ceil(log2(n)) bits of uniformInt(); } while(x >= n); return x;
-    -- but that might be slower and Silver doesn't (yet) have bitwise operators.
-    else map(\ i::Integer -> (if i > 0 then i else -i) % (max - min + 1) + min, random);
+  -- Uniform integer in range is actually kinda tricky to do correctly, so this is a primitive
+  randomRange = randomRangeInteger;
 }
 
 -- Does not allow for generating NaN or infinities, at the moment
@@ -86,6 +81,10 @@ top::RandomGen<b> ::= RandomGen<a> (RandomGen<b> ::= a)
 
 production randomInteger
 top::RandomGen<Integer> ::=
+{}
+
+production randomRangeInteger
+top::RandomGen<Integer> ::= Integer Integer
 {}
 
 production randomFloat

--- a/grammars/silver/core/Random.sv
+++ b/grammars/silver/core/Random.sv
@@ -10,7 +10,7 @@ class Random a {
   random :: RandomGen<a>;
 }
 
--- Uniform random integer on [0, INT_MAX]
+-- Uniform random integer on [INT_MIN, INT_MAX]
 instance Random Integer {
   random = randomInteger();
 }
@@ -45,7 +45,7 @@ instance RandomRange Integer {
     -- The right method is something like
     -- do { x = the low ceil(log2(n)) bits of uniformInt(); } while(x >= n); return x;
     -- but that might be slower and Silver doesn't (yet) have bitwise operators.
-    else map(\ i::Integer -> i % (max - min + 1) + min, random);
+    else map(\ i::Integer -> (if i > 0 then i else -i) % (max - min + 1) + min, random);
 }
 
 -- Does not allow for generating NaN or infinities, at the moment

--- a/grammars/silver/core/Random.sv
+++ b/grammars/silver/core/Random.sv
@@ -1,0 +1,134 @@
+grammar silver:core;
+
+@{-
+Types for which random values can be generated.
+-}
+class Random a {
+  random :: RandomGen<a>;
+}
+
+instance Random Integer {
+  random = randomInteger();
+}
+
+instance Random Float {
+  random = randomFloat();
+}
+
+instance Random Boolean {
+  random = randomBoolean();
+}
+
+@{-
+Types for which random values can be generated, uniformly distributed over some range.
+
+Note that this is not a subclass of Ord since we may have instances for partial orders.
+
+If a has an instance for Ord, then instances should satisfy:
+  runRandomGen(randomRange(min, max)) >= min
+  runRandomGen(randomRange(min, max)) < max
+-}
+class Random a => RandomRange a {
+  randomRange :: (RandomGen<a> ::= a a);
+}
+
+instance RandomRange Integer {
+  randomRange = \ min::Integer max::Integer -> map(\ i::Integer -> i % (max - min) + min, random);
+}
+
+instance RandomRange Float {
+  randomRange = \ min::Float max::Float -> map(\ f::Float -> f * (max - min) + min, random);
+}
+
+instance RandomRange Boolean {
+  randomRange = \ min::Boolean max::Boolean ->
+    case min, max of
+    | false, false -> pure(false)
+    | false, true -> random
+    | true, false -> error("Invalid range")
+    | true, true -> pure(true)
+    end;
+}
+
+-- Monad for computations involving random number generation
+nonterminal RandomGen<a>;
+
+production mapRandomGen
+top::RandomGen<b> ::= (b ::= a) RandomGen<a>
+{}
+
+production apRandomGen
+top::RandomGen<b> ::= RandomGen<(b ::= a)> RandomGen<a>
+{}
+
+production pureRandomGen
+top::RandomGen<a> ::= a
+{}
+
+production bindRandomGen
+top::RandomGen<b> ::= RandomGen<a> (RandomGen<b> ::= a)
+{}
+
+production randomInteger
+top::RandomGen<Integer> ::=
+{}
+
+production randomFloat
+top::RandomGen<Float> ::=
+{}
+
+production randomBoolean
+top::RandomGen<Boolean> ::=
+{}
+
+instance Functor RandomGen {
+  map = mapRandomGen;
+}
+
+instance Apply RandomGen {
+  ap = apRandomGen;
+}
+
+instance Applicative RandomGen {
+  pure = pureRandomGen;
+}
+
+instance Bind RandomGen {
+  bind = bindRandomGen; 
+}
+
+instance Monad RandomGen {}
+
+@{-
+  Run a RandomGen computation, using an arbitrary seed.
+  Warning: this function is nondeterministic (may vary between runs) and thus impure -
+  use at your own risk!
+  
+  @param r  The computation to run
+  @return  The result of the computation
+-}
+function runRandomGen
+a ::= r::RandomGen<a>
+{
+  return error("foreign function");
+} foreign {
+  "java": return "common.RandomGen.runRandomGen(originCtx, %r%)";
+}
+
+@{-
+  Run a RandomGen computation, using an arbitrary seed.
+  Warning: this function is nondeterministic (may vary between runs) and thus impure -
+  use at your own risk!
+
+  @param seed  The initial seed value for the random number generator
+  @param r  The computation to run
+  @return  The result of the computation
+-}
+function runSeedRandomGen
+a ::= seed::Integer r::RandomGen<a>
+{
+  return error("foreign function");
+} foreign {
+  "java": return "common.RandomGen.runRandomGen(originCtx, %seed%, %r%)";
+}
+

--- a/runtime/java/src/common/RandomGen.java
+++ b/runtime/java/src/common/RandomGen.java
@@ -31,6 +31,13 @@ public final class RandomGen {
   			return runRandomGen(ctx, rng, ((NodeFactory<NRandomGen>)r.getChild(1)).invoke(ctx, new Object[] {val}, null));
   		} else if (r instanceof PrandomInteger) {
   			return rng.nextInt();
+  		} else if (r instanceof PrandomRangeInteger) {
+  			final int lower = (Integer)r.getChild(0);
+  			final int upper = (Integer)r.getChild(1);
+  			if (lower > upper) {
+  				throw new SilverError("Empty Integer range [" + lower + ", " + upper + "]");
+  			}
+  			return rng.nextInt(upper - lower + 1) + lower;  // TODO: I think this could be more robust against signed overflow.
   		} else if (r instanceof PrandomFloat) {
   			return rng.nextFloat();
   		} else if (r instanceof PrandomBoolean) {

--- a/runtime/java/src/common/RandomGen.java
+++ b/runtime/java/src/common/RandomGen.java
@@ -1,0 +1,42 @@
+package common;
+
+import java.util.*;
+
+import common.exceptions.*;
+import silver.core.*;
+
+public final class RandomGen {
+	public static Object runRandomGen(final OriginContext ctx, final int seed, final NRandomGen r) {
+		return runRandomGen(ctx, new Random(seed), r);
+	}
+
+	public static Object runRandomGen(final OriginContext ctx, final NRandomGen r) {
+		return runRandomGen(ctx, new Random(), r);
+	}
+
+	// "Interpret" a RandomGen computation using the specified Random generator
+	@SuppressWarnings("unchecked")
+	public static Object runRandomGen(final OriginContext ctx, final Random rng, final NRandomGen r) {
+		if (r instanceof PmapRandomGen) {
+			final Object val = runRandomGen(ctx, rng, (NRandomGen)r.getChild(1));
+			return ((NodeFactory<?>)r.getChild(0)).invoke(ctx, new Object[] {val}, null);
+		} else if (r instanceof PapRandomGen) {
+			final NodeFactory<?> fn = (NodeFactory<?>)runRandomGen(ctx, rng, (NRandomGen)r.getChild(0));
+			final Object val = runRandomGen(ctx, rng, (NRandomGen)r.getChild(1));
+			return fn.invoke(ctx, new Object[] {val}, null);
+		} else if (r instanceof PpureRandomGen) {
+			return r.getChild(0);
+  		} else if (r instanceof PbindRandomGen) {
+  			final Object val = runRandomGen(ctx, rng, (NRandomGen)r.getChild(0));
+  			return runRandomGen(ctx, rng, ((NodeFactory<NRandomGen>)r.getChild(1)).invoke(ctx, new Object[] {val}, null));
+  		} else if (r instanceof PrandomInteger) {
+  			return rng.nextInt();
+  		} else if (r instanceof PrandomFloat) {
+  			return rng.nextFloat();
+  		} else if (r instanceof PrandomBoolean) {
+  			return rng.nextBoolean();
+  		} else {
+  			throw new SilverError("Unsupported RandomGen constructor: " + r.getName());  // Not SilverInternalError, someone could define a new RandomGen production
+  		}
+	}
+}

--- a/test/silver_features/Tuple.sv
+++ b/test/silver_features/Tuple.sv
@@ -239,12 +239,12 @@ equalityTest(("one", 2).1, "one", String, silver_tests);
 
 -- tests that tuple selectors do not hide child errors
 
-wrongCode "Undeclared value 'random'" {
+wrongCode "Undeclared value 'notdefined'" {
 
 function fun
 String ::=
 {
-  return random.1;
+  return notdefined.1;
 }
 
 }

--- a/upload-override-jars
+++ b/upload-override-jars
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eu
 
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
-if [[ -n "$(git status --porcelain)" ]]; then
-	echo "You have uncommitted changes! Refusing to run."
-	exit 1
-fi
+# if [[ -n "$(git status --porcelain)" ]]; then
+# 	echo "You have uncommitted changes! Refusing to run."
+# 	exit 1
+# fi
 
 branch_name="$(git rev-parse --abbrev-ref HEAD)"
+encoded_branch_name="$(curl -Gso /dev/null -w %{url_effective} --data-urlencode $branch_name "" | cut -c 3-)"
 commit_hash="$(git rev-parse HEAD)"
 
 # If your username on the your development machine doesn't match your username
@@ -19,5 +20,5 @@ commit_hash="$(git rev-parse HEAD)"
 #   User nathan
 rsync -Pa jars/ foundry.remexre.xyz:/melt/jenkins/export-scratch/melt-jenkins/${commit_hash}-jars/
 
-echo "Now go to https://foundry.remexre.xyz/jenkins/job/melt-umn/job/silver/job/$branch_name/build and"
+echo "Now go to https://foundry.remexre.xyz/jenkins/job/melt-umn/job/silver/job/$encoded_branch_name/build and"
 echo "pass /export/scratch/melt-jenkins/${commit_hash}-jars as OVERRIDE_JARS"


### PR DESCRIPTION
# Changes
I got sick of dealing with lots of impure generator functions for various types.  Also, implicit monads would be helpful in generating random regex match strings.  So, here's an actual monad for random generation.  Also allows for pure computations from a fixed seed, which is helpful for reproducible test cases.  

Also, fixed a bug in the `upload-override-jars` script, which wasn't properly encoding the printed Jenkins build URL.

# Documentation
I added doc comments for the new `Random` type class.  
