### PR TITLE
Expand and factor out random utilities into a separate library

### DIFF
--- a/grammars/silver/compiler/extension/treegen/TerminalGen.sv
+++ b/grammars/silver/compiler/extension/treegen/TerminalGen.sv
@@ -39,9 +39,9 @@ top::Expr ::= 'genArbTerminal' '(' te::TypeExpr ',' '_' ')'
 }
 
 concrete production genArbTerminalExpr
-top::Expr ::= 'genArbTerminal' '(' te::TypeExpr ',' starProb::Expr ',' loc::Expr ')'
+top::Expr ::= 'genArbTerminal' '(' te::TypeExpr ',' loc::Expr ')'
 {
-  top.unparse = s"genArbTerminal(${te.unparse}, ${starProb.unparse}, ${loc.unparse})";
+  top.unparse = s"genArbTerminal(${te.unparse}, ${loc.unparse})";
   forwards to
     mkFunctionInvocation(top.location,
       genArbTerminalNoLocExpr('genArbTerminal', '(', te, ',', '_', ')', location=top.location),

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -50,8 +50,8 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
 
   local commaIfKids :: String = if length(namedSig.inputElements)!=0 then "," else "";
   local commaIfAnnos :: String = if length(namedSig.namedInputElements)!=0 then "," else "";
-  local commaIfKidsOrAnnos :: String = if length(namedSig.inputElements)!=0 || length(namedSig.namedInputElements)!=0 then "," else "";
-  local commaIfKidsAndAnnos :: String = if length(namedSig.inputElements)!=0 && length(namedSig.namedInputElements)!=0 then "," else "";
+  local commaIfContexts :: String = if length(namedSig.contexts)!=0 then "," else "";
+  local commaIfAny :: String = if length(namedSig.inputElements)!=0 || length(namedSig.namedInputElements)!=0 || length(namedSig.contexts)!=0 then "," else "";
 
   local contexts::Contexts = foldContexts(namedSig.contexts);
   contexts.boundVariables = namedSig.freeVariables;
@@ -89,7 +89,7 @@ ${namedSig.inhOccursIndexDecls}
 ${namedSig.childStatic}
     }
 
-    public ${className}(final NOriginInfo origin ${commaIfKidsOrAnnos} ${namedSig.javaSignature}) {
+    public ${className}(final NOriginInfo origin ${commaIfAny} ${namedSig.javaSignature}) {
         super(${if wantsTracking then "origin"++commaIfAnnos else ""}${implode(", ", map((.annoRefElem), namedSig.namedInputElements))});
 ${implode("", map(makeChildAssign, namedSig.inputElements))}
 ${contexts.contextInitTrans}
@@ -227,7 +227,7 @@ ${body.translation}
             ${implode("\n\t\t", map(makeAnnoReify(fName, _), namedSig.namedInputElements))}
             ${namedSig.contextRuntimeResolve}
 
-            return new ${className}(${if wantsTracking then "new silver.core.PoriginOriginInfo(common.OriginsUtil.SET_FROM_REIFICATION_OIT, origAST, rules, true)"++commaIfKidsOrAnnos else ""} ${namedSig.refInvokeTrans});
+            return new ${className}(${if wantsTracking then "new silver.core.PoriginOriginInfo(common.OriginsUtil.SET_FROM_REIFICATION_OIT, origAST, rules, true)"++commaIfAny else ""} ${namedSig.refInvokeTrans});
         }
 
         public ${className} constructDirect(

--- a/grammars/silver/core/List.sv
+++ b/grammars/silver/core/List.sv
@@ -356,20 +356,6 @@ function repeat
          else v :: repeat(v, times-1);
 }
 
-function randomShuffle
-RandomGen<[a]> ::= elems::[a]
-{
-  return
-    if null(elems) then pure([])
-    else do {
-      i :: Integer <- randomRange(0, length(elems) - 1);
-      let hd :: [a] = take(i, elems);
-      let tl :: [a] = drop(i, elems);
-      rest :: [a] <- randomShuffle(hd ++ tail(tl));
-      return head(tl) :: rest;
-    };
-}
-
 function range
 [Integer] ::= lower::Integer upper::Integer
 {

--- a/grammars/silver/core/Random.sv
+++ b/grammars/silver/core/Random.sv
@@ -5,8 +5,8 @@ grammar silver:core;
 -- Associated utilities are defined in silver:util:random.
 nonterminal RandomGen<a>;
 
--- Pure random "token" for use with threaded attributes.
-type RandomToken foreign = "java.util.Random";
+-- Pure random "token" for use with threaded attributes, represented as just a seed value.
+type RandomToken foreign = "Long";
 
 production mapRandomGen
 top::RandomGen<b> ::= (b ::= a) RandomGen<a>

--- a/grammars/silver/core/Random.sv
+++ b/grammars/silver/core/Random.sv
@@ -1,67 +1,12 @@
 grammar silver:core;
 
-@{-
-Types for which random values can be generated.
-
-This class imposes no restrictions on the range or distribution of random values,
-as there may be instances for types with no notion of ordering/equality.
--}
-class Random a {
-  random :: RandomGen<a>;
-}
-
--- Uniform random integer on [INT_MIN, INT_MAX]
-instance Random Integer {
-  random = randomInteger();
-}
-
--- Uniform random float on [0.0, 1.0)
-instance Random Float {
-  random = randomFloat();
-}
-
--- 50/50 true or false
-instance Random Boolean {
-  random = randomBoolean();
-}
-
-@{-
-Types for which random values can be generated, uniformly distributed over some closed range [min, max].
-
-Note that this is not a subclass of Ord since we may have instances for partial orders.
-
-If a has an instance for Ord, then instances should satisfy:
-  runRandomGen(randomRange(min, max)) >= min
-  runRandomGen(randomRange(min, max)) <= max
--}
-class Random a => RandomRange a {
-  randomRange :: (RandomGen<a> ::= a a);
-}
-
-instance RandomRange Integer {
-  -- Uniform integer in range is actually kinda tricky to do correctly, so this is a primitive
-  randomRange = randomRangeInteger;
-}
-
--- Does not allow for generating NaN or infinities, at the moment
-instance RandomRange Float {
-  randomRange = \ min::Float max::Float ->
-    if min > max then error(s"Empty Float range [${toString(min)}, ${toString(max)}]")
-    else map(\ f::Float -> f * (max - min) + min, random);
-}
-
-instance RandomRange Boolean {
-  randomRange = \ min::Boolean max::Boolean ->
-    case min, max of
-    | false, false -> pure(false)
-    | false, true -> random
-    | true, false -> error("Empty Boolean range")
-    | true, true -> pure(true)
-    end;
-}
-
--- Monad for computations involving random number generation
+-- Monad for computations involving random number generation.
+-- This must live in silver:core because the runtime depends on these productions.
+-- Associated utilities are defined in silver:util:random.
 nonterminal RandomGen<a>;
+
+-- Pure random "token" for use with threaded attributes.
+type RandomToken foreign = "java.util.Random";
 
 production mapRandomGen
 top::RandomGen<b> ::= (b ::= a) RandomGen<a>
@@ -108,41 +53,7 @@ instance Applicative RandomGen {
 }
 
 instance Bind RandomGen {
-  bind = bindRandomGen; 
+  bind = bindRandomGen;
 }
 
 instance Monad RandomGen {}
-
-@{-
-  Run a RandomGen computation, using an arbitrary seed.
-  Warning: this function is nondeterministic (may vary between runs) and thus impure;
-  use at your own risk!
-  
-  @param r  The computation to run
-  @return  The result of the computation
--}
-function runRandomGen
-a ::= r::RandomGen<a>
-{
-  return error("foreign function");
-} foreign {
-  "java": return "common.RandomGen.runRandomGen(originCtx, %r%)";
-}
-
-@{-
-  Run a RandomGen computation, using an arbitrary seed.
-  Warning: this function is nondeterministic (may vary between runs) and thus impure;
-  use at your own risk!
-
-  @param seed  The initial seed value for the random number generator
-  @param r  The computation to run
-  @return  The result of the computation
--}
-function runSeedRandomGen
-a ::= seed::Integer r::RandomGen<a>
-{
-  return error("foreign function");
-} foreign {
-  "java": return "common.RandomGen.runRandomGen(originCtx, %seed%, %r%)";
-}
-

--- a/grammars/silver/core/Random.sv
+++ b/grammars/silver/core/Random.sv
@@ -40,6 +40,10 @@ production randomBoolean
 top::RandomGen<Boolean> ::=
 {}
 
+production randomToken_
+top::RandomGen<RandomToken> ::=
+{}
+
 instance Functor RandomGen {
   map = mapRandomGen;
 }

--- a/grammars/silver/core/Random.sv
+++ b/grammars/silver/core/Random.sv
@@ -6,6 +6,8 @@ grammar silver:core;
 nonterminal RandomGen<a>;
 
 -- Pure random "token" for use with threaded attributes, represented as just a seed value.
+-- Unlike IOToken, this is essentially safe to reuse, besides the possibility of
+-- repeating random values.
 type RandomToken foreign = "Long";
 
 production mapRandomGen

--- a/grammars/silver/regex/Arbitrary.sv
+++ b/grammars/silver/regex/Arbitrary.sv
@@ -1,5 +1,7 @@
 grammar silver:regex;
 
+import silver:util:random;
+
 -- Generate a random string matching a regex
 implicit synthesized attribute genArbMatch::RandomGen<String>;
 

--- a/grammars/silver/util/random/Arbitrary.sv
+++ b/grammars/silver/util/random/Arbitrary.sv
@@ -1,4 +1,4 @@
-grammar silver:core;
+grammar silver:util:random;
 
 -- TODO: Consider adding a Shrink type class for use in conjuction with Arbitrary in randomized testing.
 -- See https://hackage.haskell.org/package/QuickCheck-2.14.2/docs/Test-QuickCheck.html#v:shrink

--- a/grammars/silver/util/random/Random.sv
+++ b/grammars/silver/util/random/Random.sv
@@ -1,0 +1,61 @@
+grammar silver:util:random;
+
+@{-
+Types for which random values can be generated.
+
+This class imposes no restrictions on the range or distribution of random values,
+as there may be instances for types with no notion of ordering/equality.
+-}
+class Random a {
+  random :: RandomGen<a>;
+}
+
+-- Uniform random integer on [INT_MIN, INT_MAX]
+instance Random Integer {
+  random = randomInteger();
+}
+
+-- Uniform random float on [0.0, 1.0)
+instance Random Float {
+  random = randomFloat();
+}
+
+-- 50/50 true or false
+instance Random Boolean {
+  random = randomBoolean();
+}
+
+@{-
+Types for which random values can be generated, uniformly distributed over some closed range [min, max].
+
+Note that this is not a subclass of Ord since we may have instances for partial orders.
+
+If a has an instance for Ord, then instances should satisfy:
+  runRandomGen(randomRange(min, max)) >= min
+  runRandomGen(randomRange(min, max)) <= max
+-}
+class Random a => RandomRange a {
+  randomRange :: (RandomGen<a> ::= a a);
+}
+
+instance RandomRange Integer {
+  -- Uniform integer in range is actually kinda tricky to do correctly, so this is a primitive
+  randomRange = randomRangeInteger;
+}
+
+-- Does not allow for generating NaN or infinities, at the moment
+instance RandomRange Float {
+  randomRange = \ min::Float max::Float ->
+    if min > max then error(s"Empty Float range [${toString(min)}, ${toString(max)}]")
+    else map(\ f::Float -> f * (max - min) + min, random);
+}
+
+instance RandomRange Boolean {
+  randomRange = \ min::Boolean max::Boolean ->
+    case min, max of
+    | false, false -> pure(false)
+    | false, true -> random
+    | true, false -> error("Empty Boolean range")
+    | true, true -> pure(true)
+    end;
+}

--- a/grammars/silver/util/random/Random.sv
+++ b/grammars/silver/util/random/Random.sv
@@ -8,21 +8,25 @@ as there may be instances for types with no notion of ordering/equality.
 -}
 class Random a {
   random :: RandomGen<a>;
+  randomT :: ((a, RandomToken) ::= RandomToken) = runTokenRandomGen(_, random);
 }
 
 -- Uniform random integer on [INT_MIN, INT_MAX]
 instance Random Integer {
   random = randomInteger();
+  randomT = randomTInteger;
 }
 
 -- Uniform random float on [0.0, 1.0)
 instance Random Float {
   random = randomFloat();
+  randomT = randomTFloat;
 }
 
 -- 50/50 true or false
 instance Random Boolean {
   random = randomBoolean();
+  randomT = randomTBoolean;
 }
 
 @{-
@@ -36,11 +40,14 @@ If a has an instance for Ord, then instances should satisfy:
 -}
 class Random a => RandomRange a {
   randomRange :: (RandomGen<a> ::= a a);
+  randomRangeT :: ((a, RandomToken) ::= a a RandomToken) =
+    \ min::a max::a token::RandomToken -> runTokenRandomGen(token, randomRange(min, max));
 }
 
 instance RandomRange Integer {
   -- Uniform integer in range is actually kinda tricky to do correctly, so this is a primitive
   randomRange = randomRangeInteger;
+  randomRangeT = randomRangeTInteger;
 }
 
 -- Does not allow for generating NaN or infinities, at the moment

--- a/grammars/silver/util/random/RandomMonad.sv
+++ b/grammars/silver/util/random/RandomMonad.sv
@@ -44,6 +44,6 @@ function runTokenRandomGen
 (a, RandomToken) ::= token::RandomToken r::RandomGen<a>
 {
   return error("foreign function");
-} {-foreign {
+} foreign {
   "java": return "common.RandomGen.evalRandomTokenOp(%token%, (rng) -> common.RandomGen.runRandomGen(originCtx, rng, %r%))";
-}-}
+}

--- a/grammars/silver/util/random/RandomMonad.sv
+++ b/grammars/silver/util/random/RandomMonad.sv
@@ -32,3 +32,18 @@ a ::= seed::Integer r::RandomGen<a>
 } foreign {
   "java": return "common.RandomGen.runRandomGen(originCtx, %seed%, %r%)";
 }
+
+@{-
+  Run a RandomGen computation, using a random token.
+
+  @param toek  The random number generator to use
+  @param r  The computation to run
+  @return  The result of the computation
+-}
+function runTokenRandomGen
+(a, RandomToken) ::= token::RandomToken r::RandomGen<a>
+{
+  return error("foreign function");
+} foreign {
+  "java": return "new silver.core.Ppair(common.RandomGen.runRandomGen(originCtx, %token%, %r%), new java.util.Random(%token%.nextLong()))";
+}

--- a/grammars/silver/util/random/RandomMonad.sv
+++ b/grammars/silver/util/random/RandomMonad.sv
@@ -44,6 +44,6 @@ function runTokenRandomGen
 (a, RandomToken) ::= token::RandomToken r::RandomGen<a>
 {
   return error("foreign function");
-} foreign {
-  "java": return "new silver.core.Ppair(common.RandomGen.runRandomGen(originCtx, %token%, %r%), new java.util.Random(%token%.nextLong()))";
-}
+} {-foreign {
+  "java": return "common.RandomGen.evalRandomTokenOp(%token%, (rng) -> common.RandomGen.runRandomGen(originCtx, rng, %r%))";
+}-}

--- a/grammars/silver/util/random/RandomMonad.sv
+++ b/grammars/silver/util/random/RandomMonad.sv
@@ -2,24 +2,34 @@ grammar silver:util:random;
 
 @{-
   Run a RandomGen computation, using an arbitrary seed.
-  Warning: this function is nondeterministic (may vary between runs) and thus impure;
-  use at your own risk!
   
   @param r  The computation to run
-  @return  The result of the computation
+  @param ioIn  The IO token
+  @return  An IOVal containing the result of the computation
 -}
-function runRandomGen
-a ::= r::RandomGen<a>
+function runRandomGenT
+IOVal<a> ::= r::RandomGen<a> ioIn::IOToken
 {
   return error("foreign function");
 } foreign {
-  "java": return "common.RandomGen.runRandomGen(originCtx, %r%)";
+  "java": return "%ioIn%.runRandomGen(originCtx, %r%)";
+}
+
+@{-
+  Run a RandomGen computation, using an arbitrary seed (IO monadic version.)
+  
+  @param r  The computation to run
+-}
+production runRandomGen
+top::IO<a> ::= r::RandomGen<a>
+{
+  local res::IOVal<a> = runRandomGenT(r, top.stateIn);
+  top.stateOut = res.io;
+  top.stateVal = res.iovalue;
 }
 
 @{-
   Run a RandomGen computation, using an arbitrary seed.
-  Warning: this function is nondeterministic (may vary between runs) and thus impure;
-  use at your own risk!
 
   @param seed  The initial seed value for the random number generator
   @param r  The computation to run

--- a/grammars/silver/util/random/RandomMonad.sv
+++ b/grammars/silver/util/random/RandomMonad.sv
@@ -36,7 +36,7 @@ a ::= seed::Integer r::RandomGen<a>
 @{-
   Run a RandomGen computation, using a random token.
 
-  @param toek  The random number generator to use
+  @param token  The random number generator to use
   @param r  The computation to run
   @return  The result of the computation
 -}

--- a/grammars/silver/util/random/RandomMonad.sv
+++ b/grammars/silver/util/random/RandomMonad.sv
@@ -1,0 +1,34 @@
+grammar silver:util:random;
+
+@{-
+  Run a RandomGen computation, using an arbitrary seed.
+  Warning: this function is nondeterministic (may vary between runs) and thus impure;
+  use at your own risk!
+  
+  @param r  The computation to run
+  @return  The result of the computation
+-}
+function runRandomGen
+a ::= r::RandomGen<a>
+{
+  return error("foreign function");
+} foreign {
+  "java": return "common.RandomGen.runRandomGen(originCtx, %r%)";
+}
+
+@{-
+  Run a RandomGen computation, using an arbitrary seed.
+  Warning: this function is nondeterministic (may vary between runs) and thus impure;
+  use at your own risk!
+
+  @param seed  The initial seed value for the random number generator
+  @param r  The computation to run
+  @return  The result of the computation
+-}
+function runSeedRandomGen
+a ::= seed::Integer r::RandomGen<a>
+{
+  return error("foreign function");
+} foreign {
+  "java": return "common.RandomGen.runRandomGen(originCtx, %seed%, %r%)";
+}

--- a/grammars/silver/util/random/RandomToken.sv
+++ b/grammars/silver/util/random/RandomToken.sv
@@ -1,0 +1,70 @@
+grammar silver:util:random;
+
+@{--
+Monadic action to generate a RandomToken in the RandomGen Monad.
+-}
+global randomToken::RandomGen<RandomToken> = randomToken_();
+
+@{--
+Utility attribute pair to thread a random token through an abstract syntax tree.
+-}
+threaded attribute randomIn, randomOut :: RandomToken;
+
+@{--
+Utility for creating a random value using the token-based random library.
+Example:
+  production foo::RandomVal<Integer> = randomVal();
+  thread randomIn, randomOut on top, foo, top;
+  local fooVal::Integer = foo.randomValue;
+-}
+nonterminal RandomVal<a> with randomIn, randomOut, randomValue<a>;
+
+synthesized attribute randomValue<a>::a;
+
+production randomVal
+Random a => top::RandomVal<a> ::=
+{
+  production result::(a, RandomToken) = randomT(top.randomIn);
+  top.randomValue = result.1;
+  top.randomOut = result.2;
+}
+
+production randomRangeVal
+RandomRange a => top::RandomVal<a> ::= min::a max::a
+{
+  production result::(a, RandomToken) = randomRangeT(min, max, top.randomIn);
+  top.randomValue = result.1;
+  top.randomOut = result.2;
+}
+
+function randomTInteger
+(Integer, RandomToken) ::= token::RandomToken
+{
+  return error("foreign function");
+} foreign {
+  "java": return "new silver.core.Ppair(%token%.nextInt(), new java.util.Random(%token%.nextLong()))";
+}
+
+function randomTFloat
+(Float, RandomToken) ::= token::RandomToken
+{
+  return error("foreign function");
+} foreign {
+  "java": return "new silver.core.Ppair(%token%.nextFloat(), new java.util.Random(%token%.nextLong()))";
+}
+
+function randomTBoolean
+(Boolean, RandomToken) ::= token::RandomToken
+{
+  return error("foreign function");
+} foreign {
+  "java": return "new silver.core.Ppair(%token%.nextBoolean(), new java.util.Random(%token%.nextLong()))";
+}
+
+function randomRangeTInteger
+(Integer, RandomToken) ::= min::Integer max::Integer token::RandomToken
+{
+  return error("foreign function");
+} foreign {
+  "java": return "new silver.core.Ppair(common.RandomGen.randomRangeInteger(%min%, %max%, %token%), new java.util.Random(%token%.nextLong()))";
+}

--- a/grammars/silver/util/random/RandomToken.sv
+++ b/grammars/silver/util/random/RandomToken.sv
@@ -41,30 +41,30 @@ function randomTInteger
 (Integer, RandomToken) ::= token::RandomToken
 {
   return error("foreign function");
-} {-foreign {
+} foreign {
   "java": return "common.RandomGen.evalRandomTokenOp(%token%, java.util.Random::nextInt)";
-}-}
+}
 
 function randomTFloat
 (Float, RandomToken) ::= token::RandomToken
 {
   return error("foreign function");
-} {-foreign {
+} foreign {
   "java": return "common.RandomGen.evalRandomTokenOp(%token%, java.util.Random::nextFloat)";
-}-}
+}
 
 function randomTBoolean
 (Boolean, RandomToken) ::= token::RandomToken
 {
   return error("foreign function");
-} {-foreign {
+} foreign {
   "java": return "common.RandomGen.evalRandomTokenOp(%token%, java.util.Random::nextBoolean)";
-}-}
+}
 
 function randomRangeTInteger
 (Integer, RandomToken) ::= min::Integer max::Integer token::RandomToken
 {
   return error("foreign function");
-} {-foreign {
+} foreign {
   "java": return "common.RandomGen.evalRandomTokenOp(%token%, (rng) -> common.RandomGen.randomRangeInteger(%min%, %max%, rng))";
-}-}
+}

--- a/grammars/silver/util/random/RandomToken.sv
+++ b/grammars/silver/util/random/RandomToken.sv
@@ -10,33 +10,6 @@ Utility attribute pair to thread a random token through an abstract syntax tree.
 -}
 threaded attribute randomIn, randomOut :: RandomToken;
 
-@{--
-Utility for creating a random value using the token-based random library.
-Example:
-  production foo::RandomVal<Integer> = randomVal();
-  thread randomIn, randomOut on top, foo, top;
-  local fooVal::Integer = foo.randomValue;
--}
-nonterminal RandomVal<a> with randomIn, randomOut, randomValue<a>;
-
-synthesized attribute randomValue<a>::a;
-
-production randomVal
-Random a => top::RandomVal<a> ::=
-{
-  production result::(a, RandomToken) = randomT(top.randomIn);
-  top.randomValue = result.1;
-  top.randomOut = result.2;
-}
-
-production randomRangeVal
-RandomRange a => top::RandomVal<a> ::= min::a max::a
-{
-  production result::(a, RandomToken) = randomRangeT(min, max, top.randomIn);
-  top.randomValue = result.1;
-  top.randomOut = result.2;
-}
-
 function randomTInteger
 (Integer, RandomToken) ::= token::RandomToken
 {

--- a/grammars/silver/util/random/RandomToken.sv
+++ b/grammars/silver/util/random/RandomToken.sv
@@ -41,30 +41,30 @@ function randomTInteger
 (Integer, RandomToken) ::= token::RandomToken
 {
   return error("foreign function");
-} foreign {
-  "java": return "new silver.core.Ppair(%token%.nextInt(), new java.util.Random(%token%.nextLong()))";
-}
+} {-foreign {
+  "java": return "common.RandomGen.evalRandomTokenOp(%token%, java.util.Random::nextInt)";
+}-}
 
 function randomTFloat
 (Float, RandomToken) ::= token::RandomToken
 {
   return error("foreign function");
-} foreign {
-  "java": return "new silver.core.Ppair(%token%.nextFloat(), new java.util.Random(%token%.nextLong()))";
-}
+} {-foreign {
+  "java": return "common.RandomGen.evalRandomTokenOp(%token%, java.util.Random::nextFloat)";
+}-}
 
 function randomTBoolean
 (Boolean, RandomToken) ::= token::RandomToken
 {
   return error("foreign function");
-} foreign {
-  "java": return "new silver.core.Ppair(%token%.nextBoolean(), new java.util.Random(%token%.nextLong()))";
-}
+} {-foreign {
+  "java": return "common.RandomGen.evalRandomTokenOp(%token%, java.util.Random::nextBoolean)";
+}-}
 
 function randomRangeTInteger
 (Integer, RandomToken) ::= min::Integer max::Integer token::RandomToken
 {
   return error("foreign function");
-} foreign {
-  "java": return "new silver.core.Ppair(common.RandomGen.randomRangeInteger(%min%, %max%, %token%), new java.util.Random(%token%.nextLong()))";
-}
+} {-foreign {
+  "java": return "common.RandomGen.evalRandomTokenOp(%token%, (rng) -> common.RandomGen.randomRangeInteger(%min%, %max%, rng))";
+}-}

--- a/grammars/silver/util/random/Util.sv
+++ b/grammars/silver/util/random/Util.sv
@@ -1,0 +1,15 @@
+grammar silver:util:random;
+
+function randomShuffle
+RandomGen<[a]> ::= elems::[a]
+{
+  return
+    if null(elems) then pure([])
+    else do {
+      i :: Integer <- randomRange(0, length(elems) - 1);
+      let hd :: [a] = take(i, elems);
+      let tl :: [a] = drop(i, elems);
+      rest :: [a] <- randomShuffle(hd ++ tail(tl));
+      return head(tl) :: rest;
+    };
+}

--- a/grammars/silver/util/random/Util.sv
+++ b/grammars/silver/util/random/Util.sv
@@ -32,6 +32,9 @@ nonterminal RandomVal<a> with randomIn, randomOut, randomValue<a>;
 
 synthesized attribute randomValue<a>::a;
 
+@{--
+Create a random value using the default Random instance for the type.
+-}
 production randomVal
 Random a => top::RandomVal<a> ::=
 {
@@ -40,6 +43,12 @@ Random a => top::RandomVal<a> ::=
   top.randomOut = result.2;
 }
 
+@{--
+Create a random value using the default RandomRange instance for the type.
+
+@param min  The minimum bound for the random value.
+@param max  The maximum bound for the random value.
+-}
 production randomRangeVal
 RandomRange a => top::RandomVal<a> ::= min::a max::a
 {
@@ -48,6 +57,11 @@ RandomRange a => top::RandomVal<a> ::= min::a max::a
   top.randomOut = result.2;
 }
 
+@{--
+Create a random value using a monadic RandomGen action.
+
+@param g  The random generator to use to generate a value.
+-}
 production randomGenVal
 top::RandomVal<a> ::= g::RandomGen<a>
 {

--- a/make-dist
+++ b/make-dist
@@ -43,6 +43,8 @@ tar -zcvf $SV.tar.gz \
  $SV/grammars/silver/util/treemap/ \
  $SV/grammars/silver/util/treeset/ \
  $SV/grammars/silver/util/graph/ \
+ $SV/grammars/silver/util/subprocess/ \
+ $SV/grammars/silver/util/random/ \
  $SV/grammars/silver/langutil/ \
  $SV/grammars/silver/reflect/ \
  $SV/COPYING.LESSER \

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -364,7 +364,7 @@ public class DecoratedNode implements Decorable, Typed {
 			try {
 				return forward().synthesized(attribute);
 			} catch(Throwable t) {
-				throw new TraceException("While evaling syn via forward in " + getDebugID(), t);
+				throw new TraceException("While evaling syn '" + self.getNameOfSynAttr(attribute) + "' via forward in " + getDebugID(), t);
 			}
 		} else {
 			l = self.getDefaultSynthesized(attribute);
@@ -464,7 +464,7 @@ public class DecoratedNode implements Decorable, Typed {
 		//if(forwardParent == null) {
 		//	return new MissingDefinitionException("Inherited attribute '" + self.getNameOfInhAttr(attribute) + "' not provided to " + getDebugID() + " by " + parent.getDebugID());
 		//}
-		return new TraceException("While evaling inh via forward in " + getDebugID(), t);
+		return new TraceException("While evaling inh '" + self.getNameOfInhAttr(attribute) + "' via forward in " + getDebugID(), t);
 	}
 	private final Object evalInhHere(final int attribute) {
 		try {

--- a/runtime/java/src/common/IOToken.java
+++ b/runtime/java/src/common/IOToken.java
@@ -380,6 +380,13 @@ public final class IOToken implements Typed {
 		return (int)(System.currentTimeMillis() / 1000);
 	}
 
+	/**
+	 * <pre>IOVal<a> ::= r::RandomGen<a> i::IO</pre>
+	 */
+	public NIOVal runRandomGen(final OriginContext ctx, silver.core.NRandomGen r) {
+		return this.wrap(common.RandomGen.runRandomGen(ctx, r));
+	}
+
 	@Override
 	public TypeRep getType() {
 		return new BaseTypeRep("silver:core:IO");

--- a/runtime/java/src/common/RandomGen.java
+++ b/runtime/java/src/common/RandomGen.java
@@ -32,18 +32,22 @@ public final class RandomGen {
   		} else if (r instanceof PrandomInteger) {
   			return rng.nextInt();
   		} else if (r instanceof PrandomRangeInteger) {
-  			final int lower = (Integer)r.getChild(0);
-  			final int upper = (Integer)r.getChild(1);
-  			if (lower > upper) {
-  				throw new SilverError("Empty Integer range [" + lower + ", " + upper + "]");
-  			}
-  			return rng.nextInt(upper - lower + 1) + lower;  // TODO: I think this could be more robust against signed overflow.
+  			return randomRangeInteger((Integer)r.getChild(0), (Integer)r.getChild(1), rng);
   		} else if (r instanceof PrandomFloat) {
   			return rng.nextFloat();
   		} else if (r instanceof PrandomBoolean) {
   			return rng.nextBoolean();
+  		} else if (r instanceof PrandomToken_) {
+  			return new Random(rng.nextLong());
   		} else {
   			throw new SilverError("Unsupported RandomGen constructor: " + r.getName());  // Not SilverInternalError, someone could define a new RandomGen production
   		}
+	}
+	
+	public static int randomRangeInteger(final int lower, final int upper, final Random rng) {
+		if (lower > upper) {
+			throw new SilverError("Empty Integer range [" + lower + ", " + upper + "]");
+		}
+		return rng.nextInt(upper - lower + 1) + lower;  // TODO: I think this could be more robust against signed overflow.
 	}
 }

--- a/runtime/java/src/common/RandomGen.java
+++ b/runtime/java/src/common/RandomGen.java
@@ -1,6 +1,7 @@
 package common;
 
 import java.util.*;
+import java.util.function.Function;
 
 import common.exceptions.*;
 import silver.core.*;
@@ -38,16 +39,22 @@ public final class RandomGen {
   		} else if (r instanceof PrandomBoolean) {
   			return rng.nextBoolean();
   		} else if (r instanceof PrandomToken_) {
-  			return new Random(rng.nextLong());
+  			return rng.nextLong();
   		} else {
   			throw new SilverError("Unsupported RandomGen constructor: " + r.getName());  // Not SilverInternalError, someone could define a new RandomGen production
   		}
 	}
-	
+
 	public static int randomRangeInteger(final int lower, final int upper, final Random rng) {
 		if (lower > upper) {
 			throw new SilverError("Empty Integer range [" + lower + ", " + upper + "]");
 		}
 		return rng.nextInt(upper - lower + 1) + lower;  // TODO: I think this could be more robust against signed overflow.
+	}
+
+	public static Ppair evalRandomTokenOp(final long token, Function<Random, Object> op) {
+		final Random rng = new Random(token);
+		final Object result = op.apply(rng);
+		return new Ppair(result, rng.nextLong());
 	}
 }

--- a/tutorials/simple/src/simple/abstractsyntax/Expr.sv
+++ b/tutorials/simple/src/simple/abstractsyntax/Expr.sv
@@ -1,5 +1,7 @@
 grammar simple:abstractsyntax;
 
+imports silver:util:random;
+
 {--
  - Names (identifiers) are useful to abstract as nonterminals, because we
  - frequently want to do similar things to them: look them up in the

--- a/tutorials/simple/src/simple/arb/driver/Driver.sv
+++ b/tutorials/simple/src/simple/arb/driver/Driver.sv
@@ -5,6 +5,7 @@ import silver:langutil:pp as pp;
 import simple:abstractsyntax as ast;
 import simple:concretesyntax as cst;
 import silver:reflect;
+import silver:util:random;
 
 function arbDriver
 IOToken ::= args::[String]

--- a/tutorials/simple/src/simple/arb/driver/Driver.sv
+++ b/tutorials/simple/src/simple/arb/driver/Driver.sv
@@ -14,10 +14,10 @@ IOToken ::= args::[String]
 {
   local depth :: Integer = toInteger(head(args));
   
-  local r_cst :: cst:Root = runRandomGen(generator(3, depth));
+  local r_cst :: IOVal<cst:Root> = runRandomGenT(generator(3, depth), io_in);
 
-  --local r_ast :: ast:Root = runRandomGen(generator(3, depth));
-  local r_ast :: ast:Root = r_cst.ast;
+  --local r_ast :: IOVal<ast:Root> = runRandomGenT(generator(3, depth), io_in);
+  local r_ast :: ast:Root = r_cst.iovalue.ast;
 
   local print_success :: IOToken = 
     printT( "AST: \n" ++ pp:show(100, reflect(new(r_ast))) ++
@@ -29,7 +29,7 @@ IOToken ::= args::[String]
             else "\n" ++
                  messagesToString(r_ast.errors) ++ "\n"
            )
-           , io_in );
+           , r_cst.io );
 
   local write_success :: IOToken =
     writeFileT("output.c", r_ast.ast:c_code, print_success);


### PR DESCRIPTION
# Changes
This change moves most of the random utilities from silver:core to silver:util:random (excluding those that are build dependencies for the runtime, which consequently must stay in silver:core.)  Additionally more utilities are added, including a "token based" alternative to the `RandomGen` monad, analogous to the IO token.  This is advantageous for use with "threaded" attributes, e.g. if we want to forward based on a random choice.  

# Documentation
I have added doc comments for the new library features.  This change does not affect any core features of Silver.  
