### PR TITLE
Fix bug with building multiple grammars

### DIFF
--- a/grammars/silver/compiler/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/driver/BuildProcess.sv
@@ -137,7 +137,8 @@ IOVal<Decorated Compilation> ::=
   -- a list that's terminated when the response count is equal to the number of emitted
   -- grammar names.
   local grammarStream :: [String] =
-    buildGrammars ++ eatGrammars(1, buildGrammars, rootStream.iovalue, unit.grammarList);
+    buildGrammars ++
+    eatGrammars(length(buildGrammars), buildGrammars, rootStream.iovalue, unit.grammarList);
   
   -- This is, essentially, a data structure representing a compilation.
   -- Note that it is pure: it doesn't take any actions.


### PR DESCRIPTION
# Changes
Fixes bug with https://github.com/melt-umn/silver/pull/641 causing some grammar dependencies to not be built when multiple build gramamrs are specified

# Documentation
None, this is a 2-line fix.  
