### PR TITLE
Include partially decorated children in propagated monoid attribute equations

### DIFF
--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -311,8 +311,6 @@ top::DefLHS ::= q::QName
 {
   top.name = q.name;
   top.unparse = q.unparse;
-
-  top.errors := q.lookupValue.errors ++ forward.errors;
   
   forwards to (if null(q.lookupValue.dcls)
                then errorDefLHS(_, location=_)
@@ -330,6 +328,7 @@ top::DefLHS ::= q::PartiallyDecorated QName
   top.unparse = q.unparse;
   top.found = false;
   
+  top.errors <- q.lookupValue.errors;
   top.errors <-
     if top.typerep.isError then [] else [err(q.location, "Cannot define attributes on " ++ q.name)];
   top.typerep = q.lookupValue.typeScheme.monoType;

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -120,20 +120,6 @@ top::Expr ::= q::PartiallyDecorated QName
     else noVertex();
 }
 
--- Still need these equations since propagate ignores decorated references
-aspect production functionInvocation
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
-{
-  top.flowDeps <- e.flowDeps ++ es.flowDeps ++ annos.flowDeps;
-  top.flowDefs <- e.flowDefs ++ es.flowDefs ++ annos.flowDefs;
-}
-aspect production partialApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
-{
-  top.flowDeps <- e.flowDeps ++ es.flowDeps ++ annos.flowDeps;
-  top.flowDefs <- e.flowDefs ++ es.flowDefs ++ annos.flowDefs;
-}
-
 aspect production forwardAccess
 top::Expr ::= e::Expr '.' 'forward'
 {
@@ -144,11 +130,6 @@ top::Expr ::= e::Expr '.' 'forward'
     end;
 }
 
-aspect production errorAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
-{
-  top.flowDefs <- e.flowDefs;
-}
 -- Note that below we IGNORE the flow deps of the lhs if we know what it is
 -- this is because by default the lhs will have 'taking ref' flow deps (see above)
 aspect production synDecoratedAccessHandler
@@ -159,7 +140,6 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
     | hasVertex(vertex) -> vertex.synVertex(q.attrDcl.fullName) :: vertex.eqVertex
     | noVertex() -> e.flowDeps
     end;
-  top.flowDefs <- e.flowDefs;
 }
 aspect production inhDecoratedAccessHandler
 top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
@@ -169,27 +149,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
     | hasVertex(vertex) -> vertex.inhVertex(q.attrDcl.fullName) :: vertex.eqVertex
     | noVertex() -> e.flowDeps
     end;
-  top.flowDefs <- e.flowDefs;
 }
-aspect production errorDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
-{
-  top.flowDeps <- []; -- errors, who cares?
-  top.flowDefs <- e.flowDefs;
-}
-aspect production terminalAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
-{
-  top.flowDeps <- e.flowDeps;
-  top.flowDefs <- e.flowDefs;
-}
-aspect production annoAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
-{
-  top.flowDeps <- e.flowDeps;
-  top.flowDefs <- e.flowDefs;
-}
-
 
 aspect production decorateExprWith
 top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
@@ -245,18 +205,7 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e1::Expr ';'
 aspect production exprRef
 top::Expr ::= e::PartiallyDecorated Expr
 {
-  -- This production is somewhat special, for example, error is := []
-  -- That's because the errors should have already been appeared wherever it's anchored.
-  
-  -- But, here we DO pass flowDeps through because this affects wherever this expression
-  -- is used, not just where it appears.
-  
-  -- So definitely don't consider making this []!
-  
-  top.flowDeps <- e.flowDeps;
   top.flowVertexInfo = e.flowVertexInfo;
-  top.flowDefs <- e.flowDefs; -- I guess? I haven't thought about this exactly.
-  -- i.e. whether this has already been included. shouldn't hurt to do so though.
 }
 
 -- FROM LET TODO

--- a/grammars/silver/compiler/extension/autoattr/Monoid.sv
+++ b/grammars/silver/compiler/extension/autoattr/Monoid.sv
@@ -125,7 +125,6 @@ top::ProductionStmt ::= attr::PartiallyDecorated QName
     filter(
       \ input::NamedSignatureElement ->
         isDecorable(input.typerep, top.env) &&
-        !input.typerep.isPartiallyDecorated &&  -- Don't include partially decorated children.  TODO make this configurable?
         !null(getOccursDcl(attrFullName, input.typerep.typeName, top.env)),
       top.frame.signature.inputElements);
   local res :: Expr = 

--- a/grammars/silver/compiler/extension/templating/StringTemplating.sv
+++ b/grammars/silver/compiler/extension/templating/StringTemplating.sv
@@ -46,9 +46,6 @@ top::Expr ::= a::Expr b::Expr
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
   
   thread downSubst, upSubst on top, a, b, forward;
-  -- These are wrapped in exprRef in the forward, so include their errors here:
-  top.errors <- a.errors;
-  top.errors <- b.errors;
   
   forwards to
     mkStrFunctionInvocation(

--- a/grammars/silver/compiler/extension/tuple/Tuple.sv
+++ b/grammars/silver/compiler/extension/tuple/Tuple.sv
@@ -51,7 +51,6 @@ top::Expr ::= tuple::Expr '.' a::IntConst
   local accessIndex::Integer = toInteger(a.lexeme);
 
   top.unparse = tuple.unparse ++ "." ++ a.lexeme;
-  top.errors <- tuple.errors;
 
   -- Ensure that we extract the tupleElems from the underlying chain of pair types if the tuple type is decorated.
   local ty :: Type = performSubstitution(tuple.typerep, tuple.upSubst);

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -54,10 +54,6 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
   e.downSubst = top.downSubst;
   forward.downSubst = e.upSubst;
   
-  -- ensureDecoratedExpr is currently wrapping 'e' in 'exprRef' which suppresses errors
-  -- TODO: the use of 'exprRef' should be reviewed, given that this error slipped through...
-  top.errors := e.errors ++ forward.errors;
-  
   forwards to matchPrimitiveReal(ensureDecoratedExpr(e), t, pr, f, location=top.location);
 }
 {--


### PR DESCRIPTION
# Changes
It seems that in almost every case, the desired behavior for monoid attributes on partially decorated children is to include the value of the attribute on the child.  For example in host languages that have non-forwarding productions with partially decorated children, we probably want to include the error messages from the partially decorate children.  In the rare cases where this is not the desired behavior, one can simply not propagate the attribute for the production.

This allows for a significant cleanup in Silver, removing a number of `<-` equations for partially decorated children.  It also seems to be much more straightforward for `exprRef` to include error messages from its child in its errors; this allows for the removal of a number of interfering equations.

# Documentation
The behavior of partially decorated children with respect to automatic attributes seems to have been previously undocumented, however I have added some notes about this at https://github.com/melt-umn/melt-website/tree/feature%2Fmonoid-partial-dec-propagate
