### PR TITLE
Support building multiple unrelated grammars in a single invocation of silver

### DIFF
--- a/deep-rebuild
+++ b/deep-rebuild
@@ -42,16 +42,15 @@ fi
 
 # Should backup old jars here
 
-echo "Before we start, let's get this thing built ..."
 echo ""
 echo "   Silver Build"
 echo " > Silver Build"
 echo "   Runtime Build"
 echo "   Silver Build"
 echo ""
-java $JVM_ARGS --clean silver:xml:ast
 echo "Start ..."
-time java $JVM_ARGS --relative-jar --clean silver:compiler:composed:Default
+# Also building silver:xml:ast here since the runtime depends on that
+time java $JVM_ARGS --relative-jar --clean silver:compiler:composed:Default silver:xml:ast
 
 # Modifications may have been made to the runtime
 

--- a/grammars/silver/compiler/analysis/warnings/exporting/Graph.sv
+++ b/grammars/silver/compiler/analysis/warnings/exporting/Graph.sv
@@ -28,7 +28,7 @@ Either<String  Decorated CmdArgs> ::= args::[String]
   -- omitting from descriptions deliberately!
 }
 aspect production compilation
-top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  _  _  benv::BuildEnv
 {
   top.postOps <- if top.config.dumpDepGraph then [dumpDepGraphAction(g.grammarList)] else [];
 }

--- a/grammars/silver/compiler/composed/idetest/Analyze.sv
+++ b/grammars/silver/compiler/composed/idetest/Analyze.sv
@@ -26,7 +26,10 @@ IOVal<[Message]> ::= args::[String]  svParser::SVParser ioin::IOToken
   local envErrors :: [String] = case benvResult.iovalue of | right(s) -> s | _ -> [] end;
   
   -- Let's start preparing to build
-  local buildGrammar :: String = head(a.buildGrammars);
+  local buildGrammar :: String =
+    if length(a.buildGrammars) == 1
+    then head(a.buildGrammars)
+    else error("Exactly one build grammar expected in argument passed to ideAnalyze");
   local checkbuild :: IOVal<[String]> =
     checkPreBuild(benv, [buildGrammar], benvResult.io);
 

--- a/grammars/silver/compiler/composed/idetest/Analyze.sv
+++ b/grammars/silver/compiler/composed/idetest/Analyze.sv
@@ -70,7 +70,10 @@ IOVal<[Message]> ::= args::[String]  svParser::SVParser  ioin::IOToken
   local envErrors :: [String] = case benvResult.iovalue of | right(s) -> s | _ -> [] end;
   
   -- Let's start preparing to build
-  local buildGrammar :: String = head(a.buildGrammars);
+  local buildGrammar :: String =
+    if length(a.buildGrammars) == 1
+    then head(a.buildGrammars)
+    else error("Exactly one build grammar expected in argument passed to ideGenerate");
   local checkbuild :: IOVal<[String]> =
     checkPreBuild(benv, [buildGrammar], benvResult.io);
 

--- a/grammars/silver/compiler/composed/idetest/Analyze.sv
+++ b/grammars/silver/compiler/composed/idetest/Analyze.sv
@@ -26,13 +26,13 @@ IOVal<[Message]> ::= args::[String]  svParser::SVParser ioin::IOToken
   local envErrors :: [String] = case benvResult.iovalue of | right(s) -> s | _ -> [] end;
   
   -- Let's start preparing to build
-  local buildGrammar :: String = head(a.buildGrammar);
+  local buildGrammar :: String = head(a.buildGrammars);
   local checkbuild :: IOVal<[String]> =
-    checkPreBuild(a, benv, buildGrammar, benvResult.io);
+    checkPreBuild(benv, [buildGrammar], benvResult.io);
 
   -- Build!
   local buildrun :: IOVal<Decorated Compilation> =
-    buildRun(svParser, a, benv, buildGrammar, checkbuild.io);
+    buildRun(svParser, a, benv, [buildGrammar], checkbuild.io);
   local unit :: Decorated Compilation = buildrun.iovalue;
 
   ---- DIFFERENCE: We do *not* run the actions in the functions. Only check for errors.
@@ -67,13 +67,13 @@ IOVal<[Message]> ::= args::[String]  svParser::SVParser  ioin::IOToken
   local envErrors :: [String] = case benvResult.iovalue of | right(s) -> s | _ -> [] end;
   
   -- Let's start preparing to build
-  local buildGrammar :: String = head(a.buildGrammar);
+  local buildGrammar :: String = head(a.buildGrammars);
   local checkbuild :: IOVal<[String]> =
-    checkPreBuild(a, benv, buildGrammar, benvResult.io);
+    checkPreBuild(benv, [buildGrammar], benvResult.io);
 
   -- Build!
   local buildrun :: IOVal<Decorated Compilation> =
-    buildRun(svParser, a, benv, buildGrammar, checkbuild.io);
+    buildRun(svParser, a, benv, [buildGrammar], checkbuild.io);
   local unit :: Decorated Compilation = buildrun.iovalue;
 
   -- Run the resulting build actions

--- a/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
@@ -28,7 +28,7 @@ Either<String  Decorated CmdArgs> ::= args::[String]
 }
 
 aspect production compilation
-top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  _  _  benv::BuildEnv
 {
   top.postOps <-
     if top.config.dumpFlowGraph

--- a/grammars/silver/compiler/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/driver/BuildProcess.sv
@@ -95,18 +95,21 @@ IOErrorable<Decorated Compilation> ::=
   local benv::BuildEnv = envin.snd;
 
   -- Check environment stuff specific to building a grammar
-  local buildGrammar :: String = head(a.buildGrammar);
+  local buildGrammars :: [String] = a.buildGrammars;
   local checkbuild :: IOVal<[String]> =
-    checkPreBuild(a, benv, buildGrammar, ioin);
+    checkPreBuild(benv, buildGrammars, ioin);
 
   -- Build!
   local buildrun :: IOVal<Decorated Compilation> =
-    buildRun(svParser, a, benv, buildGrammar, checkbuild.io);
+    buildRun(svParser, a, benv, buildGrammars, checkbuild.io);
+
+  local missingGrammars::[String] =
+    removeAll(map((.declaredName), buildrun.iovalue.grammarList), buildGrammars);
 
   return if !null(checkbuild.iovalue) then
     ioval(checkbuild.io, left(runError(1, implode("\n", checkbuild.iovalue))))
-  else if null(buildrun.iovalue.grammarList) then
-    ioval(buildrun.io, left(runError(1, "The specified grammar (" ++ buildGrammar ++ ") could not be found.\n")))
+  else if !null(missingGrammars) then
+    ioval(buildrun.io, left(runError(1, "The specified grammar(s) " ++ implode(", ", missingGrammars) ++ " could not be found.\n")))
   else
     ioval(buildrun.io, right(buildrun.iovalue));
 }
@@ -121,7 +124,7 @@ IOVal<Decorated Compilation> ::=
   svParser::SVParser
   a::Decorated CmdArgs
   benv::BuildEnv
-  buildGrammar::String
+  buildGrammars::[String]
   ioin::IOToken
 {
   -- Compile grammars. There's some tricky circular program data flow here.
@@ -134,7 +137,7 @@ IOVal<Decorated Compilation> ::=
   -- a list that's terminated when the response count is equal to the number of emitted
   -- grammar names.
   local grammarStream :: [String] =
-    buildGrammar :: eatGrammars(1, [buildGrammar], rootStream.iovalue, unit.grammarList);
+    buildGrammars ++ eatGrammars(1, buildGrammars, rootStream.iovalue, unit.grammarList);
   
   -- This is, essentially, a data structure representing a compilation.
   -- Note that it is pure: it doesn't take any actions.
@@ -142,7 +145,7 @@ IOVal<Decorated Compilation> ::=
     compilation(
       foldr(consGrammars, nilGrammars(), catMaybes(rootStream.iovalue)),
       foldr(consGrammars, nilGrammars(), catMaybes(reRootStream.iovalue)),
-      buildGrammar, benv);
+      buildGrammars, benv);
   -- This is something we should probably get rid of, someday. Somehow. It's hard.
   unit.config = a;
     

--- a/grammars/silver/compiler/driver/GrammarAction.sv
+++ b/grammars/silver/compiler/driver/GrammarAction.sv
@@ -20,7 +20,7 @@ grammar silver:compiler:driver;
  -}
 
 aspect production compilation
-top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::BuildEnv
 {
   top.postOps <- [printAllParsingErrors(g.grammarList ++ r.grammarList)];
   top.postOps <- if top.config.noBindingChecking then [] else

--- a/grammars/silver/compiler/driver/util/Compilation.sv
+++ b/grammars/silver/compiler/driver/util/Compilation.sv
@@ -21,11 +21,11 @@ synthesized attribute allGrammars :: [Decorated RootSpec];
  -
  - @param g  A list of grammar initially read in
  - @param r  A list of grammars that we re-compiled, due to dirtiness in 'g'
- - @param buildGrammar  The initial grammar requested built
+ - @param buildGrammars  The initial grammars requested built
  - @param benv  The build configuration
  -}
 abstract production compilation
-top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::BuildEnv
 {
   -- the list of rootspecs coming out of g
   top.grammarList = g.grammarList;
@@ -43,7 +43,7 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::Build
   -- For example, it excludes "options" and conditional builds that aren't
   -- actually used / triggered.
   production grammarsDependedUpon :: [String] =
-    expandAllDeps([buildGrammar], [], g.compiledGrammars);
+    expandAllDeps(buildGrammars, [], g.compiledGrammars);
   
   -- Ditto the above, but rootspecs
   production grammarsRelevant :: [Decorated RootSpec] =

--- a/grammars/silver/compiler/driver/util/FlowTypes.sv
+++ b/grammars/silver/compiler/driver/util/FlowTypes.sv
@@ -9,7 +9,7 @@ import silver:util:graph as g;
 -- Hide all the flow type computation over here
 
 aspect production compilation
-top::Compilation ::= g::Grammars  r::Grammars  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::BuildEnv
 {
   -- aggregate all flow def information
   local allFlowDefs :: FlowDefs = foldr(consFlow, nilFlow(), flatMap((.flowDefs), g.grammarList));

--- a/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
@@ -72,7 +72,7 @@ Either<String  Decorated CmdArgs> ::= args::[String]
 }
 
 aspect production compilation
-top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  _  _  benv::BuildEnv
 {
   local outputLoc::String = fromMaybe(benv.silverGen ++ "/doc/", top.config.docOutOption) ++ "/";
   top.postOps <- if top.config.docGeneration then 

--- a/grammars/silver/compiler/modification/copper/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper/BuildProcess.sv
@@ -70,7 +70,7 @@ function obtainParserSpecs
 }
 
 aspect production compilation
-top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  _  _  benv::BuildEnv
 {
   -- Add the Copper compiler to the CLASSPATH. In theory, this is only
   -- necessary when building Silver (or other programs that invoke the Copper

--- a/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
@@ -8,7 +8,7 @@ import silver:reflect:nativeserialize;
 import silver:util:cmdargs;
 
 aspect production compilation
-top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  _  _  benv::BuildEnv
 {
   -- TODO: consider examining all grammars, not just grammarsToTranslate?
   -- I believe this choice was originally because we weren't serializing MdaSpecs to

--- a/grammars/silver/compiler/modification/impide/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/impide/BuildProcess.sv
@@ -13,10 +13,10 @@ import silver:util:cmdargs;
 --}
 
 aspect production compilation
-top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  _  buildGrammars::[String]  benv::BuildEnv
 {
   -- The RootSpec representing the grammar actually being built (specified on the command line)
-  local builtGrammar :: [Decorated RootSpec] = searchEnvTree(buildGrammar, g.compiledGrammars);
+  local builtGrammar :: [Decorated RootSpec] = searchEnvTree(head(buildGrammars), g.compiledGrammars);
   
   -- Empty if no ide decl in that grammar, otherwise has at least one spec... note that
   -- we're going to go with assuming there's just one IDE declaration...

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -69,8 +69,11 @@ Either<String  Decorated CmdArgs> ::= args::[String]
   flagdescs <- ["\t--one-jar  : include runtime libraries in the jar"];
 }
 aspect production compilation
-top::Compilation ::= g::Grammars  _  buildGrammar::String  benv::BuildEnv
+top::Compilation ::= g::Grammars  _  buildGrammars::[String]  benv::BuildEnv
 {
+  -- Main class, jar name, etc. are based on the first specified grammar.
+  local buildGrammar::String = head(buildGrammars);
+
   -- This is a little bit of a hack. It's only job is to allow the Eclipse support
   -- for Silver to put this file elsewhere than the local directory.
   -- e.g. --build-xml-location /path/to/workspace/project/build.xml


### PR DESCRIPTION
# Changes
Allows multiple unrelated Silver grammars to be built (and included in a jar) in a single invocation of Silver, without the need for a dummy grammar that imports all of them.  This is helpful in integrating Silver with build tools such as Bazel.  This is also faster than just invoking Silver on every grammar to be built, as we avoid the need to start another JVM and re-parse interface files.

# Documentation
The command-line help usage string has been updated.