### PR TITLE
Allow specifying the direction that children are traversed in threaded attributes

### DIFF
--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -147,7 +147,7 @@ top::AttributeDclInfo ::= inh::String synPartial::String syn::String
 }
 
 abstract production threadedInhDcl
-top::AttributeDclInfo ::= inh::String syn::String bound::[TyVar] ty::Type
+top::AttributeDclInfo ::= inh::String syn::String bound::[TyVar] ty::Type rev::Boolean
 {
   top.fullName = inh;
 
@@ -158,11 +158,11 @@ top::AttributeDclInfo ::= inh::String syn::String bound::[TyVar] ty::Type
   top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _);
   top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_); -- Allow normal inh equations
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
-  top.propagateDispatcher = propagateThreadedInh(_, syn, location=_);
+  top.propagateDispatcher = propagateThreadedInh(rev, _, syn, location=_);
 }
 
 abstract production threadedSynDcl
-top::AttributeDclInfo ::= inh::String syn::String bound::[TyVar] ty::Type
+top::AttributeDclInfo ::= inh::String syn::String bound::[TyVar] ty::Type rev::Boolean
 {
   top.fullName = syn;
 
@@ -173,5 +173,5 @@ top::AttributeDclInfo ::= inh::String syn::String bound::[TyVar] ty::Type
   top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
   top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
-  top.propagateDispatcher = propagateThreadedSyn(inh, _, location=_);
+  top.propagateDispatcher = propagateThreadedSyn(rev, inh, _, location=_);
 }

--- a/grammars/silver/compiler/extension/autoattr/Terminals.sv
+++ b/grammars/silver/compiler/extension/autoattr/Terminals.sv
@@ -3,6 +3,7 @@ grammar silver:compiler:extension:autoattr;
 terminal Propagate_kwd 'propagate' lexer classes {KEYWORD,RESERVED};
 terminal Excluding_kwd 'excluding' lexer classes {KEYWORD};
 terminal Thread_kwd    'thread'    lexer classes {KEYWORD,RESERVED};
+terminal Direction_kwd 'direction' lexer classes {KEYWORD};
 
 terminal Functor_kwd     'functor'     lexer classes {KEYWORD};
 terminal Monoid_kwd      'monoid'      lexer classes {KEYWORD};

--- a/grammars/silver/compiler/extension/autoattr/Threaded.sv
+++ b/grammars/silver/compiler/extension/autoattr/Threaded.sv
@@ -1,7 +1,9 @@
 grammar silver:compiler:extension:autoattr;
 
+import silver:compiler:definition:concrete_syntax only Left_kwd, Right_kwd;
+
 concrete production threadedAttributeDcl
-top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTypeExprs '::' te::TypeExpr d::OptDirectionMod ';'
 {
   top.unparse = s"threaded attribute ${inh.unparse}, ${syn.unparse} ${tl.unparse} :: ${te.unparse};";
   top.moduleNames := [];
@@ -26,34 +28,52 @@ top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTy
   
   forwards to
     defsAGDcl(
-      [attrDef(defaultEnvItem(threadedInhDcl(inhFName, synFName, tl.freeVariables, te.typerep, sourceGrammar=top.grammarName, sourceLocation=inh.location))),
-       attrDef(defaultEnvItem(threadedSynDcl(inhFName, synFName, tl.freeVariables, te.typerep, sourceGrammar=top.grammarName, sourceLocation=syn.location)))],
+      [attrDef(defaultEnvItem(threadedInhDcl(inhFName, synFName, tl.freeVariables, te.typerep, d.reversed, sourceGrammar=top.grammarName, sourceLocation=inh.location))),
+       attrDef(defaultEnvItem(threadedSynDcl(inhFName, synFName, tl.freeVariables, te.typerep, d.reversed, sourceGrammar=top.grammarName, sourceLocation=syn.location)))],
       location=top.location);
 }
 
+synthesized attribute reversed::Boolean;
+
+nonterminal OptDirectionMod with reversed;
+concrete productions top::OptDirectionMod
+| 'direction' '=' d::Direction
+  { top.reversed = d.reversed; }
+|
+  { top.reversed = false; }
+
+nonterminal Direction with reversed;
+concrete productions top::Direction
+| 'left' 'to' 'right'
+  { top.reversed = false; }
+| 'right' 'to' 'left'
+  { top.reversed = true; }
+
 abstract production propagateThreadedInh
-top::ProductionStmt ::= inh::PartiallyDecorated QName syn::String
+top::ProductionStmt ::= rev::Boolean inh::PartiallyDecorated QName syn::String
 {
   top.unparse = s"propagate ${inh.unparse};";
   
   local lhsName::String = top.frame.signature.outputElement.elementName;
+  local occursChildren::[String] =
+    map(
+      (.elementName),
+      filter(
+        \ ie::NamedSignatureElement ->
+          isDecorable(ie.typerep, top.env) &&
+          !ie.typerep.isPartiallyDecorated &&  -- Don't thread on partially decorated children
+          !null(getOccursDcl(inh.lookupAttribute.fullName, ie.typerep.typeName, top.env)) &&
+          !null(getOccursDcl(syn, ie.typerep.typeName, top.env)),
+        if null(getOccursDcl(syn, top.frame.lhsNtName, top.env)) && !null(top.frame.signature.inputElements)
+        then init(top.frame.signature.inputElements)
+        else top.frame.signature.inputElements));
   forwards to
     threadInhDcl(
       inh.name, syn,
       map(
         name(_, top.location),
         lhsName ::
-        map(
-          (.elementName),
-          filter(
-            \ ie::NamedSignatureElement ->
-              isDecorable(ie.typerep, top.env) &&
-              !ie.typerep.isPartiallyDecorated &&  -- Don't thread on partially decorated children
-              !null(getOccursDcl(inh.lookupAttribute.fullName, ie.typerep.typeName, top.env)) &&
-              !null(getOccursDcl(syn, ie.typerep.typeName, top.env)),
-            if null(getOccursDcl(syn, top.frame.lhsNtName, top.env)) && !null(top.frame.signature.inputElements)
-            then init(top.frame.signature.inputElements)
-            else top.frame.signature.inputElements)) ++
+        (if rev then reverse(occursChildren) else occursChildren) ++
         if null(getOccursDcl(syn, top.frame.lhsNtName, top.env)) && !null(top.frame.signature.inputElements)
         then if !null(getOccursDcl(inh.lookupAttribute.fullName, last(top.frame.signature.inputElements).typerep.typeName, top.env))
           then [last(top.frame.signature.inputElements).elementName]
@@ -63,26 +83,28 @@ top::ProductionStmt ::= inh::PartiallyDecorated QName syn::String
 }
 
 abstract production propagateThreadedSyn
-top::ProductionStmt ::= inh::String syn::PartiallyDecorated QName
+top::ProductionStmt ::= rev::Boolean inh::String syn::PartiallyDecorated QName
 {
   top.unparse = s"propagate ${syn.unparse};";
   
   local lhsName::String = top.frame.signature.outputElement.elementName;
+  local occursChildren::[String] =
+    map(
+      (.elementName),
+      filter(
+        \ ie::NamedSignatureElement ->
+          isDecorable(ie.typerep, top.env) &&
+          !ie.typerep.isPartiallyDecorated &&  -- Don't thread on partially decorated children
+          !null(getOccursDcl(inh, ie.typerep.typeName, top.env)) &&
+          !null(getOccursDcl(syn.lookupAttribute.fullName, ie.typerep.typeName, top.env)),
+        top.frame.signature.inputElements));
   forwards to
     threadSynDcl(
       inh, syn.name,
       map(
         name(_, top.location),
         lhsName ::
-        map(
-          (.elementName),
-          filter(
-            \ ie::NamedSignatureElement ->
-              isDecorable(ie.typerep, top.env) &&
-              !ie.typerep.isPartiallyDecorated &&  -- Don't thread on partially decorated children
-              !null(getOccursDcl(inh, ie.typerep.typeName, top.env)) &&
-              !null(getOccursDcl(syn.lookupAttribute.fullName, ie.typerep.typeName, top.env)),
-            top.frame.signature.inputElements)) ++
+        (if rev then reverse(occursChildren) else occursChildren) ++
         [if !null(getValueDcl("forward", top.env)) then "forward" else lhsName]),
       location=top.location);
 }

--- a/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
@@ -135,12 +135,12 @@ top::AGDcl ::= 'unification' 'attribute' synPartial::Name ',' syn::Name 'with' i
 }
 
 concrete production threadedAttributeDclMultiple
-top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTypeExprs '::' te::TypeExpr 'occurs' 'on' qs::QNames ';'
+top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTypeExprs '::' te::TypeExpr 'occurs' 'on' qs::QNames  d::OptDirectionMod ';'
 {
   top.unparse = "threaded attribute " ++ inh.unparse ++ ", " ++ syn.name ++ tl.unparse ++ " :: " ++ te.unparse ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      threadedAttributeDcl($1, $2, inh, $4, syn, tl, $7, te, $12, location=top.location),
+      threadedAttributeDcl($1, $2, inh, $4, syn, tl, $7, te, d, ';', location=top.location),
       appendAGDcl(
         makeOccursDclsHelp($1.location, qNameWithTL(qNameId(inh, location=inh.location), botlNone(location=top.location)), qs.qnames),
         makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),

--- a/grammars/silver/compiler/extension/doc/core/AGDcl.sv
+++ b/grammars/silver/compiler/extension/doc/core/AGDcl.sv
@@ -151,10 +151,10 @@ top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::T
 }
 
 aspect production threadedAttributeDcl
-top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTypeExprs '::' te::TypeExpr d::OptDirectionMod ';'
 {
   top.docForName = inh.name++" and "++syn.name++" (threaded pair)";
-  top.docUnparse = s"`threaded attribute ${inh.name}, ${syn.name}${tl.unparse} :: ${te.unparse}`";
+  top.docUnparse = s"`threaded attribute ${inh.name}, ${syn.name}${tl.unparse} :: ${te.unparse} direction=${if d.reversed then "right to left" else "left to right"}`";
   top.docDcls := [pair(inh.name, docDclInfo(inh.name, top.location, top.grammarName)),
                   pair(syn.name, docDclInfo(syn.name, top.location, top.grammarName))];
   top.docs := [mkUndocumentedItem(top.docForName, top)];

--- a/test/silver_features/Threaded.sv
+++ b/test/silver_features/Threaded.sv
@@ -1,0 +1,29 @@
+grammar silver_features;
+
+threaded attribute tinh1, tsyn1 :: [Integer] direction = left to right;
+threaded attribute tinh2, tsyn2 :: [Integer] direction = right to left;
+
+nonterminal TNT with tinh1, tinh2, tsyn1, tsyn2;
+
+production tFork
+top::TNT ::= t1::TNT t2::TNT
+{ propagate tinh1, tinh2, tsyn1, tsyn2; }
+
+production tLeaf
+top::TNT ::= i::Integer
+{
+  top.tsyn1 = top.tinh1 ++ [i];
+  top.tsyn2 = top.tinh2 ++ [i];
+}
+
+production tFwrd
+top::TNT ::= f::TNT
+{
+  propagate tinh1, tinh2, tsyn1, tsyn2;
+  forwards to tLeaf(4);
+}
+
+global tnt::TNT = tFork(tFork(tLeaf(1), tLeaf(2)), tFwrd(tLeaf(3)));
+
+equalityTest(decorate tnt with {tinh1 = [0];}.tsyn1, [0, 1, 2, 3, 4], [Integer], silver_tests);
+equalityTest(decorate tnt with {tinh2 = [0];}.tsyn2, [0, 3, 4, 2, 1], [Integer], silver_tests);


### PR DESCRIPTION
# Changes
This allows specifying the default order in which children are traversed in propagating a threaded attribute pair, by allowing `direction = left to right` or `direction = right to left` after the type in the declaration.  The default if no direction is specified remains left to right.

# Documentation
I updated the docs about threaded attributes on the website.  
