### PR TITLE
Don't avoid regenerating the parser after parser generation failed

### DIFF
--- a/grammars/silver/compiler/modification/copper/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper/BuildProcess.sv
@@ -155,7 +155,7 @@ top::DriverAction ::= spec::ParserSpec  compiledGrammars::EnvTree<Decorated Root
     if dumpFileExists then do {
       dumpFileContents::ByteArray <- readBinaryFile(dumpFile);
       let dumpMatched::Either<String Boolean> = map(eq(specCstAst, _), nativeDeserialize(dumpFileContents));
-      if dumpMatched == right(true) then do {
+      if dumpMatched == right(true) && !cmdArgs.forceCopperDump then do {
         print("Parser " ++ spec.fullName ++ " is up to date.\n");
         return 0;
       } else do {

--- a/grammars/silver/compiler/modification/copper/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper/BuildProcess.sv
@@ -136,10 +136,11 @@ top::DriverAction ::= spec::ParserSpec  compiledGrammars::EnvTree<Decorated Root
           makeName(spec.sourceGrammar), parserName, false,
           outDir ++ parserName ++ ".java", cmdArgs.forceCopperDump,
           parserName ++ ".html", cmdArgs.copperXmlDump);
-        case nativeSerialize(new(specCstAst)) of
-        | left(e) -> error("BUG: specCstAst was not serializable; hopefully this was caused by the most recent change to the copper modification: " ++ e)
-        | right(dump) -> writeBinaryFile(dumpFile, dump)
-        end;
+        when_(ret == 0,
+          case nativeSerialize(new(specCstAst)) of
+          | left(e) -> error("BUG: specCstAst was not serializable; hopefully this was caused by the most recent change to the copper modification: " ++ e)
+          | right(dump) -> writeBinaryFile(dumpFile, dump)
+          end);
         return ret;
       };
     } else do {

--- a/runtime/java/src/common/CopperUtil.java
+++ b/runtime/java/src/common/CopperUtil.java
@@ -7,6 +7,7 @@ import edu.umn.cs.melt.copper.compiletime.logging.CompilerLogger;
 import edu.umn.cs.melt.copper.compiletime.pipeline.AuxiliaryMethods;
 import edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.*;
 import edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.visitors.ParserSpecProcessor;
+import edu.umn.cs.melt.copper.main.CopperDumpControl;
 import edu.umn.cs.melt.copper.main.CopperDumpType;
 import edu.umn.cs.melt.copper.main.CopperIOType;
 import edu.umn.cs.melt.copper.main.CopperPipelineType;
@@ -15,11 +16,14 @@ import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.engines.semantics.VirtualLocation;
 import edu.umn.cs.melt.copper.runtime.io.Location;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
+
+import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
+
 import silver.core.Init;
 import silver.core.NIOVal;
 import silver.core.NLocation;
@@ -65,6 +69,10 @@ public final class CopperUtil {
     }
     params.setUsePipeline(CopperPipelineType.GRAMMARBEANS);
     params.setRunMDA(runMDA);
+    params.setDumpOutputType(CopperIOType.FILE);
+    params.setDumpFile(new File(dumpHtmlTo));
+    params.setDumpFormat(CopperDumpType.HTML);
+    params.setDump(dumpHtml? CopperDumpControl.ON : CopperDumpControl.ERROR_ONLY);
 
     CompilerLogger logger = AuxiliaryMethods.getOrMakeLogger(params);
 


### PR DESCRIPTION
# Changes
Bug fix - we were always writing out the serialized parser spec, even when parser generation failed.  This meant that in subsequent non-clean builds we wouldn't try generating the parser, and the build would instead fail later in java compilation where the generated parser java class is missing.  

# Documentation
None, this is a bug fix.
