### PR TITLE
Fix for spawning a subprocess with arguments

### DIFF
--- a/runtime/java/src/common/rawlib/RawProcessHandle.java
+++ b/runtime/java/src/common/rawlib/RawProcessHandle.java
@@ -207,6 +207,7 @@ public class RawProcessHandle {
     public static NIOVal spawnProcess(StringCatter cmd, ConsCell args, IOToken io) {
         List<StringCatter> argsList = ConsCell.toList(args);
         List<String> full_cmd = new ArrayList<String>();
+        //Convert all the args to regular Strings instead of StringCatter
         for (int i = 0; i < argsList.size(); i++) {
             full_cmd.add(i, argsList.get(i).toString());
         }

--- a/runtime/java/src/common/rawlib/RawProcessHandle.java
+++ b/runtime/java/src/common/rawlib/RawProcessHandle.java
@@ -206,7 +206,7 @@ public class RawProcessHandle {
      */
     public static NIOVal spawnProcess(StringCatter cmd, ConsCell args, IOToken io) {
         List<StringCatter> argsList = ConsCell.toList(args);
-        List<String> full_cmd = new ArrayList();
+        List<String> full_cmd = new ArrayList<String>();
         for (int i = 0; i < argsList.size(); i++) {
             full_cmd.add(i, argsList.get(i).toString());
         }

--- a/runtime/java/src/common/rawlib/RawProcessHandle.java
+++ b/runtime/java/src/common/rawlib/RawProcessHandle.java
@@ -204,7 +204,11 @@ public class RawProcessHandle {
      * <pre>IOVal<ProcessHandle> ::= cmd::String args::[String] io::IO</pre>
      */
     public static NIOVal spawnProcess(StringCatter cmd, ConsCell args, IOToken io) {
-        List<String> full_cmd = ConsCell.toList(args);
+        List<StringCatter> args = ConsCell.toList(args);
+        List<String> full_cmd = new ArrayList();
+        for (int i = 0; i < args.size(); i++) {
+            full_cmd.add(i, args.get(i).toString());
+        }
         full_cmd.add(0, cmd.toString());
         return io.wrap(new RawProcessHandle(full_cmd));
     }

--- a/runtime/java/src/common/rawlib/RawProcessHandle.java
+++ b/runtime/java/src/common/rawlib/RawProcessHandle.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 
 import common.IOToken;
 import common.ConsCell;
+import common.javainterop.ConsCellCollection;
 import common.StringCatter;
 import silver.core.NIOVal;
 
@@ -205,13 +206,12 @@ public class RawProcessHandle {
      * <pre>IOVal<ProcessHandle> ::= cmd::String args::[String] io::IO</pre>
      */
     public static NIOVal spawnProcess(StringCatter cmd, ConsCell args, IOToken io) {
-        List<StringCatter> argsList = ConsCell.toList(args);
         List<String> full_cmd = new ArrayList<String>();
+        full_cmd.add(cmd.toString());
         //Convert all the args to regular Strings instead of StringCatter
-        for (int i = 0; i < argsList.size(); i++) {
-            full_cmd.add(i, argsList.get(i).toString());
+        for (StringCatter arg : new ConsCellCollection<StringCatter>(args)) {
+            full_cmd.add(arg.toString());
         }
-        full_cmd.add(0, cmd.toString());
         return io.wrap(new RawProcessHandle(full_cmd));
     }
 

--- a/runtime/java/src/common/rawlib/RawProcessHandle.java
+++ b/runtime/java/src/common/rawlib/RawProcessHandle.java
@@ -204,10 +204,10 @@ public class RawProcessHandle {
      * <pre>IOVal<ProcessHandle> ::= cmd::String args::[String] io::IO</pre>
      */
     public static NIOVal spawnProcess(StringCatter cmd, ConsCell args, IOToken io) {
-        List<StringCatter> args = ConsCell.toList(args);
+        List<StringCatter> argsList = ConsCell.toList(args);
         List<String> full_cmd = new ArrayList();
-        for (int i = 0; i < args.size(); i++) {
-            full_cmd.add(i, args.get(i).toString());
+        for (int i = 0; i < argsList.size(); i++) {
+            full_cmd.add(i, argsList.get(i).toString());
         }
         full_cmd.add(0, cmd.toString());
         return io.wrap(new RawProcessHandle(full_cmd));

--- a/runtime/java/src/common/rawlib/RawProcessHandle.java
+++ b/runtime/java/src/common/rawlib/RawProcessHandle.java
@@ -5,6 +5,7 @@ import java.io.OutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
+import java.util.ArrayList;
 
 import common.IOToken;
 import common.ConsCell;


### PR DESCRIPTION
# Changes
This fixes the `spawnProcess` function in `silver:util:subprocess` so it doesn't crash when arguments are given for the subprocess being spawned.

# Documentation
I added a comment explaining why the `for` loop is there.  This doesn't need any further documentation because it is fixing the behavior to be the expected one and doesn't affect any code outside of the immediate function.