### PR TITLE
Fix random tree generation to consider lexical precedence

### DIFF
--- a/grammars/silver/compiler/definition/concrete_syntax/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ProductionDcl.sv
@@ -17,7 +17,6 @@ top::AGDcl ::= 'concrete' 'production' id::Name ns::ProductionSignature pm::Prod
   top.errors <- pm.errors;
   top.errors <- ns.concreteSyntaxTypeErrors;
 
-  -- TODO: we should CHANGE syntaxProduction so it just plain takes a NamedSignature!
   top.syntaxAst :=
     [ syntaxProduction(namedSig,
         foldr(consProductionMod, nilProductionMod(), pm.productionModifiers),

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/CstAst.sv
@@ -15,11 +15,14 @@ import silver:util:treeset as s;
 {--
  - Encapsulates transformations and analysis of Syntax
  -}
-closed nonterminal SyntaxRoot with location, sourceGrammar, cstErrors, copperParser, compareTo, isEqual;
-propagate compareTo, isEqual on SyntaxRoot;
+closed nonterminal SyntaxRoot with location, sourceGrammar, cstErrors, copperParser, allTerminals, allNonterminals, dominatingTerminals, compareTo, isEqual;
+propagate compareTo, isEqual, allTerminals, allNonterminals on SyntaxRoot;
 
 @{-- The Copper API object corresponding to the parser. -}
 synthesized attribute copperParser::copper:ParserBean;
+
+@{-- An environment containing all terminals that dominate any particular one. -}
+synthesized attribute dominatingTerminals::EnvTree<Decorated SyntaxDcl>;
 
 abstract production cstRoot
 top::SyntaxRoot ::=
@@ -53,6 +56,8 @@ top::SyntaxRoot ::=
   s.prefixesForTerminals = directBuildTree(terminalPrefixes);
   s.componentGrammarMarkingTerminals = directBuildTree(componentGrammarMarkingTerminals);
   s.prettyNames = tm:add(s.prettyNamesAccum, tm:empty());
+  
+  top.dominatingTerminals = directBuildTree(s.dominatingTerminalContribs);
   
   -- Move productions under their nonterminal, and sort the declarations
   production s2 :: Syntax = foldr(consSyntax, nilSyntax(), sortBy(sortKeyLte, s.cstNormalize));

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -3,8 +3,8 @@ grammar silver:compiler:definition:concrete_syntax:ast;
 import silver:util:treemap as tm;
 
 -- From TerminalModifiers
--- monoid attribute dominates_ :: [copper:ElementReference];
--- monoid attribute submits_ :: [copper:ElementReference];
+-- monoid attribute dominates_ :: [Decorated SyntaxDcl];
+-- monoid attribute submits_ :: [Decorated SyntaxDcl];
 -- synthesized attribute prefixSeperator :: Maybe<String>;
 
 autocopy attribute className :: String;
@@ -79,7 +79,7 @@ top::SyntaxLexerClassModifier ::= sub::[String]
                            "this grammar was not included in this parser. (Referenced from submit clause for lexer class)"], --TODO: come up with a way to reference a given lexer class (line numbers would be great)
                    zipWith(pair, sub, subRefs)); 
   
-  top.submits_ := map((.copperElementReference), map(head, subRefs));
+  top.submits_ := map(head, subRefs);
 }
 {--
  - The dominates list for the lexer class. Either lexer classes or terminals.
@@ -96,7 +96,7 @@ top::SyntaxLexerClassModifier ::= dom::[String]
                            "this grammar was not included in this parser. (Referenced from dominates clause for lexer class)"],
                    zipWith(pair, dom, domRefs));
 
-  top.dominates_ := map((.copperElementReference), map(head, domRefs));
+  top.dominates_ := map(head, domRefs);
 }
 
 {--

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -42,6 +42,9 @@ monoid attribute allNonterminals :: [Decorated SyntaxDcl];
 monoid attribute disambiguationClasses :: [Decorated SyntaxDcl];
 synthesized attribute domContribs :: [Decorated SyntaxDcl];
 synthesized attribute subContribs :: [Decorated SyntaxDcl];
+monoid attribute memberTerminals :: [Decorated SyntaxDcl];
+monoid attribute dominatingTerminalContribs :: [(String, Decorated SyntaxDcl)];
+synthesized attribute terminalRegex::Regex;
 autocopy attribute containingGrammar :: String;
 monoid attribute lexerClassRefDcls :: String;
 synthesized attribute exportedProds :: [String];
@@ -64,12 +67,12 @@ synthesized attribute copperGrammarElements::[copper:GrammarElement];
 {--
  - An abstract syntax tree for representing concrete syntax.
  -}
-nonterminal Syntax with compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, layoutContribs, layoutTerms, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElements;
+nonterminal Syntax with compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, layoutContribs, layoutTerms, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElements;
 propagate compareTo, isEqual on Syntax;
 
 flowtype decorate {cstEnv, classTerminals, superClasses, subClasses, containingGrammar, layoutTerms, prefixesForTerminals, componentGrammarMarkingTerminals, parserAttributeAspects, prettyNames} on Syntax, SyntaxDcl;
 
-propagate cstDcls, cstErrors, cstProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, classTerminalContribs, superClassContribs, parserAttributeAspectContribs, lexerClassRefDcls, layoutContribs, prettyNamesAccum
+propagate cstDcls, cstErrors, cstProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, superClassContribs, parserAttributeAspectContribs, lexerClassRefDcls, layoutContribs, prettyNamesAccum
   on Syntax;
 
 abstract production nilSyntax
@@ -87,7 +90,7 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-closed nonterminal SyntaxDcl with location, sourceGrammar, compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, domContribs, subContribs, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElements;
+closed nonterminal SyntaxDcl with location, sourceGrammar, compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, domContribs, subContribs, terminalRegex, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElements;
 
 synthesized attribute sortKey :: String;
 
@@ -97,10 +100,11 @@ aspect default production
 top::SyntaxDcl ::=
 {
   -- Empty values as defaults
-  propagate cstProds, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, classTerminalContribs, superClassContribs, parserAttributeAspectContribs, lexerClassRefDcls, layoutContribs, prettyNamesAccum;
-  top.domContribs = error("Internal compiler error: should only ever be demanded of lexer classes or terminals");
-  top.subContribs = error("Internal compiler error: should only ever be demanded of lexer classes or terminals");
+  propagate cstProds, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, superClassContribs, parserAttributeAspectContribs, lexerClassRefDcls, layoutContribs, prettyNamesAccum;
+  top.domContribs = error("Internal compiler error: should only ever be demanded of lexer classes");
+  top.subContribs = error("Internal compiler error: should only ever be demanded of lexer classes");
   top.exportedProds = error("Internal compiler error: should only ever be demanded of nonterminals");
+  top.terminalRegex = error("Internal compiler error: should only ever be demanded of terminals");
   top.hasCustomLayout = false;
 }
 
@@ -165,6 +169,11 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
   top.allIgnoreTerminals := if modifiers.ignored then [top.fullName] else [];
   top.allMarkingTerminals := if modifiers.marking then [top.fullName] else [];
   top.classTerminalContribs := modifiers.classTerminalContribs;
+  top.memberTerminals := [top];
+  top.dominatingTerminalContribs :=
+    map(pair(n, _), flatMap((.memberTerminals), modifiers.submits_)) ++
+    map(pair(_, top), map((.fullName), flatMap((.memberTerminals), modifiers.dominates_)));
+  top.terminalRegex = regex;
 
   -- left(terminal name) or right(string prefix)
   production pfx::[String] = searchEnvTree(n, top.prefixesForTerminals);
@@ -356,6 +365,8 @@ top::SyntaxDcl ::= n::String modifiers::SyntaxLexerClassModifiers
   top.disambiguationClasses := modifiers.disambiguationClasses;
 
   production terms :: [String] = searchEnvTree(n, top.classTerminals);
+  top.memberTerminals := flatMap(searchEnvTree(_, top.cstEnv), terms);
+
   local termsInit::String =
     foldr(
       \ term::String rest::String -> s"new common.ConsCell(Terminals.${makeCopperName(term)}.num(), ${rest})",

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -40,8 +40,8 @@ monoid attribute allProductions :: [Decorated SyntaxDcl];
 monoid attribute allProductionNames :: [String];  -- Doesn't depend on anything
 monoid attribute allNonterminals :: [Decorated SyntaxDcl];
 monoid attribute disambiguationClasses :: [Decorated SyntaxDcl];
-synthesized attribute domContribs :: [copper:ElementReference];
-synthesized attribute subContribs :: [copper:ElementReference];
+synthesized attribute domContribs :: [Decorated SyntaxDcl];
+synthesized attribute subContribs :: [Decorated SyntaxDcl];
 autocopy attribute containingGrammar :: String;
 monoid attribute lexerClassRefDcls :: String;
 synthesized attribute exportedProds :: [String];
@@ -189,9 +189,6 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
     | _ -> prettyName ++ " (" ++ n ++ ")"
     end;
 
-  top.domContribs = [top.copperElementReference];
-  top.subContribs = [top.copperElementReference];
-
   top.copperElementReference = copper:elementReference(top.sourceGrammar,
     top.location, top.containingGrammar, makeCopperName(n));
   top.copperGrammarElements =
@@ -200,10 +197,10 @@ top::SyntaxDcl ::= n::String regex::Regex modifiers::SyntaxTerminalModifiers
         modifiers.opPrecedence.isJust, modifiers.opPrecedence.fromJust,
         fromMaybe("", modifiers.opAssociation), makeTerminalName(n), 
         "RESULT = new " ++ makeTerminalName(n) ++ "(lexeme,virtualLocation,(int)getStartRealLocation().getPos(),(int)getEndRealLocation().getPos());tokenList.add(RESULT);\n" ++ modifiers.acode,
-        modifiers.lexerClasses, !null(pfx),
+        map((.copperElementReference), modifiers.lexerClasses), !null(pfx),
         copper:elementReference(top.sourceGrammar, top.location,
           top.containingGrammar, head(pfx)),
-        modifiers.submits_, modifiers.dominates_)
+        map((.copperElementReference), modifiers.submits_), map((.copperElementReference), modifiers.dominates_))
     ];
 }
 

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -12,9 +12,9 @@ monoid attribute prefixSeperatorToApply :: Maybe<String> with nothing(), orElse;
 monoid attribute prettyName :: Maybe<String> with nothing(), orElse;
 autocopy attribute terminalName :: String;
 
-monoid attribute dominates_ :: [copper:ElementReference];
-monoid attribute submits_ :: [copper:ElementReference];
-monoid attribute lexerClasses :: [copper:ElementReference];
+monoid attribute dominates_ :: [Decorated SyntaxDcl];
+monoid attribute submits_ :: [Decorated SyntaxDcl];
+monoid attribute lexerClasses :: [Decorated SyntaxDcl];
 
 {--
  - Modifiers for terminals.
@@ -128,7 +128,7 @@ top::SyntaxTerminalModifier ::= cls::[String]
   -- We "translate away" lexer classes dom/sub, by moving that info to the terminals (here)
   top.dominates_ := flatMap((.domContribs), allClsRefs);
   top.submits_ := flatMap((.subContribs), allClsRefs);
-  top.lexerClasses := map((.copperElementReference), allClsRefs);
+  top.lexerClasses := allClsRefs;
   
   local termSeps :: [Maybe<String>] = map((.prefixSeperator), allClsRefs);
   top.prefixSeperator := foldr(orElse, nothing(), termSeps);
@@ -151,7 +151,7 @@ top::SyntaxTerminalModifier ::= sub::[String]
                      else ["Terminal / Lexer Class " ++ a.fst ++ " was referenced but " ++
                            "this grammar was not included in this parser. (Referenced from submit clause on terminal " ++ top.terminalName ++ ")"],
                    zipWith(pair, sub, subRefs)); 
-  top.submits_ := map((.copperElementReference), map(head, subRefs));
+  top.submits_ := map(head, subRefs);
 }
 {--
  - The dominates list for the terminal. Either lexer classes or terminals.
@@ -167,7 +167,7 @@ top::SyntaxTerminalModifier ::= dom::[String]
                      else ["Terminal / Lexer Class " ++ a.fst ++ " was referenced but " ++
                            "this grammar was not included in this parser. (Referenced from dominates clause on terminal " ++ top.terminalName ++ ")"],
                    zipWith(pair, dom, domRefs)); 
-  top.dominates_ := map((.copperElementReference), map(head, domRefs));
+  top.dominates_ := map(head, domRefs);
 }
 {--
  - The action to take whenever this terminal is SHIFTed.

--- a/grammars/silver/compiler/extension/treegen/Arbitrary.sv
+++ b/grammars/silver/compiler/extension/treegen/Arbitrary.sv
@@ -3,6 +3,7 @@ grammar silver:compiler:extension:treegen;
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:concrete_syntax;
+imports silver:compiler:definition:concrete_syntax:ast;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
 imports silver:compiler:extension:convenience;
@@ -12,6 +13,8 @@ imports silver:compiler:modification:lambda_fn;
 imports silver:compiler:modification:let_fix;
 imports silver:compiler:metatranslation;
 
+import silver:util:treemap as tm;
+
 terminal Generator_t 'generator' lexer classes {KEYWORD};
 
 concrete production generatorDcl
@@ -19,35 +22,45 @@ top::AGDcl ::= 'generator' n::Name '::' t::TypeExpr '{' grammars::GeneratorCompo
 {
   top.unparse = s"generator ${n.unparse} :: ${t.unparse} { ${grammars.unparse} }";
 
-  -- Generator components must be imported for the translation here,
-  -- but an AGDcl can't (currently) forward to an import ModuleStmt -
-  -- resorting to a slight interfering workaround for now.
-  propagate moduleNames;
-  forward.env = occursEnv(extraOccursDefs, newScopeEnv(grammars.defs ++ extraDefs, top.env));
+  -- Compute the defs exported by the specified grammars
+  local med::ModuleExportedDefs =
+    moduleExportedDefs(
+      top.location, top.compiledGrammars, top.grammarDependencies,
+      grammars.moduleNames, []);
+  production specEnv::Decorated Env = newScopeEnv(med.defs, emptyEnv());
+  
+  -- Override defs to suppress production attributes from flowing up,
+  -- to avoid a circularity with the environment.
+  top.defs :=
+    case forward of
+    | functionDcl(_, _, ns, _) -> [funDef(top.grammarName, n.location, ns.namedSignature)]
+    | _ -> error("forward should be a function")
+    end;
+
+  -- Build the syntax AST from the specified grammars to extract lexical precedence info 
+  production syntax::SyntaxRoot = cstRoot(
+    n.name, t.typerep.typeName, foldr(consSyntax, nilSyntax(), med.syntaxAst),
+    nothing(), [], [], location=top.location, sourceGrammar=top.grammarName);
 
   production attribute implicitImports::[String] with ++;
   implicitImports := [];
   top.moduleNames <- implicitImports;
-  local extraMED::ModuleExportedDefs = moduleExportedDefs(top.location, top.compiledGrammars, top.grammarDependencies, implicitImports, []);
-  production extraDefs::[Def] = extraMED.defs;
-  production extraOccursDefs::[OccursDclInfo] = extraMED.occursDefs;
+  local extraMED::ModuleExportedDefs =
+    moduleExportedDefs(
+      top.location, top.compiledGrammars, top.grammarDependencies,
+      "silver:core" :: implicitImports, []);
+
+  -- Generator components must be imported for the translation here,
+  -- but an AGDcl can't (currently) forward to an import ModuleStmt -
+  -- resorting to a slight interfering workaround for now.
+  propagate moduleNames;
+  forward.env = occursEnv(extraMED.occursDefs, newScopeEnv(extraMED.defs, specEnv));
 
   -- Implicitly import the random library
   implicitImports <- ["silver:util:random"];
 
   -- We also depend on the silver:regex library
   implicitImports <- ["silver:regex"];
-
-  production specEnv::Decorated Env = newScopeEnv(grammars.defs, emptyEnv());
-  production specTypeDcls::[TypeDclInfo] = map((.dcl), foldr(consDefs, nilDefs(), grammars.defs).typeList);
-  production specNTs::[TypeDclInfo] =
-    filter(
-      \ d::TypeDclInfo -> d.isType && !d.isTypeAlias && d.typeScheme.monoType.isNonterminal,
-      specTypeDcls);
-  production specTerms::[TypeDclInfo] =
-    filter(
-      \ d::TypeDclInfo -> d.isType && !d.isTypeAlias && d.typeScheme.monoType.isTerminal,
-      specTypeDcls);
 
   forwards to Silver_AGDcl {
     function $Name{n}
@@ -57,8 +70,8 @@ top::AGDcl ::= 'generator' n::Name '::' t::TypeExpr '{' grammars::GeneratorCompo
         foldr(
           productionStmtAppend(_, _, location=top.location),
           errorProductionStmt([], location=top.location), -- TODO: No nullProductionStmt?
-          map(genNtLocalDecl(top.location, forward.env, specEnv, _), map((.fullName), specNTs)) ++
-          map(genTermLocalDecl(top.location, forward.env, specEnv, _), map((.fullName), specTerms)))}
+          map(genNtLocalDecl(top.location, forward.env, specEnv, _), map((.fullName), syntax.allNonterminals)) ++
+          map(genTermLocalDecl(top.location, forward.env, specEnv, syntax.dominatingTerminals, _), map((.fullName), syntax.allTerminals)))}
       return $Expr{genForType(top.location, forward.env, specEnv, Silver_Expr { 0 }, t.typerep)};
     }
   };
@@ -67,10 +80,10 @@ top::AGDcl ::= 'generator' n::Name '::' t::TypeExpr '{' grammars::GeneratorCompo
   --top.errors := unsafeTracePrint(forward.errors, forward.unparse);
 }
 
-nonterminal GeneratorComponents with config, grammarName, location, unparse, errors, defs, moduleNames, compiledGrammars, grammarDependencies;
-nonterminal GeneratorComponent with config, grammarName, location, unparse, errors, defs, moduleNames, compiledGrammars, grammarDependencies;
+nonterminal GeneratorComponents with config, grammarName, location, unparse, errors, moduleNames, compiledGrammars, grammarDependencies;
+nonterminal GeneratorComponent with config, grammarName, location, unparse, errors, moduleNames, compiledGrammars, grammarDependencies;
 
-propagate errors, defs, moduleNames on GeneratorComponents, GeneratorComponent;
+propagate errors, moduleNames on GeneratorComponents, GeneratorComponent;
 
 concrete production nilGeneratorComponent
 top::GeneratorComponents ::=
@@ -220,15 +233,30 @@ ProductionStmt ::= loc::Location  env::Decorated Env  specEnv::Decorated Env  nt
 }
 
 function genTermLocalDecl
-ProductionStmt ::= loc::Location  env::Decorated Env  specEnv::Decorated Env  t::String
+ProductionStmt ::= loc::Location  env::Decorated Env  specEnv::Decorated Env  dominatingTerminals::EnvTree<Decorated SyntaxDcl> t::String
 {
   local te::TypeExpr = nominalTypeExpr(qName(loc, t).qNameType, location=loc);
+
+  -- Filter out cantidate lexemes by checking if they match dominating terminal regexes.
+  -- TODO: This a approach is somewhat infinite, and breaks if a terminal is totally dominated by another.
+  -- Is there a better approach involving regex subtraction as a primitive?
+  local termDominated::Expr =
+    foldr(
+      or(_, '||', _, location=loc),
+      falseConst('false', location=loc),
+      map(
+        \ term::Decorated SyntaxDcl -> Silver_Expr {
+          silver:regex:matches($Expr{translate(loc, reflect(term.terminalRegex))}, term.lexeme)
+        },
+        searchEnvTree(t, dominatingTerminals)));
   return
     Silver_ProductionStmt {
       local $name{"gen_" ++ substitute(":", "_", t)}::(silver:core:RandomGen<$TypeExpr{te}> ::= Integer) =
-        let genTerm::(silver:core:RandomGen<$TypeExpr{te}> ::= Location) = genArbTerminal($TypeExpr{te}, _)
-        in \ depth::Integer -> silver:core:bind(silver:util:random:genArb(depth), genTerm)
-        end;
+        \ depth::Integer ->
+          silver:core:bind(
+            silver:core:bind(silver:util:random:genArb(depth), genArbTerminal($TypeExpr{te}, _)),
+            \ term::$TypeExpr{te} ->
+              if $Expr{termDominated} then $name{"gen_" ++ substitute(":", "_", t)}(depth) else pure(term));
     };
 }
 

--- a/grammars/silver/compiler/extension/treegen/TerminalGen.sv
+++ b/grammars/silver/compiler/extension/treegen/TerminalGen.sv
@@ -1,12 +1,17 @@
 grammar silver:compiler:extension:treegen;
 
-import silver:compiler:metatranslation;
-import silver:reflect;
-import silver:regex;
+imports silver:core hiding empty, alt;
+imports silver:regex;
+imports silver:compiler:metatranslation;
+imports silver:reflect;
+
 import silver:util:treeset as set;  -- needed for freeVars equation
 
 terminal GenArbTerminal_t 'genArbTerminal' lexer classes {KEYWORD, RESERVED};
 
+-- Note that this construct ignores lexical dominates/submits to relationships
+-- with other terminals, since we don't have a parser spec/syntax AST to extract
+-- that information.
 concrete production genArbTerminalNoLocExpr
 top::Expr ::= 'genArbTerminal' '(' te::TypeExpr ',' '_' ')'
 {

--- a/grammars/silver/compiler/modification/copper_mda/SyntaxMdaRoot.sv
+++ b/grammars/silver/compiler/modification/copper_mda/SyntaxMdaRoot.sv
@@ -7,7 +7,7 @@ import silver:util:treemap as tm;
 abstract production cstCopperMdaRoot
 top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Syntax  customStartLayout::Maybe<[String]>
 {
-  propagate compareTo, isEqual;
+  propagate compareTo, isEqual, allNonterminals, allTerminals;
 
   -- Because there may be references between the grammars, we cannot do the
   -- usual normalization.
@@ -66,6 +66,8 @@ top::SyntaxRoot ::= parsername::String  startnt::String  host::Syntax  ext::Synt
   top.cstErrors <- if !null(startFound) then []
                    else ["Nonterminal " ++ startnt ++ " was referenced but " ++
                          "this grammar was not included in this parser. (Referenced as parser's starting nonterminal)"];
+
+  top.dominatingTerminals = error("Shouldn't be demanded from cstCopperMdaRoot");
 
   -- The layout before and after the root nonterminal. By default, the layout of the root nonterminal.
   local startLayout::[copper:ElementReference] =

--- a/grammars/silver/regex/Arbitrary.sv
+++ b/grammars/silver/regex/Arbitrary.sv
@@ -97,7 +97,7 @@ top::Regex ::= r1::Regex r2::Regex
     -- i.e. when top.altCountIn == 0.
     if top.altCountIn != 0 then error("genArbMatch on alt when top.altCount != 0") else
     let i::Integer = randomRange(0, top.altCount - 1)
-    in head(dropWhile(\ r::Decorated Regex with GenInhs -> r.altCount < i, top.altOptions)).genArbMatch
+    in head(dropWhile(\ r::Decorated Regex with GenInhs -> !(r.altCountIn <= i && i < r.altCount), top.altOptions)).genArbMatch
     end;
 
   thread altCountIn, altCount on top, r1, r2, top;

--- a/test/silver_features/Main.sv
+++ b/test/silver_features/Main.sv
@@ -6,6 +6,7 @@ import silver_features:defs;
 import silver_features:cond;
 import silver_features:anno;
 import silver_features:rewrite;
+import silver_features:treegen;
 
 mainTestSuite silver_tests;
 

--- a/test/silver_features/treegen/Treegen.sv
+++ b/test/silver_features/treegen/Treegen.sv
@@ -1,0 +1,24 @@
+grammar silver_features:treegen;
+
+imports silver_features;
+imports silver:testing;
+imports silver:util:random;
+
+terminal A 'a' lexer classes C1;
+terminal AB /a|b/ lexer classes C2;
+lexer class C2;
+lexer class C1 dominates C2;
+
+synthesized attribute name::String;
+nonterminal Foo with name;
+concrete productions top::Foo
+| ab::AB { top.name = ab.lexeme; }
+
+generator genFoo::Foo {
+  silver_features:treegen;
+}
+
+equalityTest(
+  map((.name), runSeedRandomGen(42, sequence(repeat(genFoo(3, 4), 10)))),
+  repeat("b", 10),
+  [String], silver_tests);


### PR DESCRIPTION
# Changes
This PR is based on #644 and should be reviewed after merging that.

Currently using Silver's random tree generation feature to generate concrete syntax trees has a bug: a terminal may have any lexeme generated that matches its regex, even if it is dominated by other identifiers; this may lead to the generation of unparsable ASTs.  This change considers lexical precedence relationships to filter out candidate lexemes that would lead to parse errors.

# Documentation
I added source comments as needed.  This fixes a bug in an experimental feature of Silver.  
