### PR TITLE
Fixing display of missing patterns for nested lists

### DIFF
--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -585,6 +585,13 @@ Maybe<[Pattern]> ::= conPatts::[[Decorated Pattern]] varPatts::[[Decorated Patte
         | just(lst) -> just(nilListPattern('[', ']', location=bogusLoc())::lst)
         | nothing() ->
           case consSubcall of
+          --If the missing subpattern is also a cons, wrap it in parentheses to display correctly
+          --Otherwise `(a::b)::c` displays as `a::b::c`, which means something different
+          | just(consListPattern(hd1, _, tl1)::tl::lst) ->
+            just(consListPattern(
+                    nestedPatterns('(', consListPattern(hd1, '::', tl1, location=bogusLoc()), ')',
+                                   location=bogusLoc()),
+                    '::', tl, location=bogusLoc())::lst)
           | just(hd::tl::lst) ->
             just(consListPattern(hd, '::', tl, location=bogusLoc())::lst)
           | just(_) -> error("List must include patterns for at least head and tail")

--- a/test/patt/Completeness.sv
+++ b/test/patt/Completeness.sv
@@ -169,6 +169,20 @@ noWarnCode "not exhaustive" {
   }
 }
 
+--Correct display of list nesting
+--Nothing else should require special treatment for display, since no
+--   other patterns should rely on grouping
+warnCode "(_::_)::_" {
+  function fun_list_complete_nested
+  String ::=
+  {
+    return case [[1, 2]] of
+           | [] -> "nil"
+           | []::tl -> "1"
+           end;
+  }
+}
+
 
 --Maybe
 warnCode "not exhaustive" {


### PR DESCRIPTION
# Changes
In checking completeness of case expressions, we generate a pattern which is missing.  If the missing pattern is a non-empty list in a non-empty list, we need to correctly group the inner and outer lists.  For example, we want to see `(_::_)::_` rather than `_::_::_`.  This change makes it display as the former rather than the latter, where it was giving us the latter previously.

# Documentation
I added a comment explaining why we need the extra matching where I generate the missing pattern.  I also added a comment in the test file to try to explain why we don't need the formatting check for any other patterns.

This does not require any further documentation because it is a simple change which should only affect the code immediately around it and should not change anything users see, other than to make an incomplete pattern clear.
