### PR TITLE
Renaming IO types and functions in IDE grammars

### DIFF
--- a/grammars/ide/IdeProject.sv
+++ b/grammars/ide/IdeProject.sv
@@ -7,7 +7,7 @@ type IdeProject foreign;
 
 -- Get the name of the given project.
 function getProjectName
-IOVal<String> ::= proj::IdeProject  i::IO
+IOVal<String> ::= proj::IdeProject  i::IOToken
 {
   return error("Not Yet Implemented: getName");
 } foreign {
@@ -18,7 +18,7 @@ IOVal<String> ::= proj::IdeProject  i::IO
 -- Refresh the given project down to given depth, for which only pre-defined 
 -- constants (0, 1, indefinite) can be used. 
 function refreshProject
-IO ::= proj::IdeProject  i::IO
+IOToken ::= proj::IdeProject  i::IOToken
 {
   return error("Not Yet Implemented: refresh");
 } foreign {
@@ -28,7 +28,7 @@ IO ::= proj::IdeProject  i::IO
 
 -- Get the absoluet path of given project.
 function getProjectPath
-IOVal<String> ::= proj::IdeProject i::IO
+IOVal<String> ::= proj::IdeProject i::IOToken
 {
   return error("Not Yet Implemented: getProjectPath");
 } foreign {
@@ -38,7 +38,7 @@ IOVal<String> ::= proj::IdeProject i::IO
 	
 -- Get the generated path of given project, relative to root.
 function getGeneratedPath
-IOVal<String> ::= proj::IdeProject i::IO
+IOVal<String> ::= proj::IdeProject i::IOToken
 {
   return error("Not Yet Implemented: getGeneratedPath");
 } foreign {
@@ -48,7 +48,7 @@ IOVal<String> ::= proj::IdeProject i::IO
 	
 -- Get members (direct sub-resources) of given project. 
 function getProjectMembers
-IOVal<Maybe<[IdeResource]>> ::= proj::IdeProject i::IO
+IOVal<Maybe<[IdeResource]>> ::= proj::IdeProject i::IOToken
 {
   return error("Not Yet Implemented: getProjectMembers");
 } foreign {

--- a/grammars/ide/IdeResource.sv
+++ b/grammars/ide/IdeResource.sv
@@ -4,7 +4,7 @@ type IdeResource foreign;
 
 -- Delete a resource, returning true if successful.
 function delete
-IOVal<Boolean> ::= res::IdeResource i::IO
+IOVal<Boolean> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: delete");
 } foreign {
@@ -15,7 +15,7 @@ IOVal<Boolean> ::= res::IdeResource i::IO
 -- Copy a resource to another location within the project, using a path 
 -- relative to project’s root. Returns true if successful.
 function copyTo
-IOVal<Boolean> ::= res::IdeResource path::String i::IO
+IOVal<Boolean> ::= res::IdeResource path::String i::IOToken
 {
   return error("Not Yet Implemented: copyTo");
 } foreign {
@@ -26,7 +26,7 @@ IOVal<Boolean> ::= res::IdeResource path::String i::IO
 -- Move (shortcut for copy and delete) a resource to another location within 
 -- the project, using a path relative to project’s root. Returns true if successful.
 function moveTo
-IOVal<Boolean> ::= res::IdeResource path::String i::IO
+IOVal<Boolean> ::= res::IdeResource path::String i::IOToken
 {
   return error("Not Yet Implemented: moveTo");
 } foreign {
@@ -37,7 +37,7 @@ IOVal<Boolean> ::= res::IdeResource path::String i::IO
 -- Create a new file with given input as contents. The path is relative to 
 -- project root. Returns the resource if created successfully.
 function createFile
-IOVal<Maybe<IdeResource>> ::= proj::IdeProject path::String input::String i::IO
+IOVal<Maybe<IdeResource>> ::= proj::IdeProject path::String input::String i::IOToken
 {
   return error("Not Yet Implemented: createFile");
 } foreign {
@@ -47,7 +47,7 @@ IOVal<Maybe<IdeResource>> ::= proj::IdeProject path::String input::String i::IO
 
 -- Create a new folder. Returns the resource if created successfully.
 function createFolder
-IOVal<Maybe<IdeResource>> ::= proj::IdeProject path::String i::IO
+IOVal<Maybe<IdeResource>> ::= proj::IdeProject path::String i::IOToken
 {
   return error("Not Yet Implemented: createFolder");
 } foreign {
@@ -57,7 +57,7 @@ IOVal<Maybe<IdeResource>> ::= proj::IdeProject path::String i::IO
 
 -- Get the path of given resource, relative to project’s root. An empty string would be returned if the resource is linked.
 function getRelativePath
-IOVal<String> ::= res::IdeResource i::IO
+IOVal<String> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: getRelativePath");
 } foreign {
@@ -67,7 +67,7 @@ IOVal<String> ::= res::IdeResource i::IO
 
 -- Get the absolute path of given resource.
 function getAbsolutePath
-IOVal<String> ::= res::IdeResource i::IO
+IOVal<String> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: getAbsolutePath");
 } foreign {
@@ -78,7 +78,7 @@ IOVal<String> ::= res::IdeResource i::IO
 -- Get members of given resource. Returns an empty list if the resource is a 
 -- file. 
 function getResourceMembers
-IOVal<[IdeResource]> ::= res::IdeResource i::IO
+IOVal<[IdeResource]> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: getResourceMembers");
 } foreign {
@@ -88,7 +88,7 @@ IOVal<[IdeResource]> ::= res::IdeResource i::IO
 
 -- Check if the resource is a folder
 function resourceIsFolder
-IOVal<Boolean> ::= res::IdeResource i::IO
+IOVal<Boolean> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: isFolder");
 } foreign {
@@ -98,7 +98,7 @@ IOVal<Boolean> ::= res::IdeResource i::IO
 	
 -- Check if the resource is a file.
 function resourceIsFile
-IOVal<Boolean> ::= res::IdeResource i::IO
+IOVal<Boolean> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: isFile");
 } foreign {
@@ -109,7 +109,7 @@ IOVal<Boolean> ::= res::IdeResource i::IO
 -- Check whether a resource is linked from outside project’s physical location. 
 -- This is a feature from Eclipse. 
 function resourceIsLinked
-IOVal<Boolean> ::= res::IdeResource i::IO
+IOVal<Boolean> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: isLinked");
 } foreign {
@@ -120,7 +120,7 @@ IOVal<Boolean> ::= res::IdeResource i::IO
 -- Check whether a resource is hidden in Eclipse. That is, invisible to IDE 
 -- users.
 function resourceIsHidden
-IOVal<Boolean> ::= res::IdeResource i::IO
+IOVal<Boolean> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: isHidden");
 } foreign {
@@ -133,7 +133,7 @@ IOVal<Boolean> ::= res::IdeResource i::IO
 -- as compilation, out of another resource(s). Such resource is thus not 
 -- subject to user’s manual modification.
 function resourceIsDerived
-IOVal<Boolean> ::= res::IdeResource i::IO
+IOVal<Boolean> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: isDerived");
 } foreign {
@@ -144,7 +144,7 @@ IOVal<Boolean> ::= res::IdeResource i::IO
 -- Check whether the resource does exist. After deleting a resource 
 -- successfully, calling this function should return false.
 function resourceExists
-IOVal<Boolean> ::= res::IdeResource i::IO
+IOVal<Boolean> ::= res::IdeResource i::IOToken
 {
   return error("Not Yet Implemented: exists");
 } foreign {

--- a/grammars/ide/IdeUtil.sv
+++ b/grammars/ide/IdeUtil.sv
@@ -11,7 +11,7 @@ import silver:langutil;
   target: the target to be invoked in build file. For now only one target is supported.
 --}
 function ant
-IO ::= buildFile::String arguments::String target::String i::IO
+IOToken ::= buildFile::String arguments::String target::String i::IOToken
 {
   return error("Not Yet Implemented: ant");
 } foreign {
@@ -26,7 +26,7 @@ IO ::= buildFile::String arguments::String target::String i::IO
  - NOT TO BE CONFUSED WITH IdeResource. (i.e. files in the project)
  -}
 function getIdeResource
-IOVal<String> ::= resourceid::String  i::IO
+IOVal<String> ::= resourceid::String  i::IOToken
 {
   return error("Not Yet Implemented: getIdeResource");
 } foreign {

--- a/grammars/silver/compiler/composed/idetest/Analyze.sv
+++ b/grammars/silver/compiler/composed/idetest/Analyze.sv
@@ -13,7 +13,7 @@ import silver:rewrite;
 
 -- This function is mostly copied from function cmdLineRun in driver/BuildProcess.sv
 function ideAnalyze
-IOVal<[Message]> ::= args::[String]  svParser::SVParser ioin::IO
+IOVal<[Message]> ::= args::[String]  svParser::SVParser ioin::IOToken
 {
   -- Figure out arguments
   local argResult :: Either<String  Decorated CmdArgs> = parseArgs(args);
@@ -54,7 +54,7 @@ IOVal<[Message]> ::= args::[String]  svParser::SVParser ioin::IO
 
 -- This function is mostly copied from function cmdLineRun in driver/BuildProcess.sv
 function ideGenerate
-IOVal<[Message]> ::= args::[String]  svParser::SVParser  ioin::IO
+IOVal<[Message]> ::= args::[String]  svParser::SVParser  ioin::IOToken
 {
   -- Figure out arguments
   local argResult :: Either<String  Decorated CmdArgs> = parseArgs(args);

--- a/grammars/silver/compiler/composed/idetest/Main.sv
+++ b/grammars/silver/compiler/composed/idetest/Main.sv
@@ -14,7 +14,7 @@ import silver:compiler:composed:Default only svParse;
 
 -- This function is not used by IDE
 function main 
-IOVal<Integer> ::= args::[String] ioin::IO
+IOVal<Integer> ::= args::[String] ioin::IOToken
 {
   return cmdLineRun(args, svParse, ioin);
 }
@@ -43,7 +43,7 @@ temp_imp_ide_dcl svParse ".sv" {
 -- Declarations of IDE functions referred in decl block.
 
 function analyze
-IOVal<[Message]> ::= project::IdeProject  args::[IdeProperty]  i::IO
+IOVal<[Message]> ::= project::IdeProject  args::[IdeProperty]  i::IOToken
 {
   local argio :: IOVal<[String]> = getArgStrings(args, project, i);
 
@@ -53,7 +53,7 @@ IOVal<[Message]> ::= project::IdeProject  args::[IdeProperty]  i::IO
 }
 
 function generate
-IOVal<[Message]> ::= project::IdeProject  args::[IdeProperty]  i::IO
+IOVal<[Message]> ::= project::IdeProject  args::[IdeProperty]  i::IOToken
 {
   local argio :: IOVal<[String]> = getArgStrings(args, project, i);
 
@@ -66,7 +66,7 @@ IOVal<[Message]> ::= project::IdeProject  args::[IdeProperty]  i::IO
 global system_location :: Location = loc("", -1, -1, -1, -1, -1, -1);
 
 function export
-IOVal<[Message]> ::= project::IdeProject  args::[IdeProperty]  i::IO
+IOVal<[Message]> ::= project::IdeProject  args::[IdeProperty]  i::IOToken
 {
   local proj_path :: IOVal<String> = getProjectPath(project, i);
   local gen_path :: IOVal<String> = getGeneratedPath(project, proj_path.io);
@@ -76,16 +76,16 @@ IOVal<[Message]> ::= project::IdeProject  args::[IdeProperty]  i::IO
   local jarFile :: String = gen_path.iovalue ++ "/" ++ pkgName ++ ".jar";
   local targetFile :: String = proj_path.iovalue ++ "/" ++ pkgName ++ ".jar";
 
-  local fileExists :: IOVal<Boolean> = isFile(buildFile, gen_path.io);
+  local fileExists :: IOVal<Boolean> = isFileT(buildFile, gen_path.io);
 
-  local jarExists :: IOVal<Boolean> = isFile(jarFile, ant(buildFile, "", "", fileExists.io));
+  local jarExists :: IOVal<Boolean> = isFileT(jarFile, ant(buildFile, "", "", fileExists.io));
 
   return if !fileExists.iovalue then
     ioval(fileExists.io, [err(system_location, "build.xml doesn't exist. Has the project been successfully built before?")])
   else if !jarExists.iovalue then
     ioval(jarExists.io, [err(system_location, "Ant failed to generate the jar.")])
   else
-    ioval(refreshProject(project, copyFile(jarFile, targetFile, jarExists.io)), []);
+    ioval(refreshProject(project, copyFileT(jarFile, targetFile, jarExists.io)), []);
 }
 
 function fold
@@ -111,7 +111,7 @@ String ::= args::[IdeProperty]
 }
 
 function getArgStrings
-IOVal<[String]> ::= args::[IdeProperty] project::IdeProject io::IO
+IOVal<[String]> ::= args::[IdeProperty] project::IdeProject io::IOToken
 {
   local jarsio :: IOVal<String> = getIdeResource("jars", io);
   local grammarsio :: IOVal<String> = getIdeResource("grammars", jarsio.io);

--- a/runtime/java/src/common/ConsCell.java
+++ b/runtime/java/src/common/ConsCell.java
@@ -139,7 +139,7 @@ public class ConsCell implements Typed {
 
 			while (!(x instanceof NilConsCell)) {
 				if (!TypeRep.unify(tvar, Reflection.getType(x.head()))) {
-					throw new SilverInternalError("Unification failed.");
+					throw new SilverInternalError("Failed to construct list type - got a non-homogenous list!");
 				}
 				x = x.tail();
 			}


### PR DESCRIPTION
# Changes
This fixes breakages by renaming a few things in the IDE grammars that were missed by #620.

# Documentation
None added.  
