### PR TITLE
Fix another MWDA crash case caused by aspecting a non-existent production

### DIFF
--- a/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
@@ -2,7 +2,7 @@ grammar silver:compiler:definition:flow:env;
 
 import silver:compiler:definition:type;
 import silver:compiler:modification:defaultattr;
-import silver:compiler:definition:flow:driver only ProductionGraph, findProductionGraph;
+import silver:compiler:definition:flow:driver;
 import silver:compiler:driver:util; -- only for productionFlowGraphs occurrence?
 
 attribute flowEnv occurs on
@@ -34,9 +34,15 @@ aspect production aspectProductionDcl
 top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature body::ProductionBody 
 {
   -- TODO: bit of a hack, isn't it?
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
   local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
 
   {-- Used by core to send down with .frame -}
-  production myFlowGraph :: ProductionGraph = 
-    findProductionGraph(id.lookupValue.fullName, myGraphs);
+  production myFlowGraph :: ProductionGraph =
+    case searchEnvTree(id.lookupValue.fullName, myGraphs) of
+    | g :: _ -> g
+    -- In case we didn't find the flow graph (the aspected production doesn't exist?)
+    -- build an anonymous flow graph to use instead as a "best effort".
+    | [] -> constructAnonymousGraph(body.flowDefs, top.env, myGraphs, myFlow)
+    end;
 }


### PR DESCRIPTION
# Changes
When we aspect an undefined production and don't find the flow graph, create an anonymous flow graph to use in the body MWDA checks, instead of crashing.

# Documentation
Added a source comment.