### PR TITLE
Fix spelling of ConvertablePrim -> ConvertiblePrim

### DIFF
--- a/grammars/silver/core/ConvertablePrim.sv
+++ b/grammars/silver/core/ConvertablePrim.sv
@@ -5,7 +5,7 @@ grammar silver:core;
 
   This class provides the overloaded toString, toInteger, toFloat and toBoolean functions.
 -}
-class ConvertablePrim a {
+class ConvertiblePrim a {
   @{- Convert a value into a String -}
   toString :: (String ::= a);
 
@@ -19,7 +19,7 @@ class ConvertablePrim a {
   toBoolean :: (Boolean ::= a);
 }
 
-instance ConvertablePrim String {
+instance ConvertiblePrim String {
   toString = id;
   toInteger = stringToInteger;
   toFloat = stringToFloat;
@@ -50,7 +50,7 @@ Boolean ::= x::String
   "java" : return "Boolean.valueOf(%x%.toString())";
 }
 
-instance ConvertablePrim Integer {
+instance ConvertiblePrim Integer {
   toString = integerToString;
   toInteger = id;
   toFloat = integerToFloat;
@@ -73,7 +73,7 @@ Float ::= x::Integer
   "java" : return "Float.valueOf(((Integer)%x%).floatValue())";
 }
 
-instance ConvertablePrim Float {
+instance ConvertiblePrim Float {
   toString = floatToString;
   toInteger = floatToInteger;
   toFloat = id;
@@ -96,7 +96,7 @@ Integer ::= x::Float
   "java" : return "Integer.valueOf(((Float)%x%).intValue())";
 }
 
-instance ConvertablePrim Boolean {
+instance ConvertiblePrim Boolean {
   toString = \ x::Boolean -> if x then "true" else "false";
   toInteger = \ x::Boolean -> if x then 1 else 0;
   toFloat = \ x::Boolean -> if x then 1.0 else 0.0;

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -167,7 +167,7 @@ equalityTest(toString(false), "false", String, silver_tests);
 
 type MyType3 = Pair<Integer String>;
 
-wrongCode "Could not find an instance for silver:core:ConvertablePrim silver:core:Pair<Integer String> (arising from the use of toString)" {
+wrongCode "Could not find an instance for silver:core:ConvertiblePrim silver:core:Pair<Integer String> (arising from the use of toString)" {
   global m3t :: MyType3 = pair(0, "");
   equalityTest(toString(m3t), "<this fails>", String, silver_tests);
 }


### PR DESCRIPTION
# Changes
Fixes a misspelled type class name

# Documentation
This fix should be reflected in the generated documentation
