### PR TITLE
Fix all remaining flow errors in the Silver compiler

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,10 @@ melt.trynode('silver') {
     melt.archiveCommitArtifacts("jars/*.jar")
   }
 
+  stage("Modular Analyses") {
+    sh "./self-compile --clean --mwda"
+  }
+
   stage("Test") {
     // These test cases and tutorials are run as seperate tasks to allow for parallelism
     def tests = ["silver_features", "copper_features", "patt", "flow", "stdlib", "performance", "csterrors", "silver_construction", "origintracking", "implicit_monads"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ melt.trynode('silver') {
   }
 
   stage("Modular Analyses") {
-    sh "./self-compile --clean --mwda"
+    sh "./self-compile --clean --mwda --dont-translate"
   }
 
   stage("Test") {

--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -18,7 +18,7 @@ top::Expr ::=
 }
 
 aspect production forwardReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.errors <-
     case performSubstitution(top.typerep, top.finalSubst) of
@@ -28,7 +28,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production productionReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   contexts.contextLoc = q.location;
   contexts.contextSource = "the use of " ++ q.name;
@@ -37,7 +37,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production functionReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   contexts.contextLoc = q.location;
   contexts.contextSource = "the use of " ++ q.name;
@@ -46,7 +46,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production globalValueReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   contexts.contextLoc = q.location;
   contexts.contextSource = "the use of " ++ q.name;
@@ -55,7 +55,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production classMemberReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   instHead.contextLoc = q.location;
   instHead.contextSource = "the use of " ++ q.name;
@@ -87,7 +87,7 @@ top::Expr ::= e::Expr '.' q::QNameAttrOccur
 }
 
 aspect production undecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   -- We might have gotten here via a 'ntOrDec' type. So let's make certain we're UNdecorated,
   -- ensuring that type's specialization, otherwise we could end up in trouble!
@@ -105,7 +105,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production accessBouncer
-top::Expr ::= target::(Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) e::Expr  q::Decorated QNameAttrOccur
+top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::Expr  q::PartiallyDecorated QNameAttrOccur
 {
   propagate upSubst, downSubst;
 }
@@ -125,7 +125,7 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production decoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   -- We might have gotten here via a 'ntOrDec' type. So let's make certain we're decorated,
   -- ensuring that type's specialization, otherwise we could end up in trouble!

--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
@@ -103,7 +103,7 @@ top::ProductionStmt ::= 'return' e::Expr ';'
 }
 
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
@@ -117,7 +117,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 }
 
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
@@ -131,20 +131,20 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 }
 
 aspect production errorAttributeDef
-top::ProductionStmt ::= msg::[Message] dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   propagate downSubst, upSubst;
 }
 
 aspect production childDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.errors <- if isDecorable(top.typerep, top.env) then []
                 else [err(top.location, s"Inherited attributes can only be defined on (undecorated) nonterminal and partially decorated types, not ${prettyType(top.typerep)}.")];
 }
 
 aspect production localDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.errors <- if isDecorable(top.typerep, top.env) then []
                 else [err(top.location, s"Inherited attributes can only be defined on (undecorated) nonterminal and partially decorated types, not ${prettyType(top.typerep)}.")];
@@ -163,7 +163,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
 }
 
 aspect production localValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -265,7 +265,7 @@ top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
 }
 
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
@@ -285,7 +285,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 }
 
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local transitiveDeps :: [FlowVertex] = 
     expandGraph(e.flowDeps, top.frame.flowGraph);
@@ -301,7 +301,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
 ----- WARNING TODO BEGIN MASSIVE COPY & PASTE SESSION
 aspect production synBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
@@ -320,7 +320,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     else [];
 }
 aspect production synAppendColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
@@ -339,7 +339,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     else [];
 }
 aspect production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local transitiveDeps :: [FlowVertex] =
     expandGraph(e.flowDeps, top.frame.flowGraph);
@@ -351,7 +351,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     else [];
 }
 aspect production inhAppendColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local transitiveDeps :: [FlowVertex] = 
     expandGraph(e.flowDeps, top.frame.flowGraph);
@@ -413,7 +413,7 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
 }
 
 aspect production localValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   local transitiveDeps :: [FlowVertex] =
     expandGraph(e.flowDeps, top.frame.flowGraph);
@@ -453,7 +453,7 @@ top::ProductionStmt ::= 'attachNote' e::Expr ';'
 -- Partially skipping `appendCollectionValueDef`: it likewise forwards
 -- But we do have a special "exceeds check" to do here:
 aspect production appendCollectionValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   local productionFlowGraph :: ProductionGraph = top.frame.flowGraph;
   local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, productionFlowGraph);
@@ -490,7 +490,7 @@ Step 2: Let's go check on expressions. This has two purposes:
 -}
 
 aspect production childReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -501,7 +501,7 @@ top::Expr ::= q::Decorated QName
     else [];
 }
 aspect production lhsReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -511,7 +511,7 @@ top::Expr ::= q::Decorated QName
     else [];
 }
 aspect production localReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -522,7 +522,7 @@ top::Expr ::= q::Decorated QName
     else [];
 }
 aspect production forwardReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -539,7 +539,7 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   -- oh no again
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
@@ -632,7 +632,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   -- In this case, ONLY check for references.
   -- The transitive deps error will be less difficult to figure out when there's

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -685,14 +685,14 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
 
   -- Subtract the ref set from our deps
   local diff :: [String] =
-    set:toList(set:removeAll(getMinRefSet(e.typerep, top.env), set:add(inhDeps, set:empty())));
+    set:toList(set:removeAll(getMinRefSet(scrutineeType, top.env), set:add(inhDeps, set:empty())));
 
   top.errors <-
     if null(e.errors)
     && top.config.warnMissingInh
     && sinkVertexName.isJust
     && !null(diff)
-    then [mwdaWrn(top.config, e.location, "Pattern match on reference of type " ++ prettyType(e.typerep) ++ " has transitive dependencies on " ++ implode(", ", diff))]
+    then [mwdaWrn(top.config, e.location, "Pattern match on reference of type " ++ prettyType(scrutineeType) ++ " has transitive dependencies on " ++ implode(", ", diff))]
     else [];
 
 }

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
@@ -22,7 +22,7 @@ Either<String  Decorated CmdArgs> ::= args::[String]
 }
 
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur e::Expr
 {
   local exportedBy :: [String] = 
     if top.frame.hasPartialSignature
@@ -45,7 +45,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur e::
 }
 
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local exportedBy :: [String] = 
     case dl of
@@ -89,7 +89,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 --- FROM COLLECTIONS
 
 aspect production synBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local exportedBy :: [String] = 
     if top.frame.hasPartialSignature
@@ -111,7 +111,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     else [];
 }
 aspect production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local exportedBy :: [String] = 
     case dl of
@@ -163,7 +163,7 @@ top::ExprLHSExpr ::= attr::QNameAttrOccur
 
 -- These checks live here for now, since they are related to duplicate equations:
 aspect production childReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   local partialRefs::[(String, Location, [String])] = getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv);
@@ -190,7 +190,7 @@ top::Expr ::= q::Decorated QName
     end;
 }
 aspect production localReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   local partialRefs::[(String, Location, [String])] = getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv);
@@ -217,7 +217,7 @@ top::Expr ::= q::Decorated QName
     end;
 }
 aspect production lhsReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -228,7 +228,7 @@ top::Expr ::= q::Decorated QName
     end;
 }
 aspect production forwardReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -239,7 +239,7 @@ top::Expr ::= q::Decorated QName
     end;
 }
 aspect production lexicalLocalReference
-top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-

--- a/grammars/silver/compiler/definition/concrete_syntax/Root.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/Root.sv
@@ -4,6 +4,8 @@ monoid attribute syntaxAst :: [SyntaxDcl];
 monoid attribute parserSpecs :: [ParserSpec];
 
 attribute syntaxAst, parserSpecs occurs on Root, AGDcls, AGDcl;
+flowtype syntaxAst {decorate} on Root, AGDcls, AGDcl;
+flowtype parserSpecs {decorate} on Root, AGDcls, AGDcl;
 propagate syntaxAst, parserSpecs on Root, AGDcls;
 
 aspect default production

--- a/grammars/silver/compiler/definition/core/AGDcl.sv
+++ b/grammars/silver/compiler/definition/core/AGDcl.sv
@@ -6,8 +6,11 @@ grammar silver:compiler:definition:core;
 nonterminal AGDcls with config, grammarName, env, location, unparse, errors, defs, occursDefs, moduleNames, compiledGrammars, grammarDependencies, jarName;
 nonterminal AGDcl  with config, grammarName, env, location, unparse, errors, defs, occursDefs, moduleNames, compiledGrammars, grammarDependencies, jarName;
 
-flowtype decorate {config, grammarName, env, flowEnv, compiledGrammars} on AGDcls, AGDcl;
+flowtype decorate {config, grammarName, env, flowEnv, compiledGrammars, grammarDependencies} on AGDcls, AGDcl;
 flowtype forward {decorate} on AGDcls, AGDcl;
+flowtype errors {decorate} on AGDcls, AGDcl;
+flowtype defs {decorate} on AGDcls, AGDcl;
+flowtype occursDefs {decorate} on AGDcls, AGDcl;
 flowtype jarName {decorate} on AGDcls, AGDcl;
 
 propagate errors, moduleNames, jarName on AGDcls, AGDcl;

--- a/grammars/silver/compiler/definition/core/DclInfo.sv
+++ b/grammars/silver/compiler/definition/core/DclInfo.sv
@@ -5,36 +5,36 @@ import silver:compiler:modification:copper only terminalIdReference;
 {--
  - The production a variable reference should forward to for this type of value
  -}
-synthesized attribute refDispatcher :: (Expr ::= Decorated QName  Location) occurs on ValueDclInfo;
+synthesized attribute refDispatcher :: (Expr ::= PartiallyDecorated QName  Location) occurs on ValueDclInfo;
 {--
  - The production an "assignment" should forward to for this type of value
  -}
-synthesized attribute defDispatcher :: (ProductionStmt ::= Decorated QName  Expr  Location) occurs on ValueDclInfo;
+synthesized attribute defDispatcher :: (ProductionStmt ::= PartiallyDecorated QName  Expr  Location) occurs on ValueDclInfo;
 {--
  - The production an "equation" left hand side should forward to for this type of value (i.e. the 'x' in 'x.a = e')
  -}
-synthesized attribute defLHSDispatcher :: (DefLHS ::= Decorated QName  Location) occurs on ValueDclInfo;
+synthesized attribute defLHSDispatcher :: (DefLHS ::= PartiallyDecorated QName  Location) occurs on ValueDclInfo;
 
 {--
  - The handler for 'x.a' for 'a', given that 'x' is DECORATED.
  - @see accessDispather in TypeExp.sv, for the first step in that process...
  - @see decoratedAccessHandler production for where this is used
  -}
-synthesized attribute decoratedAccessHandler :: (Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) occurs on AttributeDclInfo;
+synthesized attribute decoratedAccessHandler :: (Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) occurs on AttributeDclInfo;
 {--
  - The handler for 'x.a' for 'a', given that 'x' is UNdecorated.
  - @see accessDispather in TypeExp.sv, for the first step in that process...
  - @see undecoratedAccessHandler production for where this is used
  -}
-synthesized attribute undecoratedAccessHandler :: (Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) occurs on AttributeDclInfo;
+synthesized attribute undecoratedAccessHandler :: (Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) occurs on AttributeDclInfo;
 {--
  - The production an "equation" should forward to for this type of attribute (i.e. the 'a' in 'x.a = e')
  -}
-synthesized attribute attrDefDispatcher :: (ProductionStmt ::= Decorated DefLHS  Decorated QNameAttrOccur  Expr  Location) occurs on AttributeDclInfo;
+synthesized attribute attrDefDispatcher :: (ProductionStmt ::= PartiallyDecorated DefLHS  PartiallyDecorated QNameAttrOccur  Expr  Location) occurs on AttributeDclInfo;
 {--
  - The production an "occurs on" decl should forward to for this type of attribute (for extension use, defaultAttributionDcl for all syn/inh/autocopy attrs.)
  -}
-synthesized attribute attributionDispatcher :: (AGDcl ::= Decorated QName  BracketedOptTypeExprs  QName  BracketedOptTypeExprs  Location) occurs on AttributeDclInfo;
+synthesized attribute attributionDispatcher :: (AGDcl ::= PartiallyDecorated QName  BracketedOptTypeExprs  QName  BracketedOptTypeExprs  Location) occurs on AttributeDclInfo;
 
 -- -- non-interface values
 aspect production childDcl
@@ -131,7 +131,7 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
   top.decoratedAccessHandler = accessBounceUndecorate(annoAccessHandler(_, _, location=_), _, _, _);
   top.undecoratedAccessHandler = annoAccessHandler(_, _, location=_);
   top.attrDefDispatcher =
-    \ dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, "Annotations are not defined as equations within productions")], dl, attr, e, location=l);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
 }

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -84,7 +84,7 @@ top::Expr ::= q::QName
 }
 
 abstract production errorReference
-top::Expr ::= msg::[Message]  q::Decorated QName
+top::Expr ::= msg::[Message]  q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars <- ts:fromList([q.name]);
@@ -95,7 +95,7 @@ top::Expr ::= msg::[Message]  q::Decorated QName
 
 -- TODO: We should separate this out, even, to be "nonterminal/decorable" and "as-is"
 abstract production childReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars <- ts:fromList([q.name]);
@@ -106,7 +106,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production lhsReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars <- ts:fromList([q.name]);
@@ -116,7 +116,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production localReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars <- ts:fromList([q.name]);
@@ -127,7 +127,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production forwardReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars <- ts:fromList([q.name]);
@@ -140,7 +140,7 @@ top::Expr ::= q::Decorated QName
 -- Later on, we do *not* distinguish for application.
 
 abstract production productionReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars <- ts:fromList([q.name]);
@@ -154,7 +154,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production functionReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars <- ts:fromList([q.name]);
@@ -168,7 +168,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production classMemberReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars <- ts:fromList([q.name]);
@@ -191,7 +191,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production globalValueReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars <- ts:fromList([q.name]);
@@ -272,7 +272,7 @@ top::Expr ::= e::Expr '(' ')'
 }
 
 abstract production errorApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.unparse = e.unparse ++ "(" ++ es.unparse ++ "," ++ anns.unparse ++ ")";
   top.freeVars <- e.freeVars;
@@ -293,7 +293,7 @@ top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppEx
 -- We don't distinguish anymore at this point. A production reference
 -- becomes a function, effectively.
 abstract production functionApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.unparse = e.unparse ++ "(" ++ es.unparse ++ "," ++ anns.unparse ++ ")";
   top.freeVars := e.freeVars ++ es.freeVars ++ anns.freeVars;
@@ -309,7 +309,7 @@ top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppEx
 }
 
 abstract production functionInvocation
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.unparse = e.unparse ++ "(" ++ es.unparse ++ "," ++ anns.unparse ++ ")";
   top.freeVars <- e.freeVars;
@@ -324,7 +324,7 @@ top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppEx
 }
 
 abstract production partialApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.unparse = e.unparse ++ "(" ++ es.unparse ++ "," ++ anns.unparse ++ ")";
   top.freeVars <- e.freeVars;
@@ -385,7 +385,7 @@ top::Expr ::= e::Expr '.' q::QNameAttrOccur
 }
 
 abstract production errorAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
   top.freeVars <- e.freeVars;
@@ -402,7 +402,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 abstract production annoAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
   top.freeVars <- e.freeVars;
@@ -416,7 +416,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 abstract production terminalAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
   
@@ -439,7 +439,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 abstract production undecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
   top.freeVars := e.freeVars;
@@ -458,7 +458,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
  - This production is intended to permit that.
  -}
 abstract production accessBouncer
-top::Expr ::= target::(Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) e::Expr  q::Decorated QNameAttrOccur
+top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
   propagate freeVars;
@@ -467,18 +467,18 @@ top::Expr ::= target::(Expr ::= Decorated Expr  Decorated QNameAttrOccur  Locati
   forwards to target(e, q, top.location);
 }
 function accessBounceDecorate
-Expr ::= target::(Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) e::Decorated Expr  q::Decorated QNameAttrOccur  l::Location
+Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur  l::Location
 {
   return accessBouncer(target, decorateExprWithEmpty('decorate', exprRef(e, location=l), 'with', '{', '}', location=l), q, location=l);
 }
 function accessBounceUndecorate
-Expr ::= target::(Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location) e::Decorated Expr  q::Decorated QNameAttrOccur  l::Location
+Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur  l::Location
 {
   return accessBouncer(target, mkStrFunctionInvocationDecorated(l, "silver:core:new", [e]), q, location=l);
 }
 
 abstract production decoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
   top.freeVars := e.freeVars;
@@ -495,7 +495,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 abstract production synDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
   top.freeVars <- e.freeVars;
@@ -504,7 +504,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 abstract production inhDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
   top.freeVars <- e.freeVars;
@@ -514,7 +514,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 
 -- TODO: change name. really "unknownDclAccessHandler"
 abstract production errorDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.unparse = e.unparse ++ "." ++ q.unparse;
   top.freeVars <- e.freeVars;

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -1195,12 +1195,12 @@ AnnoExpr ::= p::Pair<String Expr>
  - checks that expr well... just nest those and boom.
  -}
 function mkFunctionInvocationDecorated
-Expr ::= l::Location  e::Expr  es::[Decorated Expr]
+Expr ::= l::Location  e::Expr  es::[PartiallyDecorated Expr]
 {
   return mkFunctionInvocation(l, e, map(exprRef(_, location=l), es));
 }
 function mkStrFunctionInvocationDecorated
-Expr ::= l::Location  e::String  es::[Decorated Expr]
+Expr ::= l::Location  e::String  es::[PartiallyDecorated Expr]
 {
   return mkFunctionInvocation(l, baseExpr(qName(l, e), location=l), map(exprRef(_, location=l), es));
 }
@@ -1220,7 +1220,7 @@ Expr ::= l::Location  e::String  es::[Decorated Expr]
  - references to those children.
  -}
 abstract production exprRef
-top::Expr ::= e::Decorated Expr
+top::Expr ::= e::PartiallyDecorated Expr
 {
   top.unparse = e.unparse;
   top.freeVars <- e.freeVars;

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -15,6 +15,7 @@ nonterminal ExprInh with
 nonterminal ExprLHSExpr with
   config, grammarName, env, location, unparse, errors, freeVars, frame, name, typerep, decoratingnt, suppliedInhs, allSuppliedInhs, isRoot, originRules;
 
+flowtype unparse {} on Expr, Exprs, ExprInhs, ExprInh, ExprLHSExpr;
 flowtype freeVars {frame} on Expr, Exprs, ExprInhs, ExprInh, ExprLHSExpr;
 flowtype Expr = decorate {grammarName, env, flowEnv, downSubst, finalSubst, frame, isRoot, originRules, compiledGrammars, config}, forward {decorate};
 

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -78,9 +78,9 @@ top::Expr ::= q::QName
   top.unparse = q.unparse;
   top.freeVars := ts:fromList([q.name]);
   
-  forwards to if null(q.lookupValue.dcls)
-              then errorReference(q.lookupValue.errors, q, location=top.location)
-              else q.lookupValue.dcl.refDispatcher(q, top.location);
+  forwards to (if null(q.lookupValue.dcls)
+               then errorReference(q.lookupValue.errors, _, location=_)
+               else q.lookupValue.dcl.refDispatcher)(q, top.location);
 }
 
 abstract production errorReference
@@ -303,9 +303,10 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::P
   -- foo(x) where there is an annotation 'a'?
   -- Is this partial application, give (Foo ::= ;a::Something) or (Foo) + error.
   -- Possibly this can be solved by having somehting like "foo(x,a=?)"
-  forwards to if es.isPartial || anns.isPartial
-              then partialApplication(e, es, anns, location=top.location)
-              else functionInvocation(e, es, anns, location=top.location);
+  forwards to
+    (if es.isPartial || anns.isPartial
+     then partialApplication
+     else functionInvocation)(e, es, anns, location=top.location);
 }
 
 abstract production functionInvocation
@@ -447,8 +448,8 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
   top.errors := q.errors ++ forward.errors; -- so that these errors appear first.
   
   -- Note: LHS is UNdecorated, here we dispatch based on the kind of attribute.
-  forwards to if !q.found then errorDecoratedAccessHandler(e, q, location=top.location)
-              else q.attrDcl.undecoratedAccessHandler(e, q, top.location);
+  forwards to (if !q.found then errorDecoratedAccessHandler(_, _, location=_)
+               else q.attrDcl.undecoratedAccessHandler)(e, q, top.location);
   -- annoAccessHandler
   -- accessBouncer
 }
@@ -486,8 +487,8 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
   top.errors := q.errors ++ forward.errors; -- so that these errors appear first.
   
   -- Note: LHS is decorated, here we dispatch based on the kind of attribute.
-  forwards to if !q.found then errorDecoratedAccessHandler(e, q, location=top.location)
-              else q.attrDcl.decoratedAccessHandler(e, q, top.location);
+  forwards to (if !q.found then errorDecoratedAccessHandler(_, _, location=_)
+               else q.attrDcl.decoratedAccessHandler)(e, q, top.location);
   -- From here we go to:
   -- synDecoratedAccessHandler
   -- inhDecoratedAccessHandler

--- a/grammars/silver/compiler/definition/core/OccursDcl.sv
+++ b/grammars/silver/compiler/definition/core/OccursDcl.sv
@@ -1,7 +1,7 @@
 grammar silver:compiler:definition:core;
 
 abstract production defaultAttributionDcl
-top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
 
@@ -125,7 +125,7 @@ top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::B
 }
 
 abstract production errorAttributionDcl
-top::AGDcl ::= msg::[Message] at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= msg::[Message] at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
   top.occursDefs := [];

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -273,9 +273,9 @@ top::ProductionStmt ::= dl::DefLHS '.' attr::QNameAttrOccur '=' e::Expr ';'
     -- consider "production foo  top::DoesNotExist ::= { top.errors = ...; }"
     -- where top is a valid reference to a type that is an error type
     -- so there is an error elsewhere
-    if !dl.found || !attr.found || !null(problems)
-    then errorAttributeDef(problems, dl, attr, e, location=top.location)
-    else attr.attrDcl.attrDefDispatcher(dl, attr, e, top.location);
+    (if !dl.found || !attr.found || !null(problems)
+     then errorAttributeDef(problems, _,  _, _, location=_)
+     else attr.attrDcl.attrDefDispatcher)(dl, attr, e, top.location);
 }
 
 {- This is a helper that exist primarily to decorate 'e' and add its error messages to the list.
@@ -314,9 +314,9 @@ top::DefLHS ::= q::QName
 
   top.errors := q.lookupValue.errors ++ forward.errors;
   
-  forwards to if null(q.lookupValue.dcls)
-              then errorDefLHS(q, location=top.location)
-              else q.lookupValue.dcl.defLHSDispatcher(q, top.location);
+  forwards to (if null(q.lookupValue.dcls)
+               then errorDefLHS(_, location=_)
+               else q.lookupValue.dcl.defLHSDispatcher)(q, top.location);
 }
 
 abstract production errorDefLHS
@@ -414,9 +414,9 @@ top::ProductionStmt ::= val::QName '=' e::Expr ';'
   top.productionAttributes := [];
   top.defs := [];
   
-  forwards to if null(val.lookupValue.dcls)
-              then errorValueDef(val, e, location=top.location)
-              else val.lookupValue.dcl.defDispatcher(val, e, top.location);
+  forwards to (if null(val.lookupValue.dcls)
+               then errorValueDef(_, _, location=_)
+               else val.lookupValue.dcl.defDispatcher)(val, e, top.location);
 }
 
 abstract production errorValueDef

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -281,7 +281,7 @@ top::ProductionStmt ::= dl::DefLHS '.' attr::QNameAttrOccur '=' e::Expr ';'
 {- This is a helper that exist primarily to decorate 'e' and add its error messages to the list.
    Invariant: msg should not be null! -}
 abstract production errorAttributeDef
-top::ProductionStmt ::= msg::[Message] dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
 
@@ -291,7 +291,7 @@ top::ProductionStmt ::= msg::[Message] dl::Decorated DefLHS  attr::Decorated QNa
 }
 
 abstract production synthesizedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
 
@@ -299,7 +299,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 }
 
 abstract production inheritedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
 
@@ -320,7 +320,7 @@ top::DefLHS ::= q::QName
 }
 
 abstract production errorDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.name = q.name;
   top.unparse = q.unparse;
@@ -338,7 +338,7 @@ top::DefLHS ::= q::'forward'
 }
 
 abstract production childDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.name = q.name;
   top.unparse = q.unparse;
@@ -354,7 +354,7 @@ top::DefLHS ::= q::Decorated QName
 }
 
 abstract production lhsDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.name = q.name;
   top.unparse = q.unparse;
@@ -370,7 +370,7 @@ top::DefLHS ::= q::Decorated QName
 }
 
 abstract production localDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.name = q.name;
   top.unparse = q.unparse;
@@ -386,7 +386,7 @@ top::DefLHS ::= q::Decorated QName
 }
 
 abstract production forwardDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.name = q.name;
   top.unparse = q.unparse;
@@ -420,7 +420,7 @@ top::ProductionStmt ::= val::QName '=' e::Expr ';'
 }
 
 abstract production errorValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
 
@@ -432,7 +432,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 }
 
 abstract production localValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
 

--- a/grammars/silver/compiler/definition/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/core/ProductionDcl.sv
@@ -2,7 +2,7 @@ grammar silver:compiler:definition:core;
 
 nonterminal ProductionSignature with config, grammarName, env, location, unparse, errors, defs, constraintDefs, occursDefs, namedSignature, signatureName;
 nonterminal ProductionLHS with config, grammarName, env, location, unparse, errors, defs, outputElement;
-nonterminal ProductionRHS with config, grammarName, env, location, unparse, errors, defs, inputElements;
+nonterminal ProductionRHS with config, grammarName, env, location, unparse, errors, defs, inputElements, elementCount;
 nonterminal ProductionRHSElem with config, grammarName, env, location, unparse, errors, defs, inputElements, deterministicCount;
 
 flowtype forward {env, signatureName} on ProductionSignature;
@@ -18,6 +18,7 @@ propagate defs on ProductionRHS;
  - Used to help give names to children, when names are omitted.
  -}
 inherited attribute deterministicCount :: Integer;
+synthesized attribute elementCount::Integer;
 
 {--
  - Given to signature syntax, so as to construct a named signature representation.
@@ -122,6 +123,7 @@ top::ProductionRHS ::=
   top.unparse = "";
 
   top.inputElements = [];
+  top.elementCount = 0;
 }
 
 concrete production productionRHSCons
@@ -130,7 +132,8 @@ top::ProductionRHS ::= h::ProductionRHSElem t::ProductionRHS
   top.unparse = h.unparse ++ " " ++ t.unparse;
 
   top.inputElements = h.inputElements ++ t.inputElements;
-  h.deterministicCount = length(t.inputElements);
+  top.elementCount = 1 + t.elementCount;
+  h.deterministicCount = t.elementCount;
 }
 
 concrete production productionRHSElem

--- a/grammars/silver/compiler/definition/core/Project.sv
+++ b/grammars/silver/compiler/definition/core/Project.sv
@@ -25,6 +25,7 @@ option silver:compiler:modification:copper;
 option silver:compiler:modification:defaultattr;
 option silver:compiler:modification:collection;
 option silver:compiler:modification:copper_mda;
+option silver:compiler:modification:list;
 
 option silver:compiler:extension:testing; -- TODO this is about that buggy experiment of Eric's...
 

--- a/grammars/silver/compiler/definition/core/Project.sv
+++ b/grammars/silver/compiler/definition/core/Project.sv
@@ -27,7 +27,7 @@ option silver:compiler:modification:collection;
 option silver:compiler:modification:copper_mda;
 
 -- The list extension doesn't need to be an option here,
--- it only needs to be one of silver:compiler:definition:type and silver:compiler:translation:java:core
+-- it only needs to be one of silver:compiler:definition:type
 -- option silver:compiler:modification:list;
 
 option silver:compiler:extension:testing; -- TODO this is about that buggy experiment of Eric's...

--- a/grammars/silver/compiler/definition/core/Project.sv
+++ b/grammars/silver/compiler/definition/core/Project.sv
@@ -25,7 +25,10 @@ option silver:compiler:modification:copper;
 option silver:compiler:modification:defaultattr;
 option silver:compiler:modification:collection;
 option silver:compiler:modification:copper_mda;
-option silver:compiler:modification:list;
+
+-- The list extension doesn't need to be an option here,
+-- it only needs to be one of silver:compiler:definition:type and silver:compiler:translation:java:core
+-- option silver:compiler:modification:list;
 
 option silver:compiler:extension:testing; -- TODO this is about that buggy experiment of Eric's...
 

--- a/grammars/silver/compiler/definition/core/QName.sv
+++ b/grammars/silver/compiler/definition/core/QName.sv
@@ -228,10 +228,16 @@ top::QNameAttrOccur ::= at::QName
     else [];-}
     -- TODO: This last bit is disabled because we have problems with importing grammars multiple times.
     -- TODO FIXME: enable this, and fix the grammar import issues!
+
+  production resolvedDcl::OccursDclInfo = if top.found then head(dclsNarrowed) else
+    error("INTERNAL ERROR: Accessing dcl of occurrence " ++ at.name ++ " at " ++ top.grammarName ++ " " ++ top.location.unparse);
+  resolvedDcl.givenNonterminalType = top.attrFor;
+  production resolvedTypeScheme::PolyType = resolvedDcl.typeScheme;
+  production requiredContexts::Contexts = foldContexts(resolvedTypeScheme.contexts);
+  requiredContexts.env = top.env;
   
   top.typerep = if top.found then determineAttributeType(head(dclsNarrowed), top.attrFor) else errorType();
-  top.dcl = if top.found then head(dclsNarrowed) else
-    error("INTERNAL ERROR: Accessing dcl of occurrence " ++ at.name ++ " at " ++ top.grammarName ++ " " ++ top.location.unparse);
+  top.dcl = resolvedDcl;
   top.attrDcl = if top.found then head(attrsNarrowed) else
     -- Workaround fix for proper error reporting - appairently there are some places where this is still demanded.
     if !null(attrs) then head(attrs) else

--- a/grammars/silver/compiler/definition/core/QName.sv
+++ b/grammars/silver/compiler/definition/core/QName.sv
@@ -146,7 +146,7 @@ top::QNameType ::= id::Name ':' qn::QNameType
  -}
 nonterminal QNameAttrOccur with config, name, location, grammarName, env, unparse, attrFor, errors, typerep, dcl<OccursDclInfo>, attrDcl, found, attrFound;
 
-flowtype QNameAttrOccur = dcl {grammarName, env, attrFor}, attrDcl {grammarName, env, attrFor};
+flowtype QNameAttrOccur = decorate {grammarName, env, attrFor}, dcl {decorate}, attrDcl {decorate};
 
 {--
  - For QNameAttrOccur, the name of the LHS to look up this attribute on.

--- a/grammars/silver/compiler/definition/core/Type.sv
+++ b/grammars/silver/compiler/definition/core/Type.sv
@@ -1,10 +1,10 @@
 grammar silver:compiler:definition:core;
 
 -- LHS type gives this to 'application' for "foo(...)" calls.
-synthesized attribute applicationDispatcher :: (Expr ::= Decorated Expr  Decorated AppExprs  Decorated AnnoAppExprs  Location);
+synthesized attribute applicationDispatcher :: (Expr ::= PartiallyDecorated Expr  PartiallyDecorated AppExprs  PartiallyDecorated AnnoAppExprs  Location);
 -- LHS type gives this to 'access' for "foo.some" accesses.
 -- (See DclInfo for the next step)
-synthesized attribute accessHandler :: (Expr ::= Decorated Expr  Decorated QNameAttrOccur  Location);
+synthesized attribute accessHandler :: (Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location);
 
 -- Used for poor man's type classes
 -- TODO: Finish removing these and replace with real type classes

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -70,7 +70,7 @@ monoid attribute nonSuspectContribs :: [Pair<String [String]>];
 {-- A list of decoration sites where partial references are taken, and the attributes on those partial references -}
 monoid attribute partialRefContribs :: [(String, String, Location, [String])];
 
-propagate synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, localInhTreeContribs, prodTreeContribs, prodGraphContribs, hostSynTreeContribs, nonSuspectContribs, partialRefContribs
+propagate synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, localInhTreeContribs, localTreeContribs, prodTreeContribs, prodGraphContribs, hostSynTreeContribs, nonSuspectContribs, partialRefContribs
   on FlowDefs;
 
 abstract production consFlow

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -243,7 +243,7 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e1::Expr ';'
 }
 
 aspect production exprRef
-top::Expr ::= e::Decorated Expr
+top::Expr ::= e::PartiallyDecorated Expr
 {
   -- This production is somewhat special, for example, error is := []
   -- That's because the errors should have already been appeared wherever it's anchored.

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -39,7 +39,7 @@ top::Expr ::=
 }
 
 aspect production childReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   -- Note that q should find the actual type written in the signature, and so
   -- isDecorable on that indeed tells us whether it's something autodecorated.
@@ -64,7 +64,7 @@ top::Expr ::= q::Decorated QName
     end;
 }
 aspect production lhsReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   -- Always a decorable type, so just check how it's being used:
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
@@ -79,7 +79,7 @@ top::Expr ::= q::Decorated QName
     else noVertex();
 }
 aspect production localReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   -- Again, q give the actual type written.
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
@@ -104,7 +104,7 @@ top::Expr ::= q::Decorated QName
     end;
 }
 aspect production forwardReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   -- Again, always a decorable type.
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
@@ -122,13 +122,13 @@ top::Expr ::= q::Decorated QName
 
 -- Still need these equations since propagate ignores decorated references
 aspect production functionInvocation
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs annos::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
 {
   top.flowDeps <- e.flowDeps ++ es.flowDeps ++ annos.flowDeps;
   top.flowDefs <- e.flowDefs ++ es.flowDefs ++ annos.flowDefs;
 }
 aspect production partialApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs annos::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
 {
   top.flowDeps <- e.flowDeps ++ es.flowDeps ++ annos.flowDeps;
   top.flowDefs <- e.flowDefs ++ es.flowDefs ++ annos.flowDefs;
@@ -145,14 +145,14 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production errorAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.flowDefs <- e.flowDefs;
 }
 -- Note that below we IGNORE the flow deps of the lhs if we know what it is
 -- this is because by default the lhs will have 'taking ref' flow deps (see above)
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.flowDeps := 
     case e.flowVertexInfo of
@@ -162,7 +162,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
   top.flowDefs <- e.flowDefs;
 }
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.flowDeps :=
     case e.flowVertexInfo of
@@ -172,19 +172,19 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
   top.flowDefs <- e.flowDefs;
 }
 aspect production errorDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.flowDeps <- []; -- errors, who cares?
   top.flowDefs <- e.flowDefs;
 }
 aspect production terminalAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.flowDeps <- e.flowDeps;
   top.flowDefs <- e.flowDefs;
 }
 aspect production annoAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.flowDeps <- e.flowDeps;
   top.flowDefs <- e.flowDefs;
@@ -270,7 +270,7 @@ top::Expr ::= la::AssignExpr  e::Expr
 }
 
 aspect production lexicalLocalReference
-top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   -- Because of the auto-undecorate behavior, we need to check for the case
   -- where `t` should be equivalent to `new(t)` and report accoringly.

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -59,7 +59,7 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
 }
 
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
@@ -75,7 +75,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
       [defaultSynEq(top.frame.lhsNtName, attr.attrDcl.fullName, e.flowDeps)];
 }
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.flowDefs <-
     case dl of
@@ -87,7 +87,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 }
 
 aspect production localValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   -- TODO: So, I'm just going to assume for the moment that we're always allowed to define the eq for a local...
   -- technically, it's possible to break this if you declare it in one grammar, but define it in another, but
@@ -102,7 +102,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 -- FROM COLLECTIONS TODO
 
 aspect production synAppendColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- <- -} e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- <- -} e::Expr
 {
   local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
@@ -114,7 +114,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {-
 }
 
 aspect production inhAppendColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- <- -} e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- <- -} e::Expr
 {
   local vertex :: FlowVertex =
     case dl of
@@ -127,7 +127,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {-
     [extraEq(top.frame.fullName, vertex, e.flowDeps, true)];
 }
 aspect production synBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
@@ -143,7 +143,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
       [defaultSynEq(top.frame.lhsNtName, attr.attrDcl.fullName, e.flowDeps)];
 }
 aspect production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.flowDefs <-
     case dl of
@@ -156,7 +156,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
 
 aspect production appendCollectionValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   local locDefGram :: String = hackGramFromQName(val.lookupValue);
   -- TODO: possible bug? this would include ":local" in the gram wouldn't it?

--- a/grammars/silver/compiler/definition/flow/env/Root.sv
+++ b/grammars/silver/compiler/definition/flow/env/Root.sv
@@ -1,6 +1,9 @@
 grammar silver:compiler:definition:flow:env;
 
 attribute flowDefs, refDefs, specDefs, flowEnv occurs on Root, AGDcls, AGDcl, Grammar;
+flowtype flowDefs {decorate} on Root, AGDcls, AGDcl, Grammar;
+flowtype refDefs {decorate} on Root, AGDcls, AGDcl, Grammar;
+flowtype specDefs {decorate} on Root, AGDcls, AGDcl, Grammar;
 propagate flowDefs, refDefs, specDefs on Root, AGDcls, AGDcl, Grammar;
 
 aspect default production

--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -220,7 +220,7 @@ top::Type ::= t::Type i::Type
 }
 
 aspect production ntOrDecType
-top::Type ::= nt::Type inhs::Type hidden::Type
+top::Type ::= nt::Type inhs::Type hidden::Type defaultPartialDec::Boolean defaultInhs::Type
 {
 -- Sometimes useful for debugging.
 --  top.typepp = "Undecorable " ++ nt.typepp ++ " with  " ++ inhs.typepp ++ " specialized " ++ prettyTypeWith(hidden, []));

--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -220,7 +220,7 @@ top::Type ::= t::Type i::Type
 }
 
 aspect production ntOrDecType
-top::Type ::= nt::Type inhs::Type hidden::Type defaultPartialDec::Boolean defaultInhs::Type
+top::Type ::= nt::Type inhs::Type hidden::Type
 {
 -- Sometimes useful for debugging.
 --  top.typepp = "Undecorable " ++ nt.typepp ++ " with  " ++ inhs.typepp ++ " specialized " ++ prettyTypeWith(hidden, []));

--- a/grammars/silver/compiler/definition/type/Substitutions.sv
+++ b/grammars/silver/compiler/definition/type/Substitutions.sv
@@ -168,13 +168,13 @@ top::Type ::= tv::TyVar
 }
 
 aspect production ntOrDecType
-top::Type ::= nt::Type inhs::Type hidden::Type defaultPartialDec::Boolean defaultInhs::Type
+top::Type ::= nt::Type inhs::Type hidden::Type
 {
   -- We rely very carefully on eliminating ourselves once we've specialized!
   -- Note: we're matching on hidden.subsituted, not just hidden. Important!
   top.substituted =
     case hidden.substituted of
-    | varType(_) -> ntOrDecType(nt.substituted, inhs.substituted, hidden.substituted, defaultPartialDec, defaultInhs.substituted)
+    | varType(_) -> ntOrDecType(nt.substituted, inhs.substituted, hidden.substituted)
     | _          -> hidden.substituted
     end;
   -- For a renaming, we don't need to specialize.

--- a/grammars/silver/compiler/definition/type/Substitutions.sv
+++ b/grammars/silver/compiler/definition/type/Substitutions.sv
@@ -168,13 +168,13 @@ top::Type ::= tv::TyVar
 }
 
 aspect production ntOrDecType
-top::Type ::= nt::Type inhs::Type hidden::Type
+top::Type ::= nt::Type inhs::Type hidden::Type defaultPartialDec::Boolean defaultInhs::Type
 {
   -- We rely very carefully on eliminating ourselves once we've specialized!
   -- Note: we're matching on hidden.subsituted, not just hidden. Important!
   top.substituted =
     case hidden.substituted of
-    | varType(_) -> ntOrDecType(nt.substituted, inhs.substituted, hidden.substituted)
+    | varType(_) -> ntOrDecType(nt.substituted, inhs.substituted, hidden.substituted, defaultPartialDec, defaultInhs.substituted)
     | _          -> hidden.substituted
     end;
   -- For a renaming, we don't need to specialize.

--- a/grammars/silver/compiler/definition/type/Type.sv
+++ b/grammars/silver/compiler/definition/type/Type.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:definition:type;
 
 option silver:compiler:modification:ffi; -- foreign types
+option silver:compiler:modification:list; -- list type
 
 synthesized attribute kindrep :: Kind;
 synthesized attribute freeVariables :: [TyVar];

--- a/grammars/silver/compiler/definition/type/Unification.sv
+++ b/grammars/silver/compiler/definition/type/Unification.sv
@@ -116,7 +116,7 @@ top::Type ::= fn::String ks::[Kind] tracked::Boolean
             else emptySubst()
           else error("kind mismatch during unification for " ++ prettyType(top) ++ " and " ++ prettyType(top.unifyWith)) -- Should be impossible
         else errorSubst("Tried to unify conflicting nonterminal types " ++ fn ++ " and " ++ ofn)
-    | ntOrDecType(_, _, _, _, _) -> errorSubst("nte-nodte: try again")
+    | ntOrDecType(_, _, _) -> errorSubst("nte-nodte: try again")
     | _ -> errorSubst("Tried to unify nonterminal type " ++ fn ++ " with " ++ prettyType(top.unifyWith))
     end;
 }
@@ -150,7 +150,7 @@ top::Type ::= te::Type i::Type
   top.unify = 
     case top.unifyWith of
     | decoratedType(ote, oi) -> composeSubst(unify(te, ote), unify(i, oi))
-    | ntOrDecType(_,_,_,_,_) -> errorSubst("dte-nodte: try again")
+    | ntOrDecType(_,_,_) -> errorSubst("dte-nodte: try again")
     | _ -> errorSubst("Tried to unify decorated type with " ++ prettyType(top.unifyWith))
     end;
 }
@@ -161,13 +161,13 @@ top::Type ::= te::Type i::Type
   top.unify = 
     case top.unifyWith of
     | partiallyDecoratedType(ote, oi) -> composeSubst(unify(te, ote), unify(i, oi))
-    | ntOrDecType(_,_,_,_,_) -> errorSubst("dte-nodte: try again")
+    | ntOrDecType(_,_,_) -> errorSubst("dte-nodte: try again")
     | _ -> errorSubst("Tried to unify partially decorated type with " ++ prettyType(top.unifyWith))
     end;
 }
 
 aspect production ntOrDecType
-top::Type ::= nt::Type inhs::Type hidden::Type defaultPartialDec::Boolean defaultInhs::Type
+top::Type ::= nt::Type inhs::Type hidden::Type
 {
   -- If we're being asked to unify, then we know hidden is still a type variable,
   -- since we shouldn't be unifying with anything but fully-substituted types.

--- a/grammars/silver/compiler/definition/type/Unification.sv
+++ b/grammars/silver/compiler/definition/type/Unification.sv
@@ -116,7 +116,7 @@ top::Type ::= fn::String ks::[Kind] tracked::Boolean
             else emptySubst()
           else error("kind mismatch during unification for " ++ prettyType(top) ++ " and " ++ prettyType(top.unifyWith)) -- Should be impossible
         else errorSubst("Tried to unify conflicting nonterminal types " ++ fn ++ " and " ++ ofn)
-    | ntOrDecType(_, _, _) -> errorSubst("nte-nodte: try again")
+    | ntOrDecType(_, _, _, _, _) -> errorSubst("nte-nodte: try again")
     | _ -> errorSubst("Tried to unify nonterminal type " ++ fn ++ " with " ++ prettyType(top.unifyWith))
     end;
 }
@@ -150,7 +150,7 @@ top::Type ::= te::Type i::Type
   top.unify = 
     case top.unifyWith of
     | decoratedType(ote, oi) -> composeSubst(unify(te, ote), unify(i, oi))
-    | ntOrDecType(_,_,_) -> errorSubst("dte-nodte: try again")
+    | ntOrDecType(_,_,_,_,_) -> errorSubst("dte-nodte: try again")
     | _ -> errorSubst("Tried to unify decorated type with " ++ prettyType(top.unifyWith))
     end;
 }
@@ -161,13 +161,13 @@ top::Type ::= te::Type i::Type
   top.unify = 
     case top.unifyWith of
     | partiallyDecoratedType(ote, oi) -> composeSubst(unify(te, ote), unify(i, oi))
-    | ntOrDecType(_,_,_) -> errorSubst("dte-nodte: try again")
+    | ntOrDecType(_,_,_,_,_) -> errorSubst("dte-nodte: try again")
     | _ -> errorSubst("Tried to unify partially decorated type with " ++ prettyType(top.unifyWith))
     end;
 }
 
 aspect production ntOrDecType
-top::Type ::= nt::Type inhs::Type hidden::Type
+top::Type ::= nt::Type inhs::Type hidden::Type defaultPartialDec::Boolean defaultInhs::Type
 {
   -- If we're being asked to unify, then we know hidden is still a type variable,
   -- since we shouldn't be unifying with anything but fully-substituted types.

--- a/grammars/silver/compiler/definition/type/Util.sv
+++ b/grammars/silver/compiler/definition/type/Util.sv
@@ -226,7 +226,7 @@ top::Type ::= te::Type i::Type
 }
 
 aspect production ntOrDecType
-top::Type ::= nt::Type inhs::Type hidden::Type defaultPartialDec::Boolean defaultInhs::Type
+top::Type ::= nt::Type inhs::Type hidden::Type
 {
   top.baseType = top;
   top.argTypes = [];

--- a/grammars/silver/compiler/definition/type/Util.sv
+++ b/grammars/silver/compiler/definition/type/Util.sv
@@ -226,7 +226,7 @@ top::Type ::= te::Type i::Type
 }
 
 aspect production ntOrDecType
-top::Type ::= nt::Type inhs::Type hidden::Type
+top::Type ::= nt::Type inhs::Type hidden::Type defaultPartialDec::Boolean defaultInhs::Type
 {
   top.baseType = top;
   top.argTypes = [];

--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:extension:autoattr;
 
-synthesized attribute propagateDispatcher :: (ProductionStmt ::= Decorated QName  Location) occurs on AttributeDclInfo;
+synthesized attribute propagateDispatcher :: (ProductionStmt ::= PartiallyDecorated QName  Location) occurs on AttributeDclInfo;
 
 synthesized attribute emptyVal::Expr occurs on AttributeDclInfo;
 
@@ -46,7 +46,7 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type empty::Expr append:
   top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
   top.attrDefDispatcher = 
-    \ dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, attr.name ++ " is a monoid collection attribute, and you must use ':=' or '<-', not '='.")], dl, attr, e, location=l);
   top.attrBaseDefDispatcher = synBaseColAttributeDef(_, _, _, location=_);
   top.attrAppendDefDispatcher = synAppendColAttributeDef(_, _, _, location=_);

--- a/grammars/silver/compiler/extension/autoattr/Destruct.sv
+++ b/grammars/silver/compiler/extension/autoattr/Destruct.sv
@@ -21,7 +21,7 @@ top::AGDcl ::= 'destruct' 'attribute' inh::Name ';'
 }
 
 abstract production destructAttributionDcl
-top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
   top.moduleNames := [];
@@ -77,7 +77,7 @@ top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::B
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateDestruct
-top::ProductionStmt ::= attr::Decorated QName
+top::ProductionStmt ::= attr::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${attr.unparse};";
   

--- a/grammars/silver/compiler/extension/autoattr/Equality.sv
+++ b/grammars/silver/compiler/extension/autoattr/Equality.sv
@@ -27,7 +27,7 @@ top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::QName ';'
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateEquality
-top::ProductionStmt ::= inh::String syn::Decorated QName
+top::ProductionStmt ::= inh::String syn::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${syn.unparse};";
   

--- a/grammars/silver/compiler/extension/autoattr/Functor.sv
+++ b/grammars/silver/compiler/extension/autoattr/Functor.sv
@@ -21,7 +21,7 @@ top::AGDcl ::= 'functor' 'attribute' a::Name ';'
 }
 
 abstract production functorAttributionDcl
-top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
   top.moduleNames := [];
@@ -55,7 +55,7 @@ top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::B
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateFunctor
-top::ProductionStmt ::= attr::Decorated QName
+top::ProductionStmt ::= attr::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${attr.unparse};";
   

--- a/grammars/silver/compiler/extension/autoattr/Inherited.sv
+++ b/grammars/silver/compiler/extension/autoattr/Inherited.sv
@@ -1,7 +1,7 @@
 grammar silver:compiler:extension:autoattr;
 
 abstract production propagateInh
-top::ProductionStmt ::= attr::Decorated QName
+top::ProductionStmt ::= attr::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${attr.unparse};";
   

--- a/grammars/silver/compiler/extension/autoattr/Monoid.sv
+++ b/grammars/silver/compiler/extension/autoattr/Monoid.sv
@@ -113,7 +113,7 @@ top::Operation ::=
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateMonoid
-top::ProductionStmt ::= attr::Decorated QName
+top::ProductionStmt ::= attr::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${attr.unparse};";
   

--- a/grammars/silver/compiler/extension/autoattr/Ordering.sv
+++ b/grammars/silver/compiler/extension/autoattr/Ordering.sv
@@ -34,7 +34,7 @@ top::AGDcl ::= 'ordering' 'attribute' keySyn::Name ',' syn::Name 'with' inh::QNa
  - Propagate a ordering key synthesized attribute on the enclosing production
  -}
 abstract production propagateOrderingKey
-top::ProductionStmt ::= syn::Decorated QName
+top::ProductionStmt ::= syn::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${syn.unparse};";
 
@@ -49,7 +49,7 @@ top::ProductionStmt ::= syn::Decorated QName
  - Propagate a ordering synthesized attribute on the enclosing production
  -}
 abstract production propagateOrdering
-top::ProductionStmt ::= inh::String keySyn::String syn::Decorated QName
+top::ProductionStmt ::= inh::String keySyn::String syn::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${syn.unparse};";
   

--- a/grammars/silver/compiler/extension/autoattr/Propagate.sv
+++ b/grammars/silver/compiler/extension/autoattr/Propagate.sv
@@ -136,7 +136,7 @@ top::ProductionStmt ::= attr::QName
 }
 
 abstract production propagateError
-top::ProductionStmt ::= attr::Decorated QName
+top::ProductionStmt ::= attr::PartiallyDecorated QName
 {
   forwards to
     errorProductionStmt(

--- a/grammars/silver/compiler/extension/autoattr/Threaded.sv
+++ b/grammars/silver/compiler/extension/autoattr/Threaded.sv
@@ -32,7 +32,7 @@ top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTy
 }
 
 abstract production propagateThreadedInh
-top::ProductionStmt ::= inh::Decorated QName syn::String
+top::ProductionStmt ::= inh::PartiallyDecorated QName syn::String
 {
   top.unparse = s"propagate ${inh.unparse};";
   
@@ -63,7 +63,7 @@ top::ProductionStmt ::= inh::Decorated QName syn::String
 }
 
 abstract production propagateThreadedSyn
-top::ProductionStmt ::= inh::String syn::Decorated QName
+top::ProductionStmt ::= inh::String syn::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${syn.unparse};";
   

--- a/grammars/silver/compiler/extension/autoattr/Unification.sv
+++ b/grammars/silver/compiler/extension/autoattr/Unification.sv
@@ -30,7 +30,7 @@ top::AGDcl ::= 'unification' 'attribute' synPartial::Name ',' syn::Name 'with' i
 }
 
 abstract production unificationInhAttributionDcl
-top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
   top.moduleNames := [];
@@ -60,7 +60,7 @@ top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::B
 }
 
 abstract production propagateUnificationSynPartial
-top::ProductionStmt ::= inh::String synPartial::Decorated QName syn::String
+top::ProductionStmt ::= inh::String synPartial::PartiallyDecorated QName syn::String
 {
   top.unparse = s"propagate ${synPartial.unparse};";
   
@@ -96,7 +96,7 @@ top::ProductionStmt ::= inh::String synPartial::Decorated QName syn::String
 }
 
 abstract production propagateUnificationSyn
-top::ProductionStmt ::= inh::String synPartial::String syn::Decorated QName
+top::ProductionStmt ::= inh::String synPartial::String syn::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${syn.unparse};";
   

--- a/grammars/silver/compiler/extension/doc/core/AGDcl.sv
+++ b/grammars/silver/compiler/extension/doc/core/AGDcl.sv
@@ -201,7 +201,7 @@ top::AGDcl ::= 'type' id::Name tl::BracketedOptTypeExprs 'foreign' '=' trans::St
 
 
 aspect production defaultAttributionDcl
-top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.docForName = "";
   top.docUnparse = "";
@@ -292,7 +292,7 @@ top::AGDcl ::= n::Name
 }
 
 aspect production errorAttributionDcl
-top::AGDcl ::= msg::[Message] at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= msg::[Message] at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.docForName = "";
   top.docUnparse = "";

--- a/grammars/silver/compiler/extension/doc/core/DocumentedAGDcl.sv
+++ b/grammars/silver/compiler/extension/doc/core/DocumentedAGDcl.sv
@@ -74,7 +74,7 @@ top::AGDcl ::= comment::DocComment_t dcl::AGDcl
     dcl.downDocConfig = top.downDocConfig;
     
     top.upDocConfig <- parsed.upDocConfig ++ dcl.upDocConfig;
-    top.errors <- parsed.errors;
+    top.docErrors <- parsed.errors;
 
     local isDoubleComment::Boolean = case dcl of documentedAGDcl(_, _) -> true | _ -> false end;
     top.docs := if isDoubleComment
@@ -107,7 +107,7 @@ layout {}
     parsed.indentBy = "";
     
     top.upDocConfig <- parsed.upDocConfig;
-    top.errors <- parsed.errors;
+    top.docErrors <- parsed.errors;
 
     top.docs := [standaloneDclCommentItem(parsed)];
     top.unparse = "";

--- a/grammars/silver/compiler/extension/doc/core/RootSpec.sv
+++ b/grammars/silver/compiler/extension/doc/core/RootSpec.sv
@@ -3,25 +3,28 @@ grammar silver:compiler:extension:doc:core;
 import silver:compiler:driver:util;
 
 attribute genFiles occurs on RootSpec;
+attribute docDcls occurs on RootSpec;
 
 aspect production interfaceRootSpec
 top::RootSpec ::= _ _ _
 {
   top.genFiles := [];
+  top.docDcls := [];
 }
 
 aspect production errorRootSpec
 top::RootSpec ::= _ _ _ _ _
 {
   top.genFiles := [];
+  top.docDcls := [];
 }
 
 aspect production grammarRootSpec
 top::RootSpec ::= g::Grammar  _ _ _ _
 {
   top.genFiles := toSplitFiles(g, g.upDocConfig, [], []);
+  top.docDcls := g.docDcls;
 
-  g.docEnv = tm:add(g.docDcls, tm:empty());
   g.downDocConfig = g.upDocConfig;
 }
 
@@ -39,7 +42,7 @@ String ::= fileName::String
  - (possibly zero) into the index file.
  -}
 function toSplitFiles
-[Pair<String String>] ::= g::Decorated Grammar grammarConf::[DocConfigSetting] forIndex::[CommentItem] soFar::[Pair<String String>]
+[Pair<String String>] ::= g::Decorated Grammar with {decorate, downDocConfig} grammarConf::[DocConfigSetting] forIndex::[CommentItem] soFar::[Pair<String String>]
 {
   return case g of
        | consGrammar(this, rest) ->

--- a/grammars/silver/compiler/extension/doc/core/TypeClassDcls.sv
+++ b/grammars/silver/compiler/extension/doc/core/TypeClassDcls.sv
@@ -72,16 +72,17 @@ top::ClassBodyItem ::= comment::DocComment_t item::ClassBodyItem
 
   item.downDocConfig = top.downDocConfig;
   top.upDocConfig <- parsed.upDocConfig ++ item.upDocConfig;
-  top.errors <- parsed.errors;
+  top.docErrors <- parsed.errors;
 
   local realDclDocs::[CommentItem] = filter((\x::CommentItem->!x.stub), item.docs);
   local isDoubleComment::Boolean = length(realDclDocs) != 0;
   top.docs := if isDoubleComment
                 then [standaloneDclCommentItem(parsed)] ++ realDclDocs
                 else [dclCommentItem(top.scopeName ++ "." ++ item.docForName, item.docUnparse, item.grammarName, item.location, parsed)];
-  top.errors <- if isDoubleComment
-                  then [wrn(parsed.location, "Doc comment not immediately preceding ClassBodyItem, so association is ambiguous. Treating as standalone comment. Mark with @@{- instead of @{- to silence this warning.")]
-                  else [];
+  top.docErrors <-
+    if isDoubleComment
+    then [wrn(parsed.location, "Doc comment not immediately preceding ClassBodyItem, so association is ambiguous. Treating as standalone comment. Mark with @@{- instead of @{- to silence this warning.")]
+    else [];
 
   forwards to item;
 }
@@ -149,16 +150,17 @@ top::InstanceBodyItem ::= comment::DocComment_t item::InstanceBodyItem
 
   item.downDocConfig = top.downDocConfig;
   top.upDocConfig <- parsed.upDocConfig ++ item.upDocConfig;
-  top.errors <- parsed.errors;
+  top.docErrors <- parsed.errors;
 
   local realDclDocs::[CommentItem] = filter((\x::CommentItem->!x.stub), item.docs);
   local isDoubleComment::Boolean = length(realDclDocs) != 0;
   top.docs := if isDoubleComment
                 then [standaloneDclCommentItem(parsed)] ++ realDclDocs
                 else [dclCommentItem(top.scopeName ++ "." ++ item.docForName, item.docUnparse, item.grammarName, item.location, parsed)];
-  top.errors <- if isDoubleComment
-                  then [wrn(parsed.location, "Doc comment not immediately preceding InstanceBodyItem, so association is ambiguous. Treating as standalone comment. Mark with @@{- instead of @{- to silence this warning.")]
-                  else [];
+  top.docErrors <-
+    if isDoubleComment
+    then [wrn(parsed.location, "Doc comment not immediately preceding InstanceBodyItem, so association is ambiguous. Treating as standalone comment. Mark with @@{- instead of @{- to silence this warning.")]
+    else [];
 
   forwards to item;
 }

--- a/grammars/silver/compiler/extension/easyterminal/TerminalDcl.sv
+++ b/grammars/silver/compiler/extension/easyterminal/TerminalDcl.sv
@@ -5,6 +5,7 @@ import silver:compiler:definition:env;
 import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
 import silver:compiler:definition:concrete_syntax;
+import silver:compiler:modification:lambda_fn;
 
 import silver:regex only Regex, regexLiteral;
 
@@ -66,6 +67,8 @@ top::ProductionRHSElem ::= id::Name '::' reg::EasyTerminalRef
   top.unparse = id.unparse ++ "::" ++ reg.unparse;
   top.errors <- reg.errors;
 
+  top.lambdaBoundVars := [id.name];  -- Needed because we are forwrding based on env
+
   forwards to productionRHSElem(id, $2, typerepTypeExpr(reg.typerep, location=reg.location), location=top.location);
 }
 
@@ -74,6 +77,8 @@ top::ProductionRHSElem ::= reg::EasyTerminalRef
 {
   top.unparse = reg.unparse;
   top.errors <- reg.errors;
+
+  top.lambdaBoundVars := [];  -- Needed because we are forwrding based on env
 
   forwards to productionRHSElemType(typerepTypeExpr(reg.typerep, location=top.location), location=top.location);
 }

--- a/grammars/silver/compiler/extension/implicit_monads/BuiltInFunctions.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/BuiltInFunctions.sv
@@ -1,1 +1,0 @@
-grammar silver:compiler:extension:implicit_monads;

--- a/grammars/silver/compiler/extension/implicit_monads/Case.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Case.sv
@@ -184,7 +184,7 @@ function monadicMatchTypesNames
                                             expectedMonad=em; isRoot=iR; originRules=oR;}.mtyperep
            in
              if isMonad(ety, env) && fst(monadsMatch(ety, em, sub))
-             then ((ety, e, newName) :: subcall.1, 
+             then ((ety, e, newName) :: subcall.1,
                    baseExpr(qName(loc, newName), location=loc) :: subcall.2)
              else (subcall.1, e::subcall.2)
            end

--- a/grammars/silver/compiler/extension/implicit_monads/CopperExpr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/CopperExpr.sv
@@ -6,7 +6,7 @@ grammar silver:compiler:extension:implicit_monads;
 -}
 
 aspect production actionChildReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
@@ -18,7 +18,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production pluckTerminalReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
@@ -30,7 +30,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production terminalIdReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
@@ -42,7 +42,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production parserAttributeReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
@@ -54,7 +54,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production termAttrValueReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -2145,6 +2145,11 @@ top::AppExprs ::=
 aspect production exprRef
 top::Expr ::= e::PartiallyDecorated Expr
 {
+{- TODO: We should just be able to decorate e with the new attributes here.
+   However due to the (improper) equations on the access production, we may
+   receive an exprRef that is already decorated with these attributes.
+   Thus we must still re-decorate e until this fixed.
+
   e.mDownSubst = top.mDownSubst;
   e.expectedMonad = top.expectedMonad;
   e.monadicallyUsed = top.monadicallyUsed;
@@ -2154,6 +2159,28 @@ top::Expr ::= e::PartiallyDecorated Expr
   top.mtyperep = e.mtyperep;
   top.monadicNames = e.monadicNames;
   top.monadRewritten = e.monadRewritten;
+  -}
+  
+  local ne::Expr = new(e);
+  ne.mDownSubst = top.mDownSubst;
+  ne.env = top.env;
+  ne.flowEnv = top.flowEnv;
+  ne.config = top.config;
+  ne.compiledGrammars = top.compiledGrammars;
+  ne.grammarName = top.grammarName;
+  ne.frame = top.frame;
+  ne.finalSubst = top.finalSubst;
+  ne.downSubst = top.downSubst;
+  ne.originRules = top.originRules;
+  ne.isRoot = top.isRoot;
+  ne.expectedMonad = top.expectedMonad;
+
+  top.merrors := ne.merrors;
+  top.mUpSubst = ne.mUpSubst;
+  top.mtyperep = ne.mtyperep;
+  ne.monadicallyUsed = top.monadicallyUsed;
+  top.monadicNames = ne.monadicNames;
+  top.monadRewritten = ne.monadRewritten;
 }
 
 

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -2143,28 +2143,17 @@ top::AppExprs ::=
 
 
 aspect production exprRef
-top::Expr ::= e::Decorated Expr
+top::Expr ::= e::PartiallyDecorated Expr
 {
-  local ne::Expr = new(e);
-  ne.mDownSubst = top.mDownSubst;
-  ne.env = top.env;
-  ne.flowEnv = top.flowEnv;
-  ne.config = top.config;
-  ne.compiledGrammars = top.compiledGrammars;
-  ne.grammarName = top.grammarName;
-  ne.frame = top.frame;
-  ne.finalSubst = top.finalSubst;
-  ne.downSubst = top.downSubst;
-  ne.originRules = top.originRules;
-  ne.isRoot = top.isRoot;
-  ne.expectedMonad = top.expectedMonad;
+  e.mDownSubst = top.mDownSubst;
+  e.expectedMonad = top.expectedMonad;
+  e.monadicallyUsed = top.monadicallyUsed;
 
-  top.merrors := ne.merrors;
-  top.mUpSubst = ne.mUpSubst;
-  top.mtyperep = ne.mtyperep;
-  ne.monadicallyUsed = top.monadicallyUsed;
-  top.monadicNames = ne.monadicNames;
-  top.monadRewritten = ne.monadRewritten;
+  top.merrors := e.merrors;
+  top.mUpSubst = e.mUpSubst;
+  top.mtyperep = e.mtyperep;
+  top.monadicNames = e.monadicNames;
+  top.monadRewritten = e.monadRewritten;
 }
 
 

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -36,7 +36,7 @@ top::Expr ::= e::[Message]
 }
 
 aspect production errorReference
-top::Expr ::= msg::[Message]  q::Decorated QName
+top::Expr ::= msg::[Message]  q::PartiallyDecorated QName
 {
   top.merrors := msg;
   propagate mDownSubst, mUpSubst;
@@ -46,7 +46,7 @@ top::Expr ::= msg::[Message]  q::Decorated QName
 }
 
 aspect production childReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -60,7 +60,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production lhsReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -72,7 +72,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production localReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -86,7 +86,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production forwardReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -99,7 +99,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production productionReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -111,7 +111,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production functionReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -123,7 +123,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production classMemberReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -135,7 +135,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production globalValueReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -263,7 +263,7 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 }
 
 aspect production functionInvocation
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   local t::Expr = application(new(e), '(', new(es), ',', new(anns), ')', location=top.location);
   t.mDownSubst = top.mDownSubst;
@@ -373,7 +373,7 @@ Expr ::= monadTysLocs::[Pair<Type Integer>] funargs::AppExprs monadType::Type wr
 
 
 aspect production partialApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.merrors := error("merrors not defined on partial applications");
   top.mUpSubst = error("mUpSubst not defined on partial applications");
@@ -385,7 +385,7 @@ top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppEx
 }
 
 aspect production errorApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.merrors := [];
 
@@ -459,7 +459,7 @@ top::Expr ::= e::Expr '.' q::QNameAttrOccur
 }
 
 aspect production errorAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   local ne::Expr = new(e);
   ne.mDownSubst = top.mDownSubst;
@@ -546,7 +546,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production annoAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   local ne::Expr = new(e);
   ne.mDownSubst = top.mDownSubst;
@@ -630,7 +630,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production terminalAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   local ne::Expr = new(e);
   ne.mDownSubst = top.mDownSubst;
@@ -690,7 +690,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   local ne::Expr = new(e);
   ne.mDownSubst = top.mDownSubst;
@@ -774,7 +774,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   local ne::Expr = new(e);
   ne.mDownSubst = top.mDownSubst;
@@ -858,7 +858,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production errorDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   local ne::Expr = new(e);
   ne.mDownSubst = top.mDownSubst;
@@ -2184,7 +2184,7 @@ top::Expr ::= 'disambiguationFailure'
 
 
 aspect production lexerClassReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.mUpSubst = top.mDownSubst;
   top.mtyperep = q.lookupValue.typeScheme.typerep;

--- a/grammars/silver/compiler/extension/implicit_monads/Lambda.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Lambda.sv
@@ -19,7 +19,7 @@ top::Expr ::= params::ProductionRHS e::Expr
 
 
 aspect production lambdaParamReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;

--- a/grammars/silver/compiler/extension/implicit_monads/Lambda.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Lambda.sv
@@ -6,8 +6,6 @@ top::Expr ::= params::ProductionRHS e::Expr
   top.merrors := e.merrors;
   propagate mDownSubst, mUpSubst;
 
-  e.expectedMonad = top.expectedMonad;
-
   top.mtyperep = appTypes(functionType(length(params.inputElements), []), map((.typerep), params.inputElements) ++ [e.typerep]);
 
   e.monadicallyUsed = false;

--- a/grammars/silver/compiler/extension/implicit_monads/Let.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Let.sv
@@ -62,7 +62,7 @@ top::Expr ::= la::AssignExpr  e::Expr
                      [baseExpr(qName(top.location, x.fst.name), location=top.location),
                       buildLambda(x.fst.name,
                                   decorate x.snd with
-                                     {env=top.env; grammarName=top.grammarName; config=top.config;}.typerep,
+                                     {env=top.env; grammarName=top.grammarName; config=top.config; flowEnv=top.flowEnv;}.typerep,
                                   y, top.location)], top.location),
                inside, la.bindInList);
 }

--- a/grammars/silver/compiler/extension/implicit_monads/Let.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Let.sv
@@ -74,6 +74,7 @@ synthesized attribute bindInList::[Pair<Name TypeExpr>] occurs on AssignExpr;
 synthesized attribute mdefs::[Def] occurs on AssignExpr;
 
 attribute merrors, mDownSubst, mUpSubst, monadicNames, expectedMonad occurs on AssignExpr;
+propagate expectedMonad on AssignExpr;
 
 aspect production appendAssignExpr
 top::AssignExpr ::= a1::AssignExpr a2::AssignExpr
@@ -81,9 +82,6 @@ top::AssignExpr ::= a1::AssignExpr a2::AssignExpr
   top.merrors := a1.merrors ++ a2.merrors;
 
   propagate mDownSubst, mUpSubst;
-
-  a1.expectedMonad = top.expectedMonad;
-  a2.expectedMonad = top.expectedMonad;
 
   top.monadicNames = a1.monadicNames ++ a2.monadicNames;
 
@@ -115,8 +113,6 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
   --only place where the name occurs, so it wouldn't affect anything then either.
   e.monadicallyUsed = isMonad(e.mtyperep, top.env) && fst(monadsMatch(e.mtyperep, top.expectedMonad, top.mDownSubst)) && !isMonad(t.typerep, top.env);
   top.monadicNames = e.monadicNames;
-
-  e.expectedMonad = top.expectedMonad;
 
   top.mdefs = [lexicalLocalDef(top.grammarName, id.location, fName,
                                performSubstitution(t.typerep, top.mUpSubst),

--- a/grammars/silver/compiler/extension/implicit_monads/Let.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Let.sv
@@ -138,7 +138,7 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
 
 
 aspect production lexicalLocalReference
-top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;

--- a/grammars/silver/compiler/extension/implicit_monads/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/PrimitiveMatch.sv
@@ -6,6 +6,7 @@ attribute mtyperep, merrors, patternType, monadRewritten<PrimPatterns>,
 attribute mtyperep, merrors, patternType, monadRewritten<PrimPattern>,
           mDownSubst, mUpSubst, monadicNames, expectedMonad,
           returnFun, returnify<PrimPattern> occurs on PrimPattern;
+propagate expectedMonad on PrimPatterns, PrimPattern;
 
 --returnFun is the monad's defined Return for returnify
 inherited attribute returnFun::Expr;
@@ -56,10 +57,6 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
   pr.mDownSubst = e.mUpSubst;
   f.mDownSubst = pr.mUpSubst;
   top.mUpSubst = f.mUpSubst;
-
-  e.expectedMonad = top.expectedMonad;
-  pr.expectedMonad = top.expectedMonad;
-  f.expectedMonad = top.expectedMonad;
 
   e.monadicallyUsed = eIsMonadic;
   f.monadicallyUsed = false;
@@ -196,8 +193,6 @@ top::PrimPatterns ::= p::PrimPattern
 
   propagate mDownSubst, mUpSubst;
 
-  p.expectedMonad = top.expectedMonad;
-
   top.mtyperep = p.mtyperep;
   top.patternType = p.patternType;
 
@@ -217,9 +212,6 @@ top::PrimPatterns ::= p::PrimPattern vbar::Vbar_kwd ps::PrimPatterns
   p.mDownSubst = top.mDownSubst;
   ps.mDownSubst = p.mUpSubst;
   top.mUpSubst = ps.mUpSubst;
-
-  p.expectedMonad = top.expectedMonad;
-  ps.expectedMonad = top.expectedMonad;
 
   top.mtyperep = if isMonad(p.mtyperep, top.env) && monadsMatch(p.mtyperep, top.expectedMonad, top.mDownSubst).fst
                  then if isMonad(ps.mtyperep, top.env) && monadsMatch(ps.mtyperep, top.expectedMonad, top.mDownSubst).fst
@@ -291,8 +283,6 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   top.merrors := e.merrors;
   propagate mDownSubst, mUpSubst;
 
-  e.expectedMonad = top.expectedMonad;
-
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;
 
@@ -310,8 +300,6 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
 {
   top.merrors := e.merrors;
   propagate mDownSubst, mUpSubst;
-
-  e.expectedMonad = top.expectedMonad;
 
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;
@@ -333,8 +321,6 @@ top::PrimPattern ::= i::Int_t arr::Arrow_kwd e::Expr
   e.mDownSubst = top.mDownSubst;
   top.mUpSubst = e.mUpSubst;
 
-  e.expectedMonad = top.expectedMonad;
-
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;
 
@@ -351,8 +337,6 @@ top::PrimPattern ::= f::Float_t arr::Arrow_kwd e::Expr
 {
   top.merrors := e.merrors;
   propagate mDownSubst, mUpSubst;
-
-  e.expectedMonad = top.expectedMonad;
 
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;
@@ -371,8 +355,6 @@ top::PrimPattern ::= i::String_t arr::Arrow_kwd e::Expr
   top.merrors := e.merrors;
   propagate mDownSubst, mUpSubst;
 
-  e.expectedMonad = top.expectedMonad;
-
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;
   
@@ -389,8 +371,6 @@ top::PrimPattern ::= i::String arr::Arrow_kwd e::Expr
 {
   top.merrors := e.merrors;
   propagate mDownSubst, mUpSubst;
-
-  e.expectedMonad = top.expectedMonad;
 
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;
@@ -409,8 +389,6 @@ top::PrimPattern ::= e::Expr
   top.merrors := e.merrors;
   propagate mDownSubst, mUpSubst;
 
-  e.expectedMonad = top.expectedMonad;
-
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;
 
@@ -427,8 +405,6 @@ top::PrimPattern ::= h::Name t::Name e::Expr
 {
   top.merrors := e.merrors;
   propagate mDownSubst, mUpSubst;
-
-  e.expectedMonad = top.expectedMonad;
 
   e.monadicallyUsed = false;
   top.monadicNames = e.monadicNames;

--- a/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
@@ -182,7 +182,7 @@ function buildExplicitAttrErrors
 
 --productions for error checking on restricted attributes
 abstract production restrictedSynAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS attr::Decorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
 {
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
 
@@ -205,7 +205,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS attr::Decorated QNameAttrOccur e::E
 
 
 abstract production restrictedInhAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS attr::Decorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
 {
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
 
@@ -231,7 +231,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS attr::Decorated QNameAttrOccur e::E
 
 --productions for error checking on implicit attributes
 abstract production implicitSynAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS attr::Decorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
 {
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
 
@@ -261,7 +261,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS attr::Decorated QNameAttrOccur e::E
 
 
 abstract production implicitInhAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS attr::Decorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
 {
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
 

--- a/grammars/silver/compiler/extension/implicit_monads/Util.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Util.sv
@@ -19,7 +19,7 @@ grammar silver:compiler:extension:implicit_monads;
 
 
 --The monad of the attribute the equation for which we are rewriting
-autocopy attribute expectedMonad::Type;
+inherited attribute expectedMonad::Type;
 --The rewritten version of the current expression, exprs, etc.
 synthesized attribute monadRewritten<a>::a;
 --Errors encountered in rewriting

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -37,7 +37,7 @@ autocopy attribute matchRulePatternSize :: Integer;
 
 -- P -> E
 nonterminal MatchRule with location, config, unparse, env, frame, errors, freeVars, matchRuleList, matchRulePatternSize;
-nonterminal AbstractMatchRule with location, unparse, headPattern, isVarMatchRule, expandHeadPattern, hasCondition;
+nonterminal AbstractMatchRule with location, unparse, frame, freeVars, headPattern, isVarMatchRule, expandHeadPattern, hasCondition;
 
 -- The head pattern of a match rule
 synthesized attribute headPattern :: Decorated Pattern;
@@ -98,6 +98,7 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] complete::Boolean failExpr::Exp
     "(case " ++ implode(", ", map((.unparse), es)) ++ " of " ++ 
     implode(" | ", map((.unparse), ml)) ++ " | _ -> " ++ failExpr.unparse ++
     " end :: " ++ prettyType(retType) ++ ")";
+  top.freeVars := concat(map(getFreeVars(top.frame, _), es) ++ map(getFreeVars(top.frame, _), ml) ++ [failExpr.freeVars]);
 
   {-Checking Pattern Completeness
 
@@ -167,6 +168,15 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] complete::Boolean failExpr::Exp
                 makeLet(top.location, p.1, freshType(), p.2, rest),
               compiledCase, zipWith(pair(_, _), names, es));
   forwards to fwdResult;
+}
+
+function getFreeVars
+attribute frame occurs on a,
+attribute freeVars {frame} occurs on a =>
+ts:Set<String> ::= frame::BlockContext x::a
+{
+  x.frame = frame;
+  return x.freeVars;
 }
 
 
@@ -1107,6 +1117,12 @@ top::AbstractMatchRule ::= pl::[Decorated Pattern]
     | nothing() -> ""
     end ++
     " -> " ++ e.unparse;
+  top.freeVars := ts:removeAll(concat(map((.patternVars), pl)),
+    case cond of
+    | just((e1, just(p))) -> getFreeVars(top.frame, e1) ++ ts:removeAll(p.patternVars, e.freeVars)
+    | just((e1, nothing())) -> getFreeVars(top.frame, e1) ++ e.freeVars
+    | nothing() -> e.freeVars
+    end);
   top.headPattern = head(pl);
   -- If pl is null, and we're consulted, then we're missing patterns, pretend they're _
   top.isVarMatchRule = null(pl) || head(pl).patternIsVariable;

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -1269,10 +1269,11 @@ function ensureDecoratedExpr
 Expr ::= e::PartiallyDecorated Expr
 {
   local et :: Type = performSubstitution(e.typerep, e.upSubst);
+  local eRef :: Expr = exprRef(e, location=e.location);
 
   return if isDecorable(et, e.env)
-         then decorateExprWithEmpty('decorate', exprRef(e, location=e.location), 'with', '{', '}', location=e.location)
-         else exprRef(e, location=e.location);
+         then decorateExprWithEmpty('decorate', eRef, 'with', '{', '}', location=e.location)
+         else eRef;
 }
 
 instance Eq AbstractMatchRule {

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -1266,7 +1266,7 @@ Expr ::= l::Location s::String t::Type e::Expr o::Expr
 }
 
 function ensureDecoratedExpr
-Expr ::= e::Decorated Expr
+Expr ::= e::PartiallyDecorated Expr
 {
   local et :: Type = performSubstitution(e.typerep, e.upSubst);
 

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -116,6 +116,9 @@ aspect production errorApplication
 top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.transform = applyASTExpr(e.transform, es.transform, anns.transform);
+  e.boundVars = top.boundVars;
+  es.boundVars = top.boundVars;
+  anns.boundVars = top.boundVars;
 }
 
 aspect production functionInvocation
@@ -157,12 +160,18 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::P
 
     | _, _ -> applyASTExpr(e.transform, es.transform, anns.transform)
     end;
+  e.boundVars = top.boundVars;
+  es.boundVars = top.boundVars;
+  anns.boundVars = top.boundVars;
 }
 
 aspect production partialApplication
 top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.transform = applyASTExpr(e.transform, es.transform, anns.transform);
+  e.boundVars = top.boundVars;
+  es.boundVars = top.boundVars;
+  anns.boundVars = top.boundVars;
 }
 
 aspect production forwardAccess
@@ -199,6 +208,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
+  e.boundVars = top.boundVars;
 }
 
 aspect production annoAccessHandler
@@ -213,6 +223,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
+  e.boundVars = top.boundVars;
 }
 
 aspect production terminalAccessHandler
@@ -227,6 +238,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
+  e.boundVars = top.boundVars;
 }
 
 
@@ -292,6 +304,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
         consASTExpr(e.transform, nilASTExpr()),
         nilNamedASTExpr())
     end;
+  e.boundVars = top.boundVars;
 }
 
 aspect production inhDecoratedAccessHandler
@@ -314,6 +327,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
+  e.boundVars = top.boundVars;
 }
 
 aspect production errorDecoratedAccessHandler
@@ -336,6 +350,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
+  e.boundVars = top.boundVars;
 }
 
 aspect production decorateExprWith
@@ -363,6 +378,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
         }),
       consASTExpr(e.transform, inh.transform),
       nilNamedASTExpr());
+  e.boundVars = top.boundVars;
 }
 
 attribute transform<ASTExprs> occurs on ExprInhs;
@@ -538,6 +554,8 @@ aspect production listPlusPlus
 top::Expr ::= e1::PartiallyDecorated Expr e2::PartiallyDecorated Expr
 {
   top.transform = appendASTExpr(e1.transform, e2.transform);
+  e1.boundVars = top.boundVars;
+  e2.boundVars = top.boundVars;
 }
 
 -- TODO: Awful hack to allow case to appear on rule RHS.
@@ -556,6 +574,8 @@ top::Expr ::= 'case' es::Exprs 'of' o::Opt_Vbar_t ml::MRuleList 'end'
   decEs.env = top.env;
   decEs.flowEnv = top.flowEnv;
   decEs.boundVars = top.boundVars;
+  decEs.isRoot = top.isRoot;
+  decEs.originRules = top.originRules;
   
   top.transform =
     applyASTExpr(

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -25,7 +25,7 @@ top::Expr ::=
 }
 
 aspect production lexicalLocalReference
-top::Expr ::= q::Decorated QName _ _
+top::Expr ::= q::PartiallyDecorated QName _ _
 {
   -- In regular pattern matching nonterminal values are always effectively decorated, but we are
   -- using the same typing behavior while matching on *undecorated* trees.  So when a variable is
@@ -73,7 +73,7 @@ top::Expr ::= q::Decorated QName _ _
 }
 
 aspect production childReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
@@ -83,7 +83,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production lhsReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
@@ -93,7 +93,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production localReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
@@ -103,7 +103,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production forwardReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
@@ -113,13 +113,13 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production errorApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.transform = applyASTExpr(e.transform, es.transform, anns.transform);
 }
 
 aspect production functionInvocation
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.transform =
     case e, es of
@@ -160,7 +160,7 @@ top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppEx
 }
 
 aspect production partialApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs anns::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
 {
   top.transform = applyASTExpr(e.transform, es.transform, anns.transform);
 }
@@ -188,7 +188,7 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production errorAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.transform =
     applyASTExpr(
@@ -202,7 +202,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production annoAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.transform =
     applyASTExpr(
@@ -216,7 +216,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production terminalAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.transform =
     applyASTExpr(
@@ -231,7 +231,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 
 
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   -- Flow analysis has no way to track what e is decorated with across reflect/reify,
   -- so if the inh set is unspecialized, assume that it has the reference set.
@@ -295,7 +295,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   -- Flow analysis has no way to track what e is decorated with across reflect/reify,
   -- so if the inh set is unspecialized, assume that it has the reference set.
@@ -317,7 +317,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production errorDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   -- Flow analysis has no way to track what e is decorated with across reflect/reify,
   -- so if the inh set is unspecialized, assume that it has the reference set.
@@ -535,7 +535,7 @@ top::Expr ::= '[' es::Exprs ']'
 }
 
 aspect production listPlusPlus
-top::Expr ::= e1::Decorated Expr e2::Decorated Expr
+top::Expr ::= e1::PartiallyDecorated Expr e2::PartiallyDecorated Expr
 {
   top.transform = appendASTExpr(e1.transform, e2.transform);
 }

--- a/grammars/silver/compiler/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/compiler/extension/rewriting/Rewriting.sv
@@ -61,7 +61,7 @@ top::Expr ::= 'traverse' n::QName '(' es::AppExprs ',' anns::AnnoAppExprs ')'
     then [err(top.location, "Term rewriting requires import of silver:rewrite")]
     else [];
 
-  propagate downSubst, upSubst;
+  propagate downSubst, upSubst, freeVars;
   
   local transform::Strategy =
     traversal(n.lookupValue.fullName, es.traverseTransform, anns.traverseTransform);
@@ -193,7 +193,7 @@ concrete production ruleExpr
 top::Expr ::= 'rule' 'on' ty::TypeExpr 'of' Opt_Vbar_t ml::MRuleList 'end'
 {
   top.unparse = "rule on " ++ ty.unparse ++ " of " ++ ml.unparse ++ " end";
-  top.freeVars := checkExpr.freeVars;
+  propagate freeVars;
   
   -- Find the free type variables (i.e. lacking a definition) to add as skolem constants
   local freeTyVars::[String] =
@@ -217,6 +217,8 @@ top::Expr ::= 'rule' 'on' ty::TypeExpr 'of' Opt_Vbar_t ml::MRuleList 'end'
   checkExpr.config = top.config;
   checkExpr.compiledGrammars = top.compiledGrammars;
   checkExpr.boundVars = [];
+  checkExpr.isRoot = top.isRoot;
+  checkExpr.originRules = top.originRules;
   
   ml.matchRulePatternSize = 1;
   ml.ruleIndex = 0;

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -55,7 +55,7 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
 }
 
 abstract production strategyAttributionDcl
-top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   production attribute localErrors::[Message] with ++;
   localErrors :=
@@ -112,7 +112,7 @@ top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::B
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateStrategy
-top::ProductionStmt ::= attr::Decorated QName
+top::ProductionStmt ::= attr::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${attr.unparse}";
   

--- a/grammars/silver/compiler/extension/treegen/TerminalGen.sv
+++ b/grammars/silver/compiler/extension/treegen/TerminalGen.sv
@@ -3,6 +3,7 @@ grammar silver:compiler:extension:treegen;
 import silver:compiler:metatranslation;
 import silver:reflect;
 import silver:regex;
+import silver:util:treeset as set;  -- needed for freeVars equation
 
 terminal GenArbTerminal_t 'genArbTerminal' lexer classes {KEYWORD, RESERVED};
 
@@ -10,6 +11,7 @@ concrete production genArbTerminalNoLocExpr
 top::Expr ::= 'genArbTerminal' '(' te::TypeExpr ',' '_' ')'
 {
   top.unparse = s"genArbTerminal(${te.unparse}, _)";
+  propagate freeVars;
   
   local regex::Regex =
     case getTypeDcl(te.typerep.typeName, top.env) of

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -363,9 +363,9 @@ top::ProductionStmt ::= dl::DefLHS '.' attr::QNameAttrOccur '<-' e::Expr ';'
   attr.attrFor = dl.typerep;
 
   forwards to
-    if !dl.found || !attr.found
-    then errorAttributeDef(dl.errors ++ attr.errors, dl, attr, e, location=top.location)
-    else attr.attrDcl.attrAppendDefDispatcher(dl, attr, e, top.location);
+    (if !dl.found || !attr.found
+     then errorAttributeDef(dl.errors ++ attr.errors, _, _, _, location=_)
+     else attr.attrDcl.attrAppendDefDispatcher)(dl, attr, e, top.location);
 }
 
 concrete production attrContainsBase
@@ -381,9 +381,9 @@ top::ProductionStmt ::= dl::DefLHS '.' attr::QNameAttrOccur ':=' e::Expr ';'
   attr.attrFor = dl.typerep;
 
   forwards to
-    if !dl.found || !attr.found
-    then errorAttributeDef(dl.errors ++ attr.errors, dl, attr, e, location=top.location)
-    else attr.attrDcl.attrBaseDefDispatcher(dl, attr, e, top.location);
+    (if !dl.found || !attr.found
+     then errorAttributeDef(dl.errors ++ attr.errors, _, _, _, location=_)
+     else attr.attrDcl.attrBaseDefDispatcher)(dl, attr, e, top.location);
 }
 
 concrete production valContainsAppend
@@ -396,9 +396,10 @@ top::ProductionStmt ::= val::QName '<-' e::Expr ';'
   top.productionAttributes := [];
   top.defs := [];
   
-  forwards to if null(val.lookupValue.dcls)
-              then errorValueDef(val, e, location=top.location)
-              else val.lookupValue.dcl.appendDefDispatcher(val, e, top.location);
+  forwards to
+    (if null(val.lookupValue.dcls)
+     then errorValueDef(_, _, location=_)
+     else val.lookupValue.dcl.appendDefDispatcher)(val, e, top.location);
 }
 
 concrete production valContainsBase
@@ -411,8 +412,9 @@ top::ProductionStmt ::= val::QName ':=' e::Expr ';'
   top.productionAttributes := [];
   top.defs := [];
   
-  forwards to if null(val.lookupValue.dcls)
-              then errorValueDef(val, e, location=top.location)
-              else val.lookupValue.dcl.baseDefDispatcher(val, e, top.location);
+  forwards to
+    (if null(val.lookupValue.dcls)
+     then errorValueDef(_, _, location=_)
+     else val.lookupValue.dcl.baseDefDispatcher)(val, e, top.location);
 }
 

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -214,7 +214,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr 'with
 
 -- ERROR ON VALUE DEFS:
 abstract production errorCollectionValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.errors <- [err(top.location, "The ':=' and '<-' operators can only be used for collections. " ++ val.name ++ " is not a collection.")];
   
@@ -224,7 +224,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   forwards to errorValueDef(val, e, location=top.location);
 }
 abstract production errorColNormalValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.errors <- [err(top.location, val.name ++ " is a collection attribute, and you must use ':=' or '<-', not '='.")];
   
@@ -235,7 +235,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 -- NON-ERRORS for PRODUCTIONS
 
 abstract production baseCollectionValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.unparse = "\t" ++ val.unparse ++ " := " ++ e.unparse ++ ";";
 
@@ -249,7 +249,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
   forwards to localValueDef(val, e, location=top.location);
 }
 abstract production appendCollectionValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.unparse = "\t" ++ val.unparse ++ " <- " ++ e.unparse ++ ";";
 
@@ -266,7 +266,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 -- NON-ERRORS for SYN ATTRS
 
 abstract production synBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " := " ++ e.unparse ++ ";";
 
@@ -285,7 +285,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     else [];
 }
 abstract production synAppendColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " <- " ++ e.unparse ++ ";";
 
@@ -307,7 +307,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 -- NON-ERRORS for INHERITED ATTRS
 
 abstract production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " := " ++ e.unparse ++ ";";
 
@@ -326,7 +326,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
     else [];
 }
 abstract production inhAppendColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " <- " ++ e.unparse ++ ";";
 

--- a/grammars/silver/compiler/modification/collection/DclInfo.sv
+++ b/grammars/silver/compiler/modification/collection/DclInfo.sv
@@ -3,11 +3,11 @@ grammar silver:compiler:modification:collection;
 attribute operation, attrBaseDefDispatcher, attrAppendDefDispatcher occurs on AttributeDclInfo;
 attribute operation, baseDefDispatcher, appendDefDispatcher occurs on ValueDclInfo;
 
-synthesized attribute attrBaseDefDispatcher :: (ProductionStmt ::= Decorated DefLHS  Decorated QNameAttrOccur  Expr  Location);
-synthesized attribute attrAppendDefDispatcher :: (ProductionStmt ::= Decorated DefLHS  Decorated QNameAttrOccur  Expr  Location);
+synthesized attribute attrBaseDefDispatcher :: (ProductionStmt ::= PartiallyDecorated DefLHS  PartiallyDecorated QNameAttrOccur  Expr  Location);
+synthesized attribute attrAppendDefDispatcher :: (ProductionStmt ::= PartiallyDecorated DefLHS  PartiallyDecorated QNameAttrOccur  Expr  Location);
 
-synthesized attribute baseDefDispatcher :: (ProductionStmt ::= Decorated QName  Expr  Location);
-synthesized attribute appendDefDispatcher :: (ProductionStmt ::= Decorated QName  Expr  Location);
+synthesized attribute baseDefDispatcher :: (ProductionStmt ::= PartiallyDecorated QName  Expr  Location);
+synthesized attribute appendDefDispatcher :: (ProductionStmt ::= PartiallyDecorated QName  Expr  Location);
 
 aspect default production
 top::AttributeDclInfo ::=
@@ -15,10 +15,10 @@ top::AttributeDclInfo ::=
   top.operation = error("Internal compiler error: must be defined for all collection attribute declarations");
   
   top.attrBaseDefDispatcher =
-    \ dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, "The ':=' operator can only be used for collections. " ++ attr.name ++ " is not a collection.")], dl, attr, e, location=l);
   top.attrAppendDefDispatcher =
-    \ dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, "The '<-' operator can only be used for collections. " ++ attr.name ++ " is not a collection.")], dl, attr, e, location=l);
 }
 
@@ -43,7 +43,7 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type o::Operation
   top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
   top.attrDefDispatcher = 
-    \ dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, attr.name ++ " is a collection attribute, and you must use ':=' or '<-', not '='.")], dl, attr, e, location=l);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
 
@@ -62,7 +62,7 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type o::Operation
   top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _); -- TODO: above should probably be an error handler!
   top.attrDefDispatcher =
-    \ dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, attr.name ++ " is a collection attribute, and you must use ':=' or '<-', not '='.")], dl, attr, e, location=l);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
 

--- a/grammars/silver/compiler/modification/collection/java/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/java/Collection.sv
@@ -184,7 +184,7 @@ public class ${className} extends common.CollectionAttribute {
 
 ---------- LOCALS ---
 aspect production baseCollectionValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   -- for locals, the CA object was created already
   top.translation = s"""
@@ -193,7 +193,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 """;
 }
 aspect production appendCollectionValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   -- for locals, the CA object was created already
   top.translation = s"""
@@ -204,7 +204,7 @@ top::ProductionStmt ::= val::Decorated QName  e::Expr
 
 ---------- SYNTHESIZED ----
 aspect production synBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- := -} e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- := -} e::Expr
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} := ${e.unparse}
@@ -214,7 +214,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {-
 """;
 }
 aspect production synAppendColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- <- -} e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- <- -} e::Expr
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} <- ${e.unparse}
@@ -226,7 +226,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {-
 
 ---------- INHERITED ----
 aspect production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- := -} e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- := -} e::Expr
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} := ${e.unparse}
@@ -236,7 +236,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {-
 """;
 }
 aspect production inhAppendColAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  {- <- -} e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- <- -} e::Expr
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} <- ${e.unparse}

--- a/grammars/silver/compiler/modification/collection/java/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/java/Collection.sv
@@ -208,9 +208,9 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} := ${e.unparse}
-    if (${dl.translation}[${attr.dcl.attrOccursIndex}] == null)
-      ${dl.translation}[${attr.dcl.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}(${attr.dcl.attrOccursIndex});
-    ((common.CollectionAttribute)${dl.translation}[${attr.dcl.attrOccursIndex}]).setBase(${wrapLazy(e)});
+    if (${dl.translation}[${attr.attrOccursIndex}] == null)
+      ${dl.translation}[${attr.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}(${attr.attrOccursIndex});
+    ((common.CollectionAttribute)${dl.translation}[${attr.attrOccursIndex}]).setBase(${wrapLazy(e)});
 """;
 }
 aspect production synAppendColAttributeDef
@@ -218,9 +218,9 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} <- ${e.unparse}
-    if (${dl.translation}[${attr.dcl.attrOccursIndex}] == null)
-      ${dl.translation}[${attr.dcl.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}(${attr.dcl.attrOccursIndex});
-    ((common.CollectionAttribute)${dl.translation}[${attr.dcl.attrOccursIndex}]).addPiece(${wrapLazy(e)});
+    if (${dl.translation}[${attr.attrOccursIndex}] == null)
+      ${dl.translation}[${attr.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}(${attr.attrOccursIndex});
+    ((common.CollectionAttribute)${dl.translation}[${attr.attrOccursIndex}]).addPiece(${wrapLazy(e)});
 """;
 }
 
@@ -230,9 +230,9 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} := ${e.unparse}
-    if (${dl.translation}[${attr.dcl.attrOccursIndex}] == null)
-      ${dl.translation}[${attr.dcl.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}();
-    ((common.CollectionAttribute)${dl.translation}[${attr.dcl.attrOccursIndex}]).setBase(${wrapLazy(e)});
+    if (${dl.translation}[${attr.attrOccursIndex}] == null)
+      ${dl.translation}[${attr.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}();
+    ((common.CollectionAttribute)${dl.translation}[${attr.attrOccursIndex}]).setBase(${wrapLazy(e)});
 """;
 }
 aspect production inhAppendColAttributeDef
@@ -240,9 +240,9 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} <- ${e.unparse}
-    if (${dl.translation}[${attr.dcl.attrOccursIndex}] == null)
-      ${dl.translation}[${attr.dcl.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}();
-    ((common.CollectionAttribute)${dl.translation}[${attr.dcl.attrOccursIndex}]).addPiece(${wrapLazy(e)});
+    if (${dl.translation}[${attr.attrOccursIndex}] == null)
+      ${dl.translation}[${attr.attrOccursIndex}] = new ${makeCAClassName(attr.attrDcl.fullName)}();
+    ((common.CollectionAttribute)${dl.translation}[${attr.attrOccursIndex}]).addPiece(${wrapLazy(e)});
 """;
 }
 

--- a/grammars/silver/compiler/modification/copper/Expr.sv
+++ b/grammars/silver/compiler/modification/copper/Expr.sv
@@ -19,7 +19,7 @@ top::Expr ::= 'disambiguationFailure'
 }
 
 abstract production actionChildReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars := ts:fromList([q.name]);
@@ -35,7 +35,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production pluckTerminalReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars := ts:fromList([q.name]);
@@ -56,7 +56,7 @@ top::Expr ::= q::Decorated QName
 -- thing.  Also having type classes would let us use a more specific type than generic TerminalId,
 -- and pluckTerminalReference wouldn't need to cheat with a fresh type.
 abstract production terminalIdReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars := ts:fromList([q.name]);
@@ -74,7 +74,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production lexerClassReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars := ts:fromList([q.name]);
@@ -93,7 +93,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production parserAttributeReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars := ts:fromList([q.name]);
@@ -112,7 +112,7 @@ top::Expr ::= q::Decorated QName
 }
 
 abstract production termAttrValueReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   top.freeVars := ts:fromList([q.name]);

--- a/grammars/silver/compiler/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/compiler/modification/copper/ProductionStmt.sv
@@ -81,7 +81,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
 }
 
 abstract production parserAttributeValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
 
@@ -194,7 +194,7 @@ top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt
 
 
 abstract production parserAttributeDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.name = q.name;
   top.unparse = q.unparse;
@@ -213,7 +213,7 @@ top::DefLHS ::= q::Decorated QName
 }
 
 abstract production termAttrValueValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
 

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -88,7 +88,7 @@ top::ValueDclInfo ::= fn::String ty::Type
 }
 
 abstract production defaultLhsDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.name = q.name;
   top.unparse = q.unparse;

--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -61,7 +61,7 @@ top::ProductionRHSElem ::= id::Name '::' t::TypeExpr
 }
 
 abstract production lambdaParamReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.unparse = q.unparse;
   propagate errors;

--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -47,7 +47,9 @@ monoid attribute lambdaDefs::[Def];
 monoid attribute lambdaBoundVars::[String];
 attribute lambdaDefs, lambdaBoundVars occurs on ProductionRHS, ProductionRHSElem;
 
-flowtype ProductionRHSElem = lambdaDefs {decorate}, lambdaBoundVars {};
+flowtype lambdaDefs {decorate} on ProductionRHS, ProductionRHSElem;
+flowtype lambdaBoundVars {} on ProductionRHS;
+flowtype lambdaBoundVars {deterministicCount} on ProductionRHSElem;
 
 propagate lambdaDefs, lambdaBoundVars on ProductionRHS;
 

--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -47,7 +47,7 @@ monoid attribute lambdaDefs::[Def];
 monoid attribute lambdaBoundVars::[String];
 attribute lambdaDefs, lambdaBoundVars occurs on ProductionRHS, ProductionRHSElem;
 
-flowtype ProductionRHSElem = lambdaDefs {decorate}, lambdaBoundVars {decorate};
+flowtype ProductionRHSElem = lambdaDefs {decorate}, lambdaBoundVars {};
 
 propagate lambdaDefs, lambdaBoundVars on ProductionRHS;
 

--- a/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
@@ -87,7 +87,7 @@ String ::= s::String
 }
 
 aspect production lambdaParamReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.translation = s"((${top.typerep.transType})common.Util.demand(${makeLambdaParamValueName(q.lookupValue.fullName)}))";
   top.lazyTranslation = top.translation;

--- a/grammars/silver/compiler/modification/let_fix/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/Let.sv
@@ -139,9 +139,9 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 
   top.typerep = 
     case q.lookupValue.typeScheme.monoType of
-    | ntOrDecType(t, i, _, defaultPartialDec, defaultInhs) -> ntOrDecType(t, i, freshType(), defaultPartialDec, defaultInhs)
-    | decoratedType(t, i) -> ntOrDecType(t, i, freshType(), false, i)
-    | partiallyDecoratedType(t, i) -> ntOrDecType(t, i, freshType(), true, i)
+    | ntOrDecType(t, i, _) -> ntOrDecType(t, i, freshType())
+    | decoratedType(t, i) -> ntOrDecType(t, i, freshType())
+    | partiallyDecoratedType(t, i) -> ntOrDecType(t, i, freshType())
     | t -> t
     end;
 

--- a/grammars/silver/compiler/modification/let_fix/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/Let.sv
@@ -116,7 +116,7 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
 }
 
 abstract production lexicalLocalReference
-top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   top.unparse = q.unparse;
   top.errors := [];

--- a/grammars/silver/compiler/modification/let_fix/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/Let.sv
@@ -139,9 +139,9 @@ top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 
   top.typerep = 
     case q.lookupValue.typeScheme.monoType of
-    | ntOrDecType(t, i, _) -> ntOrDecType(t, i, freshType())
-    | decoratedType(t, i) -> ntOrDecType(t, i, freshType())
-    | partiallyDecoratedType(t, i) -> ntOrDecType(t, i, freshType())
+    | ntOrDecType(t, i, _, defaultPartialDec, defaultInhs) -> ntOrDecType(t, i, freshType(), defaultPartialDec, defaultInhs)
+    | decoratedType(t, i) -> ntOrDecType(t, i, freshType(), false, i)
+    | partiallyDecoratedType(t, i) -> ntOrDecType(t, i, freshType(), true, i)
     | t -> t
     end;
 

--- a/grammars/silver/compiler/modification/let_fix/java/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/java/Let.sv
@@ -63,7 +63,7 @@ String ::= fn::String  et::String  ty::String
 }
 
 aspect production lexicalLocalReference
-top::Expr ::= q::Decorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   -- To account for a magic case where we generate a let expression with a type
   -- that is, for example, a ntOrDecType or something,

--- a/grammars/silver/compiler/modification/list/List.sv
+++ b/grammars/silver/compiler/modification/list/List.sv
@@ -96,7 +96,7 @@ top::Exprs ::= e1::Expr ',' e2::Exprs
 -- Overloaded operators --------------------------------------------------------
 
 abstract production listPlusPlus
-top::Expr ::= e1::Decorated Expr e2::Decorated Expr
+top::Expr ::= e1::PartiallyDecorated Expr e2::PartiallyDecorated Expr
 {
   forwards to mkStrFunctionInvocationDecorated(e1.location, "silver:core:append", [e1,e2]);
 }

--- a/grammars/silver/compiler/modification/list/List.sv
+++ b/grammars/silver/compiler/modification/list/List.sv
@@ -57,9 +57,7 @@ concrete production consListOp
 top::Expr ::= h::Expr '::' t::Expr
 {
   top.unparse = "(" ++ h.unparse ++ " :: " ++ t.unparse ++ ")" ;
-  
-  h.downSubst = top.downSubst; t.downSubst = top.downSubst; -- TODO BUG: don't know what this is needed... unparse apparently??
-  
+
   forwards to mkStrFunctionInvocation(top.location, "silver:core:cons", [h, t]);
 }
 
@@ -67,8 +65,6 @@ concrete production fullList
 top::Expr ::= '[' es::Exprs ']'
 { 
   top.unparse = "[ " ++ es.unparse ++ " ]";
-  
-  es.downSubst = top.downSubst; -- TODO again, pretty printing garbage.
 
   forwards to es.listtrans;
 }

--- a/grammars/silver/compiler/modification/list/Project.sv
+++ b/grammars/silver/compiler/modification/list/Project.sv
@@ -4,4 +4,5 @@ imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:core;
 
-exports silver:compiler:modification:list:java with silver:compiler:translation:java:type;
+exports silver:compiler:modification:list:java with silver:compiler:translation:java:core;  -- special case for []
+exports silver:compiler:modification:list:java:type with silver:compiler:translation:java:type;  -- listCtrType translation

--- a/grammars/silver/compiler/modification/list/Type.sv
+++ b/grammars/silver/compiler/modification/list/Type.sv
@@ -34,5 +34,4 @@ top::Type ::=
     | listCtrType() -> emptySubst()
     | _ -> errorSubst("Tried to unify List with " ++ prettyType(top.unifyWith))
     end;
-
 }

--- a/grammars/silver/compiler/modification/list/java/List.sv
+++ b/grammars/silver/compiler/modification/list/java/List.sv
@@ -1,22 +1,8 @@
 grammar silver:compiler:modification:list:java;
 
 import silver:compiler:modification:list;
-import silver:compiler:definition:type;
-import silver:compiler:definition:env;
 import silver:compiler:definition:core;
-import silver:compiler:translation:java:type;
-import silver:compiler:translation:java:core; -- for the nil hack
-
-aspect production listCtrType
-top::Type ::=
-{
-  top.transType = "common.ConsCell";
-  top.transCovariantType = "common.ConsCell";
-  top.transClassType = "common.ConsCell";
-  top.transTypeRep = "new common.BaseTypeRep(\"[]\")";
-  top.transTypeName = "List";
-}
-
+import silver:compiler:translation:java:core;
 
 -- A wonderous hack
 aspect production emptyList

--- a/grammars/silver/compiler/modification/list/java/type/Type.sv
+++ b/grammars/silver/compiler/modification/list/java/type/Type.sv
@@ -1,0 +1,15 @@
+grammar silver:compiler:modification:list:java:type;
+
+import silver:compiler:modification:list;
+import silver:compiler:definition:type;
+import silver:compiler:translation:java:type;
+
+aspect production listCtrType
+top::Type ::=
+{
+  top.transType = "common.ConsCell";
+  top.transCovariantType = "common.ConsCell";
+  top.transClassType = "common.ConsCell";
+  top.transTypeRep = "new common.BaseTypeRep(\"[]\")";
+  top.transTypeName = "List";
+}

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -81,8 +81,7 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
    - decorated by matchPrimitive before we got here, so we should either
    - have a decorated expr, or some other type.
    -}
-  local attribute scrutineeType :: Type;
-  scrutineeType = performSubstitution(e.typerep, e.upSubst);
+  production scrutineeType :: Type = performSubstitution(e.typerep, e.upSubst);
   
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
   errCheck2 = check(f.typerep, t.typerep);

--- a/grammars/silver/compiler/modification/primitivepattern/Types.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/Types.sv
@@ -401,7 +401,7 @@ top::OccursDclInfo ::= fnat::String ntty::Type atty::Type oc::Context tvs::[TyVa
   top.typeScheme = monoType(atty);
   
   oc.boundVariables = tvs;
-  top.transContext = s"${scrutineeTrans}.${oc.transContextMemberName}";
+  top.attrOccursIndex = s"${scrutineeTrans}.${oc.transContextMemberName}";
 
   -- Never appears for anything on which we can define an equation
   top.attrOccursIndexName = error("Not needed");
@@ -417,8 +417,7 @@ top::OccursDclInfo ::= fnat::String ntty::Type atty::Type oc::Context tvs::[TyVa
   top.isAnnotation = true;
   
   oc.boundVariables = tvs;
-  top.transContext = s"${scrutineeTrans}.${oc.transContextMemberName}";
-
+  top.attrOccursIndex = error("Not actually an attribute");
   top.attrOccursIndexName = error("Not actually an attribute");
   top.attrOccursInitIndex = error("Not actually an attribute");
 }

--- a/grammars/silver/compiler/modification/primitivepattern/Types.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/Types.sv
@@ -1,6 +1,9 @@
 grammar silver:compiler:modification:primitivepattern;
 
-import silver:compiler:modification:ffi only foreignType; -- so we cover foreignType with the 'refine' hack below. TODO
+ -- so we cover these types with the 'refine' hack below.
+import silver:compiler:modification:ffi only foreignType;
+import silver:compiler:modification:list only listCtrType;
+
 import silver:compiler:translation:java;
 
 {--
@@ -247,6 +250,16 @@ top::Type ::= fn::String  transType::String  params::[Type]
         then refineAll( params, op )
         else errorSubst("Tried to refine conflicting foreign types " ++ fn ++ " and " ++ ofn)
     | _ -> errorSubst("Tried to refine foreign type " ++ fn ++ " with " ++ prettyType(top.refineWith))
+    end;
+}
+
+aspect production listCtrType
+top::Type ::=
+{
+  top.refine =
+    case top.refineWith of
+    | listCtrType() -> emptySubst()
+    | _ -> errorSubst("Tried to refine [] with " ++ prettyType(top.refineWith))
     end;
 }
 

--- a/grammars/silver/compiler/translation/java/core/DclInfo.sv
+++ b/grammars/silver/compiler/translation/java/core/DclInfo.sv
@@ -1,7 +1,7 @@
 grammar silver:compiler:translation:java:core;
 
 
-attribute attrOccursIndexName, attrOccursInitIndex, attrOccursIndex occurs on OccursDclInfo;
+attribute attrOccursIndexName, attrOccursInitIndex, attrGlobalOccursInitIndex, attrOccursIndex occurs on OccursDclInfo;
 
 {--
  - The name of the occurs variable. e.g. silver_def_core_pp__ON__silver_def_core_Expr
@@ -14,6 +14,12 @@ synthesized attribute attrOccursIndexName :: String;
  -}
 synthesized attribute attrOccursInitIndex :: String;
 {--
+ - Index of the attribute used for initializating attribute equations.
+ - Only defined for global occurs-on declarations, doesn't depend on transContextDeps.
+ - e.g. silver.def.core.silver_def_core_pp__ON__silver_def_core_Expr
+ -}
+synthesized attribute attrGlobalOccursInitIndex :: String;
+{--
  - Index of the attribute used for accessing the attribute on a DecoratedNode.
  - e.g. silver.def.core.silver_def_core_pp__ON__silver_def_core_Expr
  - or foo.bar.PExpr.d_foo_bar_inh__a for an inherited occurs-on constraint
@@ -23,40 +29,44 @@ synthesized attribute attrOccursIndex :: String;
 aspect default production
 top::OccursDclInfo ::=
 {
-  top.attrOccursIndex = top.transContext;
+  top.attrGlobalOccursInitIndex = error("Should only be accessed on global occursDcl");
 }
-
 
 aspect production occursDcl
 top::OccursDclInfo ::= fnnt::String fnat::String ntty::Type atty::Type
 {
   top.attrOccursIndexName = makeIdName(fnat ++ "__ON__" ++ fnnt);
-  top.attrOccursInitIndex = top.attrOccursIndex;
-  top.attrOccursIndex = makeName(top.sourceGrammar) ++ ".Init." ++ top.attrOccursIndexName;
+  top.attrOccursInitIndex = top.attrGlobalOccursInitIndex;
+  top.attrGlobalOccursInitIndex = makeName(top.sourceGrammar) ++ ".Init." ++ top.attrOccursIndexName;
+  top.attrOccursIndex = top.attrOccursInitIndex;
 }
 aspect production occursInstConstraintDcl
 top::OccursDclInfo ::= fnat::String ntty::Type atty::Type tvs::[TyVar]
 {
   top.attrOccursIndexName = makeIdName(fnat ++ "__ON__" ++ ntty.transTypeName);
   top.attrOccursInitIndex = top.attrOccursIndex;
+  top.attrOccursIndex = makeConstraintDictName(fnat, ntty, tvs);
 }
 aspect production occursSigConstraintDcl
 top::OccursDclInfo ::= fnat::String ntty::Type atty::Type ns::NamedSignature
 {
   top.attrOccursIndexName = makeIdName(fnat ++ "__ON__" ++ ntty.transTypeName);
   top.attrOccursInitIndex = makeProdName(ns.fullName) ++ "." ++ top.attrOccursIndexName;
+  top.attrOccursIndex = s"((${makeProdName(ns.fullName)})(context.undecorate())).${makeConstraintDictName(fnat, ntty, ns.freeVariables)}";
 }
 aspect production occursSuperDcl
 top::OccursDclInfo ::= fnat::String atty::Type baseDcl::InstDclInfo
 {
   top.attrOccursIndexName = makeIdName(fnat ++ "__ON__" ++ transTypeNameWith(baseDcl.typeScheme.typerep, baseDcl.typeScheme.boundVars));
   top.attrOccursInitIndex = top.attrOccursIndex;
+  top.attrOccursIndex = baseDcl.transContext ++ s".${makeInstanceSuperAccessorName(fnat)}()";
 }
 aspect production annoInstanceDcl
 top::OccursDclInfo ::= fnnt::String fnat::String ntty::Type atty::Type
 {
   top.attrOccursIndexName = error("Not actually an attribute");
   top.attrOccursInitIndex = error("Not actually an attribute");
+  top.attrGlobalOccursInitIndex = error("Not actually an attribute");
   top.attrOccursIndex = error("Not actually an attribute");
 }
 aspect production annoInstConstraintDcl

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -544,7 +544,7 @@ top::Exprs ::= e1::Expr ',' e2::Exprs
 }
 
 aspect production exprRef
-top::Expr ::= e::Decorated Expr
+top::Expr ::= e::PartiallyDecorated Expr
 {
   top.translation = e.translation;
   top.lazyTranslation = e.lazyTranslation;

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -276,18 +276,18 @@ top::Expr ::= e::Expr '.' 'forward'
 aspect production synDecoratedAccessHandler
 top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
-  top.translation = wrapAccessWithOT(top, s"${e.translation}.synthesized(${q.dcl.attrOccursIndex})");
+  top.translation = wrapAccessWithOT(top, s"${e.translation}.synthesized(${q.attrOccursIndex})");
 
   top.lazyTranslation = 
     case e, top.frame.lazyApplication of
     | childReference(cqn), true -> 
         if isDecorable(cqn.lookupValue.typeScheme.typerep, top.env)
         then
-          s"context.childDecoratedSynthesizedLazy(${top.frame.className}.i_${cqn.lookupValue.fullName}, ${q.dcl.attrOccursIndex})"
+          s"context.childDecoratedSynthesizedLazy(${top.frame.className}.i_${cqn.lookupValue.fullName}, ${q.attrOccursIndex})"
         else
-          s"context.childAsIsSynthesizedLazy(${top.frame.className}.i_${cqn.lookupValue.fullName}, ${q.dcl.attrOccursIndex})"
+          s"context.childAsIsSynthesizedLazy(${top.frame.className}.i_${cqn.lookupValue.fullName}, ${q.attrOccursIndex})"
     | lhsReference(_), true ->
-        s"context.contextSynthesizedLazy(${q.dcl.attrOccursIndex})"
+        s"context.contextSynthesizedLazy(${q.attrOccursIndex})"
     | _, _ -> wrapThunk(top.translation, top.frame.lazyApplication)
     end;
 }
@@ -295,11 +295,11 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 aspect production inhDecoratedAccessHandler
 top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
-  top.translation = wrapAccessWithOT(top, s"${e.translation}.inherited(${q.dcl.attrOccursIndex})");
+  top.translation = wrapAccessWithOT(top, s"${e.translation}.inherited(${q.attrOccursIndex})");
 
   top.lazyTranslation = 
     case e, top.frame.lazyApplication of
-    | lhsReference(_), true -> s"context.contextInheritedLazy(${q.dcl.attrOccursIndex})"
+    | lhsReference(_), true -> s"context.contextInheritedLazy(${q.attrOccursIndex})"
     | _, _ -> wrapThunk(top.translation, top.frame.lazyApplication)
     end;
 }
@@ -395,7 +395,7 @@ top::ExprInhs ::= lhs::ExprInh inh::ExprInhs
 aspect production exprLhsExpr
 top::ExprLHSExpr ::= q::QNameAttrOccur
 {
-  top.nameTrans = [q.dcl.attrOccursIndex];
+  top.nameTrans = [q.attrOccursIndex];
 }
 
 

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -178,21 +178,6 @@ top::Expr ::= q::PartiallyDecorated QName
     then directThunk
     else top.translation;
 }
-
-aspect production application
-top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
-{
-  -- TODO: Flow error here, since these aren't in the reference set of Expr.
-  -- We would like a way to decorate a `Decorated Expr` with additional attributes
-  -- such that these equations could be written on `functionInvocation` instead...
-  e.invokeArgs = es;
-  e.invokeNamedArgs = anns;
-  e.sameProdAsProductionDefinedOn = case e of
-                                    | baseExpr(qn) -> qn.name == last(explode(":", top.frame.fullName))
-                                    | _ -> false
-                                    end;
-}
-
 aspect production errorApplication
 top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
 {
@@ -205,6 +190,14 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::
 {
   top.translation = e.invokeTranslation;
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
+
+  e.invokeArgs = es;
+  e.invokeNamedArgs = annos;
+  e.sameProdAsProductionDefinedOn =
+    case e of
+    | baseExpr(qn) -> qn.name == last(explode(":", top.frame.fullName))
+    | _ -> false
+    end;
 }
 
 function argsTranslation

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -56,14 +56,14 @@ top::Expr ::= msg::[Message]
 }
 
 aspect production errorReference
-top::Expr ::= msg::[Message]  q::Decorated QName
+top::Expr ::= msg::[Message]  q::PartiallyDecorated QName
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
   top.lazyTranslation = top.translation;
 }
 
 aspect production childReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local childIDref :: String =
     top.frame.className ++ ".i_" ++ q.lookupValue.fullName;
@@ -87,7 +87,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production localReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.translation =
     if isDecorable(q.lookupValue.typeScheme.typerep, top.env)
@@ -107,7 +107,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production lhsReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.translation =
     if isDecorable(finalType(top), top.env)
@@ -118,7 +118,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production forwardReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.translation =
     if isDecorable(finalType(top), top.env)
@@ -130,7 +130,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production productionReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.translation =
     if null(typeScheme.contexts)
@@ -143,7 +143,7 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production functionReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   -- functions, unlike productions, can return a type variable.
   -- as such, we have to cast it to the real inferred final type.
@@ -158,14 +158,14 @@ top::Expr ::= q::Decorated QName
 }
 
 aspect production classMemberReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   top.translation = s"((${finalType(top).transType})${instHead.transContext}.${makeInstanceMemberAccessorName(q.lookupValue.fullName)}(${implode(", ", contexts.transContexts)}))";
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
 
 aspect production globalValueReference
-top::Expr ::= q::Decorated QName
+top::Expr ::= q::PartiallyDecorated QName
 {
   local directThunk :: String =
     s"${makeName(q.lookupValue.dcl.sourceGrammar)}.Init.global_${fullNameToShort(q.lookupValue.fullName)}" ++
@@ -194,14 +194,14 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 }
 
 aspect production errorApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs annos::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
   top.lazyTranslation = top.translation;
 }
 
 aspect production functionInvocation
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs annos::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
 {
   top.translation = e.invokeTranslation;
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
@@ -231,7 +231,7 @@ String ::= e::Decorated AnnoAppExprs
 function int2str String ::= i::Integer { return toString(i); }
 
 aspect production partialApplication
-top::Expr ::= e::Decorated Expr es::Decorated AppExprs annos::Decorated AnnoAppExprs
+top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
 {
   local step1 :: String = e.translation;
   -- Note: we check for nullity of the index lists instead of use
@@ -260,14 +260,14 @@ top::Expr ::= e::Decorated Expr es::Decorated AppExprs annos::Decorated AnnoAppE
 }
 
 aspect production errorAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
   top.lazyTranslation = top.translation;
 }
 
 aspect production errorDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
   top.lazyTranslation = top.translation;
@@ -281,7 +281,7 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.translation = wrapAccessWithOT(top, s"${e.translation}.synthesized(${q.dcl.attrOccursIndex})");
 
@@ -300,7 +300,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   top.translation = wrapAccessWithOT(top, s"${e.translation}.inherited(${q.dcl.attrOccursIndex})");
 
@@ -312,7 +312,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production terminalAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   local accessor :: String =
     if q.name == "lexeme" || q.name == "location"
@@ -331,7 +331,7 @@ top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
 }
 
 aspect production annoAccessHandler
-top::Expr ::= e::Decorated Expr  q::Decorated QNameAttrOccur
+top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
   -- Note that the transType is specific to the nonterminal we're accessing from.
   top.translation = s"((${finalType(top).transType})((${makeAnnoName(q.attrDcl.fullName)})${e.translation}).getAnno_${makeIdName(q.attrDcl.fullName)}())";

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -76,6 +76,7 @@ top::NamedSignature ::= fn::String ctxs::Contexts ty::Type
 {
   top.javaSignature = error("Translation shouldn't be demanded from global signature");
   top.refInvokeTrans = error("Translation shouldn't be demanded from global signature");
+  top.contextRuntimeResolve := error("Translation shouldn't be demanded from global signature");
   top.childTypeVarElems = error("Translation shouldn't be demanded from global signature");
   top.childStatic = error("Translation shouldn't be demanded from global signature");
   top.childDecls = error("Translation shouldn't be demanded from global signature");
@@ -192,6 +193,14 @@ top::Context ::= i1::Type i2::Type
   top.contextSigElem = s"final ${top.transType} ${makeInhSubsetName(i1, i2, top.boundVariables)}";
   top.contextRefElem = makeInhSubsetName(i1, i2, top.boundVariables);
   top.contextRuntimeResolve := s"final ${top.transType} ${makeInhSubsetName(i1, i2, top.boundVariables)} = null;";
+}
+
+aspect production typeErrorContext
+top::Context ::= _
+{
+  top.contextSigElem = error("Translation demanded in the presence of errors");
+  top.contextRefElem = error("Translation demanded in the presence of errors");
+  top.contextRuntimeResolve := error("Translation demanded in the presence of errors");
 }
 
 propagate typeChildren on NamedSignatureElements;

--- a/grammars/silver/compiler/translation/java/core/OccursDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/OccursDcl.sv
@@ -1,7 +1,7 @@
 grammar silver:compiler:translation:java:core;
 
 aspect production defaultAttributionDcl
-top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   local ntfn :: String = nt.lookupType.fullName;
   local occursType :: String = if at.lookupAttribute.dcl.isSynthesized then "syn" else "inh";
@@ -30,7 +30,7 @@ top::AGDcl ::= at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::B
 }
 
 aspect production errorAttributionDcl
-top::AGDcl ::= msg::[Message] at::Decorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= msg::[Message] at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.setupInh := error("Internal compiler error: translation not defined in the presence of errors");
   top.valueWeaving := error("Internal compiler error: translation not defined in the presence of errors");

--- a/grammars/silver/compiler/translation/java/core/OccursDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/OccursDcl.sv
@@ -13,13 +13,13 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
     if at.lookupAttribute.dcl.isAnnotation then
       ""
     else
-      s"\t\t${makeNTName(ntfn)}.occurs_${occursType}[${head(occursCheck).attrOccursInitIndex}] = \"${at.lookupAttribute.fullName}\";\n";
+      s"\t\t${makeNTName(ntfn)}.occurs_${occursType}[${head(occursCheck).attrGlobalOccursInitIndex}] = \"${at.lookupAttribute.fullName}\";\n";
 
   top.postInit :=
     if at.lookupAttribute.dcl.isAnnotation then
       ""
     else
-      s"\t\tcommon.RTTIManager.registerOccurs(\"${ntfn}\", \"${at.lookupAttribute.fullName}\", ${head(occursCheck).attrOccursInitIndex});\n";
+      s"\t\tcommon.RTTIManager.registerOccurs(\"${ntfn}\", \"${at.lookupAttribute.fullName}\", ${head(occursCheck).attrGlobalOccursInitIndex});\n";
 
   top.valueWeaving :=
     if at.lookupAttribute.dcl.isAnnotation then

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -137,43 +137,43 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
 }
 
 aspect production childDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.translation = s"${top.frame.className}.childInheritedAttributes[${top.frame.className}.i_${q.lookupValue.fullName}]";
 }
 
 aspect production lhsDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.translation = s"${top.frame.className}.synthesizedAttributes";
 }
 
 aspect production localDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.translation = s"${top.frame.className}.localInheritedAttributes[${q.lookupValue.dcl.attrOccursIndex}]";
 }
 
 aspect production forwardDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.translation = s"${top.frame.className}.forwardInheritedAttributes";
 }
 
 aspect production errorDefLHS
-top::DefLHS ::= q::Decorated QName
+top::DefLHS ::= q::PartiallyDecorated QName
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
 }
 
 aspect production errorAttributeDef
-top::ProductionStmt ::= msg::[Message] dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
 }
 
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.translation = 
     s"\t\t// ${dl.unparse}.${attr.unparse} = ${e.unparse}\n" ++
@@ -181,7 +181,7 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 }
 
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
   top.translation = 
     s"\t\t// ${dl.unparse}.${attr.unparse} = ${e.unparse}\n" ++
@@ -190,13 +190,13 @@ top::ProductionStmt ::= dl::Decorated DefLHS  attr::Decorated QNameAttrOccur  e:
 
 
 aspect production errorValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
 }
 
 aspect production localValueDef
-top::ProductionStmt ::= val::Decorated QName  e::Expr
+top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.translation =
 	s"\t\t// ${val.unparse} = ${e.unparse}\n" ++

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -87,7 +87,7 @@ top::ForwardInhs ::= lhs::ForwardInh rhs::ForwardInhs
 aspect production forwardLhsExpr
 top::ForwardLHSExpr ::= q::QNameAttrOccur
 {
-  top.attrName = q.dcl.attrOccursInitIndex;
+  top.attrName = q.attrOccursInitIndex;
 }
 
 aspect production localAttributeDcl
@@ -177,7 +177,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 {
   top.translation = 
     s"\t\t// ${dl.unparse}.${attr.unparse} = ${e.unparse}\n" ++
-    s"\t\t${dl.translation}[${attr.dcl.attrOccursInitIndex}] = ${wrapLazy(e)};\n";
+    s"\t\t${dl.translation}[${attr.attrOccursInitIndex}] = ${wrapLazy(e)};\n";
 }
 
 aspect production inheritedAttributeDef
@@ -185,7 +185,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 {
   top.translation = 
     s"\t\t// ${dl.unparse}.${attr.unparse} = ${e.unparse}\n" ++
-    s"\t\t${dl.translation}[${attr.dcl.attrOccursInitIndex}] = ${wrapLazy(e)};\n";
+    s"\t\t${dl.translation}[${attr.attrOccursInitIndex}] = ${wrapLazy(e)};\n";
 }
 
 

--- a/grammars/silver/compiler/translation/java/core/Project.sv
+++ b/grammars/silver/compiler/translation/java/core/Project.sv
@@ -8,7 +8,7 @@ imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 
-
+option silver:compiler:modification:list;  -- Special case translation for []
 
 function makeName
 String ::= str::String

--- a/grammars/silver/compiler/translation/java/core/Project.sv
+++ b/grammars/silver/compiler/translation/java/core/Project.sv
@@ -8,8 +8,6 @@ imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 
-option silver:compiler:modification:list;  -- Special case translation for []
-
 function makeName
 String ::= str::String
 {

--- a/grammars/silver/compiler/translation/java/core/QName.sv
+++ b/grammars/silver/compiler/translation/java/core/QName.sv
@@ -1,0 +1,10 @@
+grammar silver:compiler:translation:java:core;
+
+attribute attrOccursIndex, attrOccursInitIndex occurs on QNameAttrOccur;
+
+aspect production qNameAttrOccur
+top::QNameAttrOccur ::= at::QName
+{
+  top.attrOccursIndex = resolvedDcl.attrOccursIndex;
+  top.attrOccursInitIndex = resolvedDcl.attrOccursInitIndex;
+}

--- a/grammars/silver/compiler/translation/java/type/Context.sv
+++ b/grammars/silver/compiler/translation/java/type/Context.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:translation:java:type;
 
 import silver:compiler:definition:env;
+import silver:compiler:definition:core only QNameAttrOccur, QName, qNameAttrOccur;
 
 -- Translation of *solved* contexts, not *constraint* contexts
 synthesized attribute transContexts::[String] occurs on Contexts;
@@ -61,7 +62,7 @@ top::Context ::= attr::String args::[Type] atty::Type ntty::Type
   top.transType = "int";
   
   resolvedDcl.transContextDeps = requiredContexts.transContexts;
-  top.transContext = resolvedDcl.transContext;
+  top.transContext = resolvedDcl.attrOccursIndex;
   top.transContextDummyInit = "0";
   
   top.transContextMemberName = makeConstraintDictName(attr, ntty, top.boundVariables);
@@ -79,7 +80,7 @@ top::Context ::= attr::String args::[Type] atty::Type inhs::Type ntty::Type
   top.transType = "int";
   
   resolvedDcl.transContextDeps = requiredContexts.transContexts;
-  top.transContext = resolvedDcl.transContext;
+  top.transContext = resolvedDcl.attrOccursIndex;
   top.transContextDummyInit = "0";
   
   top.transContextMemberName = makeConstraintDictName(attr, ntty, top.boundVariables);
@@ -168,7 +169,7 @@ top::Context ::= msg::String
 
 -- The translations of the narrowed forms of the instDcl's contexts are fed back as dcl.transContextDeps 
 inherited attribute transContextDeps::[String] occurs on InstDclInfo, OccursDclInfo;
-attribute transContext occurs on InstDclInfo, OccursDclInfo;
+attribute transContext occurs on InstDclInfo;
 
 aspect production instDcl
 top::InstDclInfo ::= fn::String bound::[TyVar] contexts::[Context] ty::Type
@@ -223,46 +224,16 @@ top::InstDclInfo ::= i1::Type i2::Type fnsig::NamedSignature
   top.transContext = "null";
 }
 
-aspect production occursDcl
-top::OccursDclInfo ::= fnnt::String fnat::String ntty::Type atty::Type
-{
-  top.transContext = top.attrOccursIndex;
-}
-aspect production occursInstConstraintDcl
-top::OccursDclInfo ::= fnat::String ntty::Type atty::Type tvs::[TyVar]
-{
-  top.transContext = makeConstraintDictName(fnat, ntty, tvs);
-}
-aspect production occursSigConstraintDcl
-top::OccursDclInfo ::= fnat::String ntty::Type atty::Type ns::NamedSignature
-{
-  top.transContext = s"((${makeProdName(ns.fullName)})(context.undecorate())).${makeConstraintDictName(fnat, ntty, ns.freeVariables)}";
-}
 aspect production occursSuperDcl
 top::OccursDclInfo ::= fnat::String atty::Type baseDcl::InstDclInfo
 {
   baseDcl.transContextDeps = top.transContextDeps;
-  top.transContext = baseDcl.transContext ++ s".${makeInstanceSuperAccessorName(fnat)}()";
 }
-aspect production annoInstanceDcl
-top::OccursDclInfo ::= fnnt::String fnat::String ntty::Type atty::Type
+
+aspect production qNameAttrOccur
+top::QNameAttrOccur ::= at::QName
 {
-  top.transContext = "null";
-}
-aspect production annoInstConstraintDcl
-top::OccursDclInfo ::= fnat::String ntty::Type atty::Type tvs::[TyVar]
-{
-  top.transContext = "null";
-}
-aspect production annoSigConstraintDcl
-top::OccursDclInfo ::= fnat::String ntty::Type atty::Type ns::NamedSignature
-{
-  top.transContext = "null";
-}
-aspect production annoSuperDcl
-top::OccursDclInfo ::= fnat::String atty::Type baseDcl::InstDclInfo
-{
-  top.transContext = "null";
+  resolvedDcl.transContextDeps = requiredContexts.transContexts;
 }
 
 function makeConstraintDictName

--- a/test/flow/PartialDec.sv
+++ b/test/flow/PartialDec.sv
@@ -100,3 +100,26 @@ PartiallyDecorated PDExpr with {env2} ::= e::PDExpr
   return e;
 }
 }
+
+warnCode "Partially decorated reference of type Decorated flow:PDExpr with only {} does not contain all attributes in the reference set of e's type Decorated flow:PDExpr with only {flow:env1}" {
+aspect production dispatchThing
+top::PDExpr ::= e::Decorated PDExpr with only {env1}
+{
+  local otherRef::Decorated PDExpr with only {} = e;
+}
+}
+
+function thingWithBoundedRefArg
+{env1, env2} subset i, i subset {env1} =>  -- Uninhabited, but shouldn't give an error
+Decorated PDExpr with only {env1} ::= e::Decorated PDExpr with only i
+{
+  return e;
+}
+
+warnCode "Cannot take a partially decorated reference to e of type Decorated flow:PDExpr with only i, as the reference set is not bounded" {
+function thingWithUnboundedRefArg
+{env1, env2} subset i => Decorated PDExpr with only {env1} ::= e::Decorated PDExpr with only i
+{
+  return e;
+}
+}

--- a/test/flow/PartialDec.sv
+++ b/test/flow/PartialDec.sv
@@ -108,18 +108,3 @@ top::PDExpr ::= e::PartiallyDecorated PDExpr with {env1}
   local otherRef::PartiallyDecorated PDExpr with {} = e;
 }
 }
-
-function thingWithBoundedRefArg
-{env1, env2} subset i, i subset {env1} =>  -- Uninhabited, but shouldn't give an error
-PartiallyDecorated PDExpr with {env1} ::= e::PartiallyDecorated PDExpr with i
-{
-  return e;
-}
-
-warnCode "Cannot take a partially decorated reference to e of type PartiallyDecorated flow:PDExpr with i, as the reference set is not bounded" {
-function thingWithUnboundedRefArg
-{env1, env2} subset i => PartiallyDecorated PDExpr with {env1} ::= e::Decorated PDExpr with i
-{
-  return e;
-}
-}

--- a/test/flow/PartialDec.sv
+++ b/test/flow/PartialDec.sv
@@ -101,24 +101,24 @@ PartiallyDecorated PDExpr with {env2} ::= e::PDExpr
 }
 }
 
-warnCode "Partially decorated reference of type Decorated flow:PDExpr with only {} does not contain all attributes in the reference set of e's type Decorated flow:PDExpr with only {flow:env1}" {
+warnCode "Partially decorated reference of type PartiallyDecorated flow:PDExpr with {} does not contain all attributes in the reference set of e's type PartiallyDecorated flow:PDExpr with {flow:env1}" {
 aspect production dispatchThing
-top::PDExpr ::= e::Decorated PDExpr with only {env1}
+top::PDExpr ::= e::PartiallyDecorated PDExpr with {env1}
 {
-  local otherRef::Decorated PDExpr with only {} = e;
+  local otherRef::PartiallyDecorated PDExpr with {} = e;
 }
 }
 
 function thingWithBoundedRefArg
 {env1, env2} subset i, i subset {env1} =>  -- Uninhabited, but shouldn't give an error
-Decorated PDExpr with only {env1} ::= e::Decorated PDExpr with only i
+PartiallyDecorated PDExpr with {env1} ::= e::PartiallyDecorated PDExpr with i
 {
   return e;
 }
 
-warnCode "Cannot take a partially decorated reference to e of type Decorated flow:PDExpr with only i, as the reference set is not bounded" {
+warnCode "Cannot take a partially decorated reference to e of type PartiallyDecorated flow:PDExpr with i, as the reference set is not bounded" {
 function thingWithUnboundedRefArg
-{env1, env2} subset i => Decorated PDExpr with only {env1} ::= e::Decorated PDExpr with only i
+{env1, env2} subset i => PartiallyDecorated PDExpr with {env1} ::= e::Decorated PDExpr with i
 {
   return e;
 }


### PR DESCRIPTION
# Changes
This pull request is based on #609 and should be reviewed after that is merged.

Remaining TODOs before merging:

- [x] Fix flow errors in the implicit monads extension (#616, #615, #611 - assigned to @RandomActsOfGrammar)
- [x] Get #609 reviewed and merged
- [x] Add MWDA run in Silver's Jenkins pipeline

# Documentation
I added comments for why a few needed equations were added.  Otherwise the majority of the changes to comments consisted of deleting TODOs about flow errors that needed fixing.  

This pull request does not make any externally visible behavioral changes to Silver (besides fixing some possible corner cases that could cause a crash due to missing equations) and so no external documentation is needed.