### PR TITLE
Say which parser we are skipping generating in diagnostic messages

### DIFF
--- a/grammars/silver/compiler/modification/copper/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper/BuildProcess.sv
@@ -151,7 +151,7 @@ top::DriverAction ::= spec::ParserSpec  compiledGrammars::EnvTree<Decorated Root
       dumpFileContents::ByteArray <- readBinaryFile(dumpFile);
       let dumpMatched::Either<String Boolean> = map(eq(specCstAst, _), nativeDeserialize(dumpFileContents));
       if dumpMatched == right(true) then do {
-        print("Copper input did not change; skipping regenerating parser...\n");
+        print("Parser " ++ spec.fullName ++ " is up to date.\n");
         return 0;
       } else do {
         buildGrammar;

--- a/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
@@ -51,7 +51,7 @@ top::DriverAction ::= spec::MdaSpec  compiledGrammars::EnvTree<Decorated RootSpe
       dumpFileContents::ByteArray <- readBinaryFile(dumpFile);
       let dumpMatched::Either<String Boolean> = map(eq(specCstAst, _), nativeDeserialize(dumpFileContents));
       if dumpMatched == right(true) then do {
-        print("Copper MDA input did not change; skipping running MDA...\n");
+        print("MDA test " ++ spec.fullName ++ " is up to date.\n");
         return 0;
       } else do {
         buildGrammar;


### PR DESCRIPTION
# Changes
Changing the messages printed when a parser is up to date to be more specific.

# Documentation
None, this only changes the diagnostic messages printed by Silver. 
