### PR TITLE
Bug fixes and cleanup to attribute occurs-on contexts

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/Context.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Context.sv
@@ -6,6 +6,8 @@ monoid attribute contextErrors::[Message] occurs on Contexts, Context;
 attribute downSubst, upSubst occurs on Contexts, Context;
 propagate contextLoc, contextSource, contextErrors, downSubst, upSubst on Contexts;
 
+flowtype contextErrors {contextLoc, contextSource, env, frame, grammarName, compiledGrammars, config} on Context;
+
 aspect production instContext
 top::Context ::= cls::String t::Type
 {

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -56,6 +56,7 @@ autocopy attribute isRoot :: Boolean;
 
 autocopy attribute originRules :: [Decorated Expr];
 
+attribute grammarName, frame occurs on Contexts, Context;
 
 abstract production errorExpr
 top::Expr ::= e::[Message]
@@ -152,6 +153,10 @@ top::Expr ::= q::PartiallyDecorated QName
   production contexts::Contexts =
     foldContexts(map(performContextSubstitution(_, top.finalSubst), typeScheme.contexts));
   contexts.env = top.env;
+  contexts.frame = top.frame;
+  contexts.config = top.config;
+  contexts.grammarName = top.grammarName;
+  contexts.compiledGrammars = top.compiledGrammars;
 }
 
 abstract production functionReference
@@ -166,6 +171,10 @@ top::Expr ::= q::PartiallyDecorated QName
   production contexts::Contexts =
     foldContexts(map(performContextSubstitution(_, top.finalSubst), typeScheme.contexts));
   contexts.env = top.env;
+  contexts.frame = top.frame;
+  contexts.config = top.config;
+  contexts.grammarName = top.grammarName;
+  contexts.compiledGrammars = top.compiledGrammars;
 }
 
 abstract production classMemberReference
@@ -183,12 +192,20 @@ top::Expr ::= q::PartiallyDecorated QName
     | _ -> error("Class member should have at least one context!")
     end;
   instHead.env = top.env;
+  instHead.frame = top.frame;
+  instHead.config = top.config;
+  instHead.grammarName = top.grammarName;
+  instHead.compiledGrammars = top.compiledGrammars;
   production contexts::Contexts =
     case typeScheme.contexts of
     | _ :: cs -> foldContexts(map(performContextSubstitution(_, top.finalSubst), cs))
     | _ -> error("Class member should have at least one context!")
     end;
   contexts.env = top.env;
+  contexts.frame = top.frame;
+  contexts.config = top.config;
+  contexts.grammarName = top.grammarName;
+  contexts.compiledGrammars = top.compiledGrammars;
 }
 
 abstract production globalValueReference
@@ -206,7 +223,10 @@ top::Expr ::= q::PartiallyDecorated QName
   production contexts::Contexts =
     foldContexts(map(performContextSubstitution(_, top.finalSubst), typeScheme.contexts));
   contexts.env = top.env;
-
+  contexts.frame = top.frame;
+  contexts.config = top.config;
+  contexts.grammarName = top.grammarName;
+  contexts.compiledGrammars = top.compiledGrammars;
 }
 
 concrete production concreteForwardExpr

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -1,12 +1,14 @@
 grammar silver:compiler:definition:env;
 
+import silver:compiler:definition:core only frame, grammarName, compiledGrammars;
+
 -- Context lookup/resolution stuff lives here
 
 attribute env occurs on Context;
 
 -- This mostly exists as a convenient way to perform multiple env-dependant operations
 -- on a list of contexts without re-decorating them and repeating context resolution.
-nonterminal Contexts with env, contexts, freeVariables, boundVariables;
+nonterminal Contexts with env, config, compiledGrammars, grammarFlowTypes, contexts, freeVariables, boundVariables;
 abstract production consContext
 top::Contexts ::= h::Context t::Contexts
 {
@@ -35,6 +37,8 @@ synthesized attribute resolvedOccurs::[OccursDclInfo] occurs on Context;
 
 monoid attribute isTypeError::Boolean with false, || occurs on Contexts, Context;
 propagate isTypeError on Contexts, Context;
+
+attribute config, compiledGrammars, grammarFlowTypes occurs on Context;
 
 aspect default production
 top::Context ::=
@@ -82,6 +86,10 @@ top::Context ::= cls::String t::Type
   production requiredContexts::Contexts =
     foldContexts(map(performContextRenaming(_, resolvedSubst), resolvedTypeScheme.contexts));
   requiredContexts.env = top.env;
+  requiredContexts.frame = top.frame;
+  requiredContexts.config = top.config;
+  requiredContexts.grammarName = top.grammarName;
+  requiredContexts.compiledGrammars = top.compiledGrammars;
 }
 
 aspect production inhOccursContext
@@ -106,6 +114,10 @@ top::Context ::= attr::String args::[Type] atty::Type ntty::Type
   production requiredContexts::Contexts =
     foldContexts(map(performContextRenaming(_, resolvedSubst), resolvedTypeScheme.contexts));
   requiredContexts.env = top.env;
+  requiredContexts.frame = top.frame;
+  requiredContexts.config = top.config;
+  requiredContexts.grammarName = top.grammarName;
+  requiredContexts.compiledGrammars = top.compiledGrammars;
 }
 
 aspect production synOccursContext
@@ -130,6 +142,10 @@ top::Context ::= attr::String args::[Type] atty::Type inhs::Type ntty::Type
   production requiredContexts::Contexts =
     foldContexts(map(performContextRenaming(_, resolvedSubst), resolvedTypeScheme.contexts));
   requiredContexts.env = top.env;
+  requiredContexts.frame = top.frame;
+  requiredContexts.config = top.config;
+  requiredContexts.grammarName = top.grammarName;
+  requiredContexts.compiledGrammars = top.compiledGrammars;
 }
 
 aspect production annoOccursContext
@@ -154,6 +170,10 @@ top::Context ::= attr::String args::[Type] atty::Type ntty::Type
   production requiredContexts::Contexts =
     foldContexts(map(performContextRenaming(_, resolvedSubst), resolvedTypeScheme.contexts));
   requiredContexts.env = top.env;
+  requiredContexts.frame = top.frame;
+  requiredContexts.config = top.config;
+  requiredContexts.grammarName = top.grammarName;
+  requiredContexts.compiledGrammars = top.compiledGrammars;
 }
 
 aspect production typeableContext
@@ -182,6 +202,10 @@ top::Context ::= t::Type
       then map(compose(typeableContext, skolemType), t.freeSkolemVars)
       else resolvedDcl.typeScheme.contexts);
   requiredContexts.env = top.env;
+  requiredContexts.frame = top.frame;
+  requiredContexts.config = top.config;
+  requiredContexts.grammarName = top.grammarName;
+  requiredContexts.compiledGrammars = top.compiledGrammars;
 }
 
 synthesized attribute isTypeable::Boolean occurs on Type;

--- a/grammars/silver/compiler/definition/type/syntax/Constraint.sv
+++ b/grammars/silver/compiler/definition/type/syntax/Constraint.sv
@@ -117,9 +117,9 @@ top::Constraint ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' '
       at.name ++ " has kind " ++ prettyKind(foldr(arrowKind, starKind(), map((.kindrep), atTypeScheme.boundVars))) ++
         "but type variable(s) have kind(s) " ++ implode(", ", map(compose(prettyKind, (.kindrep)), attl.types)) ++ ".")]
     else [];
-  
+
   top.errors <- t.errorsKindStar;
-  
+
   local atTypeScheme::PolyType = at.lookupAttribute.typeScheme;
   local rewrite :: Substitution = zipVarsAndTypesIntoSubstitution(atTypeScheme.boundVars, attl.types);
   production attrTy::Type = performRenaming(atTypeScheme.typerep, rewrite);
@@ -164,9 +164,9 @@ top::Constraint ::= 'attribute' at::QName attl::BracketedOptTypeExprs i::TypeExp
     if i.typerep.kindrep != inhSetKind()
     then [err(i.location, s"${i.unparse} has kind ${prettyKind(i.typerep.kindrep)}, but kind InhSet is expected here")]
     else [];
-    
+
   top.errors <- t.errorsKindStar;
-  
+
   local atTypeScheme::PolyType = at.lookupAttribute.typeScheme;
   local rewrite :: Substitution = zipVarsAndTypesIntoSubstitution(atTypeScheme.boundVars, attl.types);
   production attrTy::Type = performRenaming(atTypeScheme.typerep, rewrite);

--- a/grammars/silver/compiler/extension/testing/EqualityTest.sv
+++ b/grammars/silver/compiler/extension/testing/EqualityTest.sv
@@ -47,6 +47,10 @@ ag::AGDcl ::= kwd::'equalityTest'
   eqCtx.env = ag.env;
   eqCtx.contextLoc = valueType.location;
   eqCtx.contextSource = "equalityTest";
+  eqCtx.frame = value.frame;
+  eqCtx.config = ag.config;
+  eqCtx.grammarName = ag.grammarName;
+  eqCtx.compiledGrammars = ag.compiledGrammars;
   localErrors <- eqCtx.contextErrors;
 
   value.downSubst = emptySubst();

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -364,7 +364,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
       case finalType(e) of
       -- Don't know the actual number of attributes for skolems with occurs-on contexts,
       -- fall back to using the max index.
-      | skolemType(_) -> foldr1(\ i1::String i2::String -> s"max(${i1}, ${i2})", inh.nameTrans) ++ " + 1"
+      | skolemType(_) -> foldr1(\ i1::String i2::String -> s"Math.max(${i1}, ${i2})", inh.nameTrans) ++ " + 1"
       | t -> s"${makeNTName(t.typeName)}.num_inh_attrs"
       end ++ ", " ++
       s"new int[]{${implode(", ", inh.nameTrans)}}, " ++ 

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -333,7 +333,7 @@ String ::= bv::[TyVar] sigInhOccurs::[(Type, String)] typeVarArray::String inhAr
   t.boundVariables = bv;
   local inhs::[String] = lookupAllBy(typeNameEq, t, sigInhOccurs);
   return s"""		if (${typeVarArray}[key] == type_${t.transTypeName}) {
-			common.Lazy[] res = new common.Lazy[${foldr1(\ i1::String i2::String -> s"max(${i1}, ${i2})", map(makeConstraintDictName(_, t, bv), inhs))} + 1];
+			common.Lazy[] res = new common.Lazy[${foldr1(\ i1::String i2::String -> s"Math.max(${i1}, ${i2})", map(makeConstraintDictName(_, t, bv), inhs))} + 1];
 ${flatMap(\ inh::String -> s"\t\t\tres[${makeConstraintDictName(inh, t, bv)}] = ${inhArray}[key][${makeIdName(inh)}__ON__${t.transTypeName}];\n", inhs)}
 			return res;
 		}


### PR DESCRIPTION
# Changes
* Fix a translation bug when there are multiple inherited occurs-on contexts for a single type variable; use `Math.max` for computing the size of the thunk array (was previously calling `max` which isn't globally defined)
* Add MWDA checks for places where a synthesized occurs-on context is solved (e.g. in calling a function with a syn occurs context) that the actual flow dependencies of the attribute are a subset of the flow type in the constraint.  I apparently forgot to implement/test this when implementing occurs-on contexts?
* Remove special-case workaround in the MWDA for lists from when they were a modification

# Documentation
This is a fix to an existing feature; no new documentation is added besides source code comments.  I added test cases for the new MWDA warnings.