### PR TITLE
Fix completeness checking for all whens

### DIFF
--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -544,9 +544,9 @@ function allConCaseCheckOverlapping
   We need the environment to look up any nonterminal matches and see
   if the nonterminal is closed or not.
 
-  We return nothing() if the patterns are complete, and just(plst) if
-  plst is an example of a missing pattern set (matching over multiple
-  values at once).
+  We return nothing() if there are some patterns and the patterns are
+  complete, and just(plst) if plst is an example of a missing pattern
+  set (matching over multiple values at once).
 -}
 function checkCompleteness
 Maybe<[Pattern]> ::= lst::[[Decorated Pattern]] env::Decorated Env

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -89,6 +89,8 @@ top::Expr ::= 'case' es::Exprs 'of' Opt_Vbar_t ml::MRuleList 'end'
 }
 
 
+--Argument `complete` controls whether we check for case completeness or not  (true -> check)
+--This is used so generated case expressions can avoid the incomplete check
 abstract production caseExpr
 top::Expr ::= es::[Expr] ml::[AbstractMatchRule] complete::Boolean failExpr::Expr retType::Type
 {
@@ -127,7 +129,7 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] complete::Boolean failExpr::Exp
 
   --If we have only conditional rules, it isn't complete
   top.errors <-
-      if length(conditionlessRules) == 0 && length(ml) > 0
+      if complete && length(conditionlessRules) == 0 && length(ml) > 0
       then [mwdaWrn(top.config, top.location,
                "This pattern-matching is not exhaustive because it only has conditional rules")]
       else [];

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -125,6 +125,13 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] complete::Boolean failExpr::Exp
       | _ -> []
       end;
 
+  --If we have only conditional rules, it isn't complete
+  top.errors <-
+      if length(conditionlessRules) == 0 && length(ml) > 0
+      then [mwdaWrn(top.config, top.location,
+               "This pattern-matching is not exhaustive because it only has conditional rules")]
+      else [];
+
 
   {-Checking Pattern Overlaps
 

--- a/test/patt/Completeness.sv
+++ b/test/patt/Completeness.sv
@@ -450,3 +450,19 @@ warnCode "not exhaustive" {
    }
 }
 
+
+--Check not exhaustive if all patterns have conditions
+warnCode "not exhaustive" {
+   function fun_test_incompleteness_all_conditions
+   String ::=
+   {
+     return
+       case 3, 4 of
+       | 1, y when y > 2 -> "first"
+       | x, 3 when x < 4 -> "second"
+       | x, y when y matches 15 -> "third"
+       | x, y when x == y -> "fourth"
+       end;
+   }
+}
+


### PR DESCRIPTION
# Changes
Fixes #546.  This checks if there are no patterns without `when` clauses but there are some match rules with `when` clauses. 
 In that case, it generates a warning for incomplete patterns.

# Documentation
I added a comment explaining the reason for the additional error check.  I also added a comment with the test to explain what it is checking.  This only affects the local code, so it doesn't need any further documentation elsewhere.  Its only effect visible to the user is in checking incomplete matching.