### PR TITLE
Fix circularity between flow analysis and type checking introduced in #660

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -66,9 +66,7 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   -- contexts in the environment.
   production infContexts::Contexts = foldContexts(e.contexts);
   infContexts.env = top.env;
-  infContexts.frame = top.frame;
-  infContexts.grammarName = top.grammarName;
-  infContexts.compiledGrammars = top.compiledGrammars;
+  infContexts.flowEnv = top.flowEnv;
 
   thread downSubst, upSubst on top, e, es, anns, infContexts, forward;
 }

--- a/grammars/silver/compiler/definition/flow/env/Occurs.sv
+++ b/grammars/silver/compiler/definition/flow/env/Occurs.sv
@@ -1,7 +1,11 @@
 grammar silver:compiler:definition:flow:env;
 
+import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
 import silver:compiler:driver:util only isExportedBy;
+
+-- Needed for specializing inh deps in syn occurs-on contexts
+attribute flowEnv occurs on Contexts, Context;
 
 aspect production attributionDcl
 top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' nt::QName nttl::BracketedOptTypeExprs ';'

--- a/test/flow/OccursContext.sv
+++ b/test/flow/OccursContext.sv
@@ -232,3 +232,15 @@ Integer ::= e::Expr
   e.env1 = [];
   return getValuePoly(e);
 }
+
+-- value missing a flowtype
+nonterminal Expr2 with env1, value;
+
+wrongCode "Ambiguous type variable a (arising from the use of getValuePoly) prevents the constraint attribute flow:value a occurs on flow:Expr2 from being solved. Note: this ambiguity might be resolved by specifying an explicit flowtype for flow:value on flow:Expr2" {
+function getValueExpr2
+Integer ::= e::Expr2
+{
+  e.env1 = [];
+  return getValuePoly(e);
+}
+}


### PR DESCRIPTION
# Changes
It turns out that one of the fixes in #660 that resolves flow types in syn occurs-on contexts by looking at the flow types is problematic, since it introduces a dependency of the flow analysis on type checking, causing potential circularity.  Instead only look at explicitly specified flow types.

# Documentation
Comments in the source code.
