### PR TITLE
Fix bug with file names for generated docs

### DIFF
--- a/grammars/silver/compiler/extension/doc/core/RootSpec.sv
+++ b/grammars/silver/compiler/extension/doc/core/RootSpec.sv
@@ -30,7 +30,7 @@ String ::= fileName::String
 {
   return foldr(
     \ ext::String file::String ->
-      if endsWith(file, ext) then substitute(ext, ".md", file) else file,
+      if endsWith(ext, file) then substitute(ext, ".md", file) else file,
     fileName, allowedSilverFileExtensions);
 }
 


### PR DESCRIPTION
# Changes
The logic for determining the names of generated documentation files has apparently been broken since #599 - the parameters to `endsWIth` were reversed, meaning that the documentation file names were the same as the source files, and thus did not appear in the website.  

# Documentation
This is a one-line bug fix.  No significant changes were made that require documentation.
