### PR TITLE
Adds println, eprint, eprintln, and switches to use them in silver:compiler.

### DIFF
--- a/grammars/silver/compiler/analysis/warnings/exporting/Graph.sv
+++ b/grammars/silver/compiler/analysis/warnings/exporting/Graph.sv
@@ -37,7 +37,7 @@ abstract production dumpDepGraphAction
 top::DriverAction ::= specs::[Decorated RootSpec]
 {
   top.io = writeFileT("deps.dot", "digraph deps {\n" ++ generateDotGraph(specs) ++ "}",
-    printT("Generating import graph\n", top.ioIn));
+    eprintlnT("Generating import graph", top.ioIn));
 
   top.code = 0;
   top.order = 0;

--- a/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
@@ -60,7 +60,7 @@ top::DriverAction ::= prodGraph::[ProductionGraph]  finalGraph::[ProductionGraph
     writeFileT("flow-types.dot", "digraph flow {\n" ++ generateFlowDotGraph(flowTypes) ++ "}",
       writeFileT("flow-deps-direct.dot", "digraph flow {\n" ++ generateDotGraph(prodGraph) ++ "}",
         writeFileT("flow-deps-transitive.dot", "digraph flow {\n" ++ generateDotGraph(finalGraph) ++ "}",
-          printT("Generating flow graphs\n", top.ioIn))));
+          eprintlnT("Generating flow graphs", top.ioIn))));
 
   top.code = 0;
   top.order = 0;

--- a/grammars/silver/compiler/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/driver/BuildProcess.sv
@@ -38,7 +38,7 @@ function performActions
 IOVal<Integer> ::= unitin::IOErrorable<Decorated Compilation>
 {
   return case unitin.iovalue of
-  | left(re) -> ioval(printT(re.message ++ "\n", unitin.io), re.code)
+  | left(re) -> ioval(eprintlnT(re.message, unitin.io), re.code)
   | right(comp) -> runAll(sortUnits(comp.postOps), unitin.io)
   end;
 }

--- a/grammars/silver/compiler/driver/CompileGrammar.sv
+++ b/grammars/silver/compiler/driver/CompileGrammar.sv
@@ -30,7 +30,7 @@ IOVal<Maybe<RootSpec>> ::=
 
   -- IO Step 4: Build the grammar, and say so
   local pr :: IOToken =
-    printT("Compiling " ++ grammarName ++ "\n\t[" ++ grammarLocation.iovalue.fromJust ++ "]\n\t[" ++ renderFileNames(files.iovalue, 0) ++ "]\n", ifaceCompile.io);
+    eprintlnT("Compiling " ++ grammarName ++ "\n\t[" ++ grammarLocation.iovalue.fromJust ++ "]\n\t[" ++ renderFileNames(files.iovalue, 0) ++ "]", ifaceCompile.io);
   
   local gramCompile :: IOVal<Pair<[Root] [ParseError]>> =
     compileFiles(svParser, grammarLocation.iovalue.fromJust, files.iovalue, pr);

--- a/grammars/silver/compiler/driver/CompileInterface.sv
+++ b/grammars/silver/compiler/driver/CompileInterface.sv
@@ -24,7 +24,7 @@ IOVal<Maybe<RootSpec>> ::= grammarName::String  silverHostGen::[String]  grammar
   local modTime :: IOVal<Integer> = fileTimeT(file, gen.io);
   
   -- IO Step 3: Let's say so, and parse it
-  local pr :: IOToken = printT("Found " ++ grammarName ++ "\n\t[" ++ file ++ "]\n", modTime.io);
+  local pr :: IOToken = eprintlnT("Found " ++ grammarName ++ "\n\t[" ++ file ++ "]", modTime.io);
   local text :: IOVal<ByteArray> = readBinaryFileT(file, pr);
 
   local ir :: Either<String InterfaceItems> = nativeDeserialize(text.iovalue);
@@ -35,12 +35,12 @@ IOVal<Maybe<RootSpec>> ::= grammarName::String  silverHostGen::[String]  grammar
     | right(i) ->
       if !null(i.interfaceErrors)
       then
-        printT("\n\tErrors unpacking interface file:\n  " ++ implode("\n  ", i.interfaceErrors) ++
-              "\n\tRecovering by parsing grammar....\n", text.io)
+        eprintlnT("\n\tErrors unpacking interface file:\n  " ++ implode("\n  ", i.interfaceErrors) ++
+                  "\n\tRecovering by parsing grammar....", text.io)
       else text.io
     | left(msg) ->
-        printT("\n\tFailed to deserialize interface file!\n" ++ msg ++
-              "\n\tRecovering by parsing grammar....\n", text.io)
+        eprintlnT("\n\tFailed to deserialize interface file!\n" ++ msg ++
+                  "\n\tRecovering by parsing grammar....", text.io)
     end;
 
   local rs :: RootSpec = interfaceRootSpec(ir.fromRight, modTime.iovalue, gen.iovalue.fromJust);

--- a/grammars/silver/compiler/driver/GrammarAction.sv
+++ b/grammars/silver/compiler/driver/GrammarAction.sv
@@ -55,7 +55,7 @@ top::DriverAction ::= specs::[Decorated RootSpec]
 
   forwards to printAllBindingErrorsHelp(specs)
   with {
-    ioIn = printT("Checking For Errors.\n", top.ioIn);
+    ioIn = eprintlnT("Checking For Errors.", top.ioIn);
   };
 }
 
@@ -67,7 +67,7 @@ top::DriverAction ::= specs::[Decorated RootSpec]
   local i :: IOToken =
     if null(errs)
     then top.ioIn
-    else printT("Errors for " ++ head(specs).declaredName ++ "\n" ++ flatMap(renderMessages(head(specs).grammarSource, _), errs) ++ "\n", top.ioIn);
+    else eprintlnT("Errors for " ++ head(specs).declaredName ++ "\n" ++ flatMap(renderMessages(head(specs).grammarSource, _), errs), top.ioIn);
 
   local recurse :: DriverAction = printAllBindingErrorsHelp(tail(specs));
   recurse.ioIn = i;
@@ -90,7 +90,7 @@ top::DriverAction ::= specs::[Decorated RootSpec]
   local i :: IOToken =
     if null(errs)
     then top.ioIn
-    else printT("Errors for " ++ head(specs).declaredName ++ "\n" ++ flatMap(renderMessages(head(specs).grammarSource, _), errs) ++ "\n", top.ioIn);
+    else eprintlnT("Errors for " ++ head(specs).declaredName ++ "\n" ++ flatMap(renderMessages(head(specs).grammarSource, _), errs), top.ioIn);
 
   local recurse :: DriverAction = printAllParsingErrors(tail(specs));
   recurse.ioIn = i;

--- a/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
@@ -100,7 +100,7 @@ top::DriverAction ::= a::Decorated CmdArgs  specs::[Decorated RootSpec]
       | _ -> []
       end), specs));
 
-  top.io = printT(report ++ "\n", top.ioIn);
+  top.io = printlnT(report, top.ioIn);
   top.code = 0;
   top.order = 5;
 }
@@ -109,7 +109,7 @@ top::DriverAction ::= a::Decorated CmdArgs  specs::[Decorated RootSpec]
 abstract production genDoc
 top::DriverAction ::= a::Decorated CmdArgs  specs::[Decorated RootSpec]  outputLoc::String
 {
-  local pr :: IOToken = printT("Generating Documentation.\n", top.ioIn);
+  local pr :: IOToken = eprintlnT("Generating Documentation.", top.ioIn);
 
   top.io = writeAll(pr, a, specs, outputLoc);
   top.code = 0;
@@ -140,8 +140,8 @@ IOToken ::= i::IOToken  r::Decorated RootSpec  outputLoc::String
   
   local pr :: IOToken =
     if mkio.iovalue
-    then printT("\t[" ++ r.declaredName ++ "]\n", mkio.io)
-    else exitT(-5, printT("\nUnrecoverable Error: Unable to create directory: " ++ path ++ "\n\n", mkio.io));
+    then eprintlnT("\t[" ++ r.declaredName ++ "]", mkio.io)
+    else exitT(-5, eprintlnT("\nUnrecoverable Error: Unable to create directory: " ++ path ++ "\n", mkio.io));
   
   local rm :: IOToken = deleteStaleDocs(pr, outputLoc, r.declaredName);
 

--- a/grammars/silver/compiler/modification/impide/BuildProcess2.sv
+++ b/grammars/silver/compiler/modification/impide/BuildProcess2.sv
@@ -16,7 +16,7 @@ top::DriverAction ::= grams::EnvTree<Decorated RootSpec> ide::IdeSpec ideGenPath
 {
   ide.compiledGrammars = grams;
   
-  local io0::IOToken = printT("[IDE plugin] Generating IDE plugin.\n", top.ioIn);
+  local io0::IOToken = eprintlnT("[IDE plugin] Generating IDE plugin.", top.ioIn);
   local io1::IOToken = deleteTreeT(ideGenPath, io0);
   local io2::IOToken =
     mkdirs(s"${ideGenPath}/plugin/src/${pkgToPath(pkgName)}/",

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -195,7 +195,7 @@ implode("\n\n", extraTopLevelDecls) ++ "\n\n" ++
 abstract production genJava
 top::DriverAction ::= a::Decorated CmdArgs  specs::[Decorated RootSpec]  silverGen::String
 {
-  local pr :: IOToken = printT("Generating Translation.\n", top.ioIn);
+  local pr :: IOToken = eprintlnT("Generating Translation.", top.ioIn);
 
   top.io = writeAll(pr, a, specs, silverGen);
   top.code = 0;
@@ -234,8 +234,8 @@ IOToken ::= i::IOToken  r::Decorated RootSpec  silverGen::String
   
   local printio :: IOToken =
     if mksrc.iovalue
-    then printT("\t[" ++ r.declaredName ++ "]\n", clean)
-    else exitT(-5, printT("\nUnrecoverable Error: Unable to create directory: " ++ srcPath ++ "\nWarning: if some interface file writes were successful, but others not, Silver's temporaries are in an inconsistent state. Use the --clean flag next run.\n\n", mksrc.io));
+    then eprintlnT("\t[" ++ r.declaredName ++ "]", clean)
+    else exitT(-5, eprintlnT("\nUnrecoverable Error: Unable to create directory: " ++ srcPath ++ "\nWarning: if some interface file writes were successful, but others not, Silver's temporaries are in an inconsistent state. Use the --clean flag next run.\n", mksrc.io));
 
   return writeBinaryFiles(srcPath, r.genBinaryFiles, writeFiles(srcPath, r.genFiles, printio));
 }

--- a/grammars/silver/core/IOMisc.sv
+++ b/grammars/silver/core/IOMisc.sv
@@ -76,7 +76,7 @@ a ::= val::a str::String
 function unsafeTraceDump
 a ::= val::a
 {
-  return unsafeTrace(val, printT(hackUnparse(val), unsafeIO()));
+  return unsafeTrace(val, printlnT(hackUnparse(val), unsafeIO()));
 }
 
 

--- a/grammars/silver/core/IOToken.sv
+++ b/grammars/silver/core/IOToken.sv
@@ -61,6 +61,35 @@ IOToken ::= s::String i::IOToken
 }
 
 @{--
+  - Like printT, but adds a trailing newline automatically.
+  -}
+function printlnT
+IOToken ::= str::String  ioIn::IOToken
+{
+  return printT(str ++ "\n", ioIn);
+}
+
+@{--
+  - Like printT, but for stderr.
+  -}
+function eprintT
+IOToken ::= str::String  ioIn::IOToken
+{
+  return error("Unimplemented foreign function: eprintT");
+} foreign {
+  "java" : return "%ioIn%.eprint(%str%)";
+}
+
+@{--
+  - Like eprintT, but adds a trailing newline automatically.
+  -}
+function eprintlnT
+IOToken ::= str::String  ioIn::IOToken
+{
+  return eprintT(str ++ "\n", ioIn);
+}
+
+@{--
  - Read a line from standard input.
  -
  - @param i  The "before" world-state token.

--- a/runtime/java/src/common/IOToken.java
+++ b/runtime/java/src/common/IOToken.java
@@ -1,13 +1,12 @@
 package common;
 
+import common.exceptions.SilverExit;
 import java.io.*;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import common.exceptions.SilverExit;
 import silver.core.NIOVal;
 import silver.core.Pioval;
 import silver.core.Pjust;
@@ -15,107 +14,117 @@ import silver.core.Pnothing;
 
 /**
  * This class represents the `<code>IO</code>` type in Silver.
- * 
+ *
  * <p>By convention we translate a Silver IO call of the form
  * `<code>IO ::= args IO</code>` to a method with the signature
  * `<code>IOToken f(args)</code>`. We return `this` or `this.wrap`
  * and the final `IO` argument is used to invoke the method.
- * 
+ *
  * <p>`<code>iotoken.print(str)</code>` means the `IOToken` must be demanded
  * before the method can be invoked, which is the desired invariant.
- * 
+ *
  * <p>Silver types are used in argument wherever possible, except for
  * primitives like `int`.
- * 
+ *
  * @author tedinski
  */
 public final class IOToken implements Typed {
-	public static final IOToken singleton = new IOToken();
-	
-	private IOToken() {}
-	
-	/**
-	 * Function that return IOToken can return `this`.
-	 * Those that return `IOVal<>` can return `this.wrap(...)`.
-	 */
-	public NIOVal wrap(Object arg) {
-		return new Pioval(this, arg);
-	}
-	
-	/**
-	 * Used for `unsafeTrace`
-	 */
-	public Object identity(Object arg) {
-		return arg;
-	}
+  public static final IOToken singleton = new IOToken();
 
-	/**
-	 * <pre>IO ::= val::Integer i::IO</pre>
-	 */
-	public IOToken exit(int status) {
-		throw new SilverExit(status);
-	}
+  private IOToken() {}
 
-	/**
-	 * <pre>IO ::= s::String i::IO</pre> 
-	 */
-	public IOToken print(StringCatter str) {
-		// TODO: Should we avoid demanding StringCatter objects?
-		System.out.print(str.toString());
-		return this;
-	}
+  /**
+   * Function that return IOToken can return `this`.
+   * Those that return `IOVal<>` can return `this.wrap(...)`.
+   */
+  public NIOVal wrap(Object arg) { return new Pioval(this, arg); }
 
-	// Used by readLineStdin
-	private static BufferedReader our_stdin = null;
-	/**
-	 * <pre>IOVal<String> ::= i::IO</pre>
-	 */
-	public NIOVal readLineStdin() {
-		try {
-			if(our_stdin == null) {
-				// Persist this, since it might buffer bytes for the NEXT line
-				our_stdin = new BufferedReader(new InputStreamReader(System.in));
-			}
-			String line = our_stdin.readLine();
-			if(line == null)
-				return this.wrap(new Pnothing());
-			else
-				return this.wrap(new Pjust(new StringCatter(line)));
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+  /**
+   * Used for `unsafeTrace`
+   */
+  public Object identity(Object arg) { return arg; }
 
-	/**
-	 * <pre>IOVal<Boolean> ::= s::String i::IO</pre>
-	 */
-	public NIOVal mkdir(StringCatter filepath) {
-		return this.wrap(new File(filepath.toString()).mkdirs());
-	}
-	
-	/**
-	 * Invokes an external command, channeling all stdin/out/err to the console normally.
-	 *
-	 * N.B. uses 'bash' to invoke the command. There are two major reasons:
-	 * (1) allows redirects in shell command, which is useful
-	 * (2) because this command takes just a single string, we must somehow deal with spaces.
-	 * e.g. 'touch "abc 123"' bash take care of interpreting the quotes for us.
-	 *
-	 * Unfortunate platform dependency though.
-	 * 
-	 * <pre>IOVal<Integer> ::= s::String i::IO</pre>
-	 *
-	 * @param shell_command A string for back to interpret and execute.
-	 * @return The exit status of the process.
-	 */
-	public NIOVal system(StringCatter shell_command) {
-		try {
-			ProcessBuilder pb = new ProcessBuilder("bash", "-c", shell_command.toString());
-			pb.inheritIO();
-			Process p = pb.start();
-			return this.wrap(p.waitFor());
-		} catch (Exception e) {
-			throw new RuntimeException(e);
+  /**
+   * <pre>IO ::= val::Integer i::IO</pre>
+   */
+  public IOToken exit(int status) { throw new SilverExit(status); }
+
+  /**
+   * <pre>IO ::= s::String i::IO</pre>
+   */
+  public IOToken print(StringCatter str) {
+    // TODO: Should we avoid demanding StringCatter objects?
+    System.out.print(str.toString());
+    return this;
+  }
+
+  /**
+   * <pre>IO ::= s::String i::IO</pre>
+   */
+  public IOToken eprint(StringCatter str) {
+    // TODO: Should we avoid demanding StringCatter objects?
+    System.err.print(str.toString());
+    return this;
+  }
+
+  // Used by readLineStdin
+  private static BufferedReader our_stdin = null;
+  /**
+   * <pre>IOVal<String> ::= i::IO</pre>
+   */
+  public NIOVal readLineStdin() {
+    try {
+      if (our_stdin == null) {
+        // Persist this, since it might buffer bytes for the NEXT line
+        our_stdin = new BufferedReader(new InputStreamReader(System.in));
+      }
+      String line = our_stdin.readLine();
+      if (line == null)
+        return this.wrap(new Pnothing());
+      else
+        return this.wrap(new Pjust(new StringCatter(line)));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * <pre>IOVal<Boolean> ::= s::String i::IO</pre>
+   */
+  public NIOVal mkdir(StringCatter filepath) {
+    return this.wrap(new File(filepath.toString()).mkdirs());
+  }
+
+  /**
+   * Invokes an external command, channeling all stdin/out/err to the console
+   * normally.
+   *
+   * N.B. uses 'bash' to invoke the command. There are two major reasons:
+   * (1) allows redirects in shell command, which is useful
+   * (2) because this command takes just a single string, we must somehow deal
+   * with spaces. e.g. 'touch "abc 123"' bash take care of interpreting the
+   * quotes for us.
+   *
+   * Unfortunate platform dependency though.
+   *
+   * <pre>IOVal<Integer> ::= s::String i::IO</pre>
+   *
+   * @param shell_command A string for back to interpret and execute.
+   * @return The exit status of the process.
+   */
+  public NIOVal system(StringCatter shell_command) {
+    try {
+      ProcessBuilder pb =
+          new ProcessBuilder("bash", "-c", shell_command.toString());
+      pb.inheritIO();
+      Process p = pb.start();
+      return this.wrap(p.waitFor());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
 		}
 	}
 

--- a/test/csterrors/silver-compile
+++ b/test/csterrors/silver-compile
@@ -13,7 +13,7 @@ pass=0
 
 # Check to ensure all these builds yield the shown string (as an error)
 function cst_test {
-    silver $ARGS $1 | grep "$2" > /dev/null
+    silver $ARGS $1 |& grep "$2" > /dev/null
     if [[ $? != 0 ]]
     then
         echo -e "\nFailure: $1 did not produce output $2"


### PR DESCRIPTION
# Changes

Resolves #633; see it for a description.

# Documentation

Added doc comments.

Arguably https://github.com/melt-umn/melt-website/blob/62b8ae7062175c30fd524540e18d90e8436cdab8/content/silver/lib/io.md and https://github.com/melt-umn/melt-website/blob/62b8ae7062175c30fd524540e18d90e8436cdab8/content/silver/concepts/io.md should be updated as well?

The former could probably go away (and become a redirect to the generated docs?).

The latter could TBH use a rewrite:

- I think the Troubles section is obsolete, and there's other misc remarks that are no longer true (e.g. us not having a unit type? why would someone write that in the docs instead of just defining one?).
- > When we fix IO all this will be thrown out anyway.

  Sad...
- I think the pre-monad Haskell comment might be incorrect too; "Tackling the Awkward Squad" describes a very different model (one that maybe could've been more convenient in Silver than it was in Haskell? Almost definitely more awkward than tokens are though). *Current* GHC Haskell actually does this as a way to implement the IO monad: https://hackage.haskell.org/package/ghc-prim-0.8.0/docs/src/GHC-Types.html#line-233

I don't super-duper want to though lol