### PR TITLE
Renaming IO types/functions - Part II

### DIFF
--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -185,7 +185,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
   -- this as to the flow analysis, and justifies all the choices below:
 
   -- First, generate our "anonymous" flow vertex name:
-  inh.decorationVertex = "__decorate" ++ toString(genIntT()) ++ ":line" ++ toString(top.location.line);
+  inh.decorationVertex = "__decorate" ++ toString(genInt()) ++ ":line" ++ toString(top.location.line);
 
   -- Next, emit the "local equation" for this anonymous flow vertex.
   -- This means only the deps in 'e', see above conceptual transformation to see why.
@@ -293,7 +293,7 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
   -- so we DO need to be transitive. Unfortunately.
   
   -- hack note: there's a test that depends on this name starting with __scrutinee. grep for it if you have to change this
-  local anonName :: String = "__scrutinee" ++ toString(genIntT()) ++ ":line" ++ toString(e.location.line);
+  local anonName :: String = "__scrutinee" ++ toString(genInt()) ++ ":line" ++ toString(e.location.line);
 
   pr.scrutineeVertexType =
     case e.flowVertexInfo of

--- a/grammars/silver/compiler/definition/type/Type.sv
+++ b/grammars/silver/compiler/definition/type/Type.sv
@@ -329,13 +329,13 @@ top::TyVar ::= k::Kind i::Integer n::String
 function freshTyVar
 TyVar ::= k::Kind
 {
-  return tyVar(k, genIntT());
+  return tyVar(k, genInt());
 }
 
 function freshTyVarNamed
 TyVar ::= k::Kind n::String
 {
-  return tyVarNamed(k, genIntT(), n);
+  return tyVarNamed(k, genInt(), n);
 }
 
 function freshType

--- a/grammars/silver/compiler/driver/CompileGrammars.sv
+++ b/grammars/silver/compiler/driver/CompileGrammars.sv
@@ -29,7 +29,7 @@ IOVal<[Maybe<RootSpec>]> ::=
     if null(need) then
       ioval(ioin, [])
     else
-      ioval(recurse.io, unsafeTraceT(now.iovalue, now.io) :: recurse.iovalue);
+      ioval(recurse.io, unsafeTrace(now.iovalue, now.io) :: recurse.iovalue);
   -- A short note about that unsafeTrace:
   -- Unfortunately, Silver lacks any way to indicate strictness in the types, and
   -- as a consequence, writing 'now.iovalue :: ...' means we can construct this

--- a/grammars/silver/compiler/driver/GrammarAction.sv
+++ b/grammars/silver/compiler/driver/GrammarAction.sv
@@ -31,7 +31,7 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::Build
 abstract production touchIfaces
 top::DriverAction ::= r::[Decorated RootSpec] genPath::String
 {
-  top.io = touchFiles(map(sviPath(_, genPath), r), top.ioIn);
+  top.io = touchFilesT(map(sviPath(_, genPath), r), top.ioIn);
   top.code = 0;
   top.order = 3;
 }

--- a/grammars/silver/compiler/driver/GrammarAction.sv
+++ b/grammars/silver/compiler/driver/GrammarAction.sv
@@ -31,7 +31,7 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::Build
 abstract production touchIfaces
 top::DriverAction ::= r::[Decorated RootSpec] genPath::String
 {
-  top.io = touchFilesT(map(sviPath(_, genPath), r), top.ioIn);
+  top.io = touchFiles(map(sviPath(_, genPath), r), top.ioIn);
   top.code = 0;
   top.order = 3;
 }
@@ -45,7 +45,7 @@ abstract production printAllBindingErrors
 top::DriverAction ::= specs::[Decorated RootSpec]
 {
   -- Force printing of status before doing error checks
-  top.code = unsafeTraceT(forward.code, forward.ioIn);
+  top.code = unsafeTrace(forward.code, forward.ioIn);
   -- For anyone encountering this hack for the first time,
   -- IO-token passing can force linearity of actions, but
   -- interleaves pure computation in annoying ways.

--- a/grammars/silver/compiler/driver/util/GrammarAction.sv
+++ b/grammars/silver/compiler/driver/util/GrammarAction.sv
@@ -24,7 +24,7 @@ IOVal<Integer> ::= l::[DriverAction] i::IOToken
   local now :: DriverAction = head(l);
   now.ioIn = i;
 
-  return  if unsafeTraceT(null(l), i) -- TODO: this is just to force strictness...
+  return  if unsafeTrace(null(l), i) -- TODO: this is just to force strictness...
 	  then ioval(i, 0)
 	  else if now.code != 0
 	       then ioval(now.io, now.code)

--- a/grammars/silver/compiler/extension/convenienceaspects/AbstractSyntax.sv
+++ b/grammars/silver/compiler/extension/convenienceaspects/AbstractSyntax.sv
@@ -131,7 +131,7 @@ function makeGeneratedNamesFromMatchRule
 
   return
     map(\pat::Pattern ->
-      name("__generated_" ++ toString(genIntT()), loc),
+      name("__generated_" ++ toString(genInt()), loc),
       collectPatternsFromPatternList(patList,[]));
 
 }

--- a/grammars/silver/compiler/extension/convenienceaspects/ConcreteSyntax.sv
+++ b/grammars/silver/compiler/extension/convenienceaspects/ConcreteSyntax.sv
@@ -58,7 +58,7 @@ concrete productions top::ConvAspectLHS
 | ty::TypeExpr
 {
   top.aspectType = ty;
-  top.aspectName = name("__generatedTop_" ++ toString(genIntT()), ty.location);
+  top.aspectName = name("__generatedTop_" ++ toString(genInt()), ty.location);
   top.unparse = ty.unparse;
 }
 

--- a/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
@@ -166,5 +166,5 @@ IOToken ::= iIn::IOToken outputLoc::String gram::String
 {
   local docPath :: String = outputLoc ++ grammarToPath(gram);
   
-  return deleteDirFiles(docPath, iIn).io;
+  return deleteDirFilesT(docPath, iIn).io;
 }

--- a/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
@@ -166,5 +166,5 @@ IOToken ::= iIn::IOToken outputLoc::String gram::String
 {
   local docPath :: String = outputLoc ++ grammarToPath(gram);
   
-  return deleteDirFilesT(docPath, iIn).io;
+  return deleteDirFiles(docPath, iIn).io;
 }

--- a/grammars/silver/compiler/extension/implicit_monads/Case.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Case.sv
@@ -172,7 +172,7 @@ function monadicMatchTypesNames
             end;
   local ntail::[String] = if null(names) then [] else tail(names);
   local newName::String = if null(names)
-                          then "__sv_expression_in_case" ++ toString(index) ++ "_" ++ toString(genIntT())
+                          then "__sv_expression_in_case" ++ toString(index) ++ "_" ++ toString(genInt())
                           else head(names);
   return case elst, tylst of
          | [], _ -> pair([], [])
@@ -419,7 +419,7 @@ top::Expr ::= 'case_any' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
         "MonadPlus and cannot be used with case_any";
 
   --we need fresh names for the expressions being matched on, which we will use to only evaluate them once
-  local newNames::[String] = map(\ x::Expr -> "__sv_mcase_var_" ++ toString(genIntT()), es.rawExprs);
+  local newNames::[String] = map(\ x::Expr -> "__sv_mcase_var_" ++ toString(genInt()), es.rawExprs);
   local params::[Pair<String Type>] = zipWith(pair, newNames, ml.patternTypeList);
   local nameExprs::[Expr] = map(\x::String -> baseExpr(qName(top.location, x), location=top.location),
                                 newNames);

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -243,7 +243,7 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   local lambda_fun::Expr = buildMonadApplicationLambda(nes.realTypes, nes.monadTypesLocations, ety, wrapReturn, top.location);
   local expanded_args::AppExprs = snocAppExprs(nes.monadRewritten, ',', presentAppExpr(ne.monadRewritten, location=top.location),
                                                location=top.location);
-  local bind_name::String = "__bindFun_" ++ toString(genIntT());
+  local bind_name::String = "__bindFun_" ++ toString(genInt());
   -- fun >>= \ bind_name -> lambda_fun(args, bind_name)
   local bind_fun_in::Expr =
         Silver_Expr {
@@ -967,7 +967,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
                      inhSetType(sort(nub(inh.suppliedInhs)))))
                  else decoratedType(performSubstitution(e.mtyperep, e.mUpSubst), inhSetType(sort(nub(inh.suppliedInhs))));
 
-  local newname::String = "__sv_bind_" ++ toString(genIntT());
+  local newname::String = "__sv_bind_" ++ toString(genInt());
   local params::ProductionRHS =
      productionRHSCons(productionRHSElem(name(newname, top.location),
                                          '::',

--- a/grammars/silver/compiler/extension/implicit_monads/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/PrimitiveMatch.sv
@@ -65,7 +65,7 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
   f.monadicallyUsed = false;
   top.monadicNames = e.monadicNames ++ pr.monadicNames ++ f.monadicNames;
 
-  local freshname::String = "__sv_bindingInAMatchExpression_" ++ toString(genIntT());
+  local freshname::String = "__sv_bindingInAMatchExpression_" ++ toString(genInt());
   local eBind::Expr = monadBind(top.location);
   local eInnerType::TypeExpr = typerepTypeExpr(monadInnerType(e.mtyperep, top.location), location=top.location);
   local binde_lambdaparams::ProductionRHS =

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -156,7 +156,7 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] complete::Boolean failExpr::Exp
     efficiency.
   -}
   local names::[String] =
-        map(\ x::Expr -> "__match_expr_" ++ toString(genIntT()), es);
+        map(\ x::Expr -> "__match_expr_" ++ toString(genInt()), es);
   local nameExprs::[Expr] =
         map(\ x::String -> baseExpr(qName(bogusLoc(), x),
                                     location=bogusLoc()), names);
@@ -337,7 +337,7 @@ Expr ::= matchEs::[Expr] ruleGroups::[[AbstractMatchRule]] finalFail::Expr
         | hd::tl -> hd
         end;
   local firstPatt::Decorated Pattern = head(firstGroup).headPattern;
-  local failName::String = "__match_fail_" ++ toString(genIntT());
+  local failName::String = "__match_fail_" ++ toString(genInt());
   local firstMatchExpr::Expr =
         case matchEs of
         | [] ->
@@ -1187,8 +1187,8 @@ Name ::= p::Decorated Pattern
 {
   local n :: String =
     case p of
-    | varPattern(pvn) -> "__sv_pv_" ++ toString(genIntT()) ++ "_" ++ pvn.name
-    | h -> "__sv_tmp_pv_" ++ toString(genIntT())
+    | varPattern(pvn) -> "__sv_pv_" ++ toString(genInt()) ++ "_" ++ pvn.name
+    | h -> "__sv_tmp_pv_" ++ toString(genInt())
     end;
   return name(n, p.location);
 }

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -639,7 +639,7 @@ top::Exprs ::= e::Expr
 {
   top.transform = consASTExpr(e.transform, nilASTExpr());
   
-  local lambdaParamName::String = "__exprs_param_" ++ toString(genIntT());
+  local lambdaParamName::String = "__exprs_param_" ++ toString(genInt());
   top.lambdaParams =
     productionRHSCons(
       productionRHSElem(
@@ -658,7 +658,7 @@ top::Exprs ::= e1::Expr ',' e2::Exprs
 {
   top.transform = consASTExpr(e1.transform, e2.transform);
   
-  local lambdaParamName::String = "__exprs_param_" ++ toString(genIntT());
+  local lambdaParamName::String = "__exprs_param_" ++ toString(genInt());
   top.lambdaParams =
     productionRHSCons(
       productionRHSElem(

--- a/grammars/silver/compiler/extension/strategyattr/StrategyUtils.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyUtils.sv
@@ -34,7 +34,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production repeatS -- name clash with repeat from core
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "repeat_" ++ toString(genIntT());
+  local recVarName::String = "repeat_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> try($StrategyExpr{s} <* $strategyQName{recVarName})
@@ -44,7 +44,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production reduce
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "reduce_" ++ toString(genIntT());
+  local recVarName::String = "reduce_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       repeat(rec $name{recVarName} -> some($strategyQName{recVarName}) <+ $StrategyExpr{s})
@@ -54,7 +54,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production bottomUp
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "bottomUp_" ++ toString(genIntT());
+  local recVarName::String = "bottomUp_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> all($strategyQName{recVarName}) <* $StrategyExpr{s}
@@ -64,7 +64,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production topDown
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "topDown_" ++ toString(genIntT());
+  local recVarName::String = "topDown_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> $StrategyExpr{s} <* all($strategyQName{recVarName})
@@ -74,7 +74,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production downUp
 top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 {
-  local recVarName::String = "downUp_" ++ toString(genIntT());
+  local recVarName::String = "downUp_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> $StrategyExpr{s1} <* all($strategyQName{recVarName}) <* $StrategyExpr{s2}
@@ -84,7 +84,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 abstract production allBottomUp
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "allBottomUp_" ++ toString(genIntT());
+  local recVarName::String = "allBottomUp_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> all($strategyQName{recVarName}) <+ $StrategyExpr{s}
@@ -94,7 +94,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production allTopDown
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "allTopDown_" ++ toString(genIntT());
+  local recVarName::String = "allTopDown_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> $StrategyExpr{s} <+ all($strategyQName{recVarName})
@@ -104,7 +104,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production allDownUp
 top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 {
-  local recVarName::String = "allDownUp_" ++ toString(genIntT());
+  local recVarName::String = "allDownUp_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> $StrategyExpr{s1} <+ all($strategyQName{recVarName}) <+ $StrategyExpr{s2}
@@ -114,7 +114,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 abstract production someBottomUp
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "someBottomUp_" ++ toString(genIntT());
+  local recVarName::String = "someBottomUp_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> some($strategyQName{recVarName}) <+ $StrategyExpr{s}
@@ -124,7 +124,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production someTopDown
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "someTopDown_" ++ toString(genIntT());
+  local recVarName::String = "someTopDown_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> $StrategyExpr{s} <+ some($strategyQName{recVarName})
@@ -134,7 +134,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production someDownUp
 top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 {
-  local recVarName::String = "someDownUp_" ++ toString(genIntT());
+  local recVarName::String = "someDownUp_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> $StrategyExpr{s1} <+ some($strategyQName{recVarName}) <+ $StrategyExpr{s2}
@@ -144,7 +144,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 abstract production onceBottomUp
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "onceBottomUp_" ++ toString(genIntT());
+  local recVarName::String = "onceBottomUp_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> one($strategyQName{recVarName}) <+ $StrategyExpr{s}
@@ -154,7 +154,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production onceTopDown
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "onceTopDown_" ++ toString(genIntT());
+  local recVarName::String = "onceTopDown_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> $StrategyExpr{s} <+ one($strategyQName{recVarName})
@@ -164,7 +164,7 @@ top::StrategyExpr ::= s::StrategyExpr
 abstract production onceDownUp
 top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 {
-  local recVarName::String = "onceDownUp_" ++ toString(genIntT());
+  local recVarName::String = "onceDownUp_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> $StrategyExpr{s1} <+ one($strategyQName{recVarName}) <+ $StrategyExpr{s2}
@@ -174,7 +174,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 abstract production innermost
 top::StrategyExpr ::= s::StrategyExpr
 {
-  local recVarName::String = "innermost_" ++ toString(genIntT());
+  local recVarName::String = "innermost_" ++ toString(genInt());
   forwards to
     Silver_StrategyExpr (top.genName) {
       rec $name{recVarName} -> bottomUp(try($StrategyExpr{s} <* $strategyQName{recVarName}))

--- a/grammars/silver/compiler/extension/testing/EqualityTest.sv
+++ b/grammars/silver/compiler/extension/testing/EqualityTest.sv
@@ -179,6 +179,6 @@ ag::AGDcl ::= kwd::'equalityTest'
   local testName :: String = "generatedTest" ++ "_" ++ 
                             substitute(".","_",kwd.filename) ++ "_" ++ 
                             toString(kwd.line) ++ "_" ++ 
-                            toString(genIntT());
+                            toString(genInt());
 }
 

--- a/grammars/silver/compiler/extension/treegen/TestFor.sv
+++ b/grammars/silver/compiler/extension/treegen/TestFor.sv
@@ -23,7 +23,7 @@ top::AGDcl ::= 'testFor' testSuite::Name ':' n::Name '::' id::QName ',' e::Expr 
   local prods :: [ValueDclInfo] = getKnownProds(id.lookupType.fullName, top.env);
 
   local l :: Location = top.location;
-  local generatedName :: String = "checkPropOn" ++ id.name ++ toString(genIntT());
+  local generatedName :: String = "checkPropOn" ++ id.name ++ toString(genInt());
   
   local fundcl :: AGDcl =
     functionDcl(
@@ -64,7 +64,7 @@ top::AGDcl ::= 'testFor' testSuite::Name ':' n::Name '::' id::QName ',' e::Expr 
 function generateTestFor
 AGDcl ::= d::ValueDclInfo  testfunname::String  l::Location  testSuite::Name
 {
-  local generatedName :: String = "genSpecificProduction" ++ substring(lastIndexOf(":", d.fullName) + 1, length(d.fullName), d.fullName) ++ toString(genIntT());
+  local generatedName :: String = "genSpecificProduction" ++ substring(lastIndexOf(":", d.fullName) + 1, length(d.fullName), d.fullName) ++ toString(genInt());
   
   local sig :: FunctionSignature =
     -- id ::= 

--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -54,8 +54,8 @@ propagate lambdaDefs, lambdaBoundVars on ProductionRHS;
 aspect production productionRHSElem
 top::ProductionRHSElem ::= id::Name '::' t::TypeExpr
 {
-  production fName :: String = toString(genIntT()) ++ ":" ++ id.name;
---  production transName :: String = "lambda_param" ++ id.name ++ toString(genIntT());
+  production fName :: String = toString(genInt()) ++ ":" ++ id.name;
+--  production transName :: String = "lambda_param" ++ id.name ++ toString(genInt());
   top.lambdaDefs := [lambdaParamDef(top.grammarName, t.location, fName, t.typerep)];
   top.lambdaBoundVars := [id.name];
 }

--- a/grammars/silver/compiler/modification/let_fix/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/Let.sv
@@ -86,7 +86,7 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
   -- explicit types. We can't use `finalSubst` here because that requires
   -- having completed type inference which requires `defs` which we're defining.
   local semiTy :: Type = performSubstitution(t.typerep, top.upSubst);
-  production fName :: String = toString(genIntT()) ++ ":" ++ id.name;
+  production fName :: String = toString(genInt()) ++ ":" ++ id.name;
 
   -- Using finalTy here, so our defs requires we have downSubst...
   -- references to this def want to know if its decorated, to enable the

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -245,7 +245,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   
   -- If there are contexts on the production, then we need to make the scrutinee available
   -- in the RHS to access their implementations.
-  local scrutineeName::String = "__scrutineeNode_" ++ toString(genIntT());
+  local scrutineeName::String = "__scrutineeNode_" ++ toString(genInt());
   local contextDefs::[Def] = concat(
     zipWith(
       \ c::Context oc::Context ->
@@ -329,7 +329,7 @@ top::PrimPattern ::= qn::Decorated QName  ns::VarBinders  e::Expr
   
   -- If there are contexts on the production, then we need to make the scrutinee available
   -- in the RHS to access their implementations.
-  local scrutineeName::String = "__scrutinee_" ++ toString(genIntT());
+  local scrutineeName::String = "__scrutinee_" ++ toString(genInt());
   local contextDefs::[Def] = concat(
     zipWith(
       \ c::Context oc::Context ->
@@ -470,8 +470,8 @@ top::PrimPattern ::= h::Name t::Name e::Expr
   
   top.freeVars := ts:removeAll([h.name, t.name], e.freeVars);
 
-  local h_fName :: String = toString(genIntT()) ++ ":" ++ h.name;
-  local t_fName :: String = toString(genIntT()) ++ ":" ++ t.name;
+  local h_fName :: String = toString(genInt()) ++ ":" ++ h.name;
+  local t_fName :: String = toString(genInt()) ++ ":" ++ t.name;
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
   local attribute errCheck2 :: TypeCheck; errCheck2.finalSubst = top.finalSubst;
   local elemType :: Type = freshType();

--- a/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
@@ -127,7 +127,7 @@ top::VarBinder ::= n::Name
   production finalTy::Type = performSubstitution(ty, top.finalSubst);
   production refSet::Maybe<[String]> = getMaxRefSet(finalTy, top.env);
 
-  production fName :: String = "__pv" ++ toString(genIntT()) ++ ":" ++ n.name;
+  production fName :: String = "__pv" ++ toString(genInt()) ++ ":" ++ n.name;
   
   -- If it's decorable, then we do projections through the production
   -- if it's not, then we treat it like a generic reference.

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -229,7 +229,7 @@ IOToken ::= i::IOToken  r::Decorated RootSpec  silverGen::String
   local mksrc :: IOVal<Boolean> =
     if mkiotest.iovalue then mkiotest else mkdirT(srcPath, mkiotest.io);
   local clean :: IOToken =
-    deleteDirFiles(srcPath, deleteDirFiles(binPath, mksrc.io).io).io;
+    deleteDirFilesT(srcPath, deleteDirFilesT(binPath, mksrc.io).io).io;
   
   local printio :: IOToken =
     if mksrc.iovalue

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -229,7 +229,7 @@ IOToken ::= i::IOToken  r::Decorated RootSpec  silverGen::String
   local mksrc :: IOVal<Boolean> =
     if mkiotest.iovalue then mkiotest else mkdirT(srcPath, mkiotest.io);
   local clean :: IOToken =
-    deleteDirFilesT(srcPath, deleteDirFilesT(binPath, mksrc.io).io).io;
+    deleteDirFiles(srcPath, deleteDirFiles(binPath, mksrc.io).io).io;
   
   local printio :: IOToken =
     if mksrc.iovalue

--- a/grammars/silver/core/IO.sv
+++ b/grammars/silver/core/IO.sv
@@ -200,6 +200,22 @@ top::IO<Boolean> ::= s::String
   top.stateVal = res.iovalue;
 }
 
+abstract production deleteFiles
+top::IO<Boolean> ::= files::[String]
+{
+  local res::IOVal<Boolean> = deleteFilesT(files, top.stateIn);
+  top.stateOut = res.io;
+  top.stateVal = res.iovalue;
+}
+
+abstract production deleteDirFiles
+top::IO<Boolean> ::= s::String
+{
+  local res::IOVal<Boolean> = deleteDirFilesT(s, top.stateIn);
+  top.stateOut = res.io;
+  top.stateVal = res.iovalue;
+}
+
 abstract production deleteTree
 top::IO<Unit> ::= s::String
 {
@@ -218,5 +234,12 @@ abstract production touchFile
 top::IO<Unit> ::= file::String
 {
   top.stateOut = touchFileT(file, top.stateIn);
+  top.stateVal = unit();
+}
+
+abstract production touchFiles
+top::IO<Unit> ::= files::[String]
+{
+  top.stateOut = touchFilesT(files, top.stateIn);
   top.stateVal = unit();
 }

--- a/grammars/silver/core/IO.sv
+++ b/grammars/silver/core/IO.sv
@@ -11,8 +11,8 @@ top::IO<b> ::= st::IO<a> fn::(IO<b> ::= a)
   local stateOut::IOToken = newState.stateOut;
   local stateVal::b = newState.stateVal;
   -- Using unsafeTrace here to demand st is evaluated before evaluating fn
-  top.stateOut = unsafeTraceT(stateOut, st.stateOut);
-  top.stateVal = unsafeTraceT(stateVal, st.stateOut);
+  top.stateOut = unsafeTrace(stateOut, st.stateOut);
+  top.stateVal = unsafeTrace(stateVal, st.stateOut);
 }
 
 
@@ -57,7 +57,7 @@ IOVal<a> ::= st::IO<a> ioIn::IOToken
 function unsafeEvalIO
 a ::= st::IO<a>
 {
-  return evalIO(st, unsafeIOT()).iovalue;
+  return evalIO(st, unsafeIO()).iovalue;
 }
 
 -- Monadic IO wrappers

--- a/grammars/silver/core/IOMisc.sv
+++ b/grammars/silver/core/IOMisc.sv
@@ -1,0 +1,116 @@
+grammar silver:core;
+
+@@{-
+
+The miscellaneous IO functions.
+
+-}
+
+@@{- # IO Misc -}
+
+@{--
+ - Die with the stated error message and a stack trace.  Note that Silver stacks
+ - may be hard to read (it's a lazy language.)
+ -
+ - @warning Does not return! Does not do any cleanup!
+ -
+ - @param msg  The path to list the contents of.
+ - @return  Does not return.
+ -}
+function error
+a ::= msg::String
+{
+  return error("Not Yet Implemented: error"); -- lol
+} foreign {
+  "java" : return "common.Util.error(%msg%.toString())";
+}
+
+@{--
+ - Generate an integer unique to this run of this process.  Starts from 0 and just
+ - counts up each call.
+ -
+ - @return  An integer unique to this process.
+ -}
+function genInt
+Integer ::=
+{
+  return error("Not Yet Implemented: genInt");
+} foreign {
+  "java" : return "common.Util.genInt()";
+}
+
+@{--
+ - Generates a random number between [0, 1)
+ -}
+function genRand
+Float ::=
+{
+  return error("Not Yet Implemented: genRand");
+} foreign {
+  "java" : return "((float)Math.random())";
+}
+
+@{--
+ - Print string when a value is demanded by the Silver runtime.
+ - When this gets executed may be unpredictable.
+ -
+ - @param val  The value to evaluate to, after the IO action is performed.
+ - @param str  The string to print.
+ - @return val, unchanged.
+ - @warning see @link[unsafeIO]
+ -}
+function unsafeTracePrint
+a ::= val::a str::String
+{
+  return unsafeTrace(val, printT(str, unsafeIO()));
+}
+
+@{--
+ - Print a stringification of a value when it is demanded by the Silver runtime.
+ - When this gets executed may be unpredictable.
+ -
+ - @param val  The value to evaluate to, printed when evaluated.
+ - @return  val, unchanged.
+ - @warning see @link[unsafeIO]
+ -}
+function unsafeTraceDump
+a ::= val::a
+{
+  return unsafeTrace(val, printT(hackUnparse(val), unsafeIO()));
+}
+
+
+
+-- Function for manipulating strings representing file and directory names.
+
+function dirNameInFilePath
+String ::= filePath::String
+{
+  return if indexOfLastSlash == -1 then filePath
+         else substring(0, indexOfLastSlash, filePath);
+
+  local attribute indexOfLastSlash :: Integer;
+  indexOfLastSlash = lastIndexOf("/", filePath);
+}
+
+function fileNameInFilePath
+String ::= filePath::String
+{
+  return if indexOfLastSlash == -1 then filePath
+         else substring(indexOfLastSlash+1, length(filePath), filePath);
+
+  local attribute indexOfLastSlash :: Integer;
+  indexOfLastSlash = lastIndexOf("/", filePath);
+}
+
+
+function splitFileNameAndExtension
+Pair<String String> ::= filePath::String
+{
+  return if indexOfLastDot == -1 then pair(filePath, "")
+         else pair(substring(0, indexOfLastDot, filePath) ,
+                   substring(indexOfLastDot+1, length(filePath), filePath));
+
+  local attribute indexOfLastDot :: Integer;
+  indexOfLastDot = lastIndexOf(".", filePath);
+}

--- a/grammars/silver/core/IOToken.sv
+++ b/grammars/silver/core/IOToken.sv
@@ -408,23 +408,6 @@ IOToken ::= files::[String] i::IOToken
 @@{- # IO Misc -}
 
 @{--
- - Die with the stated error message and a stack trace.  Note that Silver stacks
- - may be hard to read (it's a lazy language.)
- -
- - @warning Does not return! Does not do any cleanup!
- -
- - @param msg  The path to list the contents of.
- - @return  Does not return.
- -}
-function error
-a ::= msg::String
-{
-  return error("Not Yet Implemented: error"); -- lol
-} foreign {
-  "java" : return "common.Util.error(%msg%.toString())";
-}
-
-@{--
  - Create a bogus world-state token, for use with @link[unsafeTrace].
  -
  - @return  A fake world-state token.
@@ -436,32 +419,6 @@ IOToken ::=
 } foreign {
   "java" : return "common.IOToken.singleton";
 }
-
-@{--
- - Generate an integer unique to this run of this process.  Starts from 0 and just
- - counts up each call.
- -
- - @return  An integer unique to this process.
- -}
-function genInt
-Integer ::=
-{
-  return error("Not Yet Implemented: genInt");
-} foreign {
-  "java" : return "common.Util.genInt()";
-}
-
-@{--
- - Generates a random number between [0, 1)
- -}
-function genRand
-Float ::=
-{
-  return error("Not Yet Implemented: genRand");
-} foreign {
-  "java" : return "((float)Math.random())";
-}
-
 
 @{--
  - Execute an IO action when a value is demanded by the Silver runtime.
@@ -478,69 +435,4 @@ a ::= val::a act::IOToken
   return error("Not Yet Implemented: unsafeTrace");
 } foreign {
   "java" : return "common.Util.io(%act%, %val%)";
-}
-
-@{--
- - Print string when a value is demanded by the Silver runtime.
- - When this gets executed may be unpredictable.
- -
- - @param val  The value to evaluate to, after the IO action is performed.
- - @param str  The string to print.
- - @return val, unchanged.
- - @warning see @link[unsafeIO]
- -}
-function unsafeTracePrint
-a ::= val::a str::String
-{
-  return unsafeTrace(val, printT(str, unsafeIO()));
-}
-
-@{--
- - Print a stringification of a value when it is demanded by the Silver runtime.
- - When this gets executed may be unpredictable.
- -
- - @param val  The value to evaluate to, printed when evaluated.
- - @return  val, unchanged.
- - @warning see @link[unsafeIO]
- -}
-function unsafeTraceDump
-a ::= val::a
-{
-  return unsafeTrace(val, printT(hackUnparse(val), unsafeIO()));
-}
-
-
-
--- Function for manipulating strings representing file and directory names.
-
-function dirNameInFilePath
-String ::= filePath::String
-{
-  return if indexOfLastSlash == -1 then filePath
-         else substring(0, indexOfLastSlash, filePath);
-
-  local attribute indexOfLastSlash :: Integer;
-  indexOfLastSlash = lastIndexOf("/", filePath);
-}
-
-function fileNameInFilePath
-String ::= filePath::String
-{
-  return if indexOfLastSlash == -1 then filePath
-         else substring(indexOfLastSlash+1, length(filePath), filePath);
-
-  local attribute indexOfLastSlash :: Integer;
-  indexOfLastSlash = lastIndexOf("/", filePath);
-}
-
-
-function splitFileNameAndExtension
-Pair<String String> ::= filePath::String
-{
-  return if indexOfLastDot == -1 then pair(filePath, "")
-         else pair(substring(0, indexOfLastDot, filePath) ,
-                   substring(indexOfLastDot+1, length(filePath), filePath));
-
-  local attribute indexOfLastDot :: Integer;
-  indexOfLastDot = lastIndexOf(".", filePath);
 }

--- a/grammars/silver/core/IOToken.sv
+++ b/grammars/silver/core/IOToken.sv
@@ -55,7 +55,7 @@ type IOToken foreign = "common.IOToken";
 function printT
 IOToken ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: print");
+  return error("Not Yet Implemented: printT");
 } foreign {
   "java" : return "%i%.print(%s%)";
 }
@@ -69,7 +69,7 @@ IOToken ::= s::String i::IOToken
 function readLineStdinT
 IOVal<Maybe<String>> ::= i::IOToken
 {
-  return error ("Not Yet Implemented: getStr");
+  return error ("Not Yet Implemented: readLineStdinT");
 } foreign {
   "java" : return "%i%.readLineStdin()";
 }
@@ -86,7 +86,7 @@ IOVal<Maybe<String>> ::= i::IOToken
 function exitT
 IOToken ::= val::Integer i::IOToken
 {
-  return error("Not Yet Implemented: exit");
+  return error("Not Yet Implemented: exitT");
 } foreign {
   "java" : return "%i%.exit(%val%)";
 }
@@ -102,7 +102,7 @@ IOToken ::= val::Integer i::IOToken
 function mkdirT
 IOVal<Boolean> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: mkdir");
+  return error("Not Yet Implemented: mkdirT");
 } foreign {
   "java" : return "%i%.mkdir(%s%)";
 }
@@ -122,7 +122,7 @@ IOVal<Boolean> ::= s::String i::IOToken
 function systemT
 IOVal<Integer> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: system");
+  return error("Not Yet Implemented: systemT");
 } foreign {
   "java" : return "%i%.system(%s%)";
 }
@@ -138,7 +138,7 @@ IOVal<Integer> ::= s::String i::IOToken
 function writeFileT
 IOToken ::= file::String contents::String i::IOToken
 {
-  return error("Not Yet Implemented: writeFile");
+  return error("Not Yet Implemented: writeFileT");
 } foreign {
   "java" : return "%i%.writeFile(%file%, %contents%)";
 }
@@ -154,7 +154,7 @@ IOToken ::= file::String contents::String i::IOToken
 function appendFileT
 IOToken ::= file::String contents::String i::IOToken
 {
-  return error("Not Yet Implemented: appendFile");
+  return error("Not Yet Implemented: appendFileT");
 } foreign {
   "java" : return "%i%.appendFile(%file%, %contents%)";
 }
@@ -170,7 +170,7 @@ IOToken ::= file::String contents::String i::IOToken
 function writeBinaryFileT
 IOToken ::= file::String contents::ByteArray i::IOToken
 {
-  return error("Not Yet Implemented: writeBinaryFile");
+  return error("Not Yet Implemented: writeBinaryFileT");
 } foreign {
   "java" : return "%i%.writeByteFile(%file%, %contents%)";
 }
@@ -186,7 +186,7 @@ IOToken ::= file::String contents::ByteArray i::IOToken
 function readBinaryFileT
 IOVal<ByteArray> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: readBinaryFile");
+  return error("Not Yet Implemented: readBinaryFileT");
 } foreign {
   "java" : return "%i%.readByteFile(%s%)";
 }
@@ -202,7 +202,7 @@ IOVal<ByteArray> ::= s::String i::IOToken
 function fileTimeT
 IOVal<Integer> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: fileTime");
+  return error("Not Yet Implemented: fileTimeT");
 } foreign {
   "java" : return "%i%.fileTime(%s%)";
 }
@@ -217,7 +217,7 @@ IOVal<Integer> ::= s::String i::IOToken
 function isFileT
 IOVal<Boolean> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: isFile");
+  return error("Not Yet Implemented: isFileT");
 } foreign {
   "java" : return "%i%.isFile(%s%)";
 }
@@ -232,7 +232,7 @@ IOVal<Boolean> ::= s::String i::IOToken
 function isDirectoryT
 IOVal<Boolean> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: isDirectory");
+  return error("Not Yet Implemented: isDirectoryT");
 } foreign {
   "java" : return "%i%.isDirectory(%s%)";
 }
@@ -248,7 +248,7 @@ IOVal<Boolean> ::= s::String i::IOToken
 function readFileT
 IOVal<String> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: readFile");
+  return error("Not Yet Implemented: readFileT");
 } foreign {
   "java" : return "%i%.readFile(%s%)";
 }
@@ -262,7 +262,7 @@ IOVal<String> ::= s::String i::IOToken
 function cwdT
 IOVal<String> ::= i::IOToken
 {
-  return error("Not Yet Implemented: cwd");
+  return error("Not Yet Implemented: cwdT");
 } foreign {
   "java" : return "%i%.cwd()";
 }
@@ -277,7 +277,7 @@ IOVal<String> ::= i::IOToken
 function envVarT
 IOVal<String> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: envVar");
+  return error("Not Yet Implemented: envVarT");
 } foreign {
   "java" : return "%i%.envVar(%s%)";
 }
@@ -293,7 +293,7 @@ IOVal<String> ::= s::String i::IOToken
 function listContentsT
 IOVal<[String]> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: listContents");
+  return error("Not Yet Implemented: listContentsT");
 } foreign {
   "java" : return "%i%.listContents(%s%)";
 }
@@ -308,7 +308,7 @@ IOVal<[String]> ::= s::String i::IOToken
 function deleteFileT
 IOVal<Boolean> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: deleteFile");
+  return error("Not Yet Implemented: deleteFileT");
 } foreign {
   "java" : return "%i%.deleteFile(%s%)";
 }
@@ -320,10 +320,10 @@ IOVal<Boolean> ::= s::String i::IOToken
  - @param i  The "before" world-state token.
  - @return  true if all files are deleted successfully.  false otherwise.
  -}
-function deleteFiles
+function deleteFilesT
 IOVal<Boolean> ::= s::[String] i::IOToken
 {
-  return error("Not Yet Implemented: deleteFiles");
+  return error("Not Yet Implemented: deleteFilesT");
 } foreign {
   "java" : return "%i%.deleteFiles(%s%)";
 }
@@ -335,10 +335,10 @@ IOVal<Boolean> ::= s::[String] i::IOToken
  - @param i  The "before" world-state token.
  - @return  true if contents are deleted successfully.  false otherwise.
  -}
-function deleteDirFiles
+function deleteDirFilesT
 IOVal<Boolean> ::= s::String i::IOToken
 {
-  return error("Not Yet Implemented: deleteDirFiles");
+  return error("Not Yet Implemented: deleteDirFilesT");
 } foreign {
   "java" : return "%i%.deleteDirFiles(%s%)";
 }
@@ -353,7 +353,7 @@ IOVal<Boolean> ::= s::String i::IOToken
 function deleteTreeT
 IOToken ::= s::String  i::IOToken
 {
-  return error("Not Yet Implemented: deleteTree");
+  return error("Not Yet Implemented: deleteTreeT");
 } foreign {
   "java" : return "%i%.deleteTree(%s%)";
 }
@@ -369,7 +369,7 @@ IOToken ::= s::String  i::IOToken
 function copyFileT
 IOToken ::= src::String  dst::String  i::IOToken
 {
-  return error("Not Yet Implemented: copyFile");
+  return error("Not Yet Implemented: copyFileT");
 } foreign {
   "java" : return "%i%.copyFile(%src%, %dst%)";
 }
@@ -384,7 +384,7 @@ IOToken ::= src::String  dst::String  i::IOToken
 function touchFileT
 IOToken ::= file::String i::IOToken
 {
-  return error("Not Yet Implemented: touchFile");
+  return error("Not Yet Implemented: touchFileT");
 } foreign {
   "java" : return "%i%.touchFile(%file%)";
 }
@@ -396,10 +396,10 @@ IOToken ::= file::String i::IOToken
  - @param i  The IOToken token.
  - @return The IOToken token. Errors are suppressed.
  -}
-function touchFiles
+function touchFilesT
 IOToken ::= files::[String] i::IOToken
 {
-  return error("Not Yet Implemented: touchFiles");
+  return error("Not Yet Implemented: touchFilesT");
 } foreign {
   "java" : return "%i%.touchFiles(%files%)";
 }

--- a/grammars/silver/core/IOToken.sv
+++ b/grammars/silver/core/IOToken.sv
@@ -320,7 +320,7 @@ IOVal<Boolean> ::= s::String i::IOToken
  - @param i  The "before" world-state token.
  - @return  true if all files are deleted successfully.  false otherwise.
  -}
-function deleteFilesT
+function deleteFiles
 IOVal<Boolean> ::= s::[String] i::IOToken
 {
   return error("Not Yet Implemented: deleteFiles");
@@ -335,7 +335,7 @@ IOVal<Boolean> ::= s::[String] i::IOToken
  - @param i  The "before" world-state token.
  - @return  true if contents are deleted successfully.  false otherwise.
  -}
-function deleteDirFilesT
+function deleteDirFiles
 IOVal<Boolean> ::= s::String i::IOToken
 {
   return error("Not Yet Implemented: deleteDirFiles");
@@ -396,7 +396,7 @@ IOToken ::= file::String i::IOToken
  - @param i  The IOToken token.
  - @return The IOToken token. Errors are suppressed.
  -}
-function touchFilesT
+function touchFiles
 IOToken ::= files::[String] i::IOToken
 {
   return error("Not Yet Implemented: touchFiles");
@@ -425,11 +425,11 @@ a ::= msg::String
 }
 
 @{--
- - Create a bogus world-state token, for use with @link[unsafeTraceT].
+ - Create a bogus world-state token, for use with @link[unsafeTrace].
  -
  - @return  A fake world-state token.
  -}
-function unsafeIOT
+function unsafeIO
 IOToken ::=
 {
   return error("Not Yet Implemented: unsafeIO");
@@ -443,7 +443,7 @@ IOToken ::=
  -
  - @return  An integer unique to this process.
  -}
-function genIntT
+function genInt
 Integer ::=
 {
   return error("Not Yet Implemented: genInt");
@@ -454,7 +454,7 @@ Integer ::=
 @{--
  - Generates a random number between [0, 1)
  -}
-function genRandT
+function genRand
 Float ::=
 {
   return error("Not Yet Implemented: genRand");
@@ -470,9 +470,9 @@ Float ::=
  - @param val  The value to evaluate to, after the IO action is performed.
  - @param act  The world-state token to demand and consume.
  - @return  val, unchanged.
- - @warning see @link[unsafeIOT]
+ - @warning see @link[unsafeIO]
  -}
-function unsafeTraceT
+function unsafeTrace
 a ::= val::a act::IOToken
 {
   return error("Not Yet Implemented: unsafeTrace");
@@ -487,12 +487,12 @@ a ::= val::a act::IOToken
  - @param val  The value to evaluate to, after the IO action is performed.
  - @param str  The string to print.
  - @return val, unchanged.
- - @warning see @link[unsafeIOT]
+ - @warning see @link[unsafeIO]
  -}
-function unsafeTracePrintT
+function unsafeTracePrint
 a ::= val::a str::String
 {
-  return unsafeTraceT(val, printT(str, unsafeIOT()));
+  return unsafeTrace(val, printT(str, unsafeIO()));
 }
 
 @{--
@@ -501,19 +501,19 @@ a ::= val::a str::String
  -
  - @param val  The value to evaluate to, printed when evaluated.
  - @return  val, unchanged.
- - @warning see @link[unsafeIOT]
+ - @warning see @link[unsafeIO]
  -}
-function unsafeTraceDumpT
+function unsafeTraceDump
 a ::= val::a
 {
-  return unsafeTraceT(val, printT(hackUnparse(val), unsafeIOT()));
+  return unsafeTrace(val, printT(hackUnparse(val), unsafeIO()));
 }
 
 
 
 -- Function for manipulating strings representing file and directory names.
 
-function dirNameInFilePathT
+function dirNameInFilePath
 String ::= filePath::String
 {
   return if indexOfLastSlash == -1 then filePath
@@ -523,7 +523,7 @@ String ::= filePath::String
   indexOfLastSlash = lastIndexOf("/", filePath);
 }
 
-function fileNameInFilePathT
+function fileNameInFilePath
 String ::= filePath::String
 {
   return if indexOfLastSlash == -1 then filePath
@@ -534,7 +534,7 @@ String ::= filePath::String
 }
 
 
-function splitFileNameAndExtensionT
+function splitFileNameAndExtension
 Pair<String String> ::= filePath::String
 {
   return if indexOfLastDot == -1 then pair(filePath, "")

--- a/grammars/silver/core/ParseResult.sv
+++ b/grammars/silver/core/ParseResult.sv
@@ -77,7 +77,7 @@ top::ParseResult<a> ::= t::a terminals::[TerminalDescriptor]
 function parseTreeOrDieWithoutStackTrace
 a ::= pr::ParseResult<a>
 {
-  return unsafeTraceT(pr.parseTree, if pr.parseSuccess then unsafeIOT() else exitT(-1, printT(pr.parseErrors ++ "\n\n", unsafeIOT())));
+  return unsafeTrace(pr.parseTree, if pr.parseSuccess then unsafeIO() else exitT(-1, printT(pr.parseErrors ++ "\n\n", unsafeIO())));
 }
 
 

--- a/grammars/silver/rewrite/Strategy.sv
+++ b/grammars/silver/rewrite/Strategy.sv
@@ -157,7 +157,7 @@ abstract production printTerm
 top::Strategy ::=
 {
   top.pp = pp"print()";
-  top.result = unsafeTraceT(just(top.term), printT(show(80, top.term.pp) ++ "\n\n", unsafeIOT()));
+  top.result = unsafeTrace(just(top.term), printT(show(80, top.term.pp) ++ "\n\n", unsafeIO()));
 }
 
 -- Utilities

--- a/grammars/silver/testing/bin/RunTest.sv
+++ b/grammars/silver/testing/bin/RunTest.sv
@@ -13,7 +13,7 @@ IOVal<TestingResults> ::= absoluteFilePath::String ioIn::IOVal<TestingResults>
 {
  local isDir :: IOVal<Boolean> = isDirectoryT( absoluteFilePath, ioIn.io );
  local isF   :: IOVal<Boolean> = isFileT(absoluteFilePath, ioIn.io);
- local skip  :: IOVal<Boolean> = isFileT(dirNameInFilePathT(absoluteFilePath) ++
+ local skip  :: IOVal<Boolean> = isFileT(dirNameInFilePath(absoluteFilePath) ++
                                         "/tests.skip", ioIn.io);
  local text  :: IOVal<String>  = readFileT(absoluteFilePath, isF.io);
 
@@ -31,8 +31,8 @@ IOVal<TestingResults> ::= absoluteFilePath::String ioIn::IOVal<TestingResults>
 
  -- Inh. attrs. for the test.
  r_cst.ioInput = ioval (text.io, ioIn.iovalue.numFailed) ;
- r_cst.testFileName = fileNameInFilePathT(absoluteFilePath) ;
- r_cst.testFileDir = dirNameInFilePathT(absoluteFilePath) ;
+ r_cst.testFileName = fileNameInFilePath(absoluteFilePath) ;
+ r_cst.testFileDir = dirNameInFilePath(absoluteFilePath) ;
  
  local testResult :: IOVal<TestingResults> 
    = ioval ( r_cst.ioResult.io, testingResults (r_cst.ioResult.iovalue) ) ;

--- a/grammars/silver/testing/bin/TestSpecLang.sv
+++ b/grammars/silver/testing/bin/TestSpecLang.sv
@@ -138,8 +138,8 @@ IOToken ::= absoluteFilePath::String ioIn::IOToken
 
 
  r_cst.ioInput = text.io ;
- r_cst.testFileName = fileNameInFilePathT(absoluteFilePath) ;
- r_cst.testFileDir = dirNameInFilePathT(absoluteFilePath) ;
+ r_cst.testFileName = fileNameInFilePath(absoluteFilePath) ;
+ r_cst.testFileDir = dirNameInFilePath(absoluteFilePath) ;
  
  local testResult :: IOVal<Integer> = r_cst.ioResult ;
 

--- a/test/silver_features/DoNotation.sv
+++ b/test/silver_features/DoNotation.sv
@@ -37,7 +37,7 @@ global doRes4::IO<String> = do {
   readFile("test_out.txt");
 };
 
-equalityTest(evalIO(doRes4, unsafeIOT()).iovalue, "Hello, World!", String, silver_tests);
+equalityTest(evalIO(doRes4, unsafeIO()).iovalue, "Hello, World!", String, silver_tests);
 
 -- Test something that is Applicative but not Monad
 nonterminal AMaybe<a>;

--- a/test/silver_features/FuncManipulation.sv
+++ b/test/silver_features/FuncManipulation.sv
@@ -133,7 +133,7 @@ Integer ::= a::Integer  b::Integer
 
 equalityTest( addTwo(addTwo(1,_)(2),_)(addTwo(_,3)(4)), 10, Integer, silver_tests ) ;
 
-global invoker :: (Integer ::= String) = twoArgFunction(_,genIntT());
+global invoker :: (Integer ::= String) = twoArgFunction(_,genInt());
 
 -- If the arg passed in invoker is getting re-evaluated, this will result in something like
 -- [0,2,3,4,5] [1,1,1,1,1]

--- a/test/silver_features/Main.sv
+++ b/test/silver_features/Main.sv
@@ -38,7 +38,7 @@ equalityTest( toInteger(0.0) == 0, true, Boolean, silver_tests );
 equalityTest( toFloat(0) == 0.0, true, Boolean, silver_tests );
 
 -- Basic oddball tests, just to have called the functions.
-equalityTest( genIntT() >= 0, true, Boolean, silver_tests );
-equalityTest( genRandT() >= 0.0, true, Boolean, silver_tests );
+equalityTest( genInt() >= 0, true, Boolean, silver_tests );
+equalityTest( genRand() >= 0.0, true, Boolean, silver_tests );
 
 

--- a/test/stdlib/NativeSerialize.sv
+++ b/test/stdlib/NativeSerialize.sv
@@ -64,5 +64,5 @@ global bytefiletest::IO<ByteArray> = do {
   readBinaryFile("test_svb.svb");
 };
 
-equalityTest(hackUnparse(nativeDeserialize(evalIO(bytefiletest, unsafeIOT()).iovalue).fromRight), hackUnparse(val1),
+equalityTest(hackUnparse(nativeDeserialize(evalIO(bytefiletest, unsafeIO()).iovalue).fromRight), hackUnparse(val1),
   String, core_tests);


### PR DESCRIPTION
# Changes
Removing unnecessary 'T' suffixes from functions in `IOToken` which do not conflict with functions in `IO`. Introduced new file `IOMisc` for miscellaneous IO functions which do not make use of the `IOToken` type. Introduced `touchFiles`, `deleteFiles`, `deleteDirFiles` to the `IO` type. Suffixed conflicting functions in `IOToken` with `T`.

# Documentation
No new documentation introduced. Any changes to existing documentation follow the refactoring described above. 