### PR TITLE
Fix/langserver json primitive casts check

### DIFF
--- a/language-server/langserver/src/main/java/edu/umn/cs/melt/silver/langserver/SilverLanguageService.java
+++ b/language-server/langserver/src/main/java/edu/umn/cs/melt/silver/langserver/SilverLanguageService.java
@@ -249,6 +249,10 @@ public class SilverLanguageService implements TextDocumentService, WorkspaceServ
         parserFn = new CopperParserNodeFactory(parserFactory);
     }
 
+    // This method is meant to deal with jsonNull, an element that is technically
+    // not null according to java but is a null element passed through json.
+    // It gets a string from a list containing json elements and returns "" if the element
+    // is null.
     private String getJsonStringFromConfigList(List<Object> configs, int index){
         Object itemGet = configs.get(index);
         if (itemGet != null && !((JsonElement)itemGet).isJsonNull()) {


### PR DESCRIPTION
# Changes
Fixes behavior of silver-langserver as it relates to null elements being passed in configs. It would cast in the past straight to `jsonPrimitive`, which can cause issues if null is passed in.

# Documentation
I did add comments to the new method I added to the silver-langserver java code.
The changes are pretty small, and no new features are added so I didnt have a chance to add comments for anything else.
