### PR TITLE
Highlight aspect signature names as semantic tokens

### DIFF
--- a/grammars/silver/compiler/definition/core/AspectDcl.sv
+++ b/grammars/silver/compiler/definition/core/AspectDcl.sv
@@ -157,6 +157,8 @@ top::AspectProductionLHS ::= id::Name
   rType = if null(top.realSignature) then errorType() else head(top.realSignature).typerep;
 
   forwards to aspectProductionLHSFull(id, rType, location=top.location);
+} action {
+  insert semantic token IdSigNameDcl_t at id.location;
 }
 
 concrete production aspectProductionLHSTyped
@@ -167,6 +169,8 @@ top::AspectProductionLHS ::= id::Name '::' t::TypeExpr
   top.errors <- t.errors;
   
   forwards to aspectProductionLHSFull(id, t.typerep, location=top.location);
+} action {
+  insert semantic token IdSigNameDcl_t at id.location;
 }
 
 abstract production aspectProductionLHSFull
@@ -236,6 +240,8 @@ top::AspectRHSElem ::= id::Name
   top.errors <- [wrn(top.location, "Giving just a name '" ++ id.name ++ "' is deprecated in aspect signature. Please explicitly use a name and type.")];
   
   forwards to aspectRHSElemFull(id, rType, location=top.location);
+} action {
+  insert semantic token IdSigNameDcl_t at id.location;
 }
 
 concrete production aspectRHSElemTyped
@@ -246,6 +252,8 @@ top::AspectRHSElem ::= id::Name '::' t::TypeExpr
   top.errors <- t.errors;
 
   forwards to aspectRHSElemFull(id, t.typerep, location=top.location);
+} action {
+  insert semantic token IdSigNameDcl_t at id.location;
 }
 
 abstract production aspectRHSElemFull

--- a/grammars/silver/compiler/definition/core/AspectDcl.sv
+++ b/grammars/silver/compiler/definition/core/AspectDcl.sv
@@ -67,6 +67,7 @@ top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature bod
   body.frame = aspectProductionContext(namedSig, myFlowGraph, sourceGrammar=id.lookupValue.dcl.sourceGrammar); -- graph from flow:env
 } action {
   insert semantic token IdFnProd_t at id.location;
+  sigNames = [];
 }
 
 concrete production aspectFunctionDcl
@@ -117,6 +118,7 @@ top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::P
   body.frame = aspectFunctionContext(namedSig, myFlowGraph, sourceGrammar=id.lookupValue.dcl.sourceGrammar); -- graph from flow:env
 } action {
   insert semantic token IdFnProd_t at id.location;
+  sigNames = [];
 }
 
 concrete production aspectProductionSignature
@@ -135,6 +137,8 @@ top::AspectProductionSignature ::= lhs::AspectProductionLHS '::=' rhs::AspectRHS
 
   lhs.realSignature = if null(top.realSignature) then [] else [head(top.realSignature)];
   rhs.realSignature = if null(top.realSignature) then [] else tail(top.realSignature);
+} action {
+  sigNames = foldNamedSignatureElements(lhs.outputElement :: rhs.inputElements).elementNames;
 }
 
 concrete production aspectProductionLHSNone

--- a/grammars/silver/compiler/extension/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/convenience/Convenience.sv
@@ -56,6 +56,8 @@ top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTy
     nonterminalDcl(quals, $2, id, tl, nm, $8, location=top.location),
     makeOccursDcls(top.location, attrs.qnames, [qNameWithTL(qNameId(id, location=id.location), tl)]),
     location=top.location);
+} action {
+  insert semantic token IdTypeDcl_t at id.location;
 }
 
 

--- a/grammars/silver/compiler/extension/doc/core/AGDcl.sv
+++ b/grammars/silver/compiler/extension/doc/core/AGDcl.sv
@@ -182,10 +182,10 @@ top::AGDcl ::= 'functor' 'attribute' a::Name ';'
 -- }
 
 aspect production aspectDefaultProduction
-top::AGDcl ::= 'aspect' 'default' 'production' lhs::Name '::' _ '::=' body::ProductionBody 
+top::AGDcl ::= 'aspect' 'default' 'production' ns::AspectDefaultProductionSignature body::ProductionBody 
 {
-  top.docForName = "aspect default production "++lhs.name;
-  top.docUnparse = s"`aspect default production ${lhs.unparse}`";
+  top.docForName = "aspect default production "++ns.namedSignature.outputElement.typerep.typeName;
+  top.docUnparse = s"`aspect default production ${ns.unparse}`";
   top.docDcls := [];
   top.docs := [mkUndocumentedItem(top.docForName, top)];
 }

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -14,28 +14,51 @@ import silver:compiler:driver:util only RootSpec; -- ditto
 terminal Default_kwd 'default' lexer classes {KEYWORD, RESERVED};
 
 concrete production aspectDefaultProduction
-top::AGDcl ::= 'aspect' 'default' 'production' 
-               lhs::Name '::' te::TypeExpr '::=' body::ProductionBody 
+top::AGDcl ::= 'aspect' 'default' 'production' ns::AspectDefaultProductionSignature body::ProductionBody 
 {
-  top.unparse = "aspect default production\n" ++ lhs.unparse ++ "::" ++ te.unparse ++ " ::=\n" ++ body.unparse;
+  top.unparse = "aspect default production\n" ++ ns.unparse ++ "\n" ++ body.unparse;
 
   top.defs := [];
 
-  production namedSig :: NamedSignature = 
+  propagate errors, flowDefs;
+  
+  local sigDefs :: [Def] = addNewLexicalTyVars(top.grammarName, top.location, ns.lexicalTyVarKinds, ns.lexicalTypeVariables);
+
+  -- oh no again!
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  local myFlowGraph :: ProductionGraph = 
+    constructDefaultProductionGraph(ns.namedSignature, body.flowDefs, top.env, myProds, myFlow);
+
+  ns.env = newScopeEnv(sigDefs, top.env);
+
+  body.env = newScopeEnv(ns.defs, ns.env);
+  body.frame = defaultAspectContext(ns.namedSignature, myFlowGraph, sourceGrammar=top.grammarName);
+
+  body.downSubst = emptySubst();
+
+  top.setupInh := body.setupInh; -- Probably should be empty?
+  top.initProd := "\t\t//ASPECT DEFAULT PRODUCTION for " ++ ns.namedSignature.outputElement.typerep.typeName ++ "\n" ++ body.translation;
+  top.valueWeaving := body.valueWeaving; -- Probably should be empty?
+} action {
+  sigNames = [];
+}
+
+nonterminal AspectDefaultProductionSignature with config, grammarName, env, flowEnv, location, unparse, errors, defs, namedSignature, lexicalTypeVariables, lexicalTyVarKinds;
+
+concrete production aspectDefaultProductionSignature
+top::AspectDefaultProductionSignature ::= lhs::Name '::' te::TypeExpr '::='
+{
+  top.unparse = lhs.unparse ++ "::" ++ te.unparse ++ " ::=";
+  top.defs := [defaultLhsDef(top.grammarName, lhs.location, lhs.name, te.typerep)];
+  top.namedSignature =
     namedSignature(top.grammarName ++ ":default" ++ te.typerep.typeName,
       nilContext(), nilNamedSignatureElement(),
       namedSignatureElement(lhs.name, te.typerep),
       foldNamedSignatureElements(annotationsForNonterminal(te.typerep, top.env)));
 
-  propagate errors, flowDefs;
-
-  top.errors <- te.errorsKindStar;
-  top.errors <-
-    case te of
-    -- LHS must be either NT or NT<a b ...> where a b ... are all ty vars
-    | appTypeExpr(_, tl) -> tl.errorsTyVars
-    | _ -> []
-    end;
+  propagate errors, lexicalTypeVariables, lexicalTyVarKinds;
 
   local checkNT::TypeCheck = checkNonterminal(top.env, false, te.typerep);
   checkNT.downSubst = emptySubst();
@@ -46,28 +69,15 @@ top::AGDcl ::= 'aspect' 'default' 'production'
     then [err(top.location, "Default production LHS type must be a nonterminal.  Instead it is of type " ++ checkNT.leftpp)]
     else [];
 
-  local fakedDefs :: [Def] =
-    [defaultLhsDef(top.grammarName, lhs.location, lhs.name, te.typerep)];
-  
-  local sigDefs :: [Def] = addNewLexicalTyVars(top.grammarName, top.location, te.lexicalTyVarKinds, te.lexicalTypeVariables);
-
-  -- oh no again!
-  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
-
-  local myFlowGraph :: ProductionGraph = 
-    constructDefaultProductionGraph(namedSig, body.flowDefs, top.env, myProds, myFlow);
-
-  te.env = newScopeEnv(sigDefs, top.env);
-
-  body.env = newScopeEnv(fakedDefs, te.env);
-  body.frame = defaultAspectContext(namedSig, myFlowGraph, sourceGrammar=top.grammarName);
-
-  body.downSubst = emptySubst();
-
-  top.setupInh := body.setupInh; -- Probably should be empty?
-  top.initProd := "\t\t//ASPECT DEFAULT PRODUCTION for " ++ te.unparse ++ "\n" ++ body.translation;
-  top.valueWeaving := body.valueWeaving; -- Probably should be empty?
+  top.errors <- te.errorsKindStar;
+  top.errors <-
+    case te of
+    -- LHS must be either NT or NT<a b ...> where a b ... are all ty vars
+    | appTypeExpr(_, tl) -> tl.errorsTyVars
+    | _ -> []
+    end;
+} action {
+  sigNames = [lhs.name];
 }
 
 function defaultLhsDef

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -77,6 +77,7 @@ top::AspectDefaultProductionSignature ::= lhs::Name '::' te::TypeExpr '::='
     | _ -> []
     end;
 } action {
+  insert semantic token IdSigNameDcl_t at lhs.location;
   sigNames = [lhs.name];
 }
 


### PR DESCRIPTION
# Changes
This adds aspect production and aspect default production signature names to the `sigDefs` parser attribute, so they show up as "parameter" semantic tokens.  This required refactoring to the syntax of aspect default productions.  This change is new-jars due to the resulting bootstrapping, so I would appreciate getting this merged quickly.  

# Documentation
None needed, this is purely an internal change/refactor that improves semantic highlighting.
