### PR TITLE
Fix bug with lambda translation that could cause lazy arguments to be evaluated more than once

### DIFF
--- a/grammars/silver/compiler/modification/ffi/java/FunctionDcl.sv
+++ b/grammars/silver/compiler/modification/ffi/java/FunctionDcl.sv
@@ -31,7 +31,9 @@ top::FFIDef ::= name::String_t ':' 'return' code::String_t ';'
 function strictChildAccessor
 String ::= ns::NamedSignatureElement
 {
-  return "((" ++ ns.typerep.transType ++ ")common.Util.demand(" ++ ns.childRefElem ++ "))";
+  -- TODO: Slight bug here, if we refer to an argument more than once in an FFI string,
+  -- then we may evaluate argument thunks more than once!
+  return "common.Util.<" ++ ns.typerep.transType ++ ">demand(" ++ ns.childRefElem ++ ")";
 }
 
 function computeSigTranslation

--- a/grammars/silver/compiler/modification/ffi/java/FunctionDcl.sv
+++ b/grammars/silver/compiler/modification/ffi/java/FunctionDcl.sv
@@ -33,6 +33,7 @@ String ::= ns::NamedSignatureElement
 {
   -- TODO: Slight bug here, if we refer to an argument more than once in an FFI string,
   -- then we may evaluate argument thunks more than once!
+  -- E.g. "java": "Foo.bar(%x%, %x%)"
   return "common.Util.<" ++ ns.typerep.transType ++ ">demand(" ++ ns.childRefElem ++ ")";
 }
 

--- a/grammars/silver/compiler/modification/lambda_fn/DclInfo.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/DclInfo.sv
@@ -1,11 +1,24 @@
 import silver:compiler:definition:flow:ast only ExprVertexInfo, FlowVertex;
 
+synthesized attribute lambdaId::Integer occurs on ValueDclInfo;
+synthesized attribute lambdaParamIndex::Integer occurs on ValueDclInfo;
+
+aspect default production
+top::ValueDclInfo ::=
+{
+  top.lambdaParamIndex = error("Should only be demanded on lambda params");
+}
+
+
 abstract production lambdaParamDcl
-top::ValueDclInfo ::= fn::String ty::Type
+top::ValueDclInfo ::= fn::String ty::Type id::Integer paramIndex::Integer
 {
   top.fullName = fn;
 
   top.typeScheme = monoType(ty);
+
+  top.lambdaParamIndex = paramIndex;
+  top.lambdaId = id;
 
   top.refDispatcher = lambdaParamReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- should be impossible (never in scope at production level?)
@@ -13,7 +26,7 @@ top::ValueDclInfo ::= fn::String ty::Type
 }
 
 function lambdaParamDef
-Def ::= sg::String sl::Location fn::String ty::Type
+Def ::= sg::String sl::Location fn::String ty::Type id::Integer paramIndex::Integer
 {
-  return valueDef(defaultEnvItem(lambdaParamDcl(fn,ty,sourceGrammar=sg,sourceLocation=sl)));
+  return valueDef(defaultEnvItem(lambdaParamDcl(fn,ty,id,paramIndex,sourceGrammar=sg,sourceLocation=sl)));
 }

--- a/grammars/silver/compiler/modification/lambda_fn/DclInfo.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/DclInfo.sv
@@ -6,6 +6,7 @@ synthesized attribute lambdaParamIndex::Integer occurs on ValueDclInfo;
 aspect default production
 top::ValueDclInfo ::=
 {
+  top.lambdaId = error("Should only be demanded on lambda params");
   top.lambdaParamIndex = error("Should only be demanded on lambda params");
 }
 

--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -49,14 +49,14 @@ monoid attribute lambdaDefs::[Def];
 monoid attribute lambdaBoundVars::[String];
 attribute lambdaDefs, lambdaBoundVars occurs on ProductionRHS, ProductionRHSElem;
 
-flowtype lambdaDefs {decorate} on ProductionRHS, ProductionRHSElem;
+flowtype lambdaDefs {decorate, givenLambdaId, givenLambdaParamIndex} on ProductionRHS, ProductionRHSElem;
 flowtype lambdaBoundVars {} on ProductionRHS;
 flowtype lambdaBoundVars {deterministicCount} on ProductionRHSElem;
 
 propagate lambdaDefs, lambdaBoundVars on ProductionRHS;
 
-inherited attribute givenLambdaParamIndex::Integer occurs on ProductionRHS, ProductionRHSElem;
 inherited attribute givenLambdaId::Integer occurs on ProductionRHS, ProductionRHSElem;
+inherited attribute givenLambdaParamIndex::Integer occurs on ProductionRHS, ProductionRHSElem;
 propagate givenLambdaId on ProductionRHS, ProductionRHSElem;
 
 aspect production productionRHSCons

--- a/grammars/silver/compiler/modification/let_fix/java/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/java/Let.sv
@@ -19,7 +19,7 @@ top::Expr ::= la::AssignExpr  e::Expr
 
   -- We need to create these nested locals, so we have no choice but to create a thunk object so we can declare these things.
   local closureExpr :: String =
-    s"new common.Thunk<${finTy.transType}>(new common.Thunk.Evaluable() { public final ${finTy.transType} eval() { ${la.let_translation} return ${e.translation}; } })";
+    s"new common.Thunk<${finTy.transType}>(new common.Thunk.Evaluable<${finTy.transType}>() { public final ${finTy.transType} eval() { ${la.let_translation} return ${e.translation}; } })";
     --TODO: java lambdas are bugged
     --s"new common.Thunk<${finTy.transType}>(() -> { ${la.let_translation} return ${e.translation};\n})";
   

--- a/grammars/silver/compiler/translation/java/core/ClassDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ClassDcl.sv
@@ -43,7 +43,7 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr ';'
   local contexts::Contexts = foldContexts(cl.contexts);
   contexts.boundVariables = boundVars;
 
-  top.translation = s"\t${ty.typerep.transCovariantType} ${makeInstanceMemberAccessorName(id.name)}(${contexts.contextParamTrans});";
+  top.translation = s"\t${ty.typerep.transType} ${makeInstanceMemberAccessorName(id.name)}(${contexts.contextParamTrans});";
 }
 
 aspect production defaultConstraintClassBodyItem
@@ -53,7 +53,7 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e:
   contexts.boundVariables = boundVars;
 
   top.translation = s"""
-	default ${ty.typerep.transCovariantType} ${makeInstanceMemberAccessorName(id.name)}(${contexts.contextParamTrans}) {
+	default ${ty.typerep.transType} ${makeInstanceMemberAccessorName(id.name)}(${contexts.contextParamTrans}) {
 		final common.DecoratedNode context = common.TopNode.singleton;
 		//${e.unparse}
 		return ${e.generalizedTranslation};

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -552,7 +552,7 @@ String ::= exp::String  beLazy::Boolean
 function wrapThunkText
 String ::= exp::String  ty::String
 {
-  return s"new common.Thunk<${ty}>(new common.Thunk.Evaluable() { public final ${ty} eval() { return ${exp}; } })";
+  return s"new common.Thunk<${ty}>(new common.Thunk.Evaluable<${ty}>() { public final ${ty} eval() { return ${exp}; } })";
   --TODO: java lambdas are bugged
   --return s"new common.Thunk<${ty}>(() -> ${exp})";
 }

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -142,7 +142,7 @@ ${flatMap(makeInhOccursContextAccess(whatSig.freeVariables, whatSig.contextInhOc
 		return "${whatSig.fullName}";
 	}
 
-	public static ${whatSig.outputElement.typerep.transCovariantType} invoke(final common.OriginContext originCtx ${commaIfArgs} ${whatSig.javaSignature}) {
+	public static ${whatSig.outputElement.typerep.transType} invoke(final common.OriginContext originCtx ${commaIfArgs} ${whatSig.javaSignature}) {
 		try {
 ${whatResult}
 		} catch(Throwable t) {
@@ -152,15 +152,14 @@ ${whatResult}
 
 ${if null(whatSig.contexts) -- Can only use a singleton when there aren't contexts.
   then s"""
-	// Use of ? to permit casting to more specific types
-	public static final common.NodeFactory<? extends ${whatSig.outputElement.typerep.transCovariantType}> factory = new Factory();
+	public static final common.NodeFactory<${whatSig.outputElement.typerep.transCovariantType}> factory = new Factory();
 """ else s"""
-	public static final common.NodeFactory<? extends ${whatSig.outputElement.typerep.transCovariantType}> getFactory(${contexts.contextParamTrans}) {
+	public static final common.NodeFactory<${whatSig.outputElement.typerep.transCovariantType}> getFactory(${contexts.contextParamTrans}) {
 		return new Factory(${implode(", ", map(\ c::Context -> decorate c with {boundVariables = whatSig.freeVariables;}.contextRefElem, whatSig.contexts))});
 	}
 """}
 
-	public static final class Factory extends common.NodeFactory<${whatSig.outputElement.typerep.transCovariantType}> {
+	public static final class Factory extends common.NodeFactory<${whatSig.outputElement.typerep.transType}> {
 ${contexts.contextMemberDeclTrans}
 
 		public Factory(${contexts.contextParamTrans}) {
@@ -168,7 +167,7 @@ ${contexts.contextInitTrans}
 		}
 
 		@Override
-		public final ${whatSig.outputElement.typerep.transCovariantType} invoke(final common.OriginContext originCtx, final Object[] children, final Object[] namedNotApplicable) {
+		public final ${whatSig.outputElement.typerep.transType} invoke(final common.OriginContext originCtx, final Object[] children, final Object[] namedNotApplicable) {
 			return ${className}.invoke(${implode(", ", ["originCtx"] ++ map(\ c::Context -> decorate c with {boundVariables = whatSig.freeVariables;}.contextRefElem, whatSig.contexts) ++ unpackChildren(0, whatSig.inputElements))});
 		}
 		

--- a/grammars/silver/compiler/translation/java/core/GlobalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/GlobalDcl.sv
@@ -5,10 +5,10 @@ top::AGDcl ::= 'global' id::Name '::' cl::ConstraintList '=>' t::TypeExpr '=' e:
 {
   top.initValues :=
     if null(cl.contexts) then
-      s"\tpublic static final common.Thunk<${t.typerep.transCovariantType}> global_${id.name} = ${wrapThunkText(e.generalizedTranslation, t.typerep.transCovariantType)};\n"
+      s"\tpublic static final common.Thunk<${t.typerep.transCovariantType}> global_${id.name} = ${wrapThunkText(e.generalizedTranslation, t.typerep.transType)};\n"
     else s"""
 	public static final common.Thunk<${t.typerep.transCovariantType}> global_${id.name}(${implode(", ", map(\ c::Context -> decorate c with {boundVariables = boundVars;}.contextSigElem, cl.contexts))}){
-		return ${wrapThunkText(e.generalizedTranslation, t.typerep.transCovariantType)};
+		return ${wrapThunkText(e.generalizedTranslation, t.typerep.transType)};
 	}
 """;
 }

--- a/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/InstanceDcl.sv
@@ -75,7 +75,7 @@ top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
   contexts.boundVariables = boundVars;
 
   top.translation = s"""
-	public ${id.lookupValue.typeScheme.typerep.transCovariantType} ${makeInstanceMemberAccessorName(top.fullName)}(${contexts.contextParamTrans}) {
+	public ${finalType(e).transType} ${makeInstanceMemberAccessorName(top.fullName)}(${contexts.contextParamTrans}) {
 		//${e.unparse}
 		return ${e.generalizedTranslation};
 	}

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -239,7 +239,9 @@ top::NamedSignatureElement ::= n::String ty::Type
   top.childDeclElem =
 s"""private Object child_${n};
   public final ${ty.transType} getChild_${n}() {
-    return (${ty.transType}) (child_${n} = common.Util.demand(child_${n}));
+    final ${ty.transType} result = common.Util.<${ty.transType}>demand(child_${n});
+    child_${n} = result;
+    return result;
   }
 """;
 
@@ -268,7 +270,9 @@ s"""private Object child_${n};
 s"""	protected Object anno_${fn};
 	@Override
 	public final ${ty.transType} getAnno_${fn}() {
-		return (${ty.transType}) (anno_${fn} = common.Util.demand(anno_${fn}));
+		final ${ty.transType} result = common.Util.<${ty.transType}>demand(anno_${fn});
+		anno_${fn} = result;
+		return result;
 	}
 
 """;

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -185,6 +185,7 @@ implode("\n\n", extraTopLevelDecls) ++ "\n\n" ++
 
 "  <target name='grammars' depends='" ++ implode(", ", extraGrammarsDeps) ++ "'>\n" ++
 "    <javac debug='on' classpathref='compile.classpath' srcdir='${src}' destdir='${bin}' includeantruntime='false' source='1.8' target='1.8' release='8'>\n" ++
+--"      <compilerarg value=\"-Xlint:unchecked\" />" ++
     flatMap(includeJavaFiles, grammarsDependedUpon) ++
 "    </javac>\n" ++
 "  </target>\n" ++

--- a/grammars/silver/compiler/translation/java/type/Type.sv
+++ b/grammars/silver/compiler/translation/java/type/Type.sv
@@ -5,8 +5,8 @@ imports silver:compiler:translation:java:core;
 
 -- The Java type corresponding to the Silver Type
 synthesized attribute transType :: String;
--- The *covariant* Java type corresponding to the Silver Type
--- e.g. common.NodeFactory<? extends Object> instead of common.NodeFactory<Object>
+-- The *covariant* Java generic type argument corresponding to the Silver Type
+-- e.g. ? extends Object instead of Object
 synthesized attribute transCovariantType :: String;
 -- Java has crappy syntax for some things.
 -- If we want to statically refer to the class of this type, we cannot use
@@ -59,6 +59,7 @@ top::Type ::=
 aspect production varType
 top::Type ::= tv::TyVar
 {
+  top.transCovariantType = "? extends Object";
   top.transClassType = "Object";
   top.transTypeRep = s"freshTypeVar_${toString(tv.extractTyVarRep)}";
   top.transTypeName = "a" ++ toString(positionOf(tv, top.boundVariables));
@@ -67,6 +68,7 @@ top::Type ::= tv::TyVar
 aspect production skolemType
 top::Type ::= tv::TyVar
 {
+  top.transCovariantType = "? extends Object";
   top.transClassType = "Object";
   top.transTypeRep = lookup(tv, top.skolemTypeReps).fromJust;
   top.transTypeName = "a" ++ toString(positionOf(tv, top.boundVariables));
@@ -77,12 +79,12 @@ top::Type ::= c::Type a::Type
 {
   top.transType =
     case c.baseType of
-    | functionType(_, _) -> "common.NodeFactory<" ++ top.outputType.transType ++ ">"
+    | functionType(_, _) -> "common.NodeFactory<" ++ top.outputType.transCovariantType ++ ">"
     | _ -> c.transType
     end;
   top.transCovariantType =
     case c.baseType of
-    | functionType(_, _) -> "common.NodeFactory<? extends " ++ top.outputType.transCovariantType ++ ">"
+    | functionType(_, _) -> "common.NodeFactory<" ++ top.outputType.transCovariantType ++ ">"
     | _ -> c.transCovariantType
     end;
   top.transClassType = c.transClassType;

--- a/grammars/silver/compiler/translation/java/type/Type.sv
+++ b/grammars/silver/compiler/translation/java/type/Type.sv
@@ -84,7 +84,7 @@ top::Type ::= c::Type a::Type
     end;
   top.transCovariantType =
     case c.baseType of
-    | functionType(_, _) -> "common.NodeFactory<" ++ top.outputType.transCovariantType ++ ">"
+    | functionType(_, _) -> "? extends common.NodeFactory<" ++ top.outputType.transCovariantType ++ ">"
     | _ -> c.transCovariantType
     end;
   top.transClassType = c.transClassType;

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -7,7 +7,6 @@ import java.net.URI;
 
 import common.exceptions.*;
 import common.javainterop.ConsCellCollection;
-
 import silver.core.NLocation;
 import silver.core.NParseError;
 import silver.core.NParseResult;
@@ -59,10 +58,11 @@ public final class Util {
 	 * @param c  Either a value, or a Closure
 	 * @return The value, either directly, or evaluating the Closure
 	 */
-	public static Object demand(Object c) {
+	@SuppressWarnings("unchecked")
+	public static <T> T demand(Object c) {
 		if(c instanceof Thunk)
-			return ((Thunk<?>)c).eval();
-		return c;
+			return ((Thunk<T>)c).eval();
+		return (T)c;
 	}
 
 	/**


### PR DESCRIPTION
# Changes
This fixes a bug I noticed with lambdas, after demanding an argument thunk we never update the original argument to record the result - potentially causing arguments that are referenced more than once to be evaluated more than once.  Probably not a huge performance issue most of the time since we would fairly soon reach thunks that already have been evaluated.

Also some minor, slightly related cleanup that fixes a few warnings about unchecked casts.  

# Documentation
None added, this is a minor cleanup/bug fix.
