### PR TITLE
Fix bug with overly aggressive optimization in strategy attribute traversal combinators

### DIFF
--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -1,8 +1,5 @@
 grammar silver:compiler:extension:strategyattr;
 
-import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, constructAnonymousGraph;
-import silver:compiler:driver:util;
-
 abstract production strategyAttributeDcl
 top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] recVarTotalEnv::[Pair<String Boolean>] e::StrategyExpr
 {
@@ -26,16 +23,8 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
     if isTotal && !e.isTotal
     -- Not an error since we can still translate this, but the translation may raise run-time errors in case of failure
     then [wrn(e.location, s"Implementation of total strategy ${a.name} is not total")]
-    else []; 
-  
-  -- Frame doesn't really matter, since we will re-check any expressions occuring in e when propagated.
-  -- Need all this to construct a bogus frame...
-  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
-  local myFlowGraph :: ProductionGraph = 
-    constructAnonymousGraph(e.flowDefs, top.env, myProds, myFlow);
-  e.frame = bogusContext(myFlowGraph, sourceGrammar=top.grammarName);
-  
+    else [];
+
   e.recVarNameEnv = recVarNameEnv;
   e.recVarTotalEnv = recVarTotalEnv;
   e.recVarTotalNoEnvEnv = recVarTotalEnv;

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -80,14 +80,15 @@ partial strategy attribute prodStep =
       end));
 attribute prodStep occurs on MRuleList;
 
-strategy attribute simplify = innermost(genericStep <+ ntStep);
+strategy attribute genericSimplify = innermost(genericStep);
+strategy attribute ntSimplify = innermost(genericStep <+ ntStep);
 strategy attribute optimize =
-  (sequence(optimize, simplify) <+
+  (sequence(optimize, ntSimplify) <+
    choice(optimize, optimize) <+
-   allTraversal(simplify) <+
-   someTraversal(simplify) <+
-   oneTraversal(simplify) <+
-   prodTraversal(id, simplify) <+
+   allTraversal(genericSimplify) <+
+   someTraversal(genericSimplify) <+
+   oneTraversal(genericSimplify) <+
+   prodTraversal(id, genericSimplify) <+
    recComb(id, optimize) <+
    inlined(id, optimize) <+
    id) <*
@@ -97,12 +98,12 @@ nonterminal StrategyExpr with
   config, grammarName, env, location, unparse, errors, frame, compiledGrammars, flowEnv, flowDefs, -- Normal expression stuff
   genName, outerAttr, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, liftedStrategies, attrRefName, isId, isFail, isTotal, isTotalNoEnv, freeRecVars, partialRefs, totalRefs, -- Frame-independent attrs
   partialTranslation, totalTranslation, matchesFrame, -- Frame-dependent attrs
-  inlinedStrategies, genericStep, ntStep, prodStep, simplify, optimize; -- Optimization stuff
+  inlinedStrategies, genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize; -- Optimization stuff
 
 nonterminal StrategyExprs with
   config, grammarName, env, unparse, errors, frame, compiledGrammars, flowEnv, flowDefs, -- Normal expression stuff
   recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, givenInputElements, liftedStrategies, attrRefNames, containsFail, allId, freeRecVars, partialRefs, totalRefs, -- Frame-independent attrs
-  inlinedStrategies, simplify; -- Optimization stuff
+  inlinedStrategies, genericSimplify, ntSimplify; -- Optimization stuff
 
 flowtype StrategyExpr =
   decorate {env, grammarName, config, recVarNameEnv, recVarTotalEnv, outerAttr}, -- NOT frame
@@ -130,9 +131,9 @@ propagate flowDefs on StrategyExpr, StrategyExprs;
 propagate containsFail, allId on StrategyExprs;
 propagate freeRecVars on StrategyExpr, StrategyExprs excluding recComb;
 propagate partialRefs, totalRefs on StrategyExpr, StrategyExprs;
-propagate simplify on StrategyExprs;
+propagate genericSimplify, ntSimplify on StrategyExprs;
 propagate prodStep on MRuleList;
-propagate genericStep, ntStep, prodStep, simplify, optimize on StrategyExpr;
+propagate genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize on StrategyExpr;
 
 -- Convert an expression of type a to Maybe<a>
 function asPartial

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -747,7 +747,10 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
       assignExpr(id, '::', ty, '=', errorExpr([], location=top.location), location=top.location),
       caseExpr(
         [hackExprType(ty.typerep, location=top.location)],
-        ml.matchRuleList, false,
+        decorate ml with {
+	  matchRulePatternSize = 1;
+	  frame = error("not needed");  -- TODO: .matchRuleList shouldn't need this?
+	}.matchRuleList, false,
         errorExpr([], location=top.location),
         ty.typerep,
         location=top.location),
@@ -775,9 +778,6 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
     then [wrn(ty.location, "Only rules on nonterminals can have an effect")]
     else [];
   top.errors <- ty.errorsKindStar;
-  
-  ml.matchRulePatternSize = 1;
-  ml.frame = error("not needed");  -- TODO: ml.matchRuleList shouldn't need this?
   
   local res::Expr =
     caseExpr(

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -747,14 +747,14 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
       assignExpr(id, '::', ty, '=', errorExpr([], location=top.location), location=top.location),
       caseExpr(
         [hackExprType(ty.typerep, location=top.location)],
-	-- TODO: matchRuleList on MRuleList depends on frame for some reason.
-	-- Re-decorate ml here as a workaround to avoid checkExpr depending on top.frame
+        -- TODO: matchRuleList on MRuleList depends on frame for some reason.
+        -- Re-decorate ml here as a workaround to avoid checkExpr depending on top.frame
         decorate ml with {
-	  env = top.env;
-	  config = top.config;
-	  matchRulePatternSize = 1;
-	  frame = error("not needed");
-	}.matchRuleList, false,
+          env = top.env;
+          config = top.config;
+          matchRulePatternSize = 1;
+          frame = error("not needed");
+        }.matchRuleList, false,
         errorExpr([], location=top.location),
         ty.typerep,
         location=top.location),

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -747,9 +747,13 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
       assignExpr(id, '::', ty, '=', errorExpr([], location=top.location), location=top.location),
       caseExpr(
         [hackExprType(ty.typerep, location=top.location)],
+	-- TODO: matchRuleList on MRuleList depends on frame for some reason.
+	-- Re-decorate ml here as a workaround to avoid checkExpr depending on top.frame
         decorate ml with {
+	  env = top.env;
+	  config = top.config;
 	  matchRulePatternSize = 1;
-	  frame = error("not needed");  -- TODO: .matchRuleList shouldn't need this?
+	  frame = error("not needed");
 	}.matchRuleList, false,
         errorExpr([], location=top.location),
         ty.typerep,

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -2,6 +2,9 @@ grammar silver:compiler:extension:strategyattr;
 
 import silver:compiler:metatranslation;
 
+import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, constructAnonymousGraph;
+import silver:compiler:driver:util;
+
 annotation genName::String; -- Used to generate the names of lifted strategy attributes
 
 autocopy attribute recVarNameEnv::[Pair<String String>]; -- name, (isTotal, genName)
@@ -81,7 +84,17 @@ partial strategy attribute prodStep =
 attribute prodStep occurs on MRuleList;
 
 strategy attribute genericSimplify = innermost(genericStep);
-strategy attribute ntSimplify = innermost(genericStep <+ ntStep);
+strategy attribute ntSimplify =
+  (sequence(ntSimplify, ntSimplify) <+
+   choice(ntSimplify, ntSimplify) <+
+   allTraversal(genericSimplify) <+
+   someTraversal(genericSimplify) <+
+   oneTraversal(genericSimplify) <+
+   prodTraversal(id, genericSimplify) <+
+   recComb(id, ntSimplify) <+
+   inlined(id, ntSimplify) <+
+   id) <*
+  try((genericStep <+ ntStep) <* ntSimplify);
 strategy attribute optimize =
   (sequence(optimize, ntSimplify) <+
    choice(optimize, optimize) <+
@@ -95,27 +108,30 @@ strategy attribute optimize =
   try((genericStep <+ ntStep <+ prodStep) <* optimize);
 
 nonterminal StrategyExpr with
-  config, grammarName, env, location, unparse, errors, frame, compiledGrammars, flowEnv, flowDefs, -- Normal expression stuff
+  config, grammarName, env, location, unparse, errors, frame, compiledGrammars, flowEnv, -- Normal expression stuff
   genName, outerAttr, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, liftedStrategies, attrRefName, isId, isFail, isTotal, isTotalNoEnv, freeRecVars, partialRefs, totalRefs, -- Frame-independent attrs
   partialTranslation, totalTranslation, matchesFrame, -- Frame-dependent attrs
   inlinedStrategies, genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize; -- Optimization stuff
 
 nonterminal StrategyExprs with
-  config, grammarName, env, unparse, errors, frame, compiledGrammars, flowEnv, flowDefs, -- Normal expression stuff
+  config, grammarName, env, unparse, errors, compiledGrammars, flowEnv, -- Normal expression stuff
   recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, givenInputElements, liftedStrategies, attrRefNames, containsFail, allId, freeRecVars, partialRefs, totalRefs, -- Frame-independent attrs
-  inlinedStrategies, genericSimplify, ntSimplify; -- Optimization stuff
+  inlinedStrategies, genericSimplify; -- Optimization stuff
 
 flowtype StrategyExpr =
   decorate {env, grammarName, config, recVarNameEnv, recVarTotalEnv, outerAttr}, -- NOT frame
   forward {decorate},
   -- Normal expression stuff
-  unparse {}, errors {decorate, frame, compiledGrammars, flowEnv}, flowDefs {decorate, frame, compiledGrammars, flowEnv},
+  unparse {}, errors {decorate, compiledGrammars, flowEnv},
   -- Frame-independent attrs
   liftedStrategies {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr}, isTotalNoEnv {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr},
   attrRefName {recVarNameEnv}, isId {}, isFail {},
   isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate},
+  genericStep {decorate, inlinedStrategies}, genericSimplify {decorate, inlinedStrategies},
   -- Frame-dependent attrs
-  partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame}, matchesFrame {decorate, frame};
+  partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame}, matchesFrame {decorate, frame},
+  ntStep {decorate, inlinedStrategies, frame}, prodStep {decorate, inlinedStrategies, frame},
+  ntSimplify {decorate, inlinedStrategies, frame}, optimize {decorate, inlinedStrategies, frame};
 
 flowtype StrategyExprs =
   decorate {env, grammarName, config, recVarNameEnv, recVarTotalEnv}, -- NOT frame
@@ -126,12 +142,11 @@ flowtype StrategyExprs =
   attrRefNames {env, recVarNameEnv, givenInputElements},
   containsFail {}, allId {}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate};
 
-propagate errors on StrategyExpr, StrategyExprs excluding partialRef, totalRef;
-propagate flowDefs on StrategyExpr, StrategyExprs;
+propagate errors on StrategyExpr, StrategyExprs excluding partialRef, totalRef, rewriteRule;
 propagate containsFail, allId on StrategyExprs;
 propagate freeRecVars on StrategyExpr, StrategyExprs excluding recComb;
 propagate partialRefs, totalRefs on StrategyExpr, StrategyExprs;
-propagate genericSimplify, ntSimplify on StrategyExprs;
+propagate genericSimplify on StrategyExprs;
 propagate prodStep on MRuleList;
 propagate genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize on StrategyExpr;
 
@@ -300,6 +315,7 @@ top::StrategyExpr ::= s::StrategyExpr
   top.isTotalNoEnv = s.isTotalNoEnv;
   
   s.outerAttr = nothing();
+  s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
   local sBaseName::String = last(explode(":", sName));
   -- pair(child name, attr occurs on child)
@@ -387,6 +403,7 @@ top::StrategyExpr ::= s::StrategyExpr
     else [pair(sName, s)];
   
   s.outerAttr = nothing();
+  s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
   -- pair(child name, attr occurs on child)
   local childAccesses::[Pair<String Boolean>] =
@@ -464,6 +481,7 @@ top::StrategyExpr ::= s::StrategyExpr
     else [pair(sName, s)];
   
   s.outerAttr = nothing();
+  s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
   local sBaseName::String = last(explode(":", sName));
   -- pair(child name, attr occurs on child)
@@ -739,22 +757,27 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
   checkExpr.downSubst = emptySubst();
   checkExpr.finalSubst = checkExpr.upSubst;
   checkExpr.grammarName = top.grammarName;
-  checkExpr.frame = top.frame;
   checkExpr.config = top.config;
   checkExpr.compiledGrammars = top.compiledGrammars;
   checkExpr.originRules = [];
   checkExpr.isRoot = false;
+
+  -- Frame doesn't really matter, since we will re-check any expressions occuring in ml when propagated.
+  -- Need all this to construct a bogus frame...
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+  local myFlowGraph :: ProductionGraph = constructAnonymousGraph(checkExpr.flowDefs, top.env, myProds, myFlow);
+  checkExpr.frame = bogusContext(myFlowGraph, sourceGrammar=top.grammarName);
   
-  top.errors <- checkExpr.errors;
+  top.errors := checkExpr.errors;
   top.errors <-
     if !isDecorable(ty.typerep, top.env)
     then [wrn(ty.location, "Only rules on nonterminals can have an effect")]
     else [];
   top.errors <- ty.errorsKindStar;
   
-  top.flowDefs <- checkExpr.flowDefs;
-  
   ml.matchRulePatternSize = 1;
+  ml.frame = error("not needed");  -- TODO: ml.matchRuleList shouldn't need this?
   
   local res::Expr =
     caseExpr(

--- a/test/silver_features/Strategy.sv
+++ b/test/silver_features/Strategy.sv
@@ -162,6 +162,14 @@ equalityTest(
   just(seqSStmt(assignSStmt("a", addSExpr(constSExpr(2), constSExpr(1))), assignSStmt("b", constSExpr(2)))),
   Maybe<SStmt>, silver_tests);
 
+partial strategy attribute onlySStmt = assignSStmt(id, onlySExpr)
+  occurs on SStmt;
+propagate onlySStmt on SStmt;
+partial strategy attribute onlySExpr = rule on SExpr of constSExpr(i) -> constSExpr(i + 1) end
+  occurs on SExpr;
+propagate onlySExpr on SExpr;
+equalityTest(assignSStmt("a", constSExpr(42)).onlySStmt, just(assignSStmt("a", constSExpr(43))), Maybe<SStmt>, silver_tests);
+
 -- Negative tests
 inherited attribute badInh<a>::a;
 wrongCode "cannot be used as a total strategy" {


### PR DESCRIPTION
# Changes
Some strategy expression optimizations are only valid in contexts where we know on what nonterminal the strategy will be applied.  Apparently these were being applied on traversal operands, which are strategies applied on the children of productions, which may be a different nonterminal.

In the process I performed some additional cleanup of flowtypes in the strategy attribute extension (a bunch of things depend on frame that shouldn't...) and found (and fixed) another bug as a result - some nonterminal-dependent optimizations were still being performed inappropriately.  

# Documentation
This is an internal cleanup.  I added a few TODO comments where appropriate.  
