### PR TITLE
Fix another MWDA crash bug

### DIFF
--- a/grammars/silver/compiler/extension/testing/EqualityTest.sv
+++ b/grammars/silver/compiler/extension/testing/EqualityTest.sv
@@ -183,6 +183,6 @@ ag::AGDcl ::= kwd::'equalityTest'
   local testName :: String = "generatedTest" ++ "_" ++ 
                             substitute(".","_",kwd.filename) ++ "_" ++ 
                             toString(kwd.line) ++ "_" ++ 
-                            toString(genInt());
+                            toString(kwd.column);
 }
 

--- a/grammars/silver/compiler/extension/testing/EqualityTest.sv
+++ b/grammars/silver/compiler/extension/testing/EqualityTest.sv
@@ -181,6 +181,7 @@ ag::AGDcl ::= kwd::'equalityTest'
             ';', location=ag.location), location=ag.location), '}', location=ag.location), location=ag.location);
 
   local testName :: String = "generatedTest" ++ "_" ++ 
+                            substitute(":","_",ag.grammarName) ++ "_" ++ 
                             substitute(".","_",kwd.filename) ++ "_" ++ 
                             toString(kwd.line) ++ "_" ++ 
                             toString(kwd.column);


### PR DESCRIPTION
# Changes
Avoid naming generated prods with `genInt()`.  

Due to the circularity in the driver in determining which grammars need to be re-built based on changes in interface files, flow type inference and production graph construction are run using flow defs initially loaded from interface files of untouched grammars that are re-built, rather than the defs from the rebuilt grammar.  When a production is named using `genInt()`, the name of the production can change between the interface file and the rebuilt grammar, despite the source grammar not being changed.  The flow analysis then crashes when it can't find the production graph for the new production name, since it had a different name in the production flow graph.

Generally speaking, we should avoid naming anything that ends up in an interface file using `genInt`, for the above reasons.

# Documentation
None needed, really.