### PR TITLE
Fix unchecked cast warnings in translation and runtime

### DIFF
--- a/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/GrammarElement.sv
@@ -10,7 +10,7 @@ GrammarElement ::= sourceGrammar::String  location::Location  id::String
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "common.CopperUtil.makeDisambiguationFunction(%sourceGrammar%.toString(), %location%, %id%.toString(), %code%.toString(), new common.javainterop.ConsCellCollection(%members%), %applicableToSubsets%)";
+  "java" : return "common.CopperUtil.makeDisambiguationFunction(%sourceGrammar%.toString(), %location%, %id%.toString(), %code%.toString(), new common.javainterop.ConsCellCollection<>(%members%), %applicableToSubsets%)";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Nonterminal
@@ -42,7 +42,7 @@ GrammarElement ::= sourceGrammar::String  location::Location  id::String
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "common.CopperUtil.makeProduction(%sourceGrammar%.toString(), %location%, %id%.toString(), %hasPrecedence% ? %precedence_% : null, %hasOperator% ? (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%operator_% : null, %code%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%lhs%, new common.javainterop.ConsCellCollection(%rhs%), new common.javainterop.ConsCellCollection(%prodLayout%))";
+  "java" : return "common.CopperUtil.makeProduction(%sourceGrammar%.toString(), %location%, %id%.toString(), %hasPrecedence% ? %precedence_% : null, %hasOperator% ? (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%operator_% : null, %code%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%lhs%, new common.javainterop.ConsCellCollection<>(%rhs%), new common.javainterop.ConsCellCollection<>(%prodLayout%))";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Terminal
@@ -55,7 +55,7 @@ GrammarElement ::= sourceGrammar::String  location::Location  id::String
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "common.CopperUtil.makeTerminal(%sourceGrammar%.toString(), %location%, %id%.toString(), %pp%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex)%regex%, %hasPrecedence% ? %precedence_% : null, %associativity%.toString(), %type_%.toString(), %code%.toString(), new common.javainterop.ConsCellCollection(%classes_%), %hasPrefix% ? (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%prefix_% : null, new common.javainterop.ConsCellCollection(%submits_%), new common.javainterop.ConsCellCollection(%dominates_%))";
+  "java" : return "common.CopperUtil.makeTerminal(%sourceGrammar%.toString(), %location%, %id%.toString(), %pp%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex)%regex%, %hasPrecedence% ? %precedence_% : null, %associativity%.toString(), %type_%.toString(), %code%.toString(), new common.javainterop.ConsCellCollection<>(%classes_%), %hasPrefix% ? (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%prefix_% : null, new common.javainterop.ConsCellCollection<>(%submits_%), new common.javainterop.ConsCellCollection<>(%dominates_%))";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.TerminalClass

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Misc.sv
@@ -11,7 +11,7 @@ ParserBean ::= sourceGrammar::String  location::Location  id::String
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "common.CopperUtil.makeParserBean(%sourceGrammar%.toString(), %location%, %id%.toString(), %name%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new common.javainterop.ConsCellCollection(%startLayout%), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)%grammar_%)";
+  "java" : return "common.CopperUtil.makeParserBean(%sourceGrammar%.toString(), %location%, %id%.toString(), %name%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new common.javainterop.ConsCellCollection<>(%startLayout%), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)%grammar_%)";
 }
 
 function extendedParserBean
@@ -23,7 +23,7 @@ ParserBean ::= sourceGrammar::String  location::Location  id::String
 {
   return error("copper FFI function");
 } foreign {
-  "java" : return "common.CopperUtil.makeExtendedParserBean(%sourceGrammar%.toString(), %location%, %id%.toString(), %name%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new common.javainterop.ConsCellCollection(%startLayout%), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)%hostGrammar%, (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)%extGrammar%)";
+  "java" : return "common.CopperUtil.makeExtendedParserBean(%sourceGrammar%.toString(), %location%, %id%.toString(), %name%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.CopperElementReference)%startSymbol%, new common.javainterop.ConsCellCollection<>(%startLayout%), %parserClassAuxCode%.toString(), %parserInitCode%.toString(), %preambleCode%.toString(), (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)%hostGrammar%, (edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Grammar)%extGrammar%)";
 }
 
 function compileParserBeanT
@@ -57,7 +57,7 @@ Grammar ::= sourceGrammar::String  location::Location  id::String
 {
   return error("copper FFI function");
 } foreign {
-  "java": return "common.CopperUtil.makeGrammar(%sourceGrammar%.toString(), %location%, %id%.toString(), new common.javainterop.ConsCellCollection(%grammarElements%))";
+  "java": return "common.CopperUtil.makeGrammar(%sourceGrammar%.toString(), %location%, %id%.toString(), new common.javainterop.ConsCellCollection<>(%grammarElements%))";
 }
 
 function extensionGrammar
@@ -68,5 +68,5 @@ Grammar ::= sourceGrammar::String  location::Location  id::String
 {
   return error("copper FFI function");
 } foreign {
-  "java": return "common.CopperUtil.makeExtensionGrammar(%sourceGrammar%.toString(), %location%, %id%.toString(), new common.javainterop.ConsCellCollection(%grammarElements%), new common.javainterop.ConsCellCollection(%markingTerminals%), new common.javainterop.ConsCellCollection(%bridgeProductions%), new common.javainterop.ConsCellCollection(%glueDisambiguationFunctions%))";
+  "java": return "common.CopperUtil.makeExtensionGrammar(%sourceGrammar%.toString(), %location%, %id%.toString(), new common.javainterop.ConsCellCollection<>(%grammarElements%), new common.javainterop.ConsCellCollection<>(%markingTerminals%), new common.javainterop.ConsCellCollection<>(%bridgeProductions%), new common.javainterop.ConsCellCollection<>(%glueDisambiguationFunctions%))";
 }

--- a/grammars/silver/compiler/definition/concrete_syntax/copper/Regex.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/copper/Regex.sv
@@ -18,7 +18,7 @@ Regex ::= subexps::[Regex]
 {
   return error("copper FFI function");
 } foreign {
-  "java": return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ChoiceRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection(%subexps%)))";
+  "java": return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ChoiceRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection<>(%subexps%)))";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ConcatenationRegex
@@ -27,7 +27,7 @@ Regex ::= subexps::[Regex]
 {
   return error("copper FFI function");
 } foreign {
-  "java": return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ConcatenationRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection(%subexps%)))";
+  "java": return "new edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ConcatenationRegex().addSubexps(new java.util.ArrayList<edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.Regex>(new common.javainterop.ConsCellCollection<>(%subexps%)))";
 }
 
 -- edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.KleeneStarRegex

--- a/grammars/silver/compiler/definition/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/definition/core/InstanceDcl.sv
@@ -16,7 +16,7 @@ top::AGDcl ::= 'instance' cl::ConstraintList '=>' id::QNameType ty::TypeExpr '{'
     foldContexts(if id.lookupType.found && !foldContexts(cl.contexts).isTypeError then dcl.superContexts else []);
   superContexts.env = body.env;
   
-  top.defs := [instDef(top.grammarName, id.location, fName, boundVars, cl.contexts, ty.typerep)];
+  top.defs := [instDef(top.grammarName, id.location, fName, boundVars, cl.contexts, ty.typerep, body.definedMembers)];
   
   top.errors <- id.lookupType.errors;
   top.errors <-
@@ -73,7 +73,7 @@ autocopy attribute instanceType::Type;
 inherited attribute expectedClassMembers::[Pair<String Boolean>];
 
 nonterminal InstanceBody with
-  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers;
+  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, definedMembers;
 nonterminal InstanceBodyItem with
   config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, fullName;
 
@@ -83,6 +83,7 @@ concrete production consInstanceBody
 top::InstanceBody ::= h::InstanceBodyItem t::InstanceBody
 {
   top.unparse = h.unparse ++ "\n" ++ t.unparse;
+  top.definedMembers = h.fullName :: t.definedMembers;
 
   h.expectedClassMembers = top.expectedClassMembers;
   t.expectedClassMembers =
@@ -92,6 +93,7 @@ concrete production nilInstanceBody
 top::InstanceBody ::= 
 {
   top.unparse = "";
+  top.definedMembers = [];
 
   top.errors <-
     flatMap(

--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -19,9 +19,11 @@ synthesized attribute isTypeAlias :: Boolean;
 synthesized attribute isClass :: Boolean;
 synthesized attribute classMembers :: [Pair<String Boolean>];
 
+-- instances
 inherited attribute givenInstanceType :: Type;
 synthesized attribute superContexts :: [Context];
 synthesized attribute typerep2 :: Type; -- Used for binary constraint instances
+synthesized attribute definedMembers :: [String];
 
 -- values
 synthesized attribute namedSignature :: NamedSignature;
@@ -360,24 +362,26 @@ top::OccursDclInfo ::= fnat::String atty::Type baseDcl::InstDclInfo
   top.typeScheme = constraintType(baseDcl.typeScheme.boundVars, baseDcl.typeScheme.contexts, atty);
 }
 
-nonterminal InstDclInfo with sourceGrammar, sourceLocation, fullName, typeScheme, typerep2, isTypeError;
+nonterminal InstDclInfo with sourceGrammar, sourceLocation, fullName, typeScheme, typerep2, isTypeError, definedMembers;
 
 aspect default production
 top::InstDclInfo ::=
 {
   top.isTypeError := false;
+  top.definedMembers = [];
   top.typerep2 = error("Internal compiler error: must be defined for all binary constraint instances");
 }
 
 -- Class instances
 abstract production instDcl
-top::InstDclInfo ::= fn::String bound::[TyVar] contexts::[Context] ty::Type
+top::InstDclInfo ::= fn::String bound::[TyVar] contexts::[Context] ty::Type definedMembers::[String]
 {
   top.fullName = fn;
   
   top.typeScheme = constraintType(bound, contexts, ty);
 
   top.isTypeError := any(map((.isTypeError), contexts));
+  top.definedMembers = definedMembers;
 }
 abstract production instConstraintDcl
 top::InstDclInfo ::= fntc::String ty::Type tvs::[TyVar]

--- a/grammars/silver/compiler/definition/env/Defs.sv
+++ b/grammars/silver/compiler/definition/env/Defs.sv
@@ -222,9 +222,9 @@ Def ::= sg::String  sl::Location  fn::String  supers::[Context]  tv::TyVar  k::K
   return typeDef(defaultEnvItem(clsDcl(fn,supers,tv,k,members,sourceGrammar=sg,sourceLocation=sl)));
 }
 function instDef
-Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  contexts::[Context]  ty::Type  dm::[String]
+Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  contexts::[Context]  ty::Type  definedMembers::[String]
 {
-  return tcInstDef(instDcl(fn,bound,contexts,ty,dm,sourceGrammar=sg,sourceLocation=sl));
+  return tcInstDef(instDcl(fn,bound,contexts,ty,definedMembers,sourceGrammar=sg,sourceLocation=sl));
 }
 function sigConstraintDef
 Def ::= sg::String  sl::Location  fn::String  ty::Type  ns::NamedSignature

--- a/grammars/silver/compiler/definition/env/Defs.sv
+++ b/grammars/silver/compiler/definition/env/Defs.sv
@@ -222,9 +222,9 @@ Def ::= sg::String  sl::Location  fn::String  supers::[Context]  tv::TyVar  k::K
   return typeDef(defaultEnvItem(clsDcl(fn,supers,tv,k,members,sourceGrammar=sg,sourceLocation=sl)));
 }
 function instDef
-Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  contexts::[Context]  ty::Type
+Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  contexts::[Context]  ty::Type  dm::[String]
 {
-  return tcInstDef(instDcl(fn,bound,contexts,ty,sourceGrammar=sg,sourceLocation=sl));
+  return tcInstDef(instDcl(fn,bound,contexts,ty,dm,sourceGrammar=sg,sourceLocation=sl));
 }
 function sigConstraintDef
 Def ::= sg::String  sl::Location  fn::String  ty::Type  ns::NamedSignature

--- a/grammars/silver/compiler/modification/collection/java/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/java/Collection.sv
@@ -97,6 +97,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr 'with
 
   top.setupInh <- s"""
     ${top.frame.className}.localAttributes[${ugh_dcl_hack.attrOccursIndex}] = new common.CollectionAttribute() {
+  @SuppressWarnings("unchecked")
       public Object eval(common.DecoratedNode context) {
         common.OriginContext originCtx = context.originCtx;
         common.Lazy base = this.getBase();
@@ -134,6 +135,7 @@ public class ${className} extends common.CollectionAttribute {
     super(index);
   }
 
+  @SuppressWarnings("unchecked")
   public Object eval(common.DecoratedNode context) {
     common.OriginContext originCtx = context.originCtx;
     ${te.typerep.transType} result = (${te.typerep.transType})this.getBase().eval(context);
@@ -167,6 +169,7 @@ public class ${className} extends common.CollectionAttribute {
     super();
   }
 
+  @SuppressWarnings("unchecked")
   public Object eval(common.DecoratedNode context) {
     common.OriginContext originCtx = context.originCtx;
     ${te.typerep.transType} result = (${te.typerep.transType})this.getBase().eval(context);

--- a/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
@@ -55,8 +55,7 @@ ${makeTyVarDecls(5, finTy.freeVariables)}
 aspect production lambdaParamReference
 top::Expr ::= q::PartiallyDecorated QName
 {
-  local paramRef::String = s"lambda_${toString(q.lookupValue.dcl.lambdaId)}_args[${toString(q.lookupValue.dcl.lambdaParamIndex)}]";
-  top.translation = s"((${top.typerep.transType})(${paramRef} = common.Util.demand(${paramRef})))";
+  top.translation = s"common.Util.<${finalType(top).transType}>demandIndex(lambda_${toString(q.lookupValue.dcl.lambdaId)}_args, ${toString(q.lookupValue.dcl.lambdaParamIndex)})";
   top.lazyTranslation = top.translation;
 }
 

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -499,7 +499,9 @@ top::PrimPattern ::= h::Name t::Name e::Expr
       listTrans :: String = performSubstitution(top.scrutineeType, top.finalSubst).transType
     in
       "if(!scrutineeIter.nil()) {" ++
+      "@SuppressWarnings(\"unchecked\") " ++
       makeSpecialLocalBinding(h_fName, s"(${elemTrans})scrutinee.head()", elemTrans) ++
+      "@SuppressWarnings(\"unchecked\") " ++
       makeSpecialLocalBinding(t_fName, s"(${listTrans})scrutinee.tail()", listTrans) ++
       "return " ++ e.translation ++ "; }"
     end;

--- a/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
@@ -163,10 +163,10 @@ top::VarBinder ::= n::Name
 
   top.translation = 
     makeSpecialLocalBinding(fName, 
-      "(" ++ actualTy.transType ++ ")scrutinee." ++ 
+      "scrutinee." ++ 
         (if isDecorable(top.bindingType, top.env)
          then "childDecorated("
-         else "childAsIs(") ++
+         else s"<${actualTy.transType}>childAsIs(") ++
         toString(top.bindingIndex) ++ ")",
       actualTy.transType);
   

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -170,7 +170,7 @@ top::Expr ::= q::PartiallyDecorated QName
     if !null(resolvedDcl.typeScheme.boundVars) || !contains(q.lookupValue.fullName, resolvedDcl.definedMembers)
     -- The resolved instance has a polymorphic implementation for the member,
     -- or relies on a default implementation, which may have a more general type.
-    -- This means that we must insert a cast to the more specific infered result type.
+    -- This means that we must insert a cast to the more specific inferred result type.
     then s"common.Util.<${finalType(top).transType}>uncheckedCast(${transContextMember})"
     else transContextMember;
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -44,7 +44,7 @@ top::Expr ::=
 {
   top.invokeTranslation =
     -- dynamic method invocation
-    s"((${finalType(top).outputType.transType})${top.translation}.invoke(${makeOriginContextRef(top)}, new Object[]{${argsTranslation(top.invokeArgs)}}, ${namedargsTranslation(top.invokeNamedArgs)}))";
+    castIfPoly(top, s"${top.translation}.invoke(${makeOriginContextRef(top)}, new Object[]{${argsTranslation(top.invokeArgs)}}, ${namedargsTranslation(top.invokeNamedArgs)})");
   top.generalizedTranslation = top.translation;
 }
 
@@ -73,7 +73,7 @@ top::Expr ::= q::PartiallyDecorated QName
     then if finalType(top).isDecorated
          then s"((${finalType(top).transType})context.childDecorated(${childIDref}))"
          else s"((${finalType(top).transType})context.childDecorated(${childIDref}).undecorate())"
-    else s"((${finalType(top).transType})context.childAsIs(${childIDref}))";
+    else s"context.<${finalType(top).transType}>childAsIs(${childIDref})";
   -- the reason we do .childDecorated().undecorate() is that it's not safe to mix as-is/decorated accesses to the same child.
   -- this is a potential source of minor inefficiency for functions that do not decorate.
 
@@ -94,7 +94,7 @@ top::Expr ::= q::PartiallyDecorated QName
     then if finalType(top).isDecorated
          then s"((${finalType(top).transType})context.localDecorated(${q.lookupValue.dcl.attrOccursIndex}))"
          else s"((${finalType(top).transType})context.localDecorated(${q.lookupValue.dcl.attrOccursIndex}).undecorate())"
-    else s"((${finalType(top).transType})context.localAsIs(${q.lookupValue.dcl.attrOccursIndex}))";
+    else s"context.<${finalType(top).transType}>localAsIs(${q.lookupValue.dcl.attrOccursIndex})";
   -- reminder: look at comments for childReference
 
   top.lazyTranslation =
@@ -139,7 +139,7 @@ top::Expr ::= q::PartiallyDecorated QName
   top.lazyTranslation = top.translation;
   top.invokeTranslation =
     -- static constructor invocation
-    s"((${finalType(top).outputType.transType})new ${makeProdName(q.lookupValue.fullName)}(${implode(", ", makeNewConstructionOrigin(top, !top.sameProdAsProductionDefinedOn) ++ contexts.transContexts ++ map((.lazyTranslation), top.invokeArgs.exprs ++ reorderedAnnoAppExprs(top.invokeNamedArgs)))}))";
+    castIfPoly(top, s"new ${makeProdName(q.lookupValue.fullName)}(${implode(", ", makeNewConstructionOrigin(top, !top.sameProdAsProductionDefinedOn) ++ contexts.transContexts ++ map((.lazyTranslation), top.invokeArgs.exprs ++ reorderedAnnoAppExprs(top.invokeNamedArgs)))})");
 }
 
 aspect production functionReference
@@ -147,20 +147,32 @@ top::Expr ::= q::PartiallyDecorated QName
 {
   -- functions, unlike productions, can return a type variable.
   -- as such, we have to cast it to the real inferred final type.
-  top.translation = s"((${finalType(top).transType})${top.lazyTranslation})";
+  top.translation =
+    if !null(top.typerep.outputType.freeVariables)
+    then s"common.Util.<${finalType(top).transType}>uncheckedCast(${top.lazyTranslation})"
+    else top.lazyTranslation;
   top.lazyTranslation =
     if null(typeScheme.contexts)
     then makeProdName(q.lookupValue.fullName) ++ ".factory"
     else s"${makeProdName(q.lookupValue.fullName)}.getFactory(${implode(", ", contexts.transContexts)})";
   top.invokeTranslation =
     -- static method invocation
-    s"((${finalType(top).outputType.transType})${makeProdName(q.lookupValue.fullName)}.invoke(${implode(", ", [makeOriginContextRef(top)] ++ contexts.transContexts ++ map((.lazyTranslation), top.invokeArgs.exprs))}))";
+    castIfPoly(top, s"${makeProdName(q.lookupValue.fullName)}.invoke(${implode(", ", [makeOriginContextRef(top)] ++ contexts.transContexts ++ map((.lazyTranslation), top.invokeArgs.exprs))})");
 }
 
 aspect production classMemberReference
 top::Expr ::= q::PartiallyDecorated QName
 {
-  top.translation = s"((${finalType(top).transType})${instHead.transContext}.${makeInstanceMemberAccessorName(q.lookupValue.fullName)}(${implode(", ", contexts.transContexts)}))";
+  local transContextMember::String =
+    s"${instHead.transContext}.${makeInstanceMemberAccessorName(q.lookupValue.fullName)}(${implode(", ", contexts.transContexts)})";
+  local resolvedDcl::InstDclInfo = head(instHead.resolved);
+  top.translation =
+    if !null(resolvedDcl.typeScheme.boundVars) || !contains(q.lookupValue.fullName, resolvedDcl.definedMembers)
+    -- The resolved instance has a polymorphic implementation for the member,
+    -- or relies on a default implementation, which may have a more general type.
+    -- This means that we must insert a cast to the more specific infered result type.
+    then s"common.Util.<${finalType(top).transType}>uncheckedCast(${transContextMember})"
+    else transContextMember;
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
 
@@ -172,11 +184,11 @@ top::Expr ::= q::PartiallyDecorated QName
     if null(typeScheme.contexts) then ""
     else s"(${implode(", ", contexts.transContexts)})";
 
-  top.translation = s"((${finalType(top).transType})${directThunk}.eval())";
+  top.translation = s"common.Util.<${finalType(top).transType}>uncheckedCast(${directThunk}.eval())";
   top.lazyTranslation = 
     if top.frame.lazyApplication
     then directThunk
-    else top.translation;
+    else s"${directThunk}.eval()";
 }
 aspect production errorApplication
 top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
@@ -276,7 +288,7 @@ top::Expr ::= e::Expr '.' 'forward'
 aspect production synDecoratedAccessHandler
 top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
-  top.translation = wrapAccessWithOT(top, s"${e.translation}.synthesized(${q.attrOccursIndex})");
+  top.translation = wrapAccessWithOT(top, s"${e.translation}.<${finalType(top).transType}>synthesized(${q.attrOccursIndex})");
 
   top.lazyTranslation = 
     case e, top.frame.lazyApplication of
@@ -295,7 +307,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 aspect production inhDecoratedAccessHandler
 top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 {
-  top.translation = wrapAccessWithOT(top, s"${e.translation}.inherited(${q.attrOccursIndex})");
+  top.translation = wrapAccessWithOT(top, s"${e.translation}.<${finalType(top).transType}>inherited(${q.attrOccursIndex})");
 
   top.lazyTranslation = 
     case e, top.frame.lazyApplication of
@@ -569,3 +581,12 @@ String ::= e::Decorated Expr
   return s"new common.Lazy() { public final Object eval(final common.DecoratedNode context) { ${swizzleOrigins} return ${e.translation}; } }";
 }
 
+function castIfPoly
+String ::= e::Decorated Expr expr::String
+{
+  return
+    if !null(e.typerep.outputType.freeVariables)
+    -- If the function's result type is polymorphic, then we need to insert a cast to the actual type.
+    then s"common.Util.<${finalType(e).outputType.transType}>uncheckedCast(${expr})"
+    else expr;
+}

--- a/grammars/silver/compiler/translation/java/core/Origins.sv
+++ b/grammars/silver/compiler/translation/java/core/Origins.sv
@@ -107,9 +107,9 @@ String ::= top::Decorated Expr expr::String
   --     we know it's a primitive
   --  - polyCopy is the slowpath that uses java instanceof to check if it's tracked, and then send OI if it is
 
-  local polyCopy   :: String = s"((${ty.transType})${makeOriginContextRef(top)}.attrAccessCopyPoly(${expr}))";
-  local directCopy :: String = s"((${ty.transType})${makeOriginContextRef(top)}.attrAccessCopy((common.Tracked)${expr}))";
-  local noop       :: String = s"((${ty.transType})${expr})";
+  local polyCopy   :: String = s"${makeOriginContextRef(top)}.attrAccessCopyPoly(${expr})";
+  local directCopy :: String = s"${makeOriginContextRef(top)}.attrAccessCopy(${expr})";
+  local noop       :: String = expr;
 
   local impl :: String = if ty.transType == "Object" then polyCopy else
           (if typeWantsTracking(ty, top.config, top.env) then directCopy else noop);

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -185,7 +185,7 @@ implode("\n\n", extraTopLevelDecls) ++ "\n\n" ++
 
 "  <target name='grammars' depends='" ++ implode(", ", extraGrammarsDeps) ++ "'>\n" ++
 "    <javac debug='on' classpathref='compile.classpath' srcdir='${src}' destdir='${bin}' includeantruntime='false' source='1.8' target='1.8' release='8'>\n" ++
---"      <compilerarg value=\"-Xlint:unchecked\" />" ++
+"      <compilerarg value=\"-Xlint:unchecked\" />" ++
     flatMap(includeJavaFiles, grammarsDependedUpon) ++
 "    </javac>\n" ++
 "  </target>\n" ++

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -185,7 +185,7 @@ implode("\n\n", extraTopLevelDecls) ++ "\n\n" ++
 
 "  <target name='grammars' depends='" ++ implode(", ", extraGrammarsDeps) ++ "'>\n" ++
 "    <javac debug='on' classpathref='compile.classpath' srcdir='${src}' destdir='${bin}' includeantruntime='false' source='1.8' target='1.8' release='8'>\n" ++
-"      <compilerarg value=\"-Xlint:unchecked\" />" ++
+"      <compilerarg value=\"-Xlint:unchecked\" />\n" ++
     flatMap(includeJavaFiles, grammarsDependedUpon) ++
 "    </javac>\n" ++
 "  </target>\n" ++

--- a/grammars/silver/compiler/translation/java/type/Context.sv
+++ b/grammars/silver/compiler/translation/java/type/Context.sv
@@ -172,7 +172,7 @@ inherited attribute transContextDeps::[String] occurs on InstDclInfo, OccursDclI
 attribute transContext occurs on InstDclInfo;
 
 aspect production instDcl
-top::InstDclInfo ::= fn::String bound::[TyVar] contexts::[Context] ty::Type
+top::InstDclInfo ::= fn::String bound::[TyVar] contexts::[Context] ty::Type definedMembers::[String]
 {
   top.transContext = s"new ${makeInstanceName(top.sourceGrammar, fn, ty)}(${implode(", ", top.transContextDeps)})";
 }

--- a/grammars/silver/util/graph/Graph.sv
+++ b/grammars/silver/util/graph/Graph.sv
@@ -6,7 +6,7 @@ import silver:util:treeset as set;
  - A primitive graph representation. Edges has no special value
  - they either exist or do not.
  -}
-type Graph<a> foreign;
+type Graph<a> foreign = "java.util.TreeMap<Object,java.util.TreeSet<Object>>";
 
 @{--
  - Returns an empty graph using Ord for comparison.
@@ -36,7 +36,7 @@ Graph<a> ::= lst::[Pair<a a>] graph::Graph<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawGraph.add(%lst%, (java.util.TreeMap<Object,java.util.TreeSet<Object>>)%graph%)";
+  "java" : return "common.rawlib.RawGraph.add(%lst%, %graph%)";
 }
 
 @{--
@@ -47,7 +47,7 @@ set:Set<a> ::= vertex::a graph::Graph<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawGraph.edgesFrom(%vertex%, (java.util.TreeMap<Object,java.util.TreeSet<Object>>)%graph%)";
+  "java" : return "common.rawlib.RawGraph.edgesFrom(%vertex%, %graph%)";
 }
 
 @{--
@@ -58,7 +58,7 @@ Boolean ::= edge::Pair<a a> graph::Graph<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawGraph.contains(%edge%, (java.util.TreeMap<Object,java.util.TreeSet<Object>>)%graph%)";
+  "java" : return "common.rawlib.RawGraph.contains(%edge%, %graph%)";
 }
 
 @{--
@@ -69,7 +69,7 @@ function toList
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawGraph.toList((java.util.TreeMap<Object,java.util.TreeSet<Object>>)%graph%)";
+  "java" : return "common.rawlib.RawGraph.toList(%graph%)";
 }
 
 @{--
@@ -80,7 +80,7 @@ Graph<a> ::= graph::Graph<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawGraph.transitiveClosure((java.util.TreeMap<Object,java.util.TreeSet<Object>>)%graph%)";
+  "java" : return "common.rawlib.RawGraph.transitiveClosure(%graph%)";
 }
 
 @{--
@@ -92,6 +92,6 @@ Graph<a> ::= lst::[Pair<a a>] graph::Graph<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawGraph.repairClosure(%lst%, (java.util.TreeMap<Object,java.util.TreeSet<Object>>)%graph%)";
+  "java" : return "common.rawlib.RawGraph.repairClosure(%lst%, %graph%)";
 }
 

--- a/grammars/silver/util/treemap/TreeMap.sv
+++ b/grammars/silver/util/treemap/TreeMap.sv
@@ -5,7 +5,7 @@ grammar silver:util:treemap;
    - The names are too general otherwise.
    -}
 
-type Map<a b> foreign;
+type Map<a b> foreign = "java.util.TreeMap<Object,common.ConsCell>";
 
 @{--
  - Returns a new, empty, multimap using Ord for comparison.
@@ -37,7 +37,7 @@ Map<a b> ::= lst::[Pair<a b>] mp::Map<a b>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeMap.addList(%lst%, (java.util.TreeMap<Object,common.ConsCell>)%mp%)";
+  "java" : return "common.rawlib.RawTreeMap.addList(%lst%, %mp%)";
 }
 
 @{--
@@ -48,7 +48,7 @@ function keys
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeMap.keys((java.util.TreeMap<Object,common.ConsCell>)%mp%)";
+  "java" : return "common.rawlib.RawTreeMap.keys(%mp%)";
 }
 
 @{--
@@ -59,7 +59,7 @@ function lookup
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeMap.lookup(%key%, (java.util.TreeMap<Object,common.ConsCell>)%mp%)";
+  "java" : return "common.rawlib.RawTreeMap.lookup(%key%, %mp%)";
 }
 
 @{--
@@ -70,7 +70,7 @@ function toList
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeMap.toList((java.util.TreeMap<Object, common.ConsCell>)%mp%)";
+  "java" : return "common.rawlib.RawTreeMap.toList(%mp%)";
 }
 
 @{--
@@ -81,6 +81,6 @@ Map<a b> ::= key::a  value::[b]  mp::Map<a b>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeMap.update(%key%, %value%, (java.util.TreeMap<Object,common.ConsCell>)%mp%)";
+  "java" : return "common.rawlib.RawTreeMap.update(%key%, %value%, %mp%)";
 }
 

--- a/grammars/silver/util/treeset/TreeSet.sv
+++ b/grammars/silver/util/treeset/TreeSet.sv
@@ -5,7 +5,7 @@ grammar silver:util:treeset;
    - The names are too general otherwise.
    -}
 
-type Set<a> foreign;
+type Set<a> foreign = "java.util.TreeSet<Object>";
 
 @{--
  - Returns a new, empty, set using Ord for comparison.
@@ -37,7 +37,7 @@ Set<a> ::= lst::[a] set::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.addList(%lst%, (java.util.TreeSet<Object>)%set%)";
+  "java" : return "common.rawlib.RawTreeSet.addList(%lst%, %set%)";
 }
 
 @{--
@@ -57,7 +57,7 @@ function toList
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.toList((java.util.TreeSet<Object>)%set%)";
+  "java" : return "common.rawlib.RawTreeSet.toList(%set%)";
 }
 
 @{--
@@ -68,7 +68,7 @@ Set<a> ::= l::Set<a> r::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.union((java.util.TreeSet<Object>)%l%,(java.util.TreeSet<Object>)%r%)";
+  "java" : return "common.rawlib.RawTreeSet.union(%l%,%r%)";
 }
 
 @{--
@@ -79,7 +79,7 @@ Set<a> ::= l::Set<a> r::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.intersect((java.util.TreeSet<Object>)%l%,(java.util.TreeSet<Object>)%r%)";
+  "java" : return "common.rawlib.RawTreeSet.intersect(%l%,%r%)";
 }
 
 @{--
@@ -90,7 +90,7 @@ Set<a> ::= l::Set<a> r::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.difference((java.util.TreeSet<Object>)%l%,(java.util.TreeSet<Object>)%r%)";
+  "java" : return "common.rawlib.RawTreeSet.difference(%l%,%r%)";
 }
 
 @{--
@@ -101,7 +101,7 @@ Boolean ::= e::a set::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.contains(%e%,(java.util.TreeSet<Object>)%set%)";
+  "java" : return "common.rawlib.RawTreeSet.contains(%e%,%set%)";
 }
 
 @{--
@@ -112,7 +112,7 @@ Boolean ::= e::[a] set::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.containsAll(%e%,(java.util.TreeSet<Object>)%set%)";
+  "java" : return "common.rawlib.RawTreeSet.containsAll(%e%,%set%)";
 }
 
 @{--
@@ -123,7 +123,7 @@ Boolean ::= l::Set<a> r::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.subset((java.util.TreeSet<Object>)%l%,(java.util.TreeSet<Object>)%r%)";
+  "java" : return "common.rawlib.RawTreeSet.subset(%l%,%r%)";
 }
 
 @{--
@@ -134,7 +134,7 @@ Boolean ::= s::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.isEmpty((java.util.TreeSet<Object>)%s%)";
+  "java" : return "common.rawlib.RawTreeSet.isEmpty(%s%)";
 }
 
 @{--
@@ -145,7 +145,7 @@ Integer ::= s::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.size((java.util.TreeSet<Object>)%s%)";
+  "java" : return "common.rawlib.RawTreeSet.size(%s%)";
 }
 
 @{--
@@ -156,7 +156,7 @@ Set<a> ::= f::(Boolean ::= a)  s::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.filter(%f%, (java.util.TreeSet<Object>)%s%)";
+  "java" : return "common.rawlib.RawTreeSet.filter(%f%, %s%)";
 }
 
 @{--
@@ -167,7 +167,7 @@ Set<a> ::= lst::[a] set::Set<a>
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.rawlib.RawTreeSet.removeAll(%lst%, (java.util.TreeSet<Object>)%set%)";
+  "java" : return "common.rawlib.RawTreeSet.removeAll(%lst%, %set%)";
 }
 
 instance Eq Set<a> {

--- a/runtime/java/build.xml
+++ b/runtime/java/build.xml
@@ -27,6 +27,7 @@
 
   <target name='build' depends='init'>
     <javac debug='on' classpathref='compile.classpath' srcdir='${src}:${grammars}' destdir='${bin}' includeantruntime='false' source='1.8' target='1.8' release='8'>
+      <compilerarg value="-Xlint:unchecked" />
       <include name='common/**/*.java' />
       <include name='silver/core/*.java' />
       <include name='silver/xml/ast/*.java' />

--- a/runtime/java/src/common/ConsCell.java
+++ b/runtime/java/src/common/ConsCell.java
@@ -57,11 +57,13 @@ public class ConsCell implements Typed {
 	 * @return An equivalent Java List.
 	 */
 	public static <T> List<T> toList(ConsCell cons) {
-                List<T> lst = new LinkedList();
+        List<T> lst = new LinkedList<T>();
 		while(! cons.nil()) {
-                        T val = (T) cons.head();
-                        cons = cons.tail();
-                        lst.add(val);
+            @SuppressWarnings("unchecked")
+			T val = (T) cons.head();
+
+            cons = cons.tail();
+            lst.add(val);
 		}
 		return lst;
 	}

--- a/runtime/java/src/common/CopperUtil.java
+++ b/runtime/java/src/common/CopperUtil.java
@@ -20,7 +20,6 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import silver.core.Init;
 import silver.core.NIOVal;
 import silver.core.NLocation;
@@ -298,13 +297,13 @@ public final class CopperUtil {
       prod.setOperator(operator);
       prod.setCode(code);
       prod.setLhs(lhs);
-      ArrayList<CopperElementReference> rhs = new ArrayList(rhsConsList);
+      ArrayList<CopperElementReference> rhs = new ArrayList<>(rhsConsList);
       prod.setRhs(rhs);
       ArrayList<String> rhsVarNames = new ArrayList<String>();
       for (int i = 0; i < rhs.size(); i++)
         rhsVarNames.add(String.format("rhsVar_%d", i));
       prod.setRhsVarNames(rhsVarNames);
-      prod.setLayout(new HashSet(prodLayout));
+      prod.setLayout(new HashSet<>(prodLayout));
       return prod;
     } catch (ParseException exc) {
       throw new SilverInternalError(

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -205,8 +205,9 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @param child The number of the child to obtain.
 	 * @return The unmodified value of the child.
 	 */
-	public Object childAsIs(final int child) {
-		return self.getChild(child);
+	@SuppressWarnings("unchecked")
+	public <T> T childAsIs(final int child) {
+		return (T) self.getChild(child);
 	}
 	
 	/**
@@ -249,7 +250,8 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @param attribute The full name of the local to obtain.
 	 * @return The value of the local.
 	 */
-	public Object localAsIs(final int attribute) {
+	@SuppressWarnings("unchecked")
+	public <T> T localAsIs(final int attribute) {
 		Object o = this.localValues[attribute];
 		if(o == null) {
 			o = evalLocalAsIs(attribute);
@@ -260,7 +262,7 @@ public class DecoratedNode implements Decorable, Typed {
 			// not recommended due to IO objects (IOString, etc)
 			this.localValues[attribute] = o;
 		}
-		return o;
+		return (T) o;
 	}
 	
 	/**
@@ -322,7 +324,8 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @param attribute The full name of the attribute.
 	 * @return The value of the attribute.
 	 */
-	public Object synthesized(final int attribute) {
+	@SuppressWarnings("unchecked")
+	public <T> T synthesized(final int attribute) {
 		// common.Util.stackProbe();
 		// System.err.println("TRACE: " + getDebugID() + " demanding syn attribute: " + self.getNameOfSynAttr(attribute));
 		
@@ -335,7 +338,7 @@ public class DecoratedNode implements Decorable, Typed {
 			// CACHE : comment out to disable caching for synthesized attributes
 			this.synthesizedValues[attribute] = o;
 		}
-		return o;
+		return (T) o;
 	}
 	
 	private final Object evalSyn(final int attribute) {
@@ -427,7 +430,8 @@ public class DecoratedNode implements Decorable, Typed {
 	 * 
 	 * @see #inheritedForwarded(String)
 	 */
-	public Object inherited(final int attribute) {
+	@SuppressWarnings("unchecked")
+	public <T> T inherited(final int attribute) {
 		// common.Util.stackProbe();
 		// System.err.println("TRACE: " + getDebugID() + " demanding inh attribute: " + self.getNameOfInhAttr(attribute));
 		
@@ -443,7 +447,7 @@ public class DecoratedNode implements Decorable, Typed {
 			// we're recomputing
 			this.inheritedValues[attribute] = o;
 		}
-		return o;
+		return (T) o;
 	}
 	
 	private final Object evalInhSomehow(final int attribute) {

--- a/runtime/java/src/common/OriginContext.java
+++ b/runtime/java/src/common/OriginContext.java
@@ -1,7 +1,9 @@
 package common;
 
 import silver.core.*;
+
 import java.util.*;
+
 import common.exceptions.*;
 
 
@@ -87,6 +89,7 @@ public final class OriginContext {
 		throw new RuntimeException("Impossible state: this.variety not recognized.");
 	}
 
+	@SuppressWarnings("unchecked")
 	public <T extends Tracked> T attrAccessCopy(final T arg) {
 		switch (this.variety) {
 			case NORMAL: //We only copy if this is a 'normal' origin (i.e. it originates from a node)
@@ -98,12 +101,14 @@ public final class OriginContext {
 	}
 
 	// Used by code that does some manipulation on a type-erased generic object that might be a nonterminal.
-	public Object attrAccessCopyPoly(final Object arg) {
-		if (arg instanceof Tracked) return attrAccessCopy((Tracked)arg);
+	@SuppressWarnings("unchecked")
+	public <T> T attrAccessCopyPoly(final T arg) {
+		if (arg instanceof Tracked) return (T) attrAccessCopy((Tracked)arg);
 		return arg;
 	}
 
 	// Same as above but preserves laziness
+	@SuppressWarnings("unchecked")
 	public Object attrAccessCopyPolyThunk(final Object t) {
 		if (t instanceof Thunk)
 			return new Thunk<Object>(() -> attrAccessCopyPoly(((Thunk<Object>)t).eval()));

--- a/runtime/java/src/common/Thunk.java
+++ b/runtime/java/src/common/Thunk.java
@@ -22,6 +22,7 @@ public class Thunk<T> {
 		o = e;
 	}
 	
+	@SuppressWarnings("unchecked")
 	public T eval() {
 		if(o instanceof Evaluable) {
 			o = ((Evaluable<T>)o).eval();
@@ -40,6 +41,7 @@ public class Thunk<T> {
 	 * @param t  Either a DecoratedNode or a Thunk<DecoratedNode>
 	 * @return  Either a Node or a Thunk<Node>
 	 */
+	@SuppressWarnings("unchecked")
 	public static Object transformUndecorate(final Object t) {
 		// DecoratedNode
 		if(t instanceof DecoratedNode)

--- a/runtime/java/src/common/TopNode.java
+++ b/runtime/java/src/common/TopNode.java
@@ -27,7 +27,7 @@ public class TopNode extends DecoratedNode{ // TODO: this should become a Node!
 	}
 
 	@Override
-	public Object inherited(final int attribute) {		
+	public <T> T inherited(final int attribute) {
 		throw new SilverInternalError("No inherited attributes given to TopNode.");
 	}
 
@@ -37,12 +37,12 @@ public class TopNode extends DecoratedNode{ // TODO: this should become a Node!
 	}
 
 	@Override
-	public Lazy synthesized(final int attribute) {		
+	public <T> T synthesized(final int attribute) {
 		throw new SilverInternalError("No synthesized attributes defined on TopNode.");
 	}
 	
 	@Override
-	public Object childAsIs(final int s) {
+	public <T> T childAsIs(final int s) {
 		throw new SilverInternalError("No Children defined on TopNode.");
 	}
 
@@ -52,7 +52,7 @@ public class TopNode extends DecoratedNode{ // TODO: this should become a Node!
 	}
 
 	@Override
-	public Object localAsIs(final int attribute) {
+	public <T> T localAsIs(final int attribute) {
 		throw new SilverInternalError("No local attributes defined on TopNode.");
 	}
 

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -50,19 +50,48 @@ public final class Util {
 		// stackProbe(1_000);
 	}
 
+
 	/**
-	 * Ensures that a (potential) closure is evaluated.
+	 * There are some places in the translation where we need to perform unchecked casts,
+	 * known to be safe via Silver's static type system.
+	 * Java doesn't have a nice way of suppressing warnings on individual subexpressions,
+	 * so this function exists as a proxy.
+	 *
+	 * @param o An object
+	 * @return o
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T uncheckedCast(final Object o) {
+		return (T) o;
+	}
+
+	/**
+	 * Ensures that a (potential) thunk is evaluated.
 	 *
 	 * Use by writing  (v = Util.demand(v)), never just invoke it!
 	 *
-	 * @param c  Either a value, or a Closure
-	 * @return The value, either directly, or evaluating the Closure
+	 * @param c  Either a value, or a Thunk
+	 * @return The value, either directly, or evaluating the Thunk
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> T demand(Object c) {
+	public static <T> T demand(final Object c) {
 		if(c instanceof Thunk)
 			return ((Thunk<T>)c).eval();
 		return (T)c;
+	}
+
+	/**
+	 * Demand a (potential) thunk in an array of thunks, caching the resulting value.
+	 * This is factored out for the translation of demanding lambda arguments, to avoid unchecked casts.
+	 *
+	 * @param cs  An array that are either values or Thunks
+	 * @param i An index in the array
+	 * @return The value, either directly, or evaluating the Thunk at the index
+	 */
+	public static <T> T demandIndex(final Object[] cs, final int i) {
+		T result = demand(cs[i]);
+		cs[i] = result;
+		return result;
 	}
 
 	/**

--- a/runtime/java/src/common/javainterop/ConsCellCollection.java
+++ b/runtime/java/src/common/javainterop/ConsCellCollection.java
@@ -71,6 +71,7 @@ public class ConsCellCollection<T> extends AbstractCollection<T> {
 
 		@Override
 		public T next() {
+			@SuppressWarnings("unchecked")
 			T fst = (T) elem.head();
 			elem = elem.tail();
 			return fst;

--- a/runtime/java/src/common/rawlib/RawGraph.java
+++ b/runtime/java/src/common/rawlib/RawGraph.java
@@ -19,6 +19,7 @@ public final class RawGraph {
 	}
 	
 	// add :: (Graph<a> ::= [Pair<a a>]  Graph<a>)
+	@SuppressWarnings("unchecked")
 	public static TreeMap<Object,TreeSet<Object>> add(ConsCell l, TreeMap<Object,TreeSet<Object>> g) {
 		if(l.nil())
 			return g;
@@ -77,6 +78,7 @@ public final class RawGraph {
 	}
 	
 	// transitiveClosure :: (Graph<a> ::= Graph<a>)
+	@SuppressWarnings("unchecked")
 	public static TreeMap<Object,TreeSet<Object>> transitiveClosure(TreeMap<Object,TreeSet<Object>> g) {
 
 		final TreeMap<Object,TreeSet<Object>> ret = (TreeMap<Object,TreeSet<Object>>)g.clone();
@@ -112,6 +114,7 @@ public final class RawGraph {
 	}
 	
 	// repairClosure :: (Graph<a> ::= [Pair<a a>]  Graph<a>)
+	@SuppressWarnings("unchecked")
 	public static TreeMap<Object,TreeSet<Object>> repairClosure(
 			ConsCell l, 
 			TreeMap<Object,TreeSet<Object>> g) {

--- a/runtime/java/src/common/rawlib/RawTreeMap.java
+++ b/runtime/java/src/common/rawlib/RawTreeMap.java
@@ -14,6 +14,7 @@ public final class RawTreeMap {
 	public static TreeMap<Object, ConsCell> addList(ConsCell l, TreeMap<Object, ConsCell> t) {
 		if(l.nil())
 			return t;
+		@SuppressWarnings("unchecked")
 		TreeMap<Object,ConsCell> ret = (TreeMap<Object,ConsCell>)t.clone();
 		for(silver.core.NPair elem : new ConsCellCollection<silver.core.NPair>(l)) {
 			assert(elem instanceof silver.core.Ppair); // document as an assert why not
@@ -43,6 +44,7 @@ public final class RawTreeMap {
 		return r == null ? ConsCell.nil : (ConsCell) r;
 	}
 	public static TreeMap<Object,ConsCell> update(Object k, ConsCell v, TreeMap<Object, ConsCell> t) {
+		@SuppressWarnings("unchecked")
 		TreeMap<Object, ConsCell> ret = (TreeMap<Object, ConsCell>) t.clone();
 		ret.put(k, v);
 		return ret;

--- a/runtime/java/src/common/rawlib/RawTreeSet.java
+++ b/runtime/java/src/common/rawlib/RawTreeSet.java
@@ -12,6 +12,7 @@ public final class RawTreeSet {
 		return new TreeSet<Object>(new SilverComparator<Object>(cmp));
 	}
 	public static TreeSet<Object> addList(ConsCell l, TreeSet<Object> t) {
+		@SuppressWarnings("unchecked")
 		TreeSet<Object> ret = (TreeSet<Object>) t.clone();
 		ret.addAll(new ConsCellCollection<Object>(l));
 		return ret;
@@ -20,16 +21,19 @@ public final class RawTreeSet {
 		return ConsCellCollection.fromReverseIterator(t.descendingIterator());
 	}
 	public static TreeSet<Object> union(TreeSet<Object> l, TreeSet<Object> r) {
+		@SuppressWarnings("unchecked")
 		TreeSet<Object> ret = (TreeSet<Object>) l.clone();
 		ret.addAll(r);
 		return ret;
 	}
 	public static TreeSet<Object> intersect(TreeSet<Object> l, TreeSet<Object> r) {
+		@SuppressWarnings("unchecked")
 		TreeSet<Object> ret = (TreeSet<Object>) l.clone();
 		ret.retainAll(r);
 		return ret;
 	}
 	public static TreeSet<Object> difference(TreeSet<Object> l, TreeSet<Object> r) {
+		@SuppressWarnings("unchecked")
 		TreeSet<Object> ret = (TreeSet<Object>) l.clone();
 		ret.removeAll(r);
 		return ret;
@@ -53,6 +57,7 @@ public final class RawTreeSet {
 		return s.size();
 	}
 	public static TreeSet<Object> filter(NodeFactory<Boolean> cmp, TreeSet<Object> s) {
+		@SuppressWarnings("unchecked")
 		TreeSet<Object> ret = (TreeSet<Object>)s.clone();
 		
 		Iterator<Object> x = ret.iterator();
@@ -65,6 +70,7 @@ public final class RawTreeSet {
 		return ret;
 	}
 	public static TreeSet<Object> removeAll(ConsCell rm, TreeSet<Object> s) {
+		@SuppressWarnings("unchecked")
 		TreeSet<Object> ret = (TreeSet<Object>)s.clone();
 		ret.removeAll(new ConsCellCollection<Object>(rm));
 		return ret;


### PR DESCRIPTION
# Changes
This fixes all the "unchecked cast" warnings in the generated code and runtime, and suppresses the ones that are unavoidable but safe due to Silver's type system.

# Documentation
I have added comments to the code where needed.
No external docs, since this is an internal cleanup.
