### PR TITLE
Be more conservative about inlining strategy attributes

### DIFF
--- a/grammars/silver/compiler/extension/strategyattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/strategyattr/DclInfo.sv
@@ -6,7 +6,7 @@ synthesized attribute containsErrors::Boolean occurs on AttributeDclInfo;
 synthesized attribute liftedStrategyNames::[String] occurs on AttributeDclInfo;
 synthesized attribute givenRecVarNameEnv::[Pair<String String>] occurs on AttributeDclInfo;
 synthesized attribute givenRecVarTotalEnv::[Pair<String Boolean>] occurs on AttributeDclInfo;
-attribute partialRefs, totalRefs, mentionedNTs occurs on AttributeDclInfo;
+attribute partialRefs, totalRefs, containsTraversal occurs on AttributeDclInfo;
 synthesized attribute strategyExpr :: StrategyExpr occurs on AttributeDclInfo;
 
 aspect default production
@@ -20,14 +20,16 @@ top::AttributeDclInfo ::=
   top.givenRecVarTotalEnv = [];
   top.partialRefs := [];
   top.totalRefs := [];
-  top.mentionedNTs := [];
+  top.containsTraversal := false;
   top.strategyExpr = error("Internal compiler error: must be defined for all strategy attribute declarations");
 }
 
 abstract production strategyDcl
 top::AttributeDclInfo ::=
   fn::String isTotal::Boolean
-  containsErrors::Boolean liftedStrategyNames::[String] givenRecVarNameEnv::[Pair<String String>] givenRecVarTotalEnv::[Pair<String Boolean>] partialRefs::[String] totalRefs::[String] mentionedNTs::[String]
+  containsErrors::Boolean liftedStrategyNames::[String]
+  givenRecVarNameEnv::[Pair<String String>] givenRecVarTotalEnv::[Pair<String Boolean>]
+  partialRefs::[String] totalRefs::[String] containsTraversal::Boolean
   e::StrategyExpr
 {
   top.fullName = fn;
@@ -54,6 +56,6 @@ top::AttributeDclInfo ::=
   top.givenRecVarTotalEnv = givenRecVarTotalEnv;
   top.partialRefs := partialRefs;
   top.totalRefs := totalRefs;
-  top.mentionedNTs := mentionedNTs;
+  top.containsTraversal := containsTraversal;
   top.strategyExpr = e;
 }

--- a/grammars/silver/compiler/extension/strategyattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/strategyattr/DclInfo.sv
@@ -6,7 +6,7 @@ synthesized attribute containsErrors::Boolean occurs on AttributeDclInfo;
 synthesized attribute liftedStrategyNames::[String] occurs on AttributeDclInfo;
 synthesized attribute givenRecVarNameEnv::[Pair<String String>] occurs on AttributeDclInfo;
 synthesized attribute givenRecVarTotalEnv::[Pair<String Boolean>] occurs on AttributeDclInfo;
-attribute partialRefs, totalRefs occurs on AttributeDclInfo;
+attribute partialRefs, totalRefs, mentionedNTs occurs on AttributeDclInfo;
 synthesized attribute strategyExpr :: StrategyExpr occurs on AttributeDclInfo;
 
 aspect default production
@@ -20,13 +20,14 @@ top::AttributeDclInfo ::=
   top.givenRecVarTotalEnv = [];
   top.partialRefs := [];
   top.totalRefs := [];
+  top.mentionedNTs := [];
   top.strategyExpr = error("Internal compiler error: must be defined for all strategy attribute declarations");
 }
 
 abstract production strategyDcl
 top::AttributeDclInfo ::=
   fn::String isTotal::Boolean
-  containsErrors::Boolean liftedStrategyNames::[String] givenRecVarNameEnv::[Pair<String String>] givenRecVarTotalEnv::[Pair<String Boolean>] partialRefs::[String] totalRefs::[String]
+  containsErrors::Boolean liftedStrategyNames::[String] givenRecVarNameEnv::[Pair<String String>] givenRecVarTotalEnv::[Pair<String Boolean>] partialRefs::[String] totalRefs::[String] mentionedNTs::[String]
   e::StrategyExpr
 {
   top.fullName = fn;
@@ -53,5 +54,6 @@ top::AttributeDclInfo ::=
   top.givenRecVarTotalEnv = givenRecVarTotalEnv;
   top.partialRefs := partialRefs;
   top.totalRefs := totalRefs;
+  top.mentionedNTs := mentionedNTs;
   top.strategyExpr = e;
 }

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -39,7 +39,7 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
            defaultEnvItem(
              strategyDcl(
                fName, isTotal,
-               !null(top.errors), map(fst, e.liftedStrategies), recVarNameEnv, recVarTotalEnv, e.partialRefs, e.totalRefs, e.mentionedNTs, e,
+               !null(top.errors), map(fst, e.liftedStrategies), recVarNameEnv, recVarTotalEnv, e.partialRefs, e.totalRefs, e.containsTraversal, e,
                sourceGrammar=top.grammarName, sourceLocation=a.location)))],
         location=top.location),
       map(

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -28,7 +28,8 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
   e.recVarNameEnv = recVarNameEnv;
   e.recVarTotalEnv = recVarTotalEnv;
   e.recVarTotalNoEnvEnv = recVarTotalEnv;
-  e.outerAttr = just(a.name);
+  e.outerAttr = a.name;
+  e.isOutermost = true;
   
   local fwrd::AGDcl =
     foldr(
@@ -38,11 +39,11 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
            defaultEnvItem(
              strategyDcl(
                fName, isTotal,
-               !null(top.errors), map(fst, e.liftedStrategies), recVarNameEnv, recVarTotalEnv, e.partialRefs, e.totalRefs, e,
+               !null(top.errors), map(fst, e.liftedStrategies), recVarNameEnv, recVarTotalEnv, e.partialRefs, e.totalRefs, e.mentionedNTs, e,
                sourceGrammar=top.grammarName, sourceLocation=a.location)))],
         location=top.location),
       map(
-        \ d::Pair<String LiftedStrategy> ->
+        \ d::(String, Decorated StrategyExpr with LiftedInhs) ->
           strategyAttributeDcl(
             d.snd.isTotalNoEnv, name(d.fst, top.location), d.snd.recVarNameEnv, d.snd.recVarTotalNoEnvEnv, new(d.snd),
             location=top.location),
@@ -124,7 +125,8 @@ top::ProductionStmt ::= attr::PartiallyDecorated QName
   e.env = top.env;
   e.recVarNameEnv = attr.lookupAttribute.dcl.givenRecVarNameEnv;
   e.recVarTotalEnv = attr.lookupAttribute.dcl.givenRecVarTotalEnv;
-  e.outerAttr = just(attr.lookupAttribute.fullName);
+  e.outerAttr = attr.lookupAttribute.fullName;
+  e.isOutermost = true;
   e.inlinedStrategies = [attr.lookupAttribute.fullName]; -- Don't unfold the top-level strategy within itself
   
   production e2::StrategyExpr = e.optimize;
@@ -135,6 +137,7 @@ top::ProductionStmt ::= attr::PartiallyDecorated QName
   e2.recVarNameEnv = e.recVarNameEnv;
   e2.recVarTotalEnv = e.recVarTotalEnv;
   e2.outerAttr = e.outerAttr;
+  e2.isOutermost = e.isOutermost;
   e2.inlinedStrategies = e.inlinedStrategies;
   e2.flowEnv = top.flowEnv;
   

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -714,6 +714,8 @@ top::StrategyExpr ::= n::Name s::StrategyExpr
     else [pair(sName, s)];
   top.freeRecVars := remove(n.name, s.freeRecVars);
 
+  -- Decorate s assuming that the bound strategy is total, in order to check for totality.
+  -- See Fig 4 of the strategy attributes paper (https://www-users.cse.umn.edu/~evw/pubs/kramer20sle/kramer20sle.pdf)
   local s2::StrategyExpr = s;
   s2.recVarTotalEnv = pair(n.name, true) :: s.recVarTotalEnv;
   s2.recVarTotalNoEnvEnv = pair(n.name, true) :: s.recVarTotalNoEnvEnv;

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -28,7 +28,7 @@ monoid attribute freeRecVars::[String];
 monoid attribute partialRefs::[String];
 monoid attribute totalRefs::[String];
 monoid attribute matchesFrame::Boolean with false, ||;
-monoid attribute mentionedNTs::[String];
+monoid attribute containsTraversal::Boolean with false, ||;
 
 synthesized attribute partialTranslation::Expr; -- Maybe<a> on a
 synthesized attribute totalTranslation::Expr; -- a on a, can raise a runtime error if demanded on partial strategy expression
@@ -61,8 +61,7 @@ partial strategy attribute ntStep =
       n.matchesFrame && n.attrDcl.isStrategy &&
       !contains(n.attrDcl.fullName, top.inlinedStrategies) &&
       null(n.attrDcl.givenRecVarNameEnv) &&
-      -- Only inline when this attribute occurs on all mentioned nonterminals in the inlined attribute
-      !any(map(compose(null, getOccursDcl(top.outerAttr, _, top.env)), n.attrDcl.mentionedNTs)) ->
+      !n.attrDcl.containsTraversal ->
     inlined(n, n.attrDcl.strategyExpr, location=top.location, genName=top.genName)
   | partialRef(n) when !n.matchesFrame -> fail(location=top.location, genName=top.genName)
   | inlined(n, _) when !n.matchesFrame -> fail(location=top.location, genName=top.genName)
@@ -113,13 +112,13 @@ strategy attribute optimize =
 
 nonterminal StrategyExpr with
   config, grammarName, env, location, unparse, errors, frame, compiledGrammars, flowEnv, -- Normal expression stuff
-  genName, outerAttr, isOutermost, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, liftedStrategies, attrRefName, isId, isFail, isTotal, isTotalNoEnv, freeRecVars, partialRefs, totalRefs, mentionedNTs, -- Frame-independent attrs
+  genName, outerAttr, isOutermost, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, liftedStrategies, attrRefName, isId, isFail, isTotal, isTotalNoEnv, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
   partialTranslation, totalTranslation, matchesFrame, -- Frame-dependent attrs
   inlinedStrategies, genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize; -- Optimization stuff
 
 nonterminal StrategyExprs with
   config, grammarName, env, unparse, errors, compiledGrammars, flowEnv, -- Normal expression stuff
-  outerAttr, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, givenInputElements, liftedStrategies, attrRefNames, containsFail, allId, freeRecVars, partialRefs, totalRefs, mentionedNTs, -- Frame-independent attrs
+  outerAttr, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, givenInputElements, liftedStrategies, attrRefNames, containsFail, allId, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
   inlinedStrategies, genericSimplify; -- Optimization stuff
 
 flowtype StrategyExpr =
@@ -130,7 +129,7 @@ flowtype StrategyExpr =
   -- Frame-independent attrs
   liftedStrategies {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr, isOutermost}, isTotalNoEnv {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr, isOutermost},
   attrRefName {recVarNameEnv}, isId {}, isFail {},
-  isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate}, mentionedNTs {decorate, flowEnv},
+  isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate}, containsTraversal {decorate, flowEnv},
   genericStep {decorate, inlinedStrategies}, genericSimplify {decorate, inlinedStrategies},
   -- Frame-dependent attrs
   partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame}, matchesFrame {decorate, frame},
@@ -149,7 +148,7 @@ flowtype StrategyExprs =
 propagate errors on StrategyExpr, StrategyExprs excluding partialRef, totalRef, rewriteRule;
 propagate containsFail, allId on StrategyExprs;
 propagate freeRecVars on StrategyExpr, StrategyExprs excluding recComb;
-propagate partialRefs, totalRefs, mentionedNTs on StrategyExpr, StrategyExprs;
+propagate partialRefs, totalRefs, containsTraversal on StrategyExpr, StrategyExprs;
 propagate genericSimplify on StrategyExprs;
 propagate prodStep on MRuleList;
 propagate genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize on StrategyExpr;
@@ -317,7 +316,9 @@ top::StrategyExpr ::= s::StrategyExpr
     else [pair(sName, s)];
   top.isTotal = s.isTotal;
   top.isTotalNoEnv = s.isTotalNoEnv;
-  
+
+  top.containsTraversal <- true;
+
   s.isOutermost = false;
   s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
@@ -406,6 +407,8 @@ top::StrategyExpr ::= s::StrategyExpr
     then []
     else [pair(sName, s)];
   
+  top.containsTraversal <- true;
+
   s.isOutermost = false;
   s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
@@ -483,6 +486,8 @@ top::StrategyExpr ::= s::StrategyExpr
     if s.attrRefName.isJust
     then []
     else [pair(sName, s)];
+
+  top.containsTraversal <- true;
   
   s.isOutermost = false;
   s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
@@ -593,9 +598,7 @@ top::StrategyExpr ::= prod::QName s::StrategyExprs
     then prod.lookupValue.dcl.namedSignature.inputElements
     else [];
   
-  top.mentionedNTs <-
-    if !prod.lookupValue.found then []
-    else [prod.lookupValue.dcl.namedSignature.outputElement.typerep.typeName];
+  top.containsTraversal <- true;
   
   -- pair(child name, if attr occurs on child then just(attr name) else nothing())
   local childAccesses::[Pair<String Maybe<String>>] =
@@ -749,8 +752,6 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
 {
   top.unparse = "rule on " ++ id.name ++ "::" ++ ty.unparse ++ " of " ++ ml.unparse ++ " end";
   propagate liftedStrategies;
-
-  top.mentionedNTs <- [ty.typerep.typeName];
   
   -- Pattern matching error checking (mostly) happens on what caseExpr forwards to,
   -- so we need to decorate one of those here.

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -10,10 +10,11 @@ annotation genName::String; -- Used to generate the names of lifted strategy att
 autocopy attribute recVarNameEnv::[Pair<String String>]; -- name, (isTotal, genName)
 autocopy attribute recVarTotalEnv::[Pair<String Boolean>]; -- name, (isTotal, genName)
 autocopy attribute recVarTotalNoEnvEnv::[Pair<String Boolean>]; -- same as above but doesn't depend on env
-inherited attribute outerAttr::Maybe<String>;
+inherited attribute isOutermost::Boolean;
+autocopy attribute outerAttr::String;
 autocopy attribute inlinedStrategies::[String];
-type LiftedStrategy = Decorated StrategyExpr with {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr};
-monoid attribute liftedStrategies::[Pair<String LiftedStrategy>];
+type LiftedInhs = {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr, isOutermost};
+monoid attribute liftedStrategies::[(String, Decorated StrategyExpr with LiftedInhs)];
 synthesized attribute attrRefName::Maybe<String>;
 synthesized attribute isId::Boolean;
 synthesized attribute isFail::Boolean;
@@ -27,6 +28,7 @@ monoid attribute freeRecVars::[String];
 monoid attribute partialRefs::[String];
 monoid attribute totalRefs::[String];
 monoid attribute matchesFrame::Boolean with false, ||;
+monoid attribute mentionedNTs::[String];
 
 synthesized attribute partialTranslation::Expr; -- Maybe<a> on a
 synthesized attribute totalTranslation::Expr; -- a on a, can raise a runtime error if demanded on partial strategy expression
@@ -58,7 +60,9 @@ partial strategy attribute ntStep =
   | partialRef(n) when
       n.matchesFrame && n.attrDcl.isStrategy &&
       !contains(n.attrDcl.fullName, top.inlinedStrategies) &&
-      null(n.attrDcl.givenRecVarNameEnv) ->
+      null(n.attrDcl.givenRecVarNameEnv) &&
+      -- Only inline when this attribute occurs on all mentioned nonterminals in the inlined attribute
+      !any(map(compose(null, getOccursDcl(top.outerAttr, _, top.env)), n.attrDcl.mentionedNTs)) ->
     inlined(n, n.attrDcl.strategyExpr, location=top.location, genName=top.genName)
   | partialRef(n) when !n.matchesFrame -> fail(location=top.location, genName=top.genName)
   | inlined(n, _) when !n.matchesFrame -> fail(location=top.location, genName=top.genName)
@@ -109,24 +113,24 @@ strategy attribute optimize =
 
 nonterminal StrategyExpr with
   config, grammarName, env, location, unparse, errors, frame, compiledGrammars, flowEnv, -- Normal expression stuff
-  genName, outerAttr, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, liftedStrategies, attrRefName, isId, isFail, isTotal, isTotalNoEnv, freeRecVars, partialRefs, totalRefs, -- Frame-independent attrs
+  genName, outerAttr, isOutermost, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, liftedStrategies, attrRefName, isId, isFail, isTotal, isTotalNoEnv, freeRecVars, partialRefs, totalRefs, mentionedNTs, -- Frame-independent attrs
   partialTranslation, totalTranslation, matchesFrame, -- Frame-dependent attrs
   inlinedStrategies, genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize; -- Optimization stuff
 
 nonterminal StrategyExprs with
   config, grammarName, env, unparse, errors, compiledGrammars, flowEnv, -- Normal expression stuff
-  recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, givenInputElements, liftedStrategies, attrRefNames, containsFail, allId, freeRecVars, partialRefs, totalRefs, -- Frame-independent attrs
+  outerAttr, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, givenInputElements, liftedStrategies, attrRefNames, containsFail, allId, freeRecVars, partialRefs, totalRefs, mentionedNTs, -- Frame-independent attrs
   inlinedStrategies, genericSimplify; -- Optimization stuff
 
 flowtype StrategyExpr =
-  decorate {env, grammarName, config, recVarNameEnv, recVarTotalEnv, outerAttr}, -- NOT frame
+  decorate {env, grammarName, config, recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost}, -- NOT frame
   forward {decorate},
   -- Normal expression stuff
   unparse {}, errors {decorate, compiledGrammars, flowEnv},
   -- Frame-independent attrs
-  liftedStrategies {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr}, isTotalNoEnv {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr},
+  liftedStrategies {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr, isOutermost}, isTotalNoEnv {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr, isOutermost},
   attrRefName {recVarNameEnv}, isId {}, isFail {},
-  isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate},
+  isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate}, mentionedNTs {decorate, flowEnv},
   genericStep {decorate, inlinedStrategies}, genericSimplify {decorate, inlinedStrategies},
   -- Frame-dependent attrs
   partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame}, matchesFrame {decorate, frame},
@@ -134,18 +138,18 @@ flowtype StrategyExpr =
   ntSimplify {decorate, inlinedStrategies, frame}, optimize {decorate, inlinedStrategies, frame};
 
 flowtype StrategyExprs =
-  decorate {env, grammarName, config, recVarNameEnv, recVarTotalEnv}, -- NOT frame
+  decorate {env, grammarName, config, recVarNameEnv, recVarTotalEnv, outerAttr}, -- NOT frame
   forward {},
   -- Normal expression stuff
   -- Frame-independent attrs
-  liftedStrategies {recVarNameEnv, recVarTotalNoEnvEnv},
+  liftedStrategies {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr},
   attrRefNames {env, recVarNameEnv, givenInputElements},
   containsFail {}, allId {}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate};
 
 propagate errors on StrategyExpr, StrategyExprs excluding partialRef, totalRef, rewriteRule;
 propagate containsFail, allId on StrategyExprs;
 propagate freeRecVars on StrategyExpr, StrategyExprs excluding recComb;
-propagate partialRefs, totalRefs on StrategyExpr, StrategyExprs;
+propagate partialRefs, totalRefs, mentionedNTs on StrategyExpr, StrategyExprs;
 propagate genericSimplify on StrategyExprs;
 propagate prodStep on MRuleList;
 propagate genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize on StrategyExpr;
@@ -219,8 +223,8 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   top.isTotal = s1.isTotal && s2.isTotal;
   top.isTotalNoEnv = s1.isTotalNoEnv && s2.isTotalNoEnv;
   
-  s1.outerAttr = nothing();
-  s2.outerAttr = nothing();
+  s1.isOutermost = false;
+  s2.isOutermost = false;
   
   -- Equations for all inh attributes on the nt that we know about.
   -- This is safe because the MWDA requires that all inh dependencies of a syn attribute
@@ -283,8 +287,8 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   top.isTotal = s1.isTotal || s2.isTotal;
   top.isTotalNoEnv = s1.isTotalNoEnv || s2.isTotalNoEnv;
   
-  s1.outerAttr = nothing();
-  s2.outerAttr = nothing();
+  s1.isOutermost = false;
+  s2.isOutermost = false;
   
   top.partialTranslation =
     Silver_Expr {
@@ -314,7 +318,7 @@ top::StrategyExpr ::= s::StrategyExpr
   top.isTotal = s.isTotal;
   top.isTotalNoEnv = s.isTotalNoEnv;
   
-  s.outerAttr = nothing();
+  s.isOutermost = false;
   s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
   local sBaseName::String = last(explode(":", sName));
@@ -402,7 +406,7 @@ top::StrategyExpr ::= s::StrategyExpr
     then []
     else [pair(sName, s)];
   
-  s.outerAttr = nothing();
+  s.isOutermost = false;
   s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
   -- pair(child name, attr occurs on child)
@@ -480,7 +484,7 @@ top::StrategyExpr ::= s::StrategyExpr
     then []
     else [pair(sName, s)];
   
-  s.outerAttr = nothing();
+  s.isOutermost = false;
   s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
   local sBaseName::String = last(explode(":", sName));
@@ -589,6 +593,10 @@ top::StrategyExpr ::= prod::QName s::StrategyExprs
     then prod.lookupValue.dcl.namedSignature.inputElements
     else [];
   
+  top.mentionedNTs <-
+    if !prod.lookupValue.found then []
+    else [prod.lookupValue.dcl.namedSignature.outputElement.typerep.typeName];
+  
   -- pair(child name, if attr occurs on child then just(attr name) else nothing())
   local childAccesses::[Pair<String Maybe<String>>] =
     zipWith(pair, top.frame.signature.inputNames, s.attrRefNames);
@@ -677,7 +685,7 @@ top::StrategyExprs ::= h::StrategyExpr t::StrategyExprs
   top.containsFail <- h.isFail;
   top.allId <- h.isId;
   
-  h.outerAttr = nothing();
+  h.isOutermost = false;
   t.givenInputElements =
     if !null(top.givenInputElements) then tail(top.givenInputElements) else [];
 }
@@ -696,37 +704,39 @@ top::StrategyExpr ::= n::Name s::StrategyExpr
 {
   top.unparse = s"rec ${n.name} -> (${s.unparse})";
   
-  local sName::String = fromMaybe(top.genName ++ "_rec_body", top.outerAttr);
+  local sName::String = if top.isOutermost then top.outerAttr else top.genName ++ "_rec_body";
   top.liftedStrategies :=
-    if top.outerAttr.isJust
+    if top.isOutermost
     then s.liftedStrategies
     else [pair(sName, s)];
   top.freeRecVars := remove(n.name, s.freeRecVars);
-  top.isTotal =
-    decorate s with {
-      recVarTotalEnv = pair(n.name, true) :: s.recVarTotalEnv;
-      env = s.env; config = s.config; grammarName = s.grammarName; recVarNameEnv = s.recVarNameEnv; outerAttr = s.outerAttr;
-    }.isTotal;
-  top.isTotalNoEnv =
-    decorate s with {
-      recVarTotalNoEnvEnv = pair(n.name, true) :: s.recVarTotalNoEnvEnv;
-      config = s.config; grammarName = s.grammarName; recVarNameEnv = s.recVarNameEnv; outerAttr = s.outerAttr;
-    }.isTotalNoEnv;
+
+  local s2::StrategyExpr = s;
+  s2.recVarTotalEnv = pair(n.name, true) :: s.recVarTotalEnv;
+  s2.recVarTotalNoEnvEnv = pair(n.name, true) :: s.recVarTotalNoEnvEnv;
+  s2.env = s.env;
+  s2.config = s.config;
+  s2.grammarName = s.grammarName;
+  s2.recVarNameEnv = s.recVarNameEnv;
+  s2.outerAttr = s.outerAttr;
+  s2.isOutermost = top.isOutermost;
+  top.isTotal = s2.isTotal;
+  top.isTotalNoEnv = s2.isTotalNoEnv;
   
   s.recVarNameEnv = pair(n.name, sName) :: top.recVarNameEnv;
   s.recVarTotalEnv = pair(n.name, top.isTotal) :: top.recVarTotalEnv;
   s.recVarTotalNoEnvEnv = pair(n.name, top.isTotalNoEnv) :: top.recVarTotalNoEnvEnv;
-  s.outerAttr = top.outerAttr;
+  s.isOutermost = top.isOutermost;
   
   local sTotal::Boolean = attrIsTotal(top.env, sName);
   top.partialTranslation =
-    if top.outerAttr.isJust
+    if top.isOutermost
     then s.partialTranslation
     else if sTotal
     then asPartial(top.totalTranslation)
     else Silver_Expr { $name{top.frame.signature.outputElement.elementName}.$name{sName} };
   top.totalTranslation =
-    if top.outerAttr.isJust
+    if top.isOutermost
     then s.totalTranslation
     else if sTotal
     then Silver_Expr { $name{top.frame.signature.outputElement.elementName}.$name{sName} }
@@ -739,6 +749,8 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
 {
   top.unparse = "rule on " ++ id.name ++ "::" ++ ty.unparse ++ " of " ++ ml.unparse ++ " end";
   propagate liftedStrategies;
+
+  top.mentionedNTs <- [ty.typerep.typeName];
   
   -- Pattern matching error checking (mostly) happens on what caseExpr forwards to,
   -- so we need to decorate one of those here.
@@ -981,6 +993,7 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   top.attrRefName = just(attr.name);
   top.matchesFrame := attr.matchesFrame;
   top.isTotal = true;
+  top.isTotalNoEnv = true;
   top.totalRefs <- [attrDcl.fullName];
   
   attr.attrFor = top.frame.signature.outputElement.typerep;
@@ -1002,7 +1015,7 @@ top::StrategyExpr ::= attr::Decorated QNameAttrOccur s::StrategyExpr
     else Silver_Expr { silver:core:nothing() };
   top.totalTranslation = s.totalTranslation;
   
-  s.outerAttr = top.outerAttr;
+  s.isOutermost = top.isOutermost;
   s.inlinedStrategies = attr.attrDcl.fullName :: top.inlinedStrategies;
 }
 


### PR DESCRIPTION
# Changes
We were being a bit too aggressive about inlining strategy attributes, which led to some unexpected behavior.  For example
```
strategy attribute optimize = repeat(optimizePass)
  occurs on Root;
partial strategy attribute optimizePass = someTopDown(rule on Expr of addOp(e, const(0)) -> e end)
  occurs on Root, Expr;
propagate optimize on Root;
propagate optimizePass on Root, Expr;
```
Here `optimize` only occurs on `Root`, while `optimizePass` occurs on both `Root` and `Expr`.  When generating equations for `optimize` on `Root`, we would inline `optimizePass` into `optimize`, and see that since the rule for `Expr` always fails on `Root`, the whole `optimize` strategy reduces to just `id`.

To fix this, we need to be a bit more careful about when we allow inlining.  The conservative rule I choose was that we only inline attribute `foo` into `bar` if `foo` occurs on all the nonterminals mentioned in `foo`'s strategy expression as rules/congruences.  

# Documentation
This is a bug fix, really, so no new documentation needed.
