### PR TITLE
Fix bug with strategy attribute translation let binding not being decorated

### DIFF
--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -49,7 +49,7 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
         e.liftedStrategies));
   
   -- Uncomment for debugging
-  --forwards to unsafeTrace(fwrd, print(a.name ++ " = " ++ e.unparse ++ "; lifted  " ++ implode(",  ", map(fst, e.liftedStrategies)) ++ "\n\n", unsafeIO()));
+  --forwards to unsafeTrace(fwrd, printT(a.name ++ " = " ++ e.unparse ++ "; lifted  " ++ implode(",  ", map(fst, e.liftedStrategies)) ++ "\n\n", unsafeIO()));
 
   forwards to fwrd;
 }
@@ -167,6 +167,6 @@ top::ProductionStmt ::= attr::PartiallyDecorated QName
         attr.lookupAttribute.dcl.liftedStrategyNames));
   
   -- Uncomment for debugging
-  --forwards to unsafeTrace(fwrd, print(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ (if isTotal then e2.totalTranslation else e2.partialTranslation).unparse ++ ";\n\n", unsafeIO()));
+  --forwards to unsafeTrace(fwrd, printT(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ (if isTotal then e2.totalTranslation else e2.partialTranslation).unparse ++ ";\n\n", unsafeIO()));
   forwards to fwrd;
 }

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -796,7 +796,7 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
     else if top.frame.signature.outputElement.elementName == id.name
     then res
     else Silver_Expr {
-      let $Name{id}::$TypeExpr{ty} = $name{top.frame.signature.outputElement.elementName}
+      let $Name{id}::Decorated $TypeExpr{ty} = $name{top.frame.signature.outputElement.elementName}
       in $Expr{res}
       end
     };


### PR DESCRIPTION
# Changes
Fixes a minor bug in strategy attribute translation: when the production LHS name and the name given in a rule don't match, we introduce a let binding.  This should be a decorated reference to the actual LHS but instead was undecorated, leading to missing inherited equations when the copied LHS gets re-decorated with nothing.

# Documentation
None, this is a bug fix for an already-documented feature.  
