### PR TITLE
Changes List to be an extension rather than a modification

### DIFF
--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:analysis:warnings:flow;
 
-import silver:compiler:extension:list;
+import silver:compiler:modification:list;
 
 synthesized attribute warnMissingInh :: Boolean occurs on CmdArgs;
 

--- a/grammars/silver/compiler/extension/astconstruction/Syntax.sv
+++ b/grammars/silver/compiler/extension/astconstruction/Syntax.sv
@@ -5,7 +5,7 @@ imports silver:langutil:pp;
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type:syntax;
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 imports silver:compiler:extension:patternmatching;
 
 exports silver:reflect:concretesyntax;

--- a/grammars/silver/compiler/extension/constructparser/Construct.sv
+++ b/grammars/silver/compiler/extension/constructparser/Construct.sv
@@ -4,7 +4,7 @@ import silver:compiler:definition:env;
 import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
 import silver:compiler:modification:copper;
-import silver:compiler:extension:list;
+import silver:compiler:modification:list;
 
 terminal Construct_t 'construct' lexer classes {KEYWORD};
 terminal Translator_t 'translator' lexer classes {KEYWORD};

--- a/grammars/silver/compiler/extension/implicit_monads/Project.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Project.sv
@@ -13,7 +13,7 @@ imports silver:util:cmdargs;
 
 imports silver:compiler:extension:convenience;
 imports silver:compiler:extension:patternmatching;
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 
 imports silver:compiler:modification:lambda_fn;
 imports silver:compiler:modification:let_fix;

--- a/grammars/silver/compiler/extension/list/Project.sv
+++ b/grammars/silver/compiler/extension/list/Project.sv
@@ -1,9 +1,0 @@
-grammar silver:compiler:extension:list;
-
-imports silver:compiler:definition:type;
-imports silver:compiler:definition:env;
-imports silver:compiler:definition:core;
-
-exports silver:compiler:extension:list:java with silver:compiler:translation:java:type;
-
-

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -6,7 +6,7 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 imports silver:compiler:modification:primitivepattern;
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 
 --Get mwdaWrn production for completeness analysis
 import silver:compiler:analysis:warnings:flow;

--- a/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:extension:patternmatching;
 
-import silver:compiler:extension:list only LSqr_t, RSqr_t;
+import silver:compiler:modification:list only LSqr_t, RSqr_t;
 
 {--
  - The forms of syntactic patterns that are permissible in (nested) case expresssions.

--- a/grammars/silver/compiler/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/compiler/extension/rewriting/Rewriting.sv
@@ -13,7 +13,7 @@ imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:env;
 imports silver:compiler:translation:java:core only finalType;
 imports silver:compiler:extension:patternmatching;
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 imports silver:compiler:modification:primitivepattern;
 imports silver:compiler:modification:lambda_fn;
 imports silver:compiler:modification:let_fix;

--- a/grammars/silver/compiler/extension/silverconstruction/Syntax.sv
+++ b/grammars/silver/compiler/extension/silverconstruction/Syntax.sv
@@ -5,7 +5,7 @@ imports silver:langutil:pp;
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type:syntax;
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 imports silver:compiler:extension:patternmatching;
 
 concrete production quoteAGDcl

--- a/grammars/silver/compiler/extension/strategyattr/Project.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Project.sv
@@ -8,7 +8,7 @@ imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax hiding Arrow_t;
 imports silver:compiler:extension:autoattr;
 imports silver:compiler:extension:patternmatching;
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 --imports silver:compiler:extension:rewriting;
 imports silver:compiler:extension:silverconstruction;
 imports silver:compiler:modification:let_fix;

--- a/grammars/silver/compiler/extension/testing/EqualityTest.sv
+++ b/grammars/silver/compiler/extension/testing/EqualityTest.sv
@@ -6,7 +6,7 @@ import silver:compiler:definition:concrete_syntax;
 import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
 import silver:compiler:modification:collection;
-import silver:compiler:extension:list;
+import silver:compiler:modification:list;
 
 import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, constructAnonymousGraph; -- for the "oh no again!" hack below
 import silver:compiler:driver:util only RootSpec; -- ditto

--- a/grammars/silver/compiler/extension/testing/Helper.sv
+++ b/grammars/silver/compiler/extension/testing/Helper.sv
@@ -6,7 +6,7 @@ import silver:compiler:definition:concrete_syntax;
 import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
 import silver:compiler:modification:collection;
-import silver:compiler:extension:list;
+import silver:compiler:modification:list;
 
 -- Expression creating functions
 

--- a/grammars/silver/compiler/extension/testing/MainTestSuite.sv
+++ b/grammars/silver/compiler/extension/testing/MainTestSuite.sv
@@ -8,7 +8,7 @@ import silver:compiler:definition:type:syntax;
 
 import silver:compiler:modification:ffi;
 import silver:compiler:modification:collection;
-import silver:compiler:extension:list;
+import silver:compiler:modification:list;
 
 terminal MainTestSuite_t 'mainTestSuite' lexer classes {KEYWORD};
 terminal MakeTestSuite_t 'makeTestSuite' lexer classes {KEYWORD};

--- a/grammars/silver/compiler/extension/treegen/Arbitrary.sv
+++ b/grammars/silver/compiler/extension/treegen/Arbitrary.sv
@@ -6,7 +6,7 @@ imports silver:compiler:definition:concrete_syntax;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
 imports silver:compiler:extension:convenience;
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 imports silver:compiler:extension:tuple;
 imports silver:compiler:modification:lambda_fn;
 imports silver:compiler:modification:let_fix;

--- a/grammars/silver/compiler/extension/tuple/Type.sv
+++ b/grammars/silver/compiler/extension/tuple/Type.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:extension:tuple;
 
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 
 nonterminal ListOfTypeExprs with location, unparse, te_translation;
 

--- a/grammars/silver/compiler/host/Project.sv
+++ b/grammars/silver/compiler/host/Project.sv
@@ -30,7 +30,7 @@ exports silver:compiler:modification:impide;
 -- Pure extensions to Silver
 exports silver:compiler:extension:doc;
 exports silver:compiler:extension:convenience;
-exports silver:compiler:extension:list; -- Not really a pure extension, yuck.
+exports silver:compiler:modification:list; -- Not really a pure extension, yuck.
 exports silver:compiler:extension:easyterminal;
 exports silver:compiler:extension:deprecation;
 exports silver:compiler:extension:testing;

--- a/grammars/silver/compiler/metatranslation/Translation.sv
+++ b/grammars/silver/compiler/metatranslation/Translation.sv
@@ -7,7 +7,7 @@ imports silver:core;
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type:syntax;
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 imports silver:compiler:extension:patternmatching;
 
 function translate

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -1,7 +1,7 @@
 grammar silver:compiler:modification:collection;
 
 import silver:compiler:definition:type:syntax;
-import silver:compiler:extension:list;
+import silver:compiler:modification:list;
 
 --import silver:compiler:analysis:typechecking:core;
 import silver:compiler:driver:util;

--- a/grammars/silver/compiler/modification/copper/Project.sv
+++ b/grammars/silver/compiler/modification/copper/Project.sv
@@ -7,7 +7,7 @@ imports silver:compiler:definition:concrete_syntax:ast;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
 
-imports silver:compiler:extension:list;
+imports silver:compiler:modification:list;
 
 --imports silver:compiler:analysis:typechecking:core;
 

--- a/grammars/silver/compiler/modification/impide/IdeDecl.sv
+++ b/grammars/silver/compiler/modification/impide/IdeDecl.sv
@@ -2,7 +2,7 @@ grammar silver:compiler:modification:impide;
 
 import silver:compiler:modification:copper_mda only findSpec; -- TODO
 import silver:compiler:driver:util only RootSpec;
-import silver:compiler:extension:list;
+import silver:compiler:modification:list;
 import silver:compiler:analysis:typechecking:core;
 import silver:compiler:modification:ffi;
 import silver:compiler:definition:type;

--- a/grammars/silver/compiler/modification/list/List.sv
+++ b/grammars/silver/compiler/modification/list/List.sv
@@ -1,4 +1,4 @@
-grammar silver:compiler:extension:list;
+grammar silver:compiler:modification:list;
 
 import silver:compiler:definition:type:syntax;
 
@@ -37,7 +37,7 @@ top::TypeExpr ::= '[' ']'
     then [err(top.location, s"${top.unparse} has kind ${prettyKind(top.typerep.kindrep)}, but kind * is expected here")]
     else [];
 
-  forwards to nominalTypeExpr(qNameTypeId(terminal(IdUpper_t, "silver:core:List"), location=top.location), location=top.location);
+  forwards to typerepTypeExpr(listCtrType(),location=top.location);
 }
 
 -- The expressions -------------------------------------------------------------

--- a/grammars/silver/compiler/modification/list/Project.sv
+++ b/grammars/silver/compiler/modification/list/Project.sv
@@ -1,0 +1,7 @@
+grammar silver:compiler:modification:list;
+
+imports silver:compiler:definition:type;
+imports silver:compiler:definition:env;
+imports silver:compiler:definition:core;
+
+exports silver:compiler:modification:list:java with silver:compiler:translation:java:type;

--- a/grammars/silver/compiler/modification/list/Type.sv
+++ b/grammars/silver/compiler/modification/list/Type.sv
@@ -1,14 +1,8 @@
 grammar silver:compiler:modification:list;
 
-{- Everything about this is awful.
-   We want to have `[a]` be able to unify with `f<a>`, while also maintaining the
-   expected [a] pretty-print AND the specialized translation.  
-   This is in itself interfering, but this makes the situation even more complicated:
-   listType exists for pretty-printing, while listCtrType provides something
-   for the `f` variable in `f<a>` to unify with while maintaining the proper
-   semantic behavior and translation. 
+{-
+  listType exists here purely to provide a better pretty print.
  -}
-
 abstract production listType
 top::Type ::= el::Type
 {

--- a/grammars/silver/compiler/modification/list/Type.sv
+++ b/grammars/silver/compiler/modification/list/Type.sv
@@ -25,6 +25,7 @@ top::Type ::=
 
   top.freeVariables = [];
   top.freeSkolemVars := [];
+  top.freeFlexibleVars := [];
   top.typepp = "[]";
   
   -- Suppress its "nonterminal"ness
@@ -34,24 +35,10 @@ top::Type ::=
   top.tracked = false;
   top.kindrep = arrowKind(starKind(),starKind());
 
-  local unifExampl :: Substitution =
+  top.unify =
     case top.unifyWith of
-    | nonterminalType(ofn, oks, otracked) ->
-        if "silver:core:List" == ofn
-        then if [starKind()] == oks
-          then if otracked
-            then error("Internal Error: Mismatching trackedness for silver:core:List "  ++ " when unifying. Try rebuilding with --clean. \nSee https://github.com/melt-umn/silver/pull/333 and https://github.com/melt-umn/silver/issues/36 .")
-            else emptySubst()
-          else error("kind mismatch during unification for " ++ prettyType(top) ++ " and " ++ prettyType(top.unifyWith)) -- Should be impossible
-        else errorSubst("Tried to unify conflicting nonterminal types silver:core:List " ++ " and " ++ ofn)
     | listCtrType() -> emptySubst()
     | _ -> errorSubst("Tried to unify List with " ++ prettyType(top.unifyWith))
     end;
-  top.unify = unifExampl;
-  --top.unify = unsafeTracePrint(unifExampl, "Unify Debug: \n" ++ "\ttype: " ++ prettyType(top) ++ "\n\tunifywith: " ++ prettyType(top.unifyWith) ++ "\n\tunify: " ++  hackUnparse(unifExampl) ++ "\n");
 
-
-  --forwards to nonterminalType("silver:core:List", [starKind()], false);
-
-  top.freeFlexibleVars := [];
 }

--- a/grammars/silver/compiler/modification/list/Type.sv
+++ b/grammars/silver/compiler/modification/list/Type.sv
@@ -1,4 +1,4 @@
-grammar silver:compiler:extension:list;
+grammar silver:compiler:modification:list;
 
 {- Everything about this is awful.
    We want to have `[a]` be able to unify with `f<a>`, while also maintaining the
@@ -7,10 +7,6 @@ grammar silver:compiler:extension:list;
    listType exists for pretty-printing, while listCtrType provides something
    for the `f` variable in `f<a>` to unify with while maintaining the proper
    semantic behavior and translation. 
-   TODO: Think really, really hard about just making this ... not an extension.
-   Would lose the non-specialized implementations, but maybe that's okay since
-   alternative Silver translations should probably provide a more efficient
-   implementation of lists anyway?
  -}
 
 abstract production listType
@@ -33,13 +29,7 @@ top::Type ::=
   -- Suppress its "nonterminal"ness
   top.isNonterminal = false;
   top.isDecorated = false;
-  --top.accessHandler = errorAccessHandler; -- permit this, since we need it for default, non-specialized java version
-  
-  --top.transType -- for translation.
-  
-  -- We would *like* this to be Decorated silver:core:List to allow caching of
-  -- i_emptyList, i_lengthList, etc. in the non-specialized translation.
-  -- That's no longer possible with the switch to appType, but this has no
-  -- effect on the performance of the java translation.
-  forwards to nonterminalType("silver:core:List", [starKind()], false);
+
+  top.tracked = false;
+  top.kindrep = foldr(arrowKind,starKind(),[starKind()]);
 }

--- a/grammars/silver/compiler/modification/list/Type.sv
+++ b/grammars/silver/compiler/modification/list/Type.sv
@@ -32,4 +32,12 @@ top::Type ::=
 
   top.tracked = false;
   top.kindrep = foldr(arrowKind,starKind(),[starKind()]);
+
+  top.unify =
+    case top.unifyWith of
+    | listCtrType() -> emptySubst()
+    | _ -> errorSubst("Tried to unify List with " ++ prettyType(top.unifyWith))
+    end;
+
+  top.freeFlexibleVars := [];
 }

--- a/grammars/silver/compiler/modification/list/java/Type.sv
+++ b/grammars/silver/compiler/modification/list/java/Type.sv
@@ -1,6 +1,6 @@
-grammar silver:compiler:extension:list:java;
+grammar silver:compiler:modification:list:java;
 
-import silver:compiler:extension:list;
+import silver:compiler:modification:list;
 import silver:compiler:definition:type;
 import silver:compiler:definition:env;
 import silver:compiler:definition:core;

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -16,7 +16,7 @@ import silver:compiler:translation:java:type;
 import silver:compiler:modification:let_fix only makeSpecialLocalBinding, lexicalLocalDef;
 import silver:compiler:definition:flow:ast only noVertex;
 
-import silver:compiler:extension:list; -- Oh no, this is a hack! TODO
+import silver:compiler:modification:list; -- Oh no, this is a hack! TODO
 
 terminal Match_kwd 'match' lexer classes {KEYWORD,RESERVED}; -- temporary!!!
 

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:translation:java:core;
 
 import silver:compiler:modification:ffi only ioForeignType; -- for main type check only
+import silver:compiler:modification:list only listCtrType;
 
 aspect production functionDcl
 top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody
@@ -33,7 +34,7 @@ s"""			final common.DecoratedNode context = new P${id.name}(${argsAccess}).decor
        unify(namedSig.typerep,
          appTypes(
            functionType(2, []),
-           [appType(nonterminalType("silver:core:List", [starKind()], false), stringType()),
+           [appType(listCtrType(), stringType()),
             ioForeignType,
             appType(nonterminalType("silver:core:IOVal", [starKind()], false), intType())])).failure
     then [err(top.location, "main function must have type signature (IOVal<Integer> ::= [String] IO). Instead it has type " ++ prettyType(namedSig.typerep))]

--- a/grammars/silver/core/List.sv
+++ b/grammars/silver/core/List.sv
@@ -620,31 +620,3 @@ function tail
 } foreign {
   "java" : return "%l%.tail()";
 }
-
---------------------------------------------------------------------------------
-
-synthesized attribute i_headList<a> :: a;
-synthesized attribute i_tailList<a> :: List<a>;
-synthesized attribute i_emptyList :: Boolean;
-synthesized attribute i_lengthList :: Integer;
-
-nonterminal List<a> with i_headList<a>, i_tailList<a>, i_emptyList, i_lengthList;
-
-abstract production i_nilList
-l::List<a> ::=
-{
-  l.i_emptyList = true;
-  l.i_lengthList = 0;
-  l.i_headList = error("requested head of nil");
-  l.i_tailList = error("requested tail of nil");
-}
-
-abstract production i_consList
-l::List<a> ::= h::a  t::List<a>
-{
-  l.i_emptyList = false;
-  l.i_lengthList = t.i_lengthList + 1;
-  l.i_headList = h;
-  l.i_tailList = t;
-}
-

--- a/grammars/silver/core/List.sv
+++ b/grammars/silver/core/List.sv
@@ -552,7 +552,7 @@ Boolean ::= l::[Boolean]
 function nil
 [a] ::=
 {
-  return i_nilList();
+  return [];
 } foreign {
   "java" : return "common.ConsCell.nil";
 }
@@ -560,7 +560,7 @@ function nil
 function cons
 [a] ::= h::a  t::[a]
 {
-  return i_consList(h, t);
+  return h :: t;
 } foreign {
   "java" : return "new common.ConsCell(%?h?%, %?t?%)";
 }
@@ -568,9 +568,10 @@ function cons
 function appendList
 [a] ::= l1::[a] l2::[a]
 {
-  return if l1.i_emptyList
-         then l2
-         else cons(head(l1), append(tail(l1), l2));
+  return case l1 of
+  | h :: t -> cons(h, append(t, l2))
+  | [] -> l2
+  end;
 } foreign {
   "java" : return "common.AppendCell.append(%l1%, %?l2?%)";
 }
@@ -579,7 +580,10 @@ function appendList
 function null
 Boolean ::= l::[a]
 {
-  return l.i_emptyList;
+  return case l of
+  | [] -> true
+  | _ :: _ -> false
+  end;
 } foreign {
   "java" : return "%l%.nil()";
 }
@@ -587,7 +591,10 @@ Boolean ::= l::[a]
 function listLength  -- not called 'length' since this is a builtin language feature, but thats how you should call it.
 Integer ::= l::[a]
 {
-  return l.i_lengthList;
+  return case l of
+  | _ :: t -> 1 + listLength(t)
+  | [] -> 0
+  end;
 } foreign {
   "java" : return "Integer.valueOf(%l%.length())";
 }
@@ -595,7 +602,10 @@ Integer ::= l::[a]
 function head
 a ::= l::[a]
 {
-  return l.i_headList;
+  return case l of
+  | h :: _ -> h
+  | [] -> error("requested head of nil")
+  end;
 } foreign {
   "java" : return "%l%.head()";
 }
@@ -603,7 +613,10 @@ a ::= l::[a]
 function tail
 [a] ::= l::[a]
 {
-  return l.i_tailList;
+  return case l of
+  | _ :: t -> t
+  | [] -> error("requested tail of nil")
+  end;
 } foreign {
   "java" : return "%l%.tail()";
 }

--- a/grammars/silver/core/List.sv
+++ b/grammars/silver/core/List.sv
@@ -25,7 +25,7 @@ instance MonadFail [] {
   fail = \ String -> [];
 }
 
-instance Alt List {
+instance Alt [] {
   alt = appendList;
 }
 

--- a/grammars/silver/core/List.sv
+++ b/grammars/silver/core/List.sv
@@ -552,7 +552,9 @@ Boolean ::= l::[Boolean]
 function nil
 [a] ::=
 {
-  return [];
+  -- Foreign function expected to handle this here
+  -- Needs a new implementation if non-java translation is made.
+  return error("foreign function");
 } foreign {
   "java" : return "common.ConsCell.nil";
 }
@@ -560,7 +562,9 @@ function nil
 function cons
 [a] ::= h::a  t::[a]
 {
-  return h :: t;
+  -- Foreign function expected to handle this here
+  -- Needs a new implementation if non-java translation is made.
+  return error("foreign function");
 } foreign {
   "java" : return "new common.ConsCell(%?h?%, %?t?%)";
 }

--- a/test/silver_construction/SilverConstruction.sv
+++ b/test/silver_construction/SilverConstruction.sv
@@ -4,7 +4,7 @@ import silver:compiler:extension:patternmatching;
 import silver:compiler:extension:silverconstruction;
 import silver:compiler:definition:core;
 import silver:compiler:definition:type:syntax;
-import silver:compiler:extension:list;
+import silver:compiler:modification:list;
 
 -- TESTING Silver_Expr
 
@@ -19,7 +19,7 @@ equalityTest(hackUnparse(testExprBool(false)), "silver:compiler:definition:core:
 
 equalityTest(hackUnparse(Silver_Expr{1}), "silver:compiler:definition:core:intConst('1')", String, silver_construction_tests);
 equalityTest(hackUnparse(Silver_Expr{1.343}), "silver:compiler:definition:core:floatConst('1.343')", String, silver_construction_tests);
-equalityTest(hackUnparse(Silver_Expr{[dog, doggy, doggies]}), "silver:compiler:extension:list:fullList('[', silver:compiler:definition:core:exprsCons(silver:compiler:definition:core:baseExpr(silver:compiler:definition:core:qNameId(silver:compiler:definition:core:nameIdLower('dog'))), ',', silver:compiler:definition:core:exprsCons(silver:compiler:definition:core:baseExpr(silver:compiler:definition:core:qNameId(silver:compiler:definition:core:nameIdLower('doggy'))), ',', silver:compiler:definition:core:exprsSingle(silver:compiler:definition:core:baseExpr(silver:compiler:definition:core:qNameId(silver:compiler:definition:core:nameIdLower('doggies')))))), ']')", String, silver_construction_tests);
+equalityTest(hackUnparse(Silver_Expr{[dog, doggy, doggies]}), "silver:compiler:modification:list:fullList('[', silver:compiler:definition:core:exprsCons(silver:compiler:definition:core:baseExpr(silver:compiler:definition:core:qNameId(silver:compiler:definition:core:nameIdLower('dog'))), ',', silver:compiler:definition:core:exprsCons(silver:compiler:definition:core:baseExpr(silver:compiler:definition:core:qNameId(silver:compiler:definition:core:nameIdLower('doggy'))), ',', silver:compiler:definition:core:exprsSingle(silver:compiler:definition:core:baseExpr(silver:compiler:definition:core:qNameId(silver:compiler:definition:core:nameIdLower('doggies')))))), ']')", String, silver_construction_tests);
 
 -- TESTING Silver_Pattern
 
@@ -43,4 +43,4 @@ equalityTest(hackUnparse(Silver_TypeExpr { Boolean }), "silver:compiler:definiti
 equalityTest(hackUnparse(Silver_TypeExpr { Integer }), "silver:compiler:definition:type:syntax:integerTypeExpr('Integer')", String, silver_construction_tests);
 equalityTest(hackUnparse(Silver_TypeExpr { Float }), "silver:compiler:definition:type:syntax:floatTypeExpr('Float')", String, silver_construction_tests);
 equalityTest(hackUnparse(Silver_TypeExpr {Pair <String Integer>}), "silver:compiler:definition:type:syntax:appTypeExpr(silver:compiler:definition:type:syntax:nominalTypeExpr(silver:compiler:definition:core:qNameTypeId('Pair')), silver:compiler:definition:type:syntax:bTypeList('<', silver:compiler:definition:type:syntax:typeListCons(silver:compiler:definition:type:syntax:stringTypeExpr('String'), silver:compiler:definition:type:syntax:typeListSingle(silver:compiler:definition:type:syntax:integerTypeExpr('Integer'))), '>'))", String, silver_construction_tests);
-equalityTest (hackUnparse(Silver_TypeExpr { [Integer] }), "silver:compiler:extension:list:listTypeExpr('[', silver:compiler:definition:type:syntax:integerTypeExpr('Integer'), ']')", String, silver_construction_tests);
+equalityTest (hackUnparse(Silver_TypeExpr { [Integer] }), "silver:compiler:modification:list:listTypeExpr('[', silver:compiler:definition:type:syntax:integerTypeExpr('Integer'), ']')", String, silver_construction_tests);


### PR DESCRIPTION
# Changes
- Inlines previous `listCtrType` forward.
- Adds appropriate missing attributes (`freeVariables`,`freeSkolemVars`,`freeFlexibleVars`) to `listCtrType`
- Adds `unify` attribute for listCtrType
- Removes all references to the nonterminal List in silver:core

# Documentation
Please briefly describe the documentation you have written in the following categories, or why you didn't write documentation for a category:

For this change, documentation would not change, as the interface for lists for the users remained the same.