### PR TITLE
Fixes to incremental compilation related to the flow analysis

### DIFF
--- a/grammars/silver/compiler/definition/flow/env/RootSpec.sv
+++ b/grammars/silver/compiler/definition/flow/env/RootSpec.sv
@@ -26,8 +26,11 @@ top::InterfaceItem ::=
 abstract production flowDefsInterfaceItem
 top::InterfaceItem ::= val::[FlowDef]
 {
-  -- TODO: Ignoring flow defs for now. This isn't consistent between builds due to anon vertexes?
-  -- This shouldn't affect translation, but may cause some flow errors to only show up with --clean.
+  -- This always changes between builds due to anon vertices named using genInt().
+  -- Even if we could assign deterministic anon vertex names, changes to the flow
+  -- defs don't affect dependent grammars unless the flow analysis is run.
+  -- So we just ignore changes in flow defs here, and always rebuild dependent
+  -- grammars when running the flow analysis.
   top.isEqual = true;
 
   top.flowDefs <- val;

--- a/grammars/silver/compiler/driver/util/Compilation.sv
+++ b/grammars/silver/compiler/driver/util/Compilation.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:driver:util;
 
 import silver:compiler:definition:core only jarName, grammarErrors;
+import silver:util:treemap as map;
 
 synthesized attribute initRecompiledGrammars::[Decorated RootSpec];
 
@@ -36,12 +37,16 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::Bu
   -- the list of re-compiled rootspecs from g and r
   top.recompiledGrammars := top.initRecompiledGrammars ++ r.grammarList;
   
+  -- All grammars that were compiled due to being dirty or dependencies of dirty grammars
+  -- see all the other initially compiled grammars.
   g.compiledGrammars = directBuildTree(map(\ r::Decorated RootSpec -> (r.declaredName, r), g.grammarList));
-  -- However, we are then forced to use the interface files that we are going to
+  -- However, since we don't initially know all the grammars we are going to recheck,
+  -- we are forced to start with the interface files that we are going to
   -- recheck in the .compiledGrammars for the recheck.
-  -- That means they don't see "themselves" but their previous interface file.
   r.compiledGrammars = g.compiledGrammars;
-  -- This is actually broken and wrong! See https://github.com/melt-umn/silver/issues/673
+  -- Since we never compile a grammar more than once, this means in case of mutual dependencies
+  -- between grammars, the initially-compiled grammar may see an outdated interface file.
+  -- See https://github.com/melt-umn/silver/issues/673
 
   g.dependentGrammars = flatMap(
     \ r::Decorated RootSpec -> map(\ g::String -> (g, r.declaredName), r.allGrammarDependencies),
@@ -63,6 +68,12 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::Bu
   -- The grammars that we have recompiled, that need to be translated
   production grammarsToTranslate :: [Decorated RootSpec] = top.recompiledGrammars;
 
+  local rGrammarNames :: [String] = map((.declaredName), r.grammarList);
+  -- All grammars from g and r, excluding interface files from r that were later recompiled
+  production allLatestGrammars :: [Decorated RootSpec] =
+    r.grammarList ++
+    filter(\ rs::Decorated RootSpec -> !contains(rs.declaredName, rGrammarNames), g.grammarList);
+
   top.postOps := [];
 }
 
@@ -74,6 +85,10 @@ abstract production consGrammars
 top::Grammars ::= h::RootSpec  t::Grammars
 {
   top.grammarList = h :: t.grammarList;
+
+  -- Once we have compiled a grammar, replace the interface file rootspec when compiling dependent grammars
+  h.compiledGrammars = map:update(h.declaredName, [h], top.compiledGrammars);
+  t.compiledGrammars = h.compiledGrammars;
 }
 
 abstract production nilGrammars

--- a/grammars/silver/compiler/driver/util/FlowTypes.sv
+++ b/grammars/silver/compiler/driver/util/FlowTypes.sv
@@ -12,9 +12,9 @@ aspect production compilation
 top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::BuildEnv
 {
   -- aggregate all flow def information
-  local allFlowDefs :: FlowDefs = foldr(consFlow, nilFlow(), flatMap((.flowDefs), g.grammarList));
-  local allSpecDefs :: [(String, String, [String], [String])] = flatMap((.specDefs), g.grammarList);
-  local allRefDefs :: [(String, [String])] = flatMap((.refDefs), g.grammarList);
+  local allFlowDefs :: FlowDefs = foldr(consFlow, nilFlow(), flatMap((.flowDefs), allLatestGrammars));
+  local allSpecDefs :: [(String, String, [String], [String])] = flatMap((.specDefs), allLatestGrammars);
+  local allRefDefs :: [(String, [String])] = flatMap((.refDefs), allLatestGrammars);
   local allFlowEnv :: FlowEnv = fromFlowDefs(allSpecDefs, allRefDefs, allFlowDefs);
   
   -- Look up tree for production info
@@ -22,8 +22,8 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::Bu
   
   -- We need to know about all attributes and occurences on nonterminals.
   -- It's possible (likely) we could do better than using the overall env here.
-  local allRealDefs :: [Def] = flatMap((.defs), g.grammarList);
-  local allRealOccursDefs :: [OccursDclInfo] = flatMap((.occursDefs), g.grammarList);
+  local allRealDefs :: [Def] = flatMap((.defs), allLatestGrammars);
+  local allRealOccursDefs :: [OccursDclInfo] = flatMap((.occursDefs), allLatestGrammars);
   local allRealEnv :: Decorated Env = occursEnv(allRealOccursDefs, toEnv(allRealDefs));
   
   -- List of all productions

--- a/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
@@ -35,7 +35,7 @@ synthesized attribute patternNamedSubPatternList :: [Pair<String Decorated Patte
  - The sort (and grouping) key of the pattern.
  - "~var" if patternIsVariable is true. (TODO: actually, we should call it undefined! It's not used.)
  - fullname if it's a production.
- - otherwise, it is type-depedent, but same values should be the same!
+ - otherwise, it is type-dependent, but same values should be the same!
  -}
 synthesized attribute patternSortKey :: String;
 

--- a/grammars/silver/core/String.sv
+++ b/grammars/silver/core/String.sv
@@ -403,3 +403,11 @@ String ::= next::Integer width::Integer lines::[String]
   local ln::String = toString(next); 
   local pad::String = implode("", repeat(" ", width - length(ln)) ) ;
 }
+
+function hashString
+Integer ::= s::String
+{
+  return error("Foreign function");
+} foreign {
+  "java": return "%s%.toString().hashCode()";
+}


### PR DESCRIPTION
# Changes
This is (hopefully) the last major tweak to the build process, for now.  There are 2 major issues right now with non-clean builds, both related to the flow analysis:
1) Currently, we have a build optimization that only rebuilds downstream dependent grammars when a rebuilt grammar's interface file is changed. Comparing interface files currently ignores flow defs, because these always change between builds due to the presence of anonymous vertices named using `genInt()`.  Thus when running the flow analysis, we sometimes fail to re-check a dependent grammar that should have changed flow errors when the only change to the interface file was in the flow defs.
2) To compute the new interface file for a grammar, we must perform some error checking (some prods forward based on the presence of errors...)  When the flow analysis is enabled, this requires the flow environment, and flow types inferred from the collected flow defs.  Thus to determine whether a dependent grammar needs to be recompiled, we need to have already run the flow analysis.  Unfortunately, this means that we must run flow type inference using the flow defs from the initial compilation phase where we build dirty grammars and load their interface files, and thus re-compiled grammars see the flow (and also regular!) environment that were obtained from interface files.  This sometimes led to strange, spurious flow errors in non-clean builds about missing equations that were quite obviously there.

Both of these issues can be addressed with 2 observations:
* When we aren't running the flow analysis, the flow defs don't matter at all, so we are doing the right thing by ignoring them in interface files.
* Almost any change to a grammar will cause the flow defs to change, if we ever change the dependencies of any expression, so attempting to deterministically name anon vertices and compare flow defs from interface files when running the flow analysis doesn't accomplish much.

So the solution is to the first issue adjust the behavior of the build process depending on whether we are running the flow analysis:
* When the analysis is not run, we can just continue as before in ignoring flow defs when comparing interface files.  
* When the analysis is run, don't compare interface files and just unconditionally recompile all dependent grammars.

This also avoids the circularity mentioned in the second issue, since when the flow analysis isn't run we can ignore the final flow environment when computing the new interface file, and when the flow analysis is run we don't compare interface files at all, and all error checking happens after we know which grammars are being recompiled.  This means we can use the flow defs from the re-compiled grammars in flow type inference, and re-compiled grammars can be permitted to see themselves instead of their interface files.

This doesn't totally fix the issue involving mutually dependent grammars (#673); since we still don't ever compile a grammar more than once, some recompiled grammars see an interface file instead of another grammar that is set to be recompiled.  However the more liberal use of re-compiled grammars in place of interface files should avoid the problem in some cases.  For now we will still sometimes need to use `--clean` when changing a default ref set.

# Documentation
I added/updated plenty of source comments in the relevant places.
