### PR TITLE
Allow loading a grammar from only interface files when source grammar does not exist

### DIFF
--- a/grammars/silver/compiler/driver/CompileGrammar.sv
+++ b/grammars/silver/compiler/driver/CompileGrammar.sv
@@ -25,8 +25,10 @@ IOVal<Maybe<RootSpec>> ::=
     if clean then
       -- We just skip this search if it's a clean build
       ioval(grammarTime.io, nothing())
+    else if grammarLocation.iovalue.isJust then
+      compileInterface(grammarName, benv.silverHostGen, just(grammarTime.iovalue), grammarTime.io)
     else
-      compileInterface(grammarName, benv.silverHostGen, grammarTime.iovalue, grammarTime.io);
+      compileInterface(grammarName, benv.silverHostGen, nothing(), grammarLocation.io);
 
   -- IO Step 4: Build the grammar, and say so
   local pr :: IOToken =
@@ -42,15 +44,15 @@ IOVal<Maybe<RootSpec>> ::=
       errorRootSpec(gramCompile.iovalue.snd, grammarName, grammarLocation.iovalue.fromJust, grammarTime.iovalue, benv.silverGen);
   
   return
-    if !grammarLocation.iovalue.isJust then
+    if ifaceCompile.iovalue.isJust then
+      -- Found a valid interface file! Stop short, and return that
+      ifaceCompile
+    else if !grammarLocation.iovalue.isJust then
       -- No grammar found!
       ioval(grammarLocation.io, nothing())
     else if null(files.iovalue) then
       -- Grammar had no files!
       ioval(files.io, nothing())
-    else if ifaceCompile.iovalue.isJust then
-      -- Found a valid interface file! Stop short, and return that
-      ifaceCompile
     else
       -- Return the compiled grammar
       ioval(gramCompile.io, just(rs));

--- a/grammars/silver/compiler/driver/CompileInterface.sv
+++ b/grammars/silver/compiler/driver/CompileInterface.sv
@@ -11,7 +11,7 @@ import silver:reflect:nativeserialize;
  - @param grammarTime    The newest modification time of the source files, to compare against
  -}
 function compileInterface
-IOVal<Maybe<RootSpec>> ::= grammarName::String  silverHostGen::[String]  grammarTime::Integer  ioin::IOToken
+IOVal<Maybe<RootSpec>> ::= grammarName::String  silverHostGen::[String]  grammarTime::Maybe<Integer>  ioin::IOToken
 {
   local gramPath :: String = grammarToPath(grammarName);
 
@@ -49,7 +49,7 @@ IOVal<Maybe<RootSpec>> ::= grammarName::String  silverHostGen::[String]  grammar
     if !gen.iovalue.isJust then
       -- Didn't find one. Stop short, return nothing.
       ioval(gen.io, nothing())
-    else if modTime.iovalue < grammarTime then
+    else if grammarTime.isJust && modTime.iovalue < grammarTime.fromJust then
       -- Interface file is too old, stop short, return nothing.
       ioval(modTime.io, nothing())
     else if ir.isLeft || !null(ir.fromRight.interfaceErrors) then


### PR DESCRIPTION
# Changes
Currently Silver ignores the interface file for a grammar if the sources for the grammar cannot be found.  We may wish to support binary library distribution that does not include source files; this is a step in that direction.

# Documentation
I added comments in the source code.  Users should not notice this change, except that importing a deleted grammar might not raise an error in a non-clean build.
