### PR TITLE
Don't warn about orphaned propagate equations

### DIFF
--- a/grammars/silver/compiler/extension/autoattr/Propagate.sv
+++ b/grammars/silver/compiler/extension/autoattr/Propagate.sv
@@ -125,6 +125,14 @@ abstract production propagateOneAttr
 top::ProductionStmt ::= attr::QName
 {
   top.unparse = s"propagate ${attr.unparse};";
+
+  -- We make an exception to permit propagated equations in places that would otherwise be orphaned.
+  -- Since this is the only possible equation permitted in these contexts, having duplicates will
+  -- still yield a well-defined specification.
+  -- TOOD: Filtering based on the error message is a bit of a hack. 
+  -- With https://github.com/melt-umn/silver/issues/648 we could instead filter on an error code.
+  top.errors :=
+    filter(\ m::Message -> !startsWith(m.message, "Orphaned equation:"), forward.errors);
   
   -- Ugh, workaround for circular dependency
   top.defs := [];


### PR DESCRIPTION
# Changes
This is a prerequisite to #550. As previously discussed, autocopy handles a special case of bridge productions between host nonterminals lacking an equation for a host inherited attribute, needed by an extension production. Permitting this sort of equation to be generated via propagate allows the same class of language extensions to be written.

Note that other sorts of attributes besides just inherited attributes are safe to propagate in orphaned contexts, for the same reason.

# Documentation
Added a source comment, website updated in https://github.com/melt-umn/melt-website/pull/45.