### PR TITLE
Changing mcase forward to fix flow errors

### DIFF
--- a/grammars/silver/compiler/extension/implicit_monads/Case.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Case.sv
@@ -485,9 +485,11 @@ top::Expr ::= 'case_any' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
   top.mUpSubst = ml.mUpSubst;
   top.mtyperep = monadOfType(top.expectedMonad, freshType());
 
-  forwards to if isMonadPlus_instance
-              then applied
-              else errorExpr([err(top.location, notMonadPlus)], location=top.location);
+  --We need to forward to an errorExpr rather than the rewritten version to avoid flow errors
+  --Because this should only be used in implicit equations, it should be fine
+  forwards to errorExpr([err(top.location,
+                             "Can only use case_any in implicit equations")],
+                        location=top.location);
 }
 
 {-


### PR DESCRIPTION
# Changes
Fixes #611.  This changes `case_any` to forward to an error expression in all cases to fix the flow errors from it originally forwarding to the rewritten version relying on new inherited attributes.

# Documentation
I added a comment explaining why it forwards to the error expression.  It does not affect anything further in the code, so it does not need other developer documentation.  It should not change anything users see, so does not require any website changes.