### PR TITLE
Fix bug causing crash when referencing an undeclared type in an alias declaration

### DIFF
--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -171,7 +171,7 @@ top::TypeExpr ::= q::QNameType
   top.unparse = q.unparse;
 
   top.mentionedAliases <-
-    if q.lookupType.dcl.isTypeAlias
+    if q.lookupType.found && q.lookupType.dcl.isTypeAlias
     then q.lookupType.fullName :: q.lookupType.dcl.mentionedAliases
     else [];
 


### PR DESCRIPTION
# Changes
Minor bug fix, when checking that a type alias declaration is non-circular, we might attempt to access the declaration of an undeclared type, causing a crash.

# Documentation
None, this is a minor bug fix.