### PR TITLE
Fix skipped parser rebuilds caused by broken syntax AST equality checking

### DIFF
--- a/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
@@ -55,7 +55,7 @@ top::SyntaxRoot ::=
   s.prettyNames = tm:add(s.prettyNamesAccum, tm:empty());
   
   -- Move productions under their nonterminal, and sort the declarations
-  production s2 :: Syntax = foldr(consSyntax, nilSyntax(), sort(s.cstNormalize));
+  production s2 :: Syntax = foldr(consSyntax, nilSyntax(), sortBy(sortKeyLte, s.cstNormalize));
   s2.cstEnv = s.cstEnv;
   s2.containingGrammar = "host";
   s2.cstNTProds = error("TODO: make this environment not be decorated?"); -- TODO

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -12,9 +12,9 @@ autocopy attribute className :: String;
 {--
  - Modifiers for lexer classes.
  -}
-nonterminal SyntaxLexerClassModifiers with cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, prefixSeperator, containingGrammar, dominates_, submits_;
+nonterminal SyntaxLexerClassModifiers with compareTo, isEqual, cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, prefixSeperator, containingGrammar, dominates_, submits_;
 
-propagate cstErrors, superClassContribs, disambiguationClasses, prefixSeperator, dominates_, submits_
+propagate compareTo, isEqual, cstErrors, superClassContribs, disambiguationClasses, prefixSeperator, dominates_, submits_
   on SyntaxLexerClassModifiers;
 
 abstract production consLexerClassMod
@@ -35,7 +35,9 @@ top::SyntaxLexerClassModifiers ::=
 {--
  - Modifiers for lexer classes.
  -}
-closed nonterminal SyntaxLexerClassModifier with location, sourceGrammar, cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, prefixSeperator, containingGrammar, dominates_, submits_;
+closed nonterminal SyntaxLexerClassModifier with location, sourceGrammar, compareTo, isEqual, cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, prefixSeperator, containingGrammar, dominates_, submits_;
+
+propagate compareTo, isEqual on SyntaxLexerClassModifier;
 
 {- We default ALL attributes, so we can focus only on those that are interesting in each case... -}
 aspect default production

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/NonterminalModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/NonterminalModifiers.sv
@@ -6,9 +6,9 @@ imports silver:compiler:definition:core only nonterminalName;
  - Modifiers for nonterminals.
  -}
 
-nonterminal SyntaxNonterminalModifiers with cstEnv, cstErrors, customLayout, nonterminalName;
+nonterminal SyntaxNonterminalModifiers with compareTo, isEqual, cstEnv, cstErrors, customLayout, nonterminalName;
 
-propagate cstErrors, customLayout on SyntaxNonterminalModifiers;
+propagate compareTo, isEqual, cstErrors, customLayout on SyntaxNonterminalModifiers;
 
 abstract production consNonterminalMod
 top::SyntaxNonterminalModifiers ::= h::SyntaxNonterminalModifier  t::SyntaxNonterminalModifiers
@@ -22,7 +22,9 @@ top::SyntaxNonterminalModifiers ::=
 {--
  - Modifiers for nonterminals.
  -}
-nonterminal SyntaxNonterminalModifier with cstEnv, cstErrors, customLayout, nonterminalName;
+nonterminal SyntaxNonterminalModifier with compareTo, isEqual, cstEnv, cstErrors, customLayout, nonterminalName;
+
+propagate compareTo, isEqual on SyntaxNonterminalModifier;
 
 aspect default production
 top::SyntaxNonterminalModifier ::=

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/ProductionModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/ProductionModifiers.sv
@@ -10,9 +10,9 @@ monoid attribute productionOperator :: Maybe<Decorated SyntaxDcl> with nothing()
 {--
  - Modifiers for productions.
  -}
-nonterminal SyntaxProductionModifiers with cstEnv, cstErrors, acode, productionPrecedence, customLayout, productionOperator, productionName;
+nonterminal SyntaxProductionModifiers with compareTo, isEqual, cstEnv, cstErrors, acode, productionPrecedence, customLayout, productionOperator, productionName;
 
-propagate cstErrors, acode, productionPrecedence, customLayout, productionOperator
+propagate compareTo, isEqual, cstErrors, acode, productionPrecedence, customLayout, productionOperator
   on SyntaxProductionModifiers;
 
 abstract production consProductionMod
@@ -27,7 +27,9 @@ top::SyntaxProductionModifiers ::=
 {--
  - Modifiers for productions.
  -}
-nonterminal SyntaxProductionModifier with cstEnv, cstErrors, acode, productionPrecedence, customLayout, productionOperator, productionName;
+nonterminal SyntaxProductionModifier with compareTo, isEqual, cstEnv, cstErrors, acode, productionPrecedence, customLayout, productionOperator, productionName;
+
+propagate compareTo, isEqual on SyntaxProductionModifier;
 
 aspect default production
 top::SyntaxProductionModifier ::=

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -64,7 +64,7 @@ synthesized attribute copperGrammarElements::[copper:GrammarElement];
 {--
  - An abstract syntax tree for representing concrete syntax.
  -}
-nonterminal Syntax with cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, layoutContribs, layoutTerms, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElements, compareTo, isEqual;
+nonterminal Syntax with compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, layoutContribs, layoutTerms, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElements;
 propagate compareTo, isEqual on Syntax;
 
 flowtype decorate {cstEnv, classTerminals, superClasses, subClasses, containingGrammar, layoutTerms, prefixesForTerminals, componentGrammarMarkingTerminals, parserAttributeAspects, prettyNames} on Syntax, SyntaxDcl;
@@ -87,11 +87,11 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-closed nonterminal SyntaxDcl with location, sourceGrammar, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, domContribs, subContribs, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElements;
+closed nonterminal SyntaxDcl with location, sourceGrammar, compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, domContribs, subContribs, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElements;
 
 synthesized attribute sortKey :: String;
 
-propagate cstErrors, prefixSeperator on SyntaxDcl;
+propagate compareTo, isEqual, cstErrors, prefixSeperator on SyntaxDcl;
 
 aspect default production
 top::SyntaxDcl ::=
@@ -464,9 +464,8 @@ top::SyntaxDcl ::= n::String terms::[String] applicableToSubsets::Boolean acode:
     | syntaxNonterminal(_,_)            ->  EEE
     | syntaxProduction(_,_,_,_)         ->  FFF
 -}
-instance Eq SyntaxDcl {
-  eq = \ l::SyntaxDcl r::SyntaxDcl -> l.sortKey == r.sortKey;
-}
-instance Ord SyntaxDcl {
-  lte = \ l::SyntaxDcl r::SyntaxDcl -> l.sortKey <= r.sortKey;
-}
+
+function sortKeyLte
+Boolean ::= l::SyntaxDcl r::SyntaxDcl
+{ return l.sortKey <= r.sortKey; }
+

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -19,13 +19,13 @@ monoid attribute lexerClasses :: [copper:ElementReference];
 {--
  - Modifiers for terminals.
  -}
-nonterminal SyntaxTerminalModifiers with cstEnv, cstErrors,
+nonterminal SyntaxTerminalModifiers with compareTo, isEqual, cstEnv, cstErrors,
   classTerminalContribs, superClasses, subClasses, ignored, acode,
   opPrecedence, opAssociation, prefixSeperator, prefixSeperatorToApply,
   componentGrammarMarkingTerminals, marking, terminalName, prettyName,
   dominates_, submits_, lexerClasses;
 
-propagate cstErrors, classTerminalContribs, ignored, acode, opPrecedence,
+propagate compareTo, isEqual, cstErrors, classTerminalContribs, ignored, acode, opPrecedence,
   opAssociation, prefixSeperator, prefixSeperatorToApply, marking, prettyName,
   dominates_, submits_, lexerClasses
   on SyntaxTerminalModifiers;
@@ -48,11 +48,13 @@ top::SyntaxTerminalModifiers ::=
 {--
  - Modifiers for terminals.
  -}
-closed nonterminal SyntaxTerminalModifier with cstEnv, cstErrors,
+closed nonterminal SyntaxTerminalModifier with compareTo, isEqual, cstEnv, cstErrors,
   classTerminalContribs, superClasses, subClasses, dominates_, submits_,
   lexerClasses, ignored, acode, opPrecedence, opAssociation, prefixSeperator,
   prefixSeperatorToApply, componentGrammarMarkingTerminals, marking,
   terminalName, prettyName;
+
+propagate compareTo, isEqual on SyntaxTerminalModifier;
 
 {- We default ALL attributes, so we can focus only on those that are interesting in each case... -}
 aspect default production

--- a/grammars/silver/compiler/definition/env/NamedSignature.sv
+++ b/grammars/silver/compiler/definition/env/NamedSignature.sv
@@ -193,3 +193,9 @@ Substitution ::= ns1::NamedSignature ns2::NamedSignature
     else errorSubstitution(ns1.typerep);
 }
 
+-- Strict type equality, assuming no type vars - this is only used in comparing syntax ASTs
+instance Eq NamedSignature {
+  eq = \ ns1::NamedSignature ns2::NamedSignature ->
+    ns1.fullName == ns2.fullName &&
+    !unifyDirectional(ns1.typerep, ns2.typerep).failure;
+}

--- a/grammars/silver/compiler/definition/type/Util.sv
+++ b/grammars/silver/compiler/definition/type/Util.sv
@@ -244,3 +244,7 @@ top::Type ::= params::Integer namedParams::[String]
   top.isApplicable = true;
 }
 
+-- Strict type equality, assuming no type vars - this is only used in comparing syntax ASTs
+instance Eq Type {
+  eq = \ t1::Type t2::Type -> !unifyDirectional(t1, t2).failure;
+}

--- a/grammars/silver/compiler/modification/impide/cstast/LexerClassModifiers.sv
+++ b/grammars/silver/compiler/modification/impide/cstast/LexerClassModifiers.sv
@@ -30,6 +30,7 @@ top::SyntaxLexerClassModifier ::=
 abstract production lexerClassFont
 top::SyntaxLexerClassModifier ::= fontName::String
 {
+  propagate isEqual;
   top.cstErrors := [];
 
   top.fontAttr = makeCopperName(fontName);

--- a/grammars/silver/compiler/modification/impide/cstast/Syntax.sv
+++ b/grammars/silver/compiler/modification/impide/cstast/Syntax.sv
@@ -28,7 +28,7 @@ top::SyntaxDcl ::= fontName::String fnt::Font -- TODO: we probably? need to fact
 {
   top.fontList <- [pair(makeCopperName(fontName), fnt)];
   
-  propagate cstErrors, prefixSeperator;
+  propagate compareTo, isEqual, cstErrors, prefixSeperator;
 
   top.fullName = fontName;
   top.sortKey = "111"; -- Doesn't really matter, it doesn't show up in the copper XML

--- a/grammars/silver/compiler/modification/impide/cstast/TerminalModifiers.sv
+++ b/grammars/silver/compiler/modification/impide/cstast/TerminalModifiers.sv
@@ -56,6 +56,7 @@ String ::= d::[Decorated SyntaxDcl]
 abstract production termFont
 top::SyntaxTerminalModifier ::= fontName::String
 {
+  propagate isEqual;
   top.cstErrors := [];
 
   top.fontAttr = makeCopperName(fontName);

--- a/grammars/silver/compiler/modification/impide/spec/IdeFont.sv
+++ b/grammars/silver/compiler/modification/impide/spec/IdeFont.sv
@@ -1,22 +1,22 @@
 grammar silver:compiler:modification:impide:spec;
 
 -- TODO: er, this should probably be moved to :cstast. It's not used here!
-nonterminal Font with getTextAttribute, pluginXmlSpec;
+nonterminal Font with compareTo, isEqual, getTextAttribute, pluginXmlSpec;
 
 synthesized attribute getTextAttribute :: String;
 synthesized attribute pluginXmlSpec :: String;
 
-
 abstract production font
 top::Font ::= color::Color isBold::Boolean isItalic::Boolean
 {
+  propagate compareTo, isEqual;
   top.getTextAttribute =
     s"""TextAttributeProvider.getAttribute(display, ${toString(color.r)}, ${toString(color.g)}, ${toString(color.b)}, ${toString(isBold)}, ${toString(isItalic)})""";
   top.pluginXmlSpec = 
     s"""r="${toString(color.r)}" g="${toString(color.g)}" b="${toString(color.b)}" bold="${toString(isBold)}" italic="${toString(isItalic)}" """;
 }
 
-nonterminal Color with r, g, b;
+nonterminal Color with compareTo, isEqual, r, g, b;
 
 synthesized attribute r :: Integer;
 synthesized attribute g :: Integer;
@@ -25,6 +25,7 @@ synthesized attribute b :: Integer;
 abstract production makeColor
 top::Color ::= r::Integer g::Integer b::Integer
 {
+  propagate compareTo, isEqual;
   top.r = r;
   top.g = g;
   top.b = b;


### PR DESCRIPTION
# Changes
Fixes #643.  Apparently the equality check for whether the syntax AST used to build a parser had changed was only comparing the sort keys, which misses changes to production signatures, lexer class/terminal modifiers, etc.  

# Documentation
I added a couple of comments on some potentially confusing type class instances for `Eq Type` and `Eq NamedSignature`.  This is an internal refactor bug fix, so no external docs needed.  
