### PR TITLE
Remove usage of autocopy from Silver

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/AspectDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/AspectDcl.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:analysis:typechecking:core;
 
 attribute upSubst, downSubst, finalSubst occurs on AspectProductionSignature, AspectProductionLHS, AspectRHS, AspectRHSElem, AspectFunctionSignature, AspectFunctionLHS;
+propagate finalSubst on AspectProductionSignature, AspectProductionLHS, AspectRHS, AspectRHSElem, AspectFunctionSignature, AspectFunctionLHS;
 
 aspect production aspectProductionDcl
 top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature body::ProductionBody 

--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -9,6 +9,7 @@ propagate upSubst, downSubst
      and, or, notOp, ifThenElse, plus, minus, multiply, divide, modulus,
      decorateExprWith, exprInh, presentAppExpr,
      terminalConstructor, noteAttachment;
+propagate finalSubst on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoExpr, AnnoAppExprs;
 
 attribute contexts occurs on Expr;
 aspect default production
@@ -69,12 +70,13 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   infContexts.flowEnv = top.flowEnv;
 
   thread downSubst, upSubst on top, e, es, anns, infContexts, forward;
+  propagate finalSubst;
 }
 
 aspect production access
 top::Expr ::= e::Expr '.' q::QNameAttrOccur
 {
-  propagate upSubst, downSubst;
+  propagate upSubst, downSubst, finalSubst;
 }
 
 aspect production undecoratedAccessHandler

--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -100,7 +100,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 aspect production accessBouncer
 top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::Expr  q::PartiallyDecorated QNameAttrOccur
 {
-  propagate upSubst, downSubst;
+  propagate upSubst, downSubst, finalSubst;
 }
 
 aspect production forwardAccess

--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
@@ -4,6 +4,7 @@ grammar silver:compiler:analysis:typechecking:core;
 attribute upSubst, downSubst, finalSubst occurs on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr;
 propagate upSubst, downSubst on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr
   excluding productionStmtAppend, attachNoteStmt, forwardsTo, forwardInh, returnDef, synthesizedAttributeDef, inheritedAttributeDef, localValueDef;
+propagate finalSubst on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr;
 
 {--
  - These need an initial state only due to aspects (I think? maybe not. Investigate someday.)

--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
@@ -4,7 +4,7 @@ grammar silver:compiler:analysis:typechecking:core;
 attribute upSubst, downSubst, finalSubst occurs on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr;
 propagate upSubst, downSubst on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr
   excluding productionStmtAppend, attachNoteStmt, forwardsTo, forwardInh, returnDef, synthesizedAttributeDef, inheritedAttributeDef, localValueDef;
-propagate finalSubst on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr;
+propagate finalSubst on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr excluding productionStmtAppend;
 
 {--
  - These need an initial state only due to aspects (I think? maybe not. Investigate someday.)

--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
@@ -134,7 +134,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 aspect production errorAttributeDef
 top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {
-  propagate downSubst, upSubst;
+  propagate downSubst, upSubst, finalSubst;
 }
 
 aspect production childDefLHS

--- a/grammars/silver/compiler/analysis/typechecking/core/Project.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Project.sv
@@ -10,7 +10,7 @@ imports silver:compiler:definition:type;
 threaded attribute downSubst, upSubst :: Substitution;
 
 {-- The complete, final substitution context -}
-autocopy attribute finalSubst :: Substitution;
+inherited attribute finalSubst :: Substitution;
 
 -- We also use typerep.
 -- Such that performSubstitution(e.typerep, e.upSubst) is the expression's real type (as of that moment)

--- a/grammars/silver/compiler/definition/concrete_syntax/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ProductionDcl.sv
@@ -2,7 +2,7 @@ grammar silver:compiler:definition:concrete_syntax;
 
 import silver:compiler:modification:copper only actionDefs;
 
-autocopy attribute productionSig :: NamedSignature;
+inherited attribute productionSig :: NamedSignature;
 
 concrete production concreteProductionDcl
 top::AGDcl ::= 'concrete' 'production' id::Name ns::ProductionSignature pm::ProductionModifiers body::ProductionBody

--- a/grammars/silver/compiler/definition/concrete_syntax/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ProductionDcl.sv
@@ -7,7 +7,8 @@ inherited attribute productionSig :: NamedSignature;
 concrete production concreteProductionDcl
 top::AGDcl ::= 'concrete' 'production' id::Name ns::ProductionSignature pm::ProductionModifiers body::ProductionBody
 {
-  top.unparse = "concrete production " ++ id.unparse ++ "\n" ++ ns.unparse ++ " " ++ pm.unparse ++ "\n" ++ body.unparse; 
+  top.unparse = "concrete production " ++ id.unparse ++ "\n" ++ ns.unparse ++ " " ++ pm.unparse ++ "\n" ++ body.unparse;
+  propagate config, grammarName, compiledGrammars;
 
   production fName :: String = top.grammarName ++ ":" ++ id.name;
   production namedSig :: NamedSignature = ns.namedSignature;
@@ -39,7 +40,8 @@ closed nonterminal ProductionModifier with config, location, unparse, production
 monoid attribute productionModifiers :: [SyntaxProductionModifier];
 
 propagate productionModifiers on ProductionModifiers, ProductionModifierList;
-propagate errors on ProductionModifiers, ProductionModifierList, ProductionModifier;
+propagate config, errors, env, productionSig
+  on ProductionModifiers, ProductionModifierList, ProductionModifier;
 
 concrete production productionModifiersNone
 top::ProductionModifiers ::=

--- a/grammars/silver/compiler/definition/concrete_syntax/TerminalDcl.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/TerminalDcl.sv
@@ -41,7 +41,7 @@ top::AGDcl ::= t::TerminalKeywordModifier id::Name r::RegExpr tm::TerminalModifi
     then [wrn(r.location, "Regex contains '\\n' but not '\\r'. This is your reminder about '\\r\\n' newlines.")]
     else [];
 
-  propagate errors;
+  propagate grammarName, compiledGrammars, env, errors;
 
   top.syntaxAst := [
     syntaxTerminal(fName, r.terminalRegExprSpec,
@@ -126,7 +126,8 @@ closed nonterminal TerminalModifier with config, location, unparse, terminalModi
 monoid attribute terminalModifiers :: [SyntaxTerminalModifier];
 monoid attribute genRepeatProb :: Maybe<Float> with nothing(), orElse;
 
-propagate terminalModifiers, genRepeatProb, errors on TerminalModifiers;
+propagate config, grammarName, compiledGrammars, flowEnv, terminalModifiers, genRepeatProb, errors, env
+  on TerminalModifiers;
 
 aspect default production
 top::TerminalModifier ::=

--- a/grammars/silver/compiler/definition/concrete_syntax/TerminalDcl.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/TerminalDcl.sv
@@ -41,7 +41,7 @@ top::AGDcl ::= t::TerminalKeywordModifier id::Name r::RegExpr tm::TerminalModifi
     then [wrn(r.location, "Regex contains '\\n' but not '\\r'. This is your reminder about '\\r\\n' newlines.")]
     else [];
 
-  propagate grammarName, compiledGrammars, env, errors;
+  propagate config, grammarName, compiledGrammars, env, errors;
 
   top.syntaxAst := [
     syntaxTerminal(fName, r.terminalRegExprSpec,

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -7,7 +7,7 @@ import silver:util:treemap as tm;
 -- monoid attribute submits_ :: [Decorated SyntaxDcl];
 -- synthesized attribute prefixSeperator :: Maybe<String>;
 
-autocopy attribute className :: String;
+inherited attribute className :: String;
 
 {--
  - Modifiers for lexer classes.

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/LexerClassModifiers.sv
@@ -12,9 +12,13 @@ inherited attribute className :: String;
 {--
  - Modifiers for lexer classes.
  -}
-nonterminal SyntaxLexerClassModifiers with compareTo, isEqual, cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, prefixSeperator, containingGrammar, dominates_, submits_;
+nonterminal SyntaxLexerClassModifiers with
+  compareTo, isEqual, cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs,
+  disambiguationClasses, prefixSeperator, containingGrammar, dominates_, submits_;
 
-propagate compareTo, isEqual, cstErrors, superClassContribs, disambiguationClasses, prefixSeperator, dominates_, submits_
+propagate
+  compareTo, isEqual, cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs,
+  disambiguationClasses, prefixSeperator, containingGrammar, dominates_, submits_
   on SyntaxLexerClassModifiers;
 
 abstract production consLexerClassMod
@@ -35,9 +39,13 @@ top::SyntaxLexerClassModifiers ::=
 {--
  - Modifiers for lexer classes.
  -}
-closed nonterminal SyntaxLexerClassModifier with location, sourceGrammar, compareTo, isEqual, cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs, disambiguationClasses, prefixSeperator, containingGrammar, dominates_, submits_;
+closed nonterminal SyntaxLexerClassModifier with location, sourceGrammar,
+  compareTo, isEqual, cstEnv, cstErrors, className, classTerminals, superClasses, subClasses, superClassContribs,
+  disambiguationClasses, prefixSeperator, containingGrammar, dominates_, submits_;
 
-propagate compareTo, isEqual on SyntaxLexerClassModifier;
+propagate
+  compareTo, isEqual, cstEnv, className, classTerminals, superClasses, subClasses, containingGrammar
+  on SyntaxLexerClassModifier;
 
 {- We default ALL attributes, so we can focus only on those that are interesting in each case... -}
 aspect default production

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/NonterminalModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/NonterminalModifiers.sv
@@ -8,7 +8,7 @@ imports silver:compiler:definition:core only nonterminalName;
 
 nonterminal SyntaxNonterminalModifiers with compareTo, isEqual, cstEnv, cstErrors, customLayout, nonterminalName;
 
-propagate compareTo, isEqual, cstErrors, customLayout on SyntaxNonterminalModifiers;
+propagate compareTo, isEqual, cstEnv, cstErrors, customLayout, nonterminalName on SyntaxNonterminalModifiers;
 
 abstract production consNonterminalMod
 top::SyntaxNonterminalModifiers ::= h::SyntaxNonterminalModifier  t::SyntaxNonterminalModifiers

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/ProductionModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/ProductionModifiers.sv
@@ -10,9 +10,11 @@ monoid attribute productionOperator :: Maybe<Decorated SyntaxDcl> with nothing()
 {--
  - Modifiers for productions.
  -}
-nonterminal SyntaxProductionModifiers with compareTo, isEqual, cstEnv, cstErrors, acode, productionPrecedence, customLayout, productionOperator, productionSig;
+nonterminal SyntaxProductionModifiers with
+  compareTo, isEqual, cstEnv, cstErrors, acode, productionPrecedence, customLayout, productionOperator, productionSig;
 
-propagate compareTo, isEqual, cstErrors, acode, productionPrecedence, customLayout, productionOperator
+propagate
+  compareTo, isEqual, cstEnv, cstErrors, acode, productionPrecedence, customLayout, productionOperator, productionSig
   on SyntaxProductionModifiers;
 
 abstract production consProductionMod
@@ -27,9 +29,10 @@ top::SyntaxProductionModifiers ::=
 {--
  - Modifiers for productions.
  -}
-nonterminal SyntaxProductionModifier with compareTo, isEqual, cstEnv, cstErrors, acode, productionPrecedence, customLayout, productionOperator, productionSig;
+nonterminal SyntaxProductionModifier with
+  compareTo, isEqual, cstEnv, cstErrors, acode, productionPrecedence, customLayout, productionOperator, productionSig;
 
-propagate compareTo, isEqual on SyntaxProductionModifier;
+propagate compareTo, isEqual, cstEnv, productionSig on SyntaxProductionModifier;
 
 aspect default production
 top::SyntaxProductionModifier ::=

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -7,24 +7,24 @@ import silver:util:treeset as s;
 
 -- For looking syntax elements up by name.
 monoid attribute cstDcls :: [Pair<String Decorated SyntaxDcl>];
-autocopy attribute cstEnv :: EnvTree<Decorated SyntaxDcl>;
+inherited attribute cstEnv :: EnvTree<Decorated SyntaxDcl>;
 monoid attribute cstErrors :: [String];
 
 -- Transformation that moves productions underneath their respective nonterminals.
 monoid attribute cstProds :: [Pair<String SyntaxDcl>];
-autocopy attribute cstNTProds :: EnvTree<SyntaxDcl>;
+inherited attribute cstNTProds :: EnvTree<SyntaxDcl>;
 monoid attribute cstNormalize :: [SyntaxDcl];
 
 -- Compute and allow lookup of all terminals in a lexer class
 monoid attribute classTerminalContribs::[Pair<String String>];
-autocopy attribute classTerminals::EnvTree<String>;
+inherited attribute classTerminals::EnvTree<String>;
 monoid attribute superClassContribs::[Pair<String String>];
-autocopy attribute superClasses::EnvTree<String>;
-autocopy attribute subClasses::EnvTree<String>;
+inherited attribute superClasses::EnvTree<String>;
+inherited attribute subClasses::EnvTree<String>;
 
 -- Parser attribute action code aspects
 monoid attribute parserAttributeAspectContribs::[Pair<String String>];
-autocopy attribute parserAttributeAspects::EnvTree<String>;
+inherited attribute parserAttributeAspects::EnvTree<String>;
 
 -- TODO: Attributes that lift out various sorts of SyntaxDcls all extract references
 -- of type Decorated SyntaxDcl.  The actual set of attributes needed for translation
@@ -45,21 +45,21 @@ synthesized attribute subContribs :: [Decorated SyntaxDcl];
 monoid attribute memberTerminals :: [Decorated SyntaxDcl];
 monoid attribute dominatingTerminalContribs :: [(String, Decorated SyntaxDcl)];
 synthesized attribute terminalRegex::Regex;
-autocopy attribute containingGrammar :: String;
+inherited attribute containingGrammar :: String;
 monoid attribute lexerClassRefDcls :: String;
 synthesized attribute exportedProds :: [String];
 synthesized attribute hasCustomLayout :: Boolean;
 monoid attribute layoutContribs :: [Pair<String String>]; -- prod/nt name, prod/nt/term name
-autocopy attribute layoutTerms::EnvTree<String>;
+inherited attribute layoutTerms::EnvTree<String>;
 
-autocopy attribute prefixesForTerminals :: EnvTree<String>;
-autocopy attribute componentGrammarMarkingTerminals :: EnvTree<[String]>;
+inherited attribute prefixesForTerminals :: EnvTree<String>;
+inherited attribute componentGrammarMarkingTerminals :: EnvTree<[String]>;
 
 -- Creating unambiguous <PP>s; this is a multiset used to accumulate all the
 -- names for terminals, and the actual name for <PP> will be modified to
 -- disambiguate if it would be ambiguous.
 monoid attribute prettyNamesAccum::[Pair<String String>];
-autocopy attribute prettyNames::tm:Map<String String>;
+inherited attribute prettyNames::tm:Map<String String>;
 
 synthesized attribute copperElementReference::copper:ElementReference;
 synthesized attribute copperGrammarElements::[copper:GrammarElement];

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/Syntax.sv
@@ -67,12 +67,26 @@ synthesized attribute copperGrammarElements::[copper:GrammarElement];
 {--
  - An abstract syntax tree for representing concrete syntax.
  -}
-nonterminal Syntax with compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, layoutContribs, layoutTerms, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperGrammarElements;
-propagate compareTo, isEqual on Syntax;
+nonterminal Syntax with
+  compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize,
+  allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals,
+  disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, classTerminals,
+  superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects,
+  lexerClassRefDcls, layoutContribs, layoutTerms, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals,
+  prettyNamesAccum, prettyNames, copperGrammarElements;
 
-flowtype decorate {cstEnv, classTerminals, superClasses, subClasses, containingGrammar, layoutTerms, prefixesForTerminals, componentGrammarMarkingTerminals, parserAttributeAspects, prettyNames} on Syntax, SyntaxDcl;
+flowtype decorate {
+  cstEnv, classTerminals, superClasses, subClasses, containingGrammar,
+  layoutTerms, prefixesForTerminals, componentGrammarMarkingTerminals, parserAttributeAspects, prettyNames
+} on Syntax, SyntaxDcl;
 
-propagate cstDcls, cstErrors, cstProds, cstNormalize, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, superClassContribs, parserAttributeAspectContribs, lexerClassRefDcls, layoutContribs, prettyNamesAccum
+propagate
+  compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize,
+  allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals,
+  disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, classTerminals,
+  superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects,
+  lexerClassRefDcls, layoutContribs, layoutTerms, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals,
+  prettyNamesAccum, prettyNames
   on Syntax;
 
 abstract production nilSyntax
@@ -90,11 +104,21 @@ top::Syntax ::= s1::SyntaxDcl s2::Syntax
 {--
  - An individual declaration of a concrete syntax element.
  -}
-closed nonterminal SyntaxDcl with location, sourceGrammar, compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize, fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals, disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, classTerminals, superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects, lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms, domContribs, subContribs, terminalRegex, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals, prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElements;
+closed nonterminal SyntaxDcl with location, sourceGrammar,
+  compareTo, isEqual, cstDcls, cstEnv, cstErrors, cstProds, cstNTProds, cstNormalize,
+  fullName, sortKey, allTerminals, allIgnoreTerminals, allMarkingTerminals, allProductions, allProductionNames, allNonterminals,
+  disambiguationClasses, memberTerminals, dominatingTerminalContribs, classTerminalContribs, classTerminals,
+  superClassContribs, superClasses, subClasses, parserAttributeAspectContribs, parserAttributeAspects,
+  lexerClassRefDcls, exportedProds, hasCustomLayout, layoutContribs, layoutTerms,
+  domContribs, subContribs, terminalRegex, prefixSeperator, containingGrammar, prefixesForTerminals, componentGrammarMarkingTerminals,
+  prettyNamesAccum, prettyNames, copperElementReference, copperGrammarElements;
 
 synthesized attribute sortKey :: String;
 
-propagate compareTo, isEqual, cstErrors, prefixSeperator on SyntaxDcl;
+propagate
+  compareTo, isEqual, cstEnv, cstErrors, cstNTProds, containingGrammar, layoutTerms, prettyNames, prefixSeperator,
+  classTerminals, parserAttributeAspects, prefixesForTerminals, componentGrammarMarkingTerminals, subClasses, superClasses
+  on SyntaxDcl;
 
 aspect default production
 top::SyntaxDcl ::=

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -10,7 +10,7 @@ monoid attribute opAssociation :: Maybe<String> with nothing(), orElse; -- TODO 
 monoid attribute prefixSeperator :: Maybe<String> with nothing(), orElse;
 monoid attribute prefixSeperatorToApply :: Maybe<String> with nothing(), orElse;
 monoid attribute prettyName :: Maybe<String> with nothing(), orElse;
-autocopy attribute terminalName :: String;
+inherited attribute terminalName :: String;
 
 monoid attribute dominates_ :: [Decorated SyntaxDcl];
 monoid attribute submits_ :: [Decorated SyntaxDcl];

--- a/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/ast/TerminalModifiers.sv
@@ -25,8 +25,10 @@ nonterminal SyntaxTerminalModifiers with compareTo, isEqual, cstEnv, cstErrors,
   componentGrammarMarkingTerminals, marking, terminalName, prettyName,
   dominates_, submits_, lexerClasses;
 
-propagate compareTo, isEqual, cstErrors, classTerminalContribs, ignored, acode, opPrecedence,
-  opAssociation, prefixSeperator, prefixSeperatorToApply, marking, prettyName,
+propagate compareTo, isEqual, cstEnv, cstErrors,
+  classTerminalContribs, superClasses, subClasses, ignored, acode,
+  opPrecedence, opAssociation, prefixSeperator, prefixSeperatorToApply,
+  componentGrammarMarkingTerminals, marking, terminalName, prettyName,
   dominates_, submits_, lexerClasses
   on SyntaxTerminalModifiers;
 

--- a/grammars/silver/compiler/definition/core/AGDcl.sv
+++ b/grammars/silver/compiler/definition/core/AGDcl.sv
@@ -7,14 +7,16 @@ nonterminal AGDcls with config, grammarName, env, location, unparse, errors, def
 nonterminal AGDcl  with config, grammarName, env, location, unparse, errors, defs, occursDefs, moduleNames, compiledGrammars, grammarDependencies, jarName;
 
 flowtype decorate {config, grammarName, env, flowEnv, compiledGrammars, grammarDependencies} on AGDcls, AGDcl;
-flowtype forward {decorate} on AGDcls, AGDcl;
+flowtype forward {} on AGDcls;
+flowtype forward {decorate} on AGDcl;
 flowtype errors {decorate} on AGDcls, AGDcl;
 flowtype defs {decorate} on AGDcls, AGDcl;
 flowtype occursDefs {decorate} on AGDcls, AGDcl;
 flowtype jarName {decorate} on AGDcls, AGDcl;
 
-propagate errors, moduleNames, jarName on AGDcls, AGDcl;
-propagate defs, occursDefs on AGDcls;
+propagate config, grammarName, compiledGrammars, grammarDependencies, errors, moduleNames, jarName
+  on AGDcls, AGDcl;
+propagate env, defs, occursDefs on AGDcls;
 
 concrete production nilAGDcls
 top::AGDcls ::=
@@ -64,7 +66,7 @@ abstract production appendAGDcl
 top::AGDcl ::= h::AGDcl t::AGDcl
 {
   top.unparse = h.unparse ++ "\n" ++ t.unparse;
-  propagate defs, occursDefs;
+  propagate env, defs, occursDefs;
 
   top.errors <- warnIfMultJarName(h.jarName, t.jarName, top.location);
 }

--- a/grammars/silver/compiler/definition/core/AspectDcl.sv
+++ b/grammars/silver/compiler/definition/core/AspectDcl.sv
@@ -17,12 +17,14 @@ flowtype forward {deterministicCount, realSignature, grammarName, env, flowEnv} 
  -}
 inherited attribute realSignature :: [NamedSignatureElement];
 
-propagate errors on AspectProductionSignature, AspectProductionLHS, AspectFunctionSignature, AspectFunctionLHS, AspectRHS, AspectRHSElem;
+propagate config, grammarName, env, grammarDependencies, errors
+  on AspectProductionSignature, AspectProductionLHS, AspectFunctionSignature, AspectFunctionLHS, AspectRHS, AspectRHSElem;
 
 concrete production aspectProductionDcl
 top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature body::ProductionBody
 {
   top.unparse = "aspect production " ++ id.unparse ++ "\n" ++ ns.unparse ++ "\n" ++ body.unparse;
+  id.env = top.env;
 
   top.defs := 
     if null(body.productionAttributes) then []
@@ -79,6 +81,7 @@ concrete production aspectFunctionDcl
 top::AGDcl ::= 'aspect' 'function' id::QName ns::AspectFunctionSignature body::ProductionBody
 {
   top.unparse = "aspect function " ++ id.unparse ++ "\n" ++ ns.unparse ++ "\n" ++ body.unparse;
+  id.env = top.env;
 
   top.defs := 
     if null(body.productionAttributes) then []
@@ -175,6 +178,7 @@ concrete production aspectProductionLHSTyped
 top::AspectProductionLHS ::= id::Name '::' t::TypeExpr
 {
   top.unparse = id.unparse;
+  propagate env, grammarName;
 
   top.errors <- t.errors;
   
@@ -258,6 +262,7 @@ concrete production aspectRHSElemTyped
 top::AspectRHSElem ::= id::Name '::' t::TypeExpr
 {
   top.unparse = id.unparse ++ "::" ++ t.unparse;
+  propagate env, grammarName;
   
   top.errors <- t.errors;
 

--- a/grammars/silver/compiler/definition/core/AspectDcl.sv
+++ b/grammars/silver/compiler/definition/core/AspectDcl.sv
@@ -15,7 +15,7 @@ flowtype forward {deterministicCount, realSignature, grammarName, env, flowEnv} 
 {--
  - The signature elements from the fun/produciton being aspected.
  -}
-autocopy attribute realSignature :: [NamedSignatureElement];
+inherited attribute realSignature :: [NamedSignatureElement];
 
 propagate errors on AspectProductionSignature, AspectProductionLHS, AspectFunctionSignature, AspectFunctionLHS, AspectRHS, AspectRHSElem;
 

--- a/grammars/silver/compiler/definition/core/AspectDcl.sv
+++ b/grammars/silver/compiler/definition/core/AspectDcl.sv
@@ -178,7 +178,7 @@ concrete production aspectProductionLHSTyped
 top::AspectProductionLHS ::= id::Name '::' t::TypeExpr
 {
   top.unparse = id.unparse;
-  propagate env, grammarName;
+  propagate env, grammarName, config;
 
   top.errors <- t.errors;
   
@@ -262,7 +262,7 @@ concrete production aspectRHSElemTyped
 top::AspectRHSElem ::= id::Name '::' t::TypeExpr
 {
   top.unparse = id.unparse ++ "::" ++ t.unparse;
-  propagate env, grammarName;
+  propagate env, grammarName, config;
   
   top.errors <- t.errors;
 

--- a/grammars/silver/compiler/definition/core/Attributes.sv
+++ b/grammars/silver/compiler/definition/core/Attributes.sv
@@ -3,7 +3,7 @@ grammar silver:compiler:definition:core;
 {--
  - The grammar containing this tree.
  -}
-autocopy attribute grammarName :: String;
+inherited attribute grammarName :: String;
 
 {--
  - The name to use for the generated .jar if not overridden by -o command-line option.

--- a/grammars/silver/compiler/definition/core/ClassDcl.sv
+++ b/grammars/silver/compiler/definition/core/ClassDcl.sv
@@ -72,9 +72,9 @@ top::AGDcl ::= 'class' id::QNameType var::TypeExpr '{' body::ClassBody '}'
   insert semantic token IdTypeClassDcl_t at id.baseNameLoc;
 }
 
-autocopy attribute classHead::Context;
-autocopy attribute constraintEnv::Decorated Env;
-autocopy attribute frameContexts::[Context];  -- Only used for computing frame in members
+inherited attribute classHead::Context;
+inherited attribute constraintEnv::Decorated Env;
+inherited attribute frameContexts::[Context];  -- Only used for computing frame in members
 
 nonterminal ClassBody with
   config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;

--- a/grammars/silver/compiler/definition/core/ClassDcl.sv
+++ b/grammars/silver/compiler/definition/core/ClassDcl.sv
@@ -52,6 +52,7 @@ top::AGDcl ::= 'class' cl::ConstraintList '=>' id::QNameType var::TypeExpr '{' b
   cl.constraintPos = classPos(fName, var.freeVariables);
   cl.env = newScopeEnv(headPreDefs, top.env);
   
+  id.env = cl.env;
   var.env = cl.env;
   
   body.env = occursEnv(cl.occursDefs, newScopeEnv(headDefs, cl.env));

--- a/grammars/silver/compiler/definition/core/ClassDcl.sv
+++ b/grammars/silver/compiler/definition/core/ClassDcl.sv
@@ -5,7 +5,7 @@ import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, co
 concrete production typeClassDcl
 top::AGDcl ::= 'class' cl::ConstraintList '=>' id::QNameType var::TypeExpr '{' body::ClassBody '}'
 {
-  top.unparse = s"class ${cl.unparse} => ${id.unparse} ${var.unparse}\n{\n${body.unparse}\n}"; 
+  top.unparse = s"class ${cl.unparse} => ${id.unparse} ${var.unparse}\n{\n${body.unparse}\n}";
 
   production fName :: String = top.grammarName ++ ":" ++ id.name;
   production tv :: TyVar =
@@ -77,12 +77,14 @@ inherited attribute constraintEnv::Decorated Env;
 inherited attribute frameContexts::[Context];  -- Only used for computing frame in members
 
 nonterminal ClassBody with
-  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
+  config, grammarName, env, defs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
 nonterminal ClassBodyItem with
-  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
+  config, grammarName, env, defs, location, unparse, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars, classMembers;
 
-propagate flowDefs, errors, lexicalTypeVariables, lexicalTyVarKinds on ClassBody, ClassBodyItem;
-propagate defs on ClassBody;
+propagate
+  config, grammarName, errors, lexicalTypeVariables, lexicalTyVarKinds, classHead, constraintEnv, frameContexts, compiledGrammars
+  on ClassBody, ClassBodyItem;
+propagate env, defs on ClassBody;
 
 concrete production consClassBody
 top::ClassBody ::= h::ClassBodyItem t::ClassBody
@@ -121,6 +123,8 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr ';'
     | _ -> error("Class head is not an instContext")
     end;
   cl.env = top.constraintEnv;
+
+  ty.env = top.env;
   
   top.defs := [classMemberDef(top.grammarName, top.location, fName, boundVars, top.classHead, cl.contexts, ty.typerep)];
 
@@ -156,6 +160,8 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e:
     | _ -> error("Class head is not an instContext")
     end;
   cl.env = top.constraintEnv;
+
+  ty.env = top.env;
   
   e.isRoot = true;
   e.originRules = [];

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -33,12 +33,12 @@ propagate freeVars on Expr, Exprs, ExprInhs, ExprInh, ExprLHSExpr;
 {--
  - The nonterminal being decorated. (Used for 'decorate with {}')
  -}
-autocopy attribute decoratingnt :: Type;
+inherited attribute decoratingnt :: Type;
 {--
  - The inherited attributes being supplied in a decorate expression
  -}
 synthesized attribute suppliedInhs :: [String];
-autocopy attribute allSuppliedInhs :: [String];
+inherited attribute allSuppliedInhs :: [String];
 {--
  - A list of decorated expressions from an Exprs.
  -}
@@ -54,9 +54,9 @@ monoid attribute freeVars :: ts:Set<String>;
 
 -- Is this Expr the logical "root" of the expression? That is, will it's value be the value computed
 --  for the attribute/return value/etc that it is part of?
-autocopy attribute isRoot :: Boolean;
+inherited attribute isRoot :: Boolean;
 
-autocopy attribute originRules :: [Decorated Expr];
+inherited attribute originRules :: [Decorated Expr];
 
 attribute grammarName, frame occurs on Contexts, Context;
 
@@ -923,7 +923,7 @@ synthesized attribute appExprSize :: Integer;
 inherited attribute appExprIndex :: Integer;
 inherited attribute appExprTypereps :: [Type];
 inherited attribute appExprTyperep :: Type;
-autocopy attribute appExprApplied :: String;
+inherited attribute appExprApplied :: String;
 
 -- These are the "new" Exprs syntax. This allows missing (_) arguments, to indicate partial application.
 concrete production missingAppExpr
@@ -1023,7 +1023,7 @@ inherited attribute remainingFuncAnnotations :: [Pair<String Type>];
 {--
  - All annotations of this function
  -}
-autocopy attribute funcAnnotations :: [Pair<String Type>];
+inherited attribute funcAnnotations :: [Pair<String Type>];
 {--
  - Annotations that have not been supplied (by subtracting from remainingFuncAnnotations)
  -}

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -381,6 +381,8 @@ top::Expr ::= e::Expr '.' 'forward'
 {
   top.unparse = e.unparse ++ ".forward";
   top.typerep = e.typerep;
+
+  e.isRoot = false;
 }
 
 concrete production access
@@ -583,6 +585,8 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e::Expr ';'
   top.unparse = lhs.unparse ++ " = " ++ e.unparse ++ ";";
   
   top.suppliedInhs = lhs.suppliedInhs;
+
+  e.isRoot = false;
 }
 
 concrete production exprLhsExpr
@@ -748,6 +752,10 @@ precedence = 0
   top.unparse = "if " ++ e1.unparse ++ " then " ++ e2.unparse ++ " else " ++ e3.unparse;
 
   top.typerep = e2.typerep;
+
+  e1.isRoot=false;
+  e2.isRoot=false;
+  e3.isRoot=false;
 }
 
 concrete production intConst

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -62,6 +62,7 @@ inherited attribute isRoot :: Boolean;
 inherited attribute originRules :: [Decorated Expr];
 
 attribute grammarName, frame occurs on Contexts, Context;
+propagate grammarName, frame on Contexts, Context;
 
 abstract production errorExpr
 top::Expr ::= e::[Message]

--- a/grammars/silver/compiler/definition/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/definition/core/FunctionDcl.sv
@@ -3,7 +3,7 @@ grammar silver:compiler:definition:core;
 nonterminal FunctionSignature with config, grammarName, env, location, unparse, errors, defs, constraintDefs, occursDefs, namedSignature, signatureName;
 nonterminal FunctionLHS with config, grammarName, env, location, unparse, errors, defs, outputElement;
 
-propagate errors on FunctionSignature, FunctionLHS;
+propagate config, grammarName, errors on FunctionSignature, FunctionLHS;
 
 concrete production functionDcl
 top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody
@@ -51,6 +51,8 @@ top::FunctionSignature ::= cl::ConstraintList '=>' lhs::FunctionLHS '::=' rhs::P
   top.unparse = s"${cl.unparse} => ${lhs.unparse} ::= ${rhs.unparse}";
 
   cl.constraintPos = signaturePos(top.namedSignature);
+  cl.env = top.env;
+  lhs.env = top.env;
   rhs.env = occursEnv(cl.occursDefs, top.env);
 
   top.defs := lhs.defs ++ rhs.defs;
@@ -83,6 +85,7 @@ concrete production functionLHS
 top::FunctionLHS ::= t::TypeExpr
 {
   top.unparse = t.unparse;
+  propagate env;
 
   production attribute fName :: String;
   fName = "__func__lhs";

--- a/grammars/silver/compiler/definition/core/GrammarParts.sv
+++ b/grammars/silver/compiler/definition/core/GrammarParts.sv
@@ -16,13 +16,13 @@ flowtype Grammar = decorate {config, compiledGrammars, productionFlowGraphs, gra
 - directly or indirectly. (i.e. based on other grammar's exports)
 - NOT including options.
 -}
-autocopy attribute grammarDependencies :: [String];
+inherited attribute grammarDependencies :: [String];
 {--
  - Grammar-wide imports definitions.  Exists because we need to place
  - a file's individual imports between grammar definitions and grammar
  - wide imports.
  -}
-autocopy attribute globalImports :: Decorated Env;
+inherited attribute globalImports :: Decorated Env;
 {--
  - The definitions resulting from grammar-wide imports definitions.
  - At the top of a grammar, these are echoed down as globalImports

--- a/grammars/silver/compiler/definition/core/GrammarParts.sv
+++ b/grammars/silver/compiler/definition/core/GrammarParts.sv
@@ -39,6 +39,8 @@ synthesized attribute grammarErrors :: [Pair<String [Message]>];
 synthesized attribute allFileErrors :: [Pair<String [Message]>];
 
 propagate
+    config, compiledGrammars, productionFlowGraphs, grammarFlowTypes,
+    grammarName, env, globalImports, grammarDependencies,
     moduleNames, exportedGrammars, optionalGrammars, condBuild, defs,
     occursDefs, importedDefs, importedOccursDefs, jarName
   on Grammar;

--- a/grammars/silver/compiler/definition/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/definition/core/InstanceDcl.sv
@@ -82,8 +82,8 @@ top::AGDcl ::= 'instance' id::QNameType ty::TypeExpr '{' body::InstanceBody '}'
   insert semantic token IdTypeClass_t at id.baseNameLoc;
 }
 
-autocopy attribute className::String;
-autocopy attribute instanceType::Type;
+inherited attribute className::String;
+inherited attribute instanceType::Type;
 inherited attribute expectedClassMembers::[Pair<String Boolean>];
 
 nonterminal InstanceBody with

--- a/grammars/silver/compiler/definition/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/definition/core/InstanceDcl.sv
@@ -93,14 +93,16 @@ nonterminal InstanceBodyItem with
   config, grammarName, env, defs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, fullName;
 
 propagate 
-  config, grammarName, env, compiledGrammars, className, instanceType,
-  defs, flowDefs, errors on InstanceBody, InstanceBodyItem;
+  config, grammarName, compiledGrammars, className, instanceType,
+  defs, errors, frameContexts
+  on InstanceBody, InstanceBodyItem;
 
 concrete production consInstanceBody
 top::InstanceBody ::= h::InstanceBodyItem t::InstanceBody
 {
   top.unparse = h.unparse ++ "\n" ++ t.unparse;
   top.definedMembers = h.fullName :: t.definedMembers;
+  propagate env;
 
   h.expectedClassMembers = top.expectedClassMembers;
   t.expectedClassMembers =
@@ -149,6 +151,8 @@ top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
     else [err(id.location, s"Unexpected instance member ${id.name} for class ${top.className}")]; 
 
   top.fullName = id.lookupValue.fullName;
+
+  id.env = top.env;
 
   local cmDefs::[Def] =
     flatMap(

--- a/grammars/silver/compiler/definition/core/InstanceDcl.sv
+++ b/grammars/silver/compiler/definition/core/InstanceDcl.sv
@@ -61,6 +61,7 @@ top::AGDcl ::= 'instance' cl::ConstraintList '=>' id::QNameType ty::TypeExpr '{'
   headDefs <- [currentInstDef(top.grammarName, id.location, fName, ty.typerep)];
   
   cl.env = newScopeEnv(headPreDefs, top.env);
+  id.env = cl.env;
   ty.env = cl.env;
   
   body.env = occursEnv(cl.occursDefs, newScopeEnv(headDefs, cl.env));
@@ -87,11 +88,13 @@ inherited attribute instanceType::Type;
 inherited attribute expectedClassMembers::[Pair<String Boolean>];
 
 nonterminal InstanceBody with
-  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, definedMembers;
+  config, grammarName, env, defs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, definedMembers;
 nonterminal InstanceBodyItem with
-  config, grammarName, env, defs, flowEnv, flowDefs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, fullName;
+  config, grammarName, env, defs, location, unparse, errors, compiledGrammars, className, instanceType, frameContexts, expectedClassMembers, fullName;
 
-propagate defs, flowDefs, errors on InstanceBody, InstanceBodyItem;
+propagate 
+  config, grammarName, env, compiledGrammars, className, instanceType,
+  defs, flowDefs, errors on InstanceBody, InstanceBodyItem;
 
 concrete production consInstanceBody
 top::InstanceBody ::= h::InstanceBodyItem t::InstanceBody

--- a/grammars/silver/compiler/definition/core/ModuleStmts.sv
+++ b/grammars/silver/compiler/definition/core/ModuleStmts.sv
@@ -19,6 +19,7 @@ nonterminal WithElem with config, grammarName, location, unparse, envMaps;
 propagate config, grammarName, errors, moduleNames, defs, occursDefs, compiledGrammars, grammarDependencies
   on ModuleStmts, ModuleStmt, ImportStmt, ImportStmts;
 propagate exportedGrammars, optionalGrammars, condBuild on ModuleStmts;
+propagate env on NameList;
 
 {--
  - A list of QName strings. Used for 'only' and 'hiding'.

--- a/grammars/silver/compiler/definition/core/ModuleStmts.sv
+++ b/grammars/silver/compiler/definition/core/ModuleStmts.sv
@@ -16,7 +16,8 @@ nonterminal NameList with config, grammarName, location, unparse, names, env;
 nonterminal WithElems with config, grammarName, location, unparse, envMaps;
 nonterminal WithElem with config, grammarName, location, unparse, envMaps;
 
-propagate errors, moduleNames, defs, occursDefs on ModuleStmts, ModuleStmt, ImportStmt, ImportStmts;
+propagate config, grammarName, errors, moduleNames, defs, occursDefs, compiledGrammars, grammarDependencies
+  on ModuleStmts, ModuleStmt, ImportStmt, ImportStmts;
 propagate exportedGrammars, optionalGrammars, condBuild on ModuleStmts;
 
 {--

--- a/grammars/silver/compiler/definition/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/definition/core/NonTerminalDcl.sv
@@ -83,7 +83,8 @@ nonterminal NonterminalModifiers with config, location, unparse, errors, env, no
 nonterminal NonterminalModifierList with config, location, unparse, errors, env, nonterminalName; -- 1 or more
 closed nonterminal NonterminalModifier with config, location, unparse, errors, env, nonterminalName; -- 1
 
-propagate errors on NonterminalModifiers, NonterminalModifierList, NonterminalModifier;
+propagate config, errors, env, nonterminalName
+  on NonterminalModifiers, NonterminalModifierList, NonterminalModifier;
 
 concrete production nonterminalModifiersNone
 top::NonterminalModifiers ::=

--- a/grammars/silver/compiler/definition/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/definition/core/NonTerminalDcl.sv
@@ -29,6 +29,8 @@ top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTy
   -- Here we bind those type variables.
   tl.initialEnv = top.env;
   tl.env = tl.envBindingTyVars;
+
+  nm.env = top.env;
   
   -- Redefinition check of the name
   top.errors <- 

--- a/grammars/silver/compiler/definition/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/definition/core/NonTerminalDcl.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:definition:core;
 
-autocopy attribute nonterminalName :: String;
+inherited attribute nonterminalName :: String;
 
 concrete production nonterminalDcl
 top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTypeExprs nm::NonterminalModifiers ';'

--- a/grammars/silver/compiler/definition/core/OccursDcl.sv
+++ b/grammars/silver/compiler/definition/core/OccursDcl.sv
@@ -31,6 +31,7 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
   
   nttl.initialEnv = top.env;
   attl.env = nttl.envBindingTyVars;
+  nt.env = top.env;
   nttl.env = nttl.envBindingTyVars;
   
   local ntTypeScheme::PolyType = nt.lookupType.typeScheme;
@@ -133,6 +134,7 @@ top::AGDcl ::= msg::[Message] at::PartiallyDecorated QName attl::BracketedOptTyp
   
   nttl.initialEnv = top.env;
   attl.env = nttl.envBindingTyVars;
+  nt.env = top.env;
   nttl.env = nttl.envBindingTyVars;
   
   -- Decorate everything else to still check for errors
@@ -161,6 +163,7 @@ concrete production attributionDcl
 top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' nt::QName nttl::BracketedOptTypeExprs ';'
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
+  propagate env;
   
   -- Workaround for circular dependency due to dispatching on env:
   -- Nothing used to build the env namespaces on which we dispatch can depend on

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -35,7 +35,7 @@ nonterminal ForwardLHSExpr with
  - Context for ProductionStmt blocks. (Indicates function, production, aspect, etc)
  - Includes singature for those contexts with a signature.
  -}
-autocopy attribute frame :: BlockContext;
+inherited attribute frame :: BlockContext;
 
 {--
  - Defs of attributes that should be wrapped up as production attributes.

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -56,7 +56,8 @@ inherited attribute defLHSattr :: Decorated QNameAttrOccur;
 -- Notes flow 'up' in this from statements and then back 'down' into the via originRules.
 synthesized attribute originRuleDefs :: [Decorated Expr] occurs on ProductionStmt, ProductionStmts;
 
-propagate errors on ProductionBody, ProductionStmts, ProductionStmt, DefLHS, ForwardInhs, ForwardInh, ForwardLHSExpr;
+propagate config, grammarName, env, errors, frame, compiledGrammars on
+  ProductionBody, ProductionStmts, ProductionStmt, DefLHS, ForwardInhs, ForwardInh, ForwardLHSExpr;
 propagate defs, productionAttributes, uniqueSignificantExpression on ProductionBody, ProductionStmts;
 
 

--- a/grammars/silver/compiler/definition/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/core/ProductionDcl.sv
@@ -11,8 +11,9 @@ flowtype forward {deterministicCount, env} on ProductionRHSElem;
 
 flowtype decorate {forward, grammarName, flowEnv} on ProductionSignature, ProductionLHS, ProductionRHS, ProductionRHSElem;
 
-propagate errors on ProductionSignature, ProductionLHS, ProductionRHS, ProductionRHSElem;
-propagate defs on ProductionRHS;
+propagate config, grammarName, errors on
+  ProductionSignature, ProductionLHS, ProductionRHS, ProductionRHSElem;
+propagate env, defs on ProductionRHS;
 
 {--
  - Used to help give names to children, when names are omitted.
@@ -87,7 +88,9 @@ top::ProductionSignature ::= cl::ConstraintList '=>' lhs::ProductionLHS '::=' rh
 {
   top.unparse = s"${cl.unparse} => ${lhs.unparse} ::= ${rhs.unparse}";
   
+  cl.env = top.env;
   cl.constraintPos = signaturePos(top.namedSignature);
+  lhs.env = top.env;
   rhs.env = occursEnv(cl.occursDefs, top.env);
 
   top.defs := lhs.defs ++ rhs.defs;
@@ -118,6 +121,7 @@ concrete production productionLHS
 top::ProductionLHS ::= id::Name '::' t::TypeExpr
 {
   top.unparse = id.unparse ++ "::" ++ t.unparse;
+  propagate env;
 
   top.outputElement = namedSignatureElement(id.name, t.typerep);
 
@@ -154,6 +158,7 @@ concrete production productionRHSElem
 top::ProductionRHSElem ::= id::Name '::' t::TypeExpr
 {
   top.unparse = id.unparse ++ "::" ++ t.unparse;
+  propagate env;
 
   top.inputElements = [namedSignatureElement(id.name, t.typerep)];
 

--- a/grammars/silver/compiler/definition/core/QName.sv
+++ b/grammars/silver/compiler/definition/core/QName.sv
@@ -185,6 +185,7 @@ top::QNameAttrOccur ::= at::QName
 {
   top.name = at.name;
   top.unparse = at.unparse;
+  propagate env;
   
   -- We start with all attributes we find with the name `at`:
   local attrs :: [AttributeDclInfo] = at.lookupAttribute.dcls;

--- a/grammars/silver/compiler/definition/core/QName.sv
+++ b/grammars/silver/compiler/definition/core/QName.sv
@@ -156,7 +156,7 @@ top::QNameType ::= id::Name ':' qn::QNameType
  -}
 nonterminal QNameAttrOccur with config, name, location, grammarName, env, unparse, attrFor, errors, typerep, dcl<OccursDclInfo>, attrDcl, found, attrFound;
 
-flowtype QNameAttrOccur = decorate {grammarName, config, env, attrFor}, dcl {decorate}, attrDcl {decorate};
+flowtype QNameAttrOccur = decorate {grammarName, config, env, attrFor}, dcl {grammarName, env, attrFor}, attrDcl {grammarName, env, attrFor};
 
 {--
  - For QNameAttrOccur, the name of the LHS to look up this attribute on.

--- a/grammars/silver/compiler/definition/core/QName.sv
+++ b/grammars/silver/compiler/definition/core/QName.sv
@@ -156,7 +156,7 @@ top::QNameType ::= id::Name ':' qn::QNameType
  -}
 nonterminal QNameAttrOccur with config, name, location, grammarName, env, unparse, attrFor, errors, typerep, dcl<OccursDclInfo>, attrDcl, found, attrFound;
 
-flowtype QNameAttrOccur = decorate {grammarName, env, attrFor}, dcl {decorate}, attrDcl {decorate};
+flowtype QNameAttrOccur = decorate {grammarName, config, env, attrFor}, dcl {decorate}, attrDcl {decorate};
 
 {--
  - For QNameAttrOccur, the name of the LHS to look up this attribute on.

--- a/grammars/silver/compiler/definition/core/Root.sv
+++ b/grammars/silver/compiler/definition/core/Root.sv
@@ -19,16 +19,11 @@ nonterminal GrammarDcl with
   declaredName, grammarName, location, unparse, errors;
 
 propagate errors on Root, GrammarDcl;
-propagate moduleNames on Root;
+propagate config, compiledGrammars, grammarName, globalImports, grammarDependencies, moduleNames on Root;
 
 concrete production root
 top::Root ::= gdcl::GrammarDcl ms::ModuleStmts ims::ImportStmts ags::AGDcls
 {
-  ims.compiledGrammars = top.compiledGrammars;
-  ims.grammarDependencies = top.grammarDependencies;
-  ims.grammarName = top.grammarName;
-  ims.config = top.config;
-
   top.unparse = gdcl.unparse ++ "\n\n" ++ ms.unparse ++ "\n\n" ++ ims.unparse ++ "\n\n" ++ ags.unparse;
   top.declaredName = gdcl.declaredName;
 

--- a/grammars/silver/compiler/definition/env/Attributes.sv
+++ b/grammars/silver/compiler/definition/env/Attributes.sv
@@ -66,7 +66,7 @@ monoid attribute defs :: [Def];
 {--
  - The environment. Dun dun dunnn.
  -}
-autocopy attribute env :: Decorated Env;
+inherited attribute env :: Decorated Env;
 
 --
 -- Top-level, compiler-wide information passed down by the build process
@@ -75,16 +75,16 @@ autocopy attribute env :: Decorated Env;
 {--
 - All grammars Silver looked at. Despite the name, including interface files.
 -}
-autocopy attribute compiledGrammars :: EnvTree<Decorated RootSpec>;
+inherited attribute compiledGrammars :: EnvTree<Decorated RootSpec>;
 {--
 - Compiler configuration information, made available everywhere.
 -}
-autocopy attribute config :: Decorated CmdArgs;
+inherited attribute config :: Decorated CmdArgs;
 {--
 - Flow information computed for this grammar
 -}
-autocopy attribute productionFlowGraphs :: EnvTree<ProductionGraph>;
-autocopy attribute grammarFlowTypes :: EnvTree<FlowType>;
+inherited attribute productionFlowGraphs :: EnvTree<ProductionGraph>;
+inherited attribute grammarFlowTypes :: EnvTree<FlowType>;
 
 {--
  - The path to the origin of this root spec

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -10,6 +10,8 @@ propagate env, config, compiledGrammars, grammarFlowTypes on Context, Contexts;
 -- This mostly exists as a convenient way to perform multiple env-dependant operations
 -- on a list of contexts without re-decorating them and repeating context resolution.
 nonterminal Contexts with env, config, compiledGrammars, grammarFlowTypes, contexts, freeVariables, boundVariables;
+propagate boundVariables on Contexts;
+
 abstract production consContext
 top::Contexts ::= h::Context t::Contexts
 {

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -5,6 +5,7 @@ import silver:compiler:definition:core only frame, grammarName, compiledGrammars
 -- Context lookup/resolution stuff lives here
 
 attribute env occurs on Context;
+propagate env on Context, Contexts;
 
 -- This mostly exists as a convenient way to perform multiple env-dependant operations
 -- on a list of contexts without re-decorating them and repeating context resolution.

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -4,8 +4,8 @@ import silver:compiler:definition:core only frame, grammarName, compiledGrammars
 
 -- Context lookup/resolution stuff lives here
 
-attribute env occurs on Context;
-propagate env on Context, Contexts;
+attribute env, config, compiledGrammars, grammarFlowTypes occurs on Context;
+propagate env, config, compiledGrammars, grammarFlowTypes on Context, Contexts;
 
 -- This mostly exists as a convenient way to perform multiple env-dependant operations
 -- on a list of contexts without re-decorating them and repeating context resolution.
@@ -38,8 +38,6 @@ synthesized attribute resolvedOccurs::[OccursDclInfo] occurs on Context;
 
 monoid attribute isTypeError::Boolean with false, || occurs on Contexts, Context;
 propagate isTypeError on Contexts, Context;
-
-attribute config, compiledGrammars, grammarFlowTypes occurs on Context;
 
 aspect default production
 top::Context ::=

--- a/grammars/silver/compiler/definition/env/NamedSignature.sv
+++ b/grammars/silver/compiler/definition/env/NamedSignature.sv
@@ -173,7 +173,7 @@ Type ::= n::String l::[NamedSignatureElement]
 --------------
 
 attribute substitution, flatRenamed occurs on NamedSignature, Contexts, NamedSignatureElements, NamedSignatureElement;
-propagate flatRenamed on NamedSignature, Contexts, NamedSignatureElements, NamedSignatureElement;
+propagate substitution, flatRenamed on NamedSignature, Contexts, NamedSignatureElements, NamedSignatureElement;
 
 -- "Freshens" all the signature's type variables with new skolem constants,
 -- to avoid type vars from interface files clashing with new ones from genInt()

--- a/grammars/silver/compiler/definition/env/NamedSignature.sv
+++ b/grammars/silver/compiler/definition/env/NamedSignature.sv
@@ -84,6 +84,7 @@ top::NamedSignature ::=
  - Represents a collection of NamedSignatureElements
  -}
 nonterminal NamedSignatureElements with elements, elementNames, elementShortNames, elementTypes, freeVariables, boundVariables;
+propagate boundVariables on NamedSignatureElements;
 
 synthesized attribute elements::[NamedSignatureElement];
 synthesized attribute elementNames::[String];
@@ -117,6 +118,7 @@ global foldNamedSignatureElements::(NamedSignatureElements ::= [NamedSignatureEl
  - Represents an elements of a signature, whether input, output, or annotation.
  -}
 nonterminal NamedSignatureElement with elementName, elementShortName, typerep, freeVariables, boundVariables;
+propagate boundVariables on NamedSignatureElement;
 
 synthesized attribute elementName :: String;
 synthesized attribute elementShortName :: String;

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -209,6 +209,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
 }
 
 inherited attribute decorationVertex :: String occurs on ExprInhs, ExprInh;
+propagate decorationVertex on ExprInhs, ExprInh;
 
 aspect production exprInh
 top::ExprInh ::= lhs::ExprLHSExpr '=' e1::Expr ';'
@@ -264,7 +265,7 @@ top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 
 -- FROM PATTERN TODO
 attribute flowDeps, flowDefs, flowEnv, scrutineeVertexType occurs on PrimPatterns, PrimPattern;
-propagate flowDeps, flowDefs on PrimPatterns, PrimPattern;
+propagate flowDeps, flowDefs, flowEnv, scrutineeVertexType on PrimPatterns, PrimPattern;
 
 inherited attribute scrutineeVertexType :: VertexType;
 

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -189,7 +189,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
   top.flowDefs <- occursContextDeps(top.frame.signature, top.env, finalTy, anonVertexType(inh.decorationVertex));
 }
 
-autocopy attribute decorationVertex :: String occurs on ExprInhs, ExprInh;
+inherited attribute decorationVertex :: String occurs on ExprInhs, ExprInh;
 
 aspect production exprInh
 top::ExprInh ::= lhs::ExprLHSExpr '=' e1::Expr ';'
@@ -247,7 +247,7 @@ top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
 attribute flowDeps, flowDefs, flowEnv, scrutineeVertexType occurs on PrimPatterns, PrimPattern;
 propagate flowDeps, flowDefs on PrimPatterns, PrimPattern;
 
-autocopy attribute scrutineeVertexType :: VertexType;
+inherited attribute scrutineeVertexType :: VertexType;
 
 aspect production matchPrimitiveReal
 top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -133,6 +133,12 @@ top::Expr ::= e::Expr '.' q::QNameAttrOccur
   propagate flowEnv;
 }
 
+aspect production accessBouncer
+top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::Expr  q::PartiallyDecorated QNameAttrOccur
+{
+  propagate flowEnv;
+}
+
 aspect production forwardAccess
 top::Expr ::= e::Expr '.' 'forward'
 {

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -27,7 +27,8 @@ propagate flowDeps on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoApp
   excluding
     childReference, lhsReference, localReference, forwardReference, forwardAccess, synDecoratedAccessHandler, inhDecoratedAccessHandler,
     decorateExprWith, letp, lexicalLocalReference, matchPrimitiveReal;
-propagate flowDefs on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr;
+propagate flowDefs, flowEnv on
+  Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr;
 
 aspect default production
 top::Expr ::=
@@ -120,6 +121,18 @@ top::Expr ::= q::PartiallyDecorated QName
     else noVertex();
 }
 
+aspect production application
+top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
+{
+  propagate flowEnv;
+}
+
+aspect production access
+top::Expr ::= e::Expr '.' q::QNameAttrOccur
+{
+  propagate flowEnv;
+}
+
 aspect production forwardAccess
 top::Expr ::= e::Expr '.' 'forward'
 {
@@ -210,7 +223,7 @@ top::Expr ::= e::PartiallyDecorated Expr
 
 -- FROM LET TODO
 attribute flowDefs, flowEnv occurs on AssignExpr;
-propagate flowDefs on AssignExpr;
+propagate flowDefs, flowEnv on AssignExpr;
 
 aspect production letp
 top::Expr ::= la::AssignExpr  e::Expr

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -7,7 +7,7 @@ imports silver:compiler:definition:core;
 import silver:compiler:definition:type;
 
 
-autocopy attribute flowEnv :: FlowEnv;
+inherited attribute flowEnv :: FlowEnv;
 monoid attribute flowDefs :: [FlowDef];
 -- These are factored out of FlowDefs to avoid a circular dependency,
 -- since they are needed during type checking

--- a/grammars/silver/compiler/definition/flow/env/FunctionDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/FunctionDcl.sv
@@ -5,6 +5,7 @@ import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, co
 import silver:compiler:driver:util only RootSpec; -- actually we just want the occurrences
 
 attribute flowEnv occurs on FunctionSignature, FunctionLHS;
+propagate flowEnv on FunctionSignature, FunctionLHS;
 
 aspect production functionDcl
 top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody 

--- a/grammars/silver/compiler/definition/flow/env/FunctionDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/FunctionDcl.sv
@@ -3,6 +3,7 @@ grammar silver:compiler:definition:flow:env;
 import silver:compiler:definition:type only typerep;
 import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, constructFunctionGraph;
 import silver:compiler:driver:util only RootSpec; -- actually we just want the occurrences
+import silver:compiler:definition:type:syntax; -- actually we just want the occurrences
 
 attribute flowEnv occurs on FunctionSignature, FunctionLHS;
 propagate flowEnv on FunctionSignature, FunctionLHS;

--- a/grammars/silver/compiler/definition/flow/env/Occurs.sv
+++ b/grammars/silver/compiler/definition/flow/env/Occurs.sv
@@ -6,6 +6,7 @@ import silver:compiler:driver:util only isExportedBy;
 
 -- Needed for specializing inh deps in syn occurs-on contexts
 attribute flowEnv occurs on Contexts, Context;
+propagate flowEnv on Contexts, Context;
 
 aspect production attributionDcl
 top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' nt::QName nttl::BracketedOptTypeExprs ';'

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -59,6 +59,16 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
     end;
 }
 
+aspect production attributeDef
+top::ProductionStmt ::= dl::DefLHS '.' attr::QNameAttrOccur '=' e::Expr ';'
+{
+  propagate flowEnv;
+}
+aspect production errorAttributeDef
+top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+{
+  propagate flowEnv;
+}
 aspect production synthesizedAttributeDef
 top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
 {

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -10,7 +10,8 @@ import silver:compiler:driver:util only isExportedBy, RootSpec;
 attribute flowDefs, flowEnv occurs on ProductionBody, ProductionStmts, ProductionStmt, ForwardInhs, ForwardInh;
 attribute flowEnv occurs on DefLHS;
 
-propagate flowDefs on ProductionBody, ProductionStmts, ProductionStmt, ForwardInhs, ForwardInh;
+propagate flowDefs, flowEnv on ProductionBody, ProductionStmts, ProductionStmt, ForwardInhs, ForwardInh;
+propagate flowEnv on DefLHS;
 
 {- A short note on how flowDefs are generated:
 

--- a/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
@@ -1,11 +1,16 @@
 grammar silver:compiler:definition:flow:env;
 
 import silver:compiler:definition:type;
+import silver:compiler:definition:type:syntax;
 import silver:compiler:modification:defaultattr;
 import silver:compiler:definition:flow:driver;
 import silver:compiler:driver:util; -- only for productionFlowGraphs occurrence?
 
 attribute flowEnv occurs on
+  ProductionSignature, ProductionLHS, ProductionRHS, ProductionRHSElem,
+  AspectProductionSignature, AspectProductionLHS, AspectFunctionSignature, AspectFunctionLHS,
+  AspectRHS, AspectRHSElem;
+propagate flowEnv on
   ProductionSignature, ProductionLHS, ProductionRHS, ProductionRHSElem,
   AspectProductionSignature, AspectProductionLHS, AspectFunctionSignature, AspectFunctionLHS,
   AspectRHS, AspectRHSElem;
@@ -45,4 +50,16 @@ top::AGDcl ::= 'aspect' 'production' id::QName ns::AspectProductionSignature bod
     -- build an anonymous flow graph to use instead as a "best effort".
     | [] -> constructAnonymousGraph(body.flowDefs, top.env, myGraphs, myFlow)
     end;
+}
+
+aspect production aspectProductionLHSTyped
+top::AspectProductionLHS ::= id::Name '::' t::TypeExpr
+{
+  propagate flowEnv;
+}
+
+aspect production aspectRHSElemTyped
+top::AspectRHSElem ::= id::Name '::' t::TypeExpr
+{
+  propagate flowEnv;
 }

--- a/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
@@ -2,6 +2,7 @@ grammar silver:compiler:definition:flow:env;
 
 import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
+import silver:compiler:definition:concrete_syntax;
 import silver:compiler:modification:defaultattr;
 import silver:compiler:definition:flow:driver;
 import silver:compiler:driver:util; -- only for productionFlowGraphs occurrence?
@@ -33,6 +34,12 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
   top.flowDefs <- flatMap(
     \ ie::NamedSignatureElement -> occursContextDeps(namedSig, body.env, ie.typerep, rhsVertexType(ie.elementName)),
     namedSig.inputElements);
+}
+
+aspect production concreteProductionDcl
+top::AGDcl ::= 'concrete' 'production' id::Name ns::ProductionSignature pm::ProductionModifiers body::ProductionBody
+{
+  propagate flowEnv;
 }
 
 aspect production aspectProductionDcl

--- a/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
@@ -4,6 +4,7 @@ import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
 import silver:compiler:definition:concrete_syntax;
 import silver:compiler:modification:defaultattr;
+import silver:compiler:modification:copper;
 import silver:compiler:definition:flow:driver;
 import silver:compiler:driver:util; -- only for productionFlowGraphs occurrence?
 

--- a/grammars/silver/compiler/definition/flow/env/Root.sv
+++ b/grammars/silver/compiler/definition/flow/env/Root.sv
@@ -1,10 +1,12 @@
 grammar silver:compiler:definition:flow:env;
 
+import silver:compiler:definition:type:syntax;
+
 attribute flowDefs, refDefs, specDefs, flowEnv occurs on Root, AGDcls, AGDcl, Grammar;
 flowtype flowDefs {decorate} on Root, AGDcls, AGDcl, Grammar;
 flowtype refDefs {decorate} on Root, AGDcls, AGDcl, Grammar;
 flowtype specDefs {decorate} on Root, AGDcls, AGDcl, Grammar;
-propagate flowDefs, refDefs, specDefs on Root, AGDcls, AGDcl, Grammar;
+propagate flowDefs, refDefs, specDefs, flowEnv on Root, AGDcls, AGDcl, Grammar;
 
 aspect default production
 top::AGDcl ::=

--- a/grammars/silver/compiler/definition/flow/env/Root.sv
+++ b/grammars/silver/compiler/definition/flow/env/Root.sv
@@ -1,6 +1,9 @@
 grammar silver:compiler:definition:flow:env;
 
 import silver:compiler:definition:type:syntax;
+import silver:compiler:modification:defaultattr;
+import silver:compiler:modification:collection;
+import silver:compiler:modification:copper;
 
 attribute flowDefs, refDefs, specDefs, flowEnv occurs on Root, AGDcls, AGDcl, Grammar;
 flowtype flowDefs {decorate} on Root, AGDcls, AGDcl, Grammar;

--- a/grammars/silver/compiler/definition/flow/env/Root.sv
+++ b/grammars/silver/compiler/definition/flow/env/Root.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:definition:flow:env;
 
 import silver:compiler:definition:type:syntax;
+import silver:compiler:definition:concrete_syntax;
 import silver:compiler:modification:defaultattr;
 import silver:compiler:modification:collection;
 import silver:compiler:modification:copper;

--- a/grammars/silver/compiler/definition/flow/env/TypeClasses.sv
+++ b/grammars/silver/compiler/definition/flow/env/TypeClasses.sv
@@ -1,0 +1,8 @@
+grammar silver:compiler:definition:flow:env;
+
+import silver:compiler:definition:type:syntax;
+
+attribute flowDefs, flowEnv occurs on
+  ClassBody, ClassBodyItem, InstanceBody, InstanceBodyItem;
+propagate flowDefs, flowEnv on
+  ClassBody, ClassBodyItem, InstanceBody, InstanceBodyItem;

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -43,7 +43,7 @@ top::AGDcl ::= 'flowtype' attr::FlowSpec 'on' nts::NtList ';'
 
 nonterminal FlowSpecs with config, location, grammarName, errors, env, unparse, onNt, specDefs, compiledGrammars, flowEnv;
 
-propagate errors, specDefs on FlowSpecs;
+propagate config, grammarName, errors, env, specDefs, compiledGrammars, flowEnv on FlowSpecs;
 
 concrete production oneFlowSpec
 top::FlowSpecs ::= h::FlowSpec
@@ -60,7 +60,7 @@ nonterminal FlowSpec with config, location, grammarName, errors, env, unparse, o
 
 inherited attribute onNt :: Type;
 
-propagate errors on FlowSpec;
+propagate config, grammarName, errors, env, compiledGrammars, flowEnv on FlowSpec;
 
 concrete production flowSpecDcl
 top::FlowSpec ::= attr::FlowSpecId  '{' inhs::FlowSpecInhs '}'
@@ -109,7 +109,7 @@ nonterminal FlowSpecId with config, location, grammarName, errors, env, unparse,
 synthesized attribute synName :: String;
 synthesized attribute authorityGrammar :: String;
 
-propagate errors on FlowSpecId;
+propagate config, grammarName, errors, env, compiledGrammars, flowEnv on FlowSpecId;
 
 concrete production qnameSpecId
 top::FlowSpecId ::= syn::QNameAttrOccur
@@ -153,7 +153,7 @@ nonterminal FlowSpecInhs with config, location, grammarName, errors, env, unpars
 monoid attribute inhList :: [String];  -- The attributes in the flow specification
 monoid attribute refList :: [String];  -- Flow specifications referenced in this one (currently can only contain "decorate" / "forward")
 
-propagate errors, inhList, refList on FlowSpecInhs;
+propagate config, grammarName, errors, env, inhList, refList, flowEnv on FlowSpecInhs;
 
 concrete production nilFlowSpecInhs
 top::FlowSpecInhs ::=
@@ -175,7 +175,7 @@ nonterminal FlowSpecInh with config, location, grammarName, errors, env, unparse
 
 flowtype FlowSpecInh = forward {grammarName, env, flowEnv, onNt}, inhList {forward};
 
-propagate errors on FlowSpecInh;
+propagate config, grammarName, errors, env, inhList, refList, flowEnv on FlowSpecInh;
 
 concrete production flowSpecInh
 top::FlowSpecInh ::= inh::QNameAttrOccur
@@ -251,7 +251,7 @@ top::FlowSpecInh ::= 'forward'
 
 nonterminal NtList with config, location, grammarName, errors, env, unparse, flowSpecSpec, specDefs, compiledGrammars, flowEnv;
 
-propagate errors, specDefs on NtList;
+propagate config, grammarName, errors, env, specDefs, compiledGrammars, flowEnv on NtList;
 
 concrete production nilNtList
 top::NtList ::=
@@ -270,6 +270,8 @@ top::NtList ::= h::NtName  ','  t::NtList
 }
 
 nonterminal NtName with config, location, grammarName, errors, env, unparse, flowSpecSpec, specDefs, compiledGrammars, flowEnv;
+
+propagate config, grammarName, env, compiledGrammars, flowEnv on NtName;
 
 inherited attribute flowSpecSpec :: FlowSpec;
 

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -177,7 +177,7 @@ top::FlowSpecInhs ::= h::FlowSpecInh  ','  t::FlowSpecInhs
 
 nonterminal FlowSpecInh with config, location, grammarName, errors, env, unparse, onNt, inhList, refList, flowEnv;
 
-flowtype FlowSpecInh = forward {grammarName, env, flowEnv, onNt}, inhList {forward};
+flowtype FlowSpecInh = forward {grammarName, env, flowEnv, onNt}, inhList {forward}, errors {forward};
 
 propagate config, grammarName, errors, env, flowEnv on FlowSpecInh;
 

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -18,6 +18,8 @@ concrete production flowtypeDcl
 top::AGDcl ::= 'flowtype' nt::QName '=' specs::FlowSpecs ';'
 {
   top.unparse = "flowtype " ++ nt.unparse ++ " = " ++ specs.unparse ++ ";";
+  propagate config, grammarName, compiledGrammars, env, flowEnv;
+
   top.errors :=
     if nt.lookupType.found
     then specs.errors
@@ -34,6 +36,8 @@ concrete production flowtypeAttrDcl
 top::AGDcl ::= 'flowtype' attr::FlowSpec 'on' nts::NtList ';'
 {
   top.unparse = "flowtype " ++ attr.unparse ++ " on " ++ nts.unparse ++ ";";
+  propagate config, grammarName, compiledGrammars, env, flowEnv;
+
   top.errors := nts.errors;
   top.specDefs := nts.specDefs;
   
@@ -43,7 +47,7 @@ top::AGDcl ::= 'flowtype' attr::FlowSpec 'on' nts::NtList ';'
 
 nonterminal FlowSpecs with config, location, grammarName, errors, env, unparse, onNt, specDefs, compiledGrammars, flowEnv;
 
-propagate config, grammarName, errors, env, specDefs, compiledGrammars, flowEnv on FlowSpecs;
+propagate config, grammarName, errors, env, onNt, specDefs, compiledGrammars, flowEnv on FlowSpecs;
 
 concrete production oneFlowSpec
 top::FlowSpecs ::= h::FlowSpec
@@ -60,7 +64,7 @@ nonterminal FlowSpec with config, location, grammarName, errors, env, unparse, o
 
 inherited attribute onNt :: Type;
 
-propagate config, grammarName, errors, env, compiledGrammars, flowEnv on FlowSpec;
+propagate config, grammarName, errors, env, onNt, compiledGrammars, flowEnv on FlowSpec;
 
 concrete production flowSpecDcl
 top::FlowSpec ::= attr::FlowSpecId  '{' inhs::FlowSpecInhs '}'
@@ -153,7 +157,7 @@ nonterminal FlowSpecInhs with config, location, grammarName, errors, env, unpars
 monoid attribute inhList :: [String];  -- The attributes in the flow specification
 monoid attribute refList :: [String];  -- Flow specifications referenced in this one (currently can only contain "decorate" / "forward")
 
-propagate config, grammarName, errors, env, inhList, refList, flowEnv on FlowSpecInhs;
+propagate config, grammarName, errors, env, onNt, inhList, refList, flowEnv on FlowSpecInhs;
 
 concrete production nilFlowSpecInhs
 top::FlowSpecInhs ::=
@@ -175,7 +179,7 @@ nonterminal FlowSpecInh with config, location, grammarName, errors, env, unparse
 
 flowtype FlowSpecInh = forward {grammarName, env, flowEnv, onNt}, inhList {forward};
 
-propagate config, grammarName, errors, env, inhList, refList, flowEnv on FlowSpecInh;
+propagate config, grammarName, errors, env, flowEnv on FlowSpecInh;
 
 concrete production flowSpecInh
 top::FlowSpecInh ::= inh::QNameAttrOccur
@@ -251,7 +255,7 @@ top::FlowSpecInh ::= 'forward'
 
 nonterminal NtList with config, location, grammarName, errors, env, unparse, flowSpecSpec, specDefs, compiledGrammars, flowEnv;
 
-propagate config, grammarName, errors, env, specDefs, compiledGrammars, flowEnv on NtList;
+propagate config, grammarName, errors, env, flowSpecSpec, specDefs, compiledGrammars, flowEnv on NtList;
 
 concrete production nilNtList
 top::NtList ::=

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -58,7 +58,7 @@ top::FlowSpecs ::= h::FlowSpecs  ','  t::FlowSpec
 
 nonterminal FlowSpec with config, location, grammarName, errors, env, unparse, onNt, specDefs, compiledGrammars, flowEnv;
 
-autocopy attribute onNt :: Type;
+inherited attribute onNt :: Type;
 
 propagate errors on FlowSpec;
 
@@ -271,7 +271,7 @@ top::NtList ::= h::NtName  ','  t::NtList
 
 nonterminal NtName with config, location, grammarName, errors, env, unparse, flowSpecSpec, specDefs, compiledGrammars, flowEnv;
 
-autocopy attribute flowSpecSpec :: FlowSpec;
+inherited attribute flowSpecSpec :: FlowSpec;
 
 concrete production ntName
 top::NtName ::= nt::QName

--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -5,6 +5,8 @@ import silver:langutil:pp;
 synthesized attribute typepp :: String occurs on PolyType, Context, Type, Kind;
 inherited attribute boundVariables :: [TyVar] occurs on Context, Type;
 
+propagate boundVariables on Context, Type;
+
 function prettyType
 String ::= te::Type
 {

--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -3,7 +3,7 @@ grammar silver:compiler:definition:type;
 import silver:langutil:pp;
 
 synthesized attribute typepp :: String occurs on PolyType, Context, Type, Kind;
-autocopy attribute boundVariables :: [TyVar] occurs on Context, Type;
+inherited attribute boundVariables :: [TyVar] occurs on Context, Type;
 
 function prettyType
 String ::= te::Type

--- a/grammars/silver/compiler/definition/type/Substitutions.sv
+++ b/grammars/silver/compiler/definition/type/Substitutions.sv
@@ -80,7 +80,7 @@ Maybe<Type> ::= tv::TyVar s::Substitution
 --------------------------------------------------------------------------------
 
 -- These are for ordinary tyvar substitutions.
-autocopy attribute substitution :: Substitution occurs on Context, Type;
+inherited attribute substitution :: Substitution occurs on Context, Type;
 functor attribute substituted occurs on Context, Type;
 -- These are for flat, non-recursive replacement of tyvars with something else directly
 functor attribute flatRenamed occurs on Context, Type;

--- a/grammars/silver/compiler/definition/type/Substitutions.sv
+++ b/grammars/silver/compiler/definition/type/Substitutions.sv
@@ -85,7 +85,7 @@ functor attribute substituted occurs on Context, Type;
 -- These are for flat, non-recursive replacement of tyvars with something else directly
 functor attribute flatRenamed occurs on Context, Type;
 
-propagate substituted, flatRenamed on Context, Type
+propagate substitution, substituted, flatRenamed on Context, Type
   excluding inhOccursContext, synOccursContext, annoOccursContext, varType, skolemType, ntOrDecType;
 
 aspect production inhOccursContext

--- a/grammars/silver/compiler/definition/type/Substitutions.sv
+++ b/grammars/silver/compiler/definition/type/Substitutions.sv
@@ -85,7 +85,8 @@ functor attribute substituted occurs on Context, Type;
 -- These are for flat, non-recursive replacement of tyvars with something else directly
 functor attribute flatRenamed occurs on Context, Type;
 
-propagate substitution, substituted, flatRenamed on Context, Type
+propagate substitution on Context, Type;
+propagate substituted, flatRenamed on Context, Type
   excluding inhOccursContext, synOccursContext, annoOccursContext, varType, skolemType, ntOrDecType;
 
 aspect production inhOccursContext
@@ -178,7 +179,7 @@ top::Type ::= nt::Type inhs::Type hidden::Type
     | _          -> hidden.substituted
     end;
   -- For a renaming, we don't need to specialize.
-  propagate flatRenamed;
+  propagate substitution, flatRenamed;
 }
 
 --------------------------------------------------------------------------------

--- a/grammars/silver/compiler/definition/type/syntax/AspectDcl.sv
+++ b/grammars/silver/compiler/definition/type/syntax/AspectDcl.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:definition:type:syntax;
 
-attribute lexicalTypeVariables, lexicalTyVarKinds occurs on AspectProductionSignature, AspectProductionLHS, AspectRHS, AspectRHSElem, AspectFunctionSignature, AspectFunctionLHS;
+attribute lexicalTypeVariables, lexicalTyVarKinds occurs on
+  AspectProductionSignature, AspectProductionLHS, AspectRHS, AspectRHSElem, AspectFunctionSignature, AspectFunctionLHS;
 
 flowtype lexicalTypeVariables {realSignature, env, flowEnv, grammarName} on AspectProductionSignature, AspectProductionLHS, AspectRHS, AspectFunctionSignature, AspectFunctionLHS;
 flowtype lexicalTypeVariables {realSignature, env, flowEnv, grammarName, deterministicCount} on AspectRHSElem;

--- a/grammars/silver/compiler/definition/type/syntax/Constraint.sv
+++ b/grammars/silver/compiler/definition/type/syntax/Constraint.sv
@@ -12,7 +12,7 @@ nonterminal Constraint with config, grammarName, env, flowEnv, location, unparse
 
 flowtype Constraint = decorate {grammarName, env, flowEnv, constraintPos};
 
-propagate config, grammarName, env, flowEnv, errors, defs, occursDefs, lexicalTypeVariables, lexicalTyVarKinds
+propagate config, grammarName, env, flowEnv, errors, defs, occursDefs, lexicalTypeVariables, lexicalTyVarKinds, constraintPos
   on ConstraintList, Constraint;
 
 concrete production consConstraint

--- a/grammars/silver/compiler/definition/type/syntax/Constraint.sv
+++ b/grammars/silver/compiler/definition/type/syntax/Constraint.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:definition:type:syntax;
 
-autocopy attribute constraintPos::ConstraintPosition;
+inherited attribute constraintPos::ConstraintPosition;
 
 nonterminal ConstraintList
   -- This grammar doesn't export silver:compiler:definition:core, so the type concrete

--- a/grammars/silver/compiler/definition/type/syntax/Constraint.sv
+++ b/grammars/silver/compiler/definition/type/syntax/Constraint.sv
@@ -12,7 +12,8 @@ nonterminal Constraint with config, grammarName, env, flowEnv, location, unparse
 
 flowtype Constraint = decorate {grammarName, env, flowEnv, constraintPos};
 
-propagate errors, defs, occursDefs, lexicalTypeVariables, lexicalTyVarKinds on ConstraintList, Constraint;
+propagate config, grammarName, env, flowEnv, errors, defs, occursDefs, lexicalTypeVariables, lexicalTyVarKinds
+  on ConstraintList, Constraint;
 
 concrete production consConstraint
 top::ConstraintList ::= h::Constraint ',' t::ConstraintList

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -58,7 +58,8 @@ flowtype maybeType {grammarName, env, flowEnv} on SignatureLHS;
 flowtype types {grammarName, env, flowEnv} on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 
 propagate errors on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs excluding refTypeExpr, partialRefTypeExpr;
-propagate lexicalTypeVariables, lexicalTyVarKinds on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
+propagate config, grammarName, env, flowEnv, lexicalTypeVariables, lexicalTyVarKinds
+  on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate appLexicalTyVarKinds on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate errorsTyVars on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate errorsKindStar on TypeExprs;
@@ -227,6 +228,7 @@ top::TypeExpr ::= ty::TypeExpr tl::BracketedTypeExprs
 {
   top.unparse = ty.unparse ++ tl.unparse;
   
+  propagate grammarName, env, flowEnv;
   propagate lexicalTypeVariables; -- Needed to avoid circularity
 
   forwards to

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -50,7 +50,7 @@ flowtype typerepInhSet {decorate, onNt} on TypeExpr;
 flowtype TypeExpr =
   decorate {grammarName, env, flowEnv}, forward {decorate},
   freeVariables {decorate}, lexicalTypeVariables {decorate}, lexicalTyVarKinds {decorate},
-  errorsTyVars {decorate}, errorsKindStar {decorate};
+  errors {decorate}, errorsTyVars {decorate}, errorsKindStar {decorate};
 
 -- typerep requires flowEnv to look up default ref sets
 flowtype typerep {grammarName, env, flowEnv} on TypeExpr, Signature;

--- a/grammars/silver/compiler/driver/util/Compilation.sv
+++ b/grammars/silver/compiler/driver/util/Compilation.sv
@@ -6,6 +6,7 @@ import silver:util:treemap as map;
 synthesized attribute initRecompiledGrammars::[Decorated RootSpec];
 
 nonterminal Compilation with config, postOps, grammarList, allGrammars, initRecompiledGrammars, recompiledGrammars;
+propagate config on Compilation;
 
 flowtype postOps {config} on Compilation;
 
@@ -79,7 +80,7 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::Bu
 
 nonterminal Grammars with config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dependentGrammars, grammarList, dirtyGrammars, recompiledGrammars, jarName;
 
-propagate dirtyGrammars, recompiledGrammars, jarName, dependentGrammars on Grammars;
+propagate config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dirtyGrammars, recompiledGrammars, jarName, dependentGrammars on Grammars;
 
 abstract production consGrammars
 top::Grammars ::= h::RootSpec  t::Grammars

--- a/grammars/silver/compiler/driver/util/Compilation.sv
+++ b/grammars/silver/compiler/driver/util/Compilation.sv
@@ -80,7 +80,7 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::Bu
 
 nonterminal Grammars with config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dependentGrammars, grammarList, dirtyGrammars, recompiledGrammars, jarName;
 
-propagate config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dirtyGrammars, recompiledGrammars, jarName, dependentGrammars on Grammars;
+propagate config, productionFlowGraphs, grammarFlowTypes, dirtyGrammars, recompiledGrammars, jarName, dependentGrammars on Grammars;
 
 abstract production consGrammars
 top::Grammars ::= h::RootSpec  t::Grammars

--- a/grammars/silver/compiler/driver/util/RootSpec.sv
+++ b/grammars/silver/compiler/driver/util/RootSpec.sv
@@ -28,7 +28,7 @@ nonterminal RootSpec with
 
 flowtype RootSpec = decorate {config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dependentGrammars};
 
-propagate exportedGrammars, optionalGrammars, condBuild, defs, occursDefs on RootSpec;
+propagate productionFlowGraphs, grammarFlowTypes, exportedGrammars, optionalGrammars, condBuild, defs, occursDefs on RootSpec;
 
 {--
  - Grammars (a, b) where b depends on a

--- a/grammars/silver/compiler/extension/attrsection/AttrSection.sv.md
+++ b/grammars/silver/compiler/extension/attrsection/AttrSection.sv.md
@@ -17,7 +17,7 @@ concrete production attributeSection
 top::Expr ::= '(' '.' q::QNameAttrOccur ')'
 {
   top.unparse = s"(.${q.unparse})";
-  propagate freeVars;
+  propagate freeVars, env;
 ```
 
 In constructing the forward we need to know on what type the attribute will be accessed.

--- a/grammars/silver/compiler/extension/auto_ast/AutoAst.sv
+++ b/grammars/silver/compiler/extension/auto_ast/AutoAst.sv
@@ -10,6 +10,7 @@ concrete production autoAstDcl
 top::ProductionStmt ::= 'abstract' v::QName ';'
 {
   top.unparse = "abstract " ++ v.unparse ++ ";";
+  propagate env;
 
   local vty :: Type = v.lookupValue.typeScheme.typerep;
   

--- a/grammars/silver/compiler/extension/autoattr/Destruct.sv
+++ b/grammars/silver/compiler/extension/autoattr/Destruct.sv
@@ -25,6 +25,8 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
   top.moduleNames := [];
+
+  propagate grammarName, env, flowEnv;
   
   forwards to
     defaultAttributionDcl(

--- a/grammars/silver/compiler/extension/autoattr/Equality.sv
+++ b/grammars/silver/compiler/extension/autoattr/Equality.sv
@@ -6,6 +6,8 @@ top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::QName ';'
   top.unparse = s"equality attribute ${syn.unparse} with ${inh.unparse};";
   top.moduleNames := [];
 
+  propagate env;
+
   production attribute inhFName :: String;
   inhFName = inh.lookupAttribute.fullName;
   production attribute synFName :: String;

--- a/grammars/silver/compiler/extension/autoattr/Functor.sv
+++ b/grammars/silver/compiler/extension/autoattr/Functor.sv
@@ -25,6 +25,8 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
   top.moduleNames := [];
+
+  propagate grammarName, env, flowEnv;
   
   forwards to
     defaultAttributionDcl(

--- a/grammars/silver/compiler/extension/autoattr/Monoid.sv
+++ b/grammars/silver/compiler/extension/autoattr/Monoid.sv
@@ -7,6 +7,7 @@ concrete production monoidAttributeDcl
 top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr 'with' e::Expr ',' q::NameOrBOperator ';'
 {
   top.unparse = "monoid attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ " with " ++ e.unparse ++ ", " ++ q.unparse ++ ";";
+  propagate config, grammarName, compiledGrammars, flowEnv;
 
   production attribute fName :: String;
   fName = top.grammarName ++ ":" ++ a.name;
@@ -14,6 +15,8 @@ top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::T
   tl.initialEnv = top.env;
   tl.env = tl.envBindingTyVars;
   te.env = tl.envBindingTyVars;
+  e.env = tl.envBindingTyVars;
+  q.env = tl.envBindingTyVars;
   
   q.operatorForType = te.typerep;
   

--- a/grammars/silver/compiler/extension/autoattr/Ordering.sv
+++ b/grammars/silver/compiler/extension/autoattr/Ordering.sv
@@ -6,6 +6,8 @@ top::AGDcl ::= 'ordering' 'attribute' keySyn::Name ',' syn::Name 'with' inh::QNa
   top.unparse = s"ordering attribute ${keySyn.unparse}, ${syn.unparse} with ${inh.unparse};";
   top.moduleNames := [];
 
+  propagate env;
+
   production attribute inhFName :: String;
   inhFName = inh.lookupAttribute.fullName;
   production attribute keySynFName :: String;

--- a/grammars/silver/compiler/extension/autoattr/Propagate.sv
+++ b/grammars/silver/compiler/extension/autoattr/Propagate.sv
@@ -4,6 +4,7 @@ concrete production propagateOnNTListExcludingDcl_c
 top::AGDcl ::= 'propagate' attrs::NameList 'on' nts::NameList 'excluding' ps::ProdNameList ';'
 {
   top.unparse = s"propagate ${attrs.unparse} on ${nts.unparse} excluding ${ps.unparse};";
+  propagate env;
   
   top.errors <- ps.errors;
   forwards to propagateOnNTListDcl(attrs, nts, ps, location=top.location);
@@ -42,6 +43,7 @@ abstract production propagateOnOneNTDcl
 top::AGDcl ::= attrs::NameList nt::QName ps::ProdNameList
 {
   top.unparse = s"propagate ${attrs.unparse} on ${nt.unparse} excluding ${ps.unparse};";
+  propagate env;
   
   -- Ugh, workaround for circular dependency
   top.defs := [];
@@ -125,6 +127,7 @@ abstract production propagateOneAttr
 top::ProductionStmt ::= attr::QName
 {
   top.unparse = s"propagate ${attr.unparse};";
+  propagate env;
 
   -- We make an exception to permit propagated equations in places that would otherwise be orphaned.
   -- Since this is the only possible equation permitted in these contexts, having duplicates will
@@ -155,7 +158,7 @@ top::ProductionStmt ::= attr::PartiallyDecorated QName
 
 -- Need a seperate nonterminal since this can be empty and needs env to check errors
 nonterminal ProdNameList with config, grammarName, env, location, unparse, names, errors;
-propagate errors on ProdNameList;
+propagate config, grammarName, env, errors on ProdNameList;
 
 abstract production prodNameListNil
 top::ProdNameList ::=

--- a/grammars/silver/compiler/extension/autoattr/Threaded.sv
+++ b/grammars/silver/compiler/extension/autoattr/Threaded.sv
@@ -8,6 +8,8 @@ top::AGDcl ::= 'threaded' 'attribute' inh::Name ',' syn::Name tl::BracketedOptTy
   top.unparse = s"threaded attribute ${inh.unparse}, ${syn.unparse} ${tl.unparse} :: ${te.unparse};";
   top.moduleNames := [];
 
+  propagate grammarName, flowEnv;
+
   production attribute inhFName :: String;
   inhFName = top.grammarName ++ ":" ++ inh.name;
   production attribute synFName :: String;

--- a/grammars/silver/compiler/extension/autoattr/Unification.sv
+++ b/grammars/silver/compiler/extension/autoattr/Unification.sv
@@ -6,6 +6,8 @@ top::AGDcl ::= 'unification' 'attribute' synPartial::Name ',' syn::Name 'with' i
   top.unparse = s"unification attribute ${synPartial.unparse}, ${syn.unparse} with ${inh.unparse};";
   top.moduleNames := [];
 
+  propagate grammarName, env, flowEnv;
+
   production attribute inhFName :: String;
   inhFName = inh.lookupAttribute.fullName;
   production attribute synPartialFName :: String;
@@ -34,6 +36,8 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
 {
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
   top.moduleNames := [];
+
+  propagate grammarName, env, flowEnv;
   
   forwards to
     defaultAttributionDcl(

--- a/grammars/silver/compiler/extension/convenience/Productions.sv
+++ b/grammars/silver/compiler/extension/convenience/Productions.sv
@@ -12,6 +12,7 @@ top::AGDcl ::= 'production' id::Name ns::ProductionSignature body::ProductionBod
 -- "concrete productions" syntax
 nonterminal ProductionDclStmts with unparse, location, proddcls, lhsdcl, grammarName;
 nonterminal ProductionDclStmt with unparse, location, proddcls, lhsdcl, grammarName;
+propagate lhsdcl, grammarName on ProductionDclStmts, ProductionDclStmt;
 
 synthesized attribute proddcls :: AGDcl;
 inherited attribute lhsdcl :: ProductionLHS;
@@ -23,7 +24,7 @@ concrete production productionDclC
 top::AGDcl ::= 'concrete' 'productions' lhs::ProductionLHS stmts::ProductionDclStmts 
 {
   top.unparse = "concrete productions " ++ lhs.unparse ++ stmts.unparse;
-  propagate moduleNames, jarName; -- Avoid dependency on forward
+  propagate grammarName, moduleNames, jarName; -- Avoid dependency on forward
   
   stmts.lhsdcl = lhs;
   

--- a/grammars/silver/compiler/extension/convenience/Productions.sv
+++ b/grammars/silver/compiler/extension/convenience/Productions.sv
@@ -14,7 +14,7 @@ nonterminal ProductionDclStmts with unparse, location, proddcls, lhsdcl, grammar
 nonterminal ProductionDclStmt with unparse, location, proddcls, lhsdcl, grammarName;
 
 synthesized attribute proddcls :: AGDcl;
-autocopy attribute lhsdcl :: ProductionLHS;
+inherited attribute lhsdcl :: ProductionLHS;
 
 terminal Productions_kwd 'productions' lexer classes {KEYWORD};
 terminal ProdVBar '|';

--- a/grammars/silver/compiler/extension/do_notation/Syntax.sv
+++ b/grammars/silver/compiler/extension/do_notation/Syntax.sv
@@ -4,6 +4,7 @@ concrete production do_c
 top::Expr ::= 'do' '{' body::DoBody '}'
 {
   top.unparse = s"do {${body.unparse}}";
+  propagate frame;
 
   forwards to body.transform;
 }
@@ -40,6 +41,7 @@ concrete production mdo_c
 top::Expr ::= 'mdo' '{' body::DoBody '}'
 {
   top.unparse = s"mdo {${body.unparse}}";
+  propagate frame;
 
   body.boundVarEnv = mempty;
   body.allBoundVars = body.boundVars;

--- a/grammars/silver/compiler/extension/do_notation/Syntax.sv
+++ b/grammars/silver/compiler/extension/do_notation/Syntax.sv
@@ -96,7 +96,7 @@ nonterminal DoBinding with
   transform, transformIn,
   recBindings;
 
-propagate boundVars on DoBody, DoBinding;
+propagate frame, boundVars on DoBody, DoBinding;
 propagate freeVars on DoBinding;
 
 concrete production consDoBody

--- a/grammars/silver/compiler/extension/doc/core/DocumentedAGDcl.sv
+++ b/grammars/silver/compiler/extension/doc/core/DocumentedAGDcl.sv
@@ -53,7 +53,7 @@ top::AGDcl ::= comment::DocComment_t dcl::AGDcl
 {
     local parsed::DclComment = parseComment(top.config, comment);
 
-    local paramNamesAndForWhat::Pair<Maybe<[String]> String> = case getFirstAGDcl(dcl) of
+    local paramNamesAndForWhat::Pair<Maybe<[String]> String> = case getFirstAGDcl(forward) of
         | functionDcl(_, _, ns, _) -> pair(just(ns.argNames), "function")
         | aspectFunctionDcl(_, _, _, ns, _) -> pair(just(ns.argNames), "function")
         | productionDcl(_, _, _, ns, _) -> pair(just(ns.argNames), "production")
@@ -70,17 +70,15 @@ top::AGDcl ::= comment::DocComment_t dcl::AGDcl
     parsed.docEnv = top.docEnv;
     parsed.offsetLocation = comment.location;
     parsed.indentBy = "";
-
-    dcl.downDocConfig = top.downDocConfig;
     
-    top.upDocConfig <- parsed.upDocConfig ++ dcl.upDocConfig;
+    top.upDocConfig <- parsed.upDocConfig;
     top.docErrors <- parsed.errors;
 
-    local isDoubleComment::Boolean = case dcl of documentedAGDcl(_, _) -> true | _ -> false end;
+    local isDoubleComment::Boolean = case forward of documentedAGDcl(_, _) -> true | _ -> false end;
     top.docs := if isDoubleComment
-                  then [standaloneDclCommentItem(parsed)] ++ dcl.docs
-                  else [dclCommentItem(dcl.docForName, dcl.docUnparse, dcl.grammarName, dcl.location, parsed)]
-                       ++ if length(dcl.docs) > 1 then tail(dcl.docs) else [];
+                  then [standaloneDclCommentItem(parsed)] ++ forward.docs
+                  else [dclCommentItem(forward.docForName, forward.docUnparse, forward.grammarName, dcl.location, parsed)]
+                       ++ if length(forward.docs) > 1 then tail(forward.docs) else [];
     top.errors <- if isDoubleComment
                     then [wrn(parsed.location, "Doc comment not immediately preceding AGDcl, so association is ambiguous. Treating as standalone comment. Mark with @@{- instead of @{- to silence this warning.")]
                     else [];

--- a/grammars/silver/compiler/extension/doc/core/Root.sv
+++ b/grammars/silver/compiler/extension/doc/core/Root.sv
@@ -42,6 +42,7 @@ attribute docDcls occurs on Grammar, Root, AGDcls, AGDcl, ClassBodyItem, Instanc
 @{- Environment of all documented AGDcls, flowing back down after being computed from @link[docDcls].  -}
 inherited attribute docEnv :: tm:Map<String DocDclInfo>;
 attribute docEnv occurs on Root, AGDcls, AGDcl, ClassBodyItem, InstanceBodyItem, ClassBody, InstanceBody;
+propagate docEnv on AGDcls, AGDcl, ClassBodyItem, InstanceBodyItem, ClassBody, InstanceBody;
 
 @{- Errors arising from ill-formed doc comments.  -}
 monoid attribute docErrors :: [Message];

--- a/grammars/silver/compiler/extension/doc/core/Root.sv
+++ b/grammars/silver/compiler/extension/doc/core/Root.sv
@@ -40,7 +40,7 @@ synthesized attribute docDcls :: [Pair<String DocDclInfo>] with ++;
 attribute docDcls occurs on Grammar, Root, AGDcls, AGDcl, ClassBodyItem, InstanceBodyItem, ClassBody, InstanceBody;
 
 @{- Environment of all documented AGDcls, flowing back down after being computed from @link[docDcls].  -}
-autocopy attribute docEnv :: tm:Map<String DocDclInfo>;
+inherited attribute docEnv :: tm:Map<String DocDclInfo>;
 attribute docEnv occurs on Root, AGDcls, AGDcl, ClassBodyItem, InstanceBodyItem, ClassBody, InstanceBody;
 
 @{- Errors arising from ill-formed doc comments.  -}

--- a/grammars/silver/compiler/extension/doc/core/TypeClassDcls.sv
+++ b/grammars/silver/compiler/extension/doc/core/TypeClassDcls.sv
@@ -5,6 +5,7 @@ attribute docForName occurs on ClassBodyItem, InstanceBodyItem;
 
 @{- What to prefix 'child' declaration names with in docs and for hyperlinking. -}
 inherited attribute scopeName :: String occurs on ClassBody, ClassBodyItem, InstanceBody, InstanceBodyItem;
+propagate scopeName on ClassBody, ClassBodyItem, InstanceBody, InstanceBodyItem;
 
 aspect production typeClassDcl
 top::AGDcl ::= 'class' cl::ConstraintList '=>' id::QNameType var::TypeExpr '{' body::ClassBody '}'
@@ -70,15 +71,14 @@ top::ClassBodyItem ::= comment::DocComment_t item::ClassBodyItem
   parsed.offsetLocation = comment.location;
   parsed.indentBy = ">";
 
-  item.downDocConfig = top.downDocConfig;
-  top.upDocConfig <- parsed.upDocConfig ++ item.upDocConfig;
+  top.upDocConfig <- parsed.upDocConfig;
   top.docErrors <- parsed.errors;
 
-  local realDclDocs::[CommentItem] = filter((\x::CommentItem->!x.stub), item.docs);
+  local realDclDocs::[CommentItem] = filter((\x::CommentItem->!x.stub), forward.docs);
   local isDoubleComment::Boolean = length(realDclDocs) != 0;
   top.docs := if isDoubleComment
                 then [standaloneDclCommentItem(parsed)] ++ realDclDocs
-                else [dclCommentItem(top.scopeName ++ "." ++ item.docForName, item.docUnparse, item.grammarName, item.location, parsed)];
+                else [dclCommentItem(top.scopeName ++ "." ++ forward.docForName, forward.docUnparse, forward.grammarName, item.location, parsed)];
   top.docErrors <-
     if isDoubleComment
     then [wrn(parsed.location, "Doc comment not immediately preceding ClassBodyItem, so association is ambiguous. Treating as standalone comment. Mark with @@{- instead of @{- to silence this warning.")]
@@ -148,15 +148,14 @@ top::InstanceBodyItem ::= comment::DocComment_t item::InstanceBodyItem
   parsed.offsetLocation = comment.location;
   parsed.indentBy = ">";
 
-  item.downDocConfig = top.downDocConfig;
-  top.upDocConfig <- parsed.upDocConfig ++ item.upDocConfig;
+  top.upDocConfig <- parsed.upDocConfig;
   top.docErrors <- parsed.errors;
 
-  local realDclDocs::[CommentItem] = filter((\x::CommentItem->!x.stub), item.docs);
+  local realDclDocs::[CommentItem] = filter((\x::CommentItem->!x.stub), forward.docs);
   local isDoubleComment::Boolean = length(realDclDocs) != 0;
   top.docs := if isDoubleComment
                 then [standaloneDclCommentItem(parsed)] ++ realDclDocs
-                else [dclCommentItem(top.scopeName ++ "." ++ item.docForName, item.docUnparse, item.grammarName, item.location, parsed)];
+                else [dclCommentItem(top.scopeName ++ "." ++ forward.docForName, forward.docUnparse, forward.grammarName, item.location, parsed)];
   top.docErrors <-
     if isDoubleComment
     then [wrn(parsed.location, "Doc comment not immediately preceding InstanceBodyItem, so association is ambiguous. Treating as standalone comment. Mark with @@{- instead of @{- to silence this warning.")]

--- a/grammars/silver/compiler/extension/doc/core/TypeClassDcls.sv
+++ b/grammars/silver/compiler/extension/doc/core/TypeClassDcls.sv
@@ -4,7 +4,7 @@ attribute docUnparse occurs on ClassBodyItem, InstanceBodyItem;
 attribute docForName occurs on ClassBodyItem, InstanceBodyItem;
 
 @{- What to prefix 'child' declaration names with in docs and for hyperlinking. -}
-autocopy attribute scopeName :: String occurs on ClassBody, ClassBodyItem, InstanceBody, InstanceBodyItem;
+inherited attribute scopeName :: String occurs on ClassBody, ClassBodyItem, InstanceBody, InstanceBodyItem;
 
 aspect production typeClassDcl
 top::AGDcl ::= 'class' cl::ConstraintList '=>' id::QNameType var::TypeExpr '{' body::ClassBody '}'

--- a/grammars/silver/compiler/extension/doc/core/doclang/DclComment.sv
+++ b/grammars/silver/compiler/extension/doc/core/doclang/DclComment.sv
@@ -46,6 +46,9 @@ nonterminal DclCommentLines layout {} with body, location, docEnv, errors;
 nonterminal DclCommentParts layout {} with body, location, docEnv, errors;
 nonterminal DclCommentPart layout {} with body, location, docEnv, errors;
 
+propagate docEnv on
+    DclComment, DclCommentBlocks, DclCommentStrictBlocks, DclCommentBlock,
+    DclCommentLines, DclCommentParts, DclCommentPart;
 propagate errors on DclCommentBlocks, DclCommentStrictBlocks, DclCommentBlock,
     DclCommentLines, DclCommentParts, DclCommentPart;
 

--- a/grammars/silver/compiler/extension/easyterminal/TerminalDcl.sv
+++ b/grammars/silver/compiler/extension/easyterminal/TerminalDcl.sv
@@ -66,6 +66,7 @@ concrete production productionRhsElemEasyReg
 top::ProductionRHSElem ::= id::Name '::' reg::EasyTerminalRef
 {
   top.unparse = id.unparse ++ "::" ++ reg.unparse;
+  propagate env;
   top.errors <- reg.errors;
 
   top.lambdaBoundVars := [id.name];  -- Needed because we are forwrding based on env
@@ -77,6 +78,7 @@ concrete production productionRhsElemTypeEasyReg
 top::ProductionRHSElem ::= reg::EasyTerminalRef
 {
   top.unparse = reg.unparse;
+  propagate env;
   top.errors <- reg.errors;
 
   top.lambdaBoundVars := [];  -- Needed because we are forwrding based on env
@@ -88,6 +90,7 @@ concrete production aspectRHSElemEasyReg
 top::AspectRHSElem ::= reg::EasyTerminalRef
 {
   top.unparse = reg.unparse;
+  propagate env;
   top.errors <- reg.errors;
 
   forwards to aspectRHSElemNone('_', location=reg.location); -- TODO This isn't checking if the type is right!!
@@ -97,6 +100,7 @@ concrete production aspectRHSElemTypedEasyReg
 top::AspectRHSElem ::= id::Name '::' reg::EasyTerminalRef
 {
   top.unparse = id.unparse ++ " :: " ++ reg.unparse;
+  propagate env;
   top.errors <- reg.errors;
 
   forwards to aspectRHSElemTyped(id, $2, typerepTypeExpr(reg.typerep, location=reg.location), location=top.location);
@@ -107,7 +111,7 @@ concrete production terminalExprReg
 top::Expr ::= reg::EasyTerminalRef
 {
   top.unparse = reg.unparse;
-  propagate freeVars;
+  propagate env, freeVars;
   top.errors <- reg.errors;
   
   local escapedName :: String = escapeString(reg.easyString);

--- a/grammars/silver/compiler/extension/implicit_monads/AttributeDefs.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/AttributeDefs.sv
@@ -5,6 +5,7 @@ concrete production attributeDclInh_Restricted
 top::AGDcl ::= 'restricted' 'inherited' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
   top.unparse = "restricted inherited attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
+  propagate grammarName, flowEnv;
 
   top.moduleNames := [];
 
@@ -34,6 +35,7 @@ concrete production attributeDclSyn_Restricted
 top::AGDcl ::= 'restricted' 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
   top.unparse = "restricted synthesized attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
+  propagate grammarName, flowEnv;
 
   top.moduleNames := [];
 
@@ -65,6 +67,7 @@ concrete production attributeDclInh_Implicit
 top::AGDcl ::= 'implicit' 'inherited' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
   top.unparse = "implicit inherited attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
+  propagate grammarName, flowEnv;
 
   top.moduleNames := [];
 
@@ -96,6 +99,7 @@ concrete production attributeDclSyn_Implicit
 top::AGDcl ::= 'implicit' 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
   top.unparse = "implicit synthesized attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
+  propagate grammarName, flowEnv;
 
   top.moduleNames := [];
 

--- a/grammars/silver/compiler/extension/implicit_monads/Case.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Case.sv
@@ -378,6 +378,7 @@ concrete production mcaseExpr_c
 top::Expr ::= 'case_any' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
 {
   top.unparse = "case_any " ++ es.unparse ++ " of " ++ ml.unparse ++ " end";
+  propagate config, frame, env;
 
   top.merrors := [];
   top.merrors <- if isMonadPlus_instance then [] else [err(top.location, notMonadPlus)];

--- a/grammars/silver/compiler/extension/implicit_monads/Case.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Case.sv
@@ -78,7 +78,6 @@ top::Expr ::= 'case' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
   redeces.config = top.config;
   redeces.flowEnv = top.flowEnv;
   redeces.expectedMonad = top.expectedMonad;
-  redeces.isRoot = top.isRoot;
   redeces.originRules = top.originRules;
 
   {-

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -1921,7 +1921,7 @@ synthesized attribute realTypes::[Type] occurs on AppExpr, AppExprs;
 attribute expectedMonad occurs on AppExpr, AppExprs;
 propagate expectedMonad on AppExpr, AppExprs;
 --Whether we're in a special case where monad arguments are allowed, despite the normal prohibition
-autocopy attribute monadArgumentsAllowed::Boolean occurs on AppExpr, AppExprs;
+inherited attribute monadArgumentsAllowed::Boolean occurs on AppExpr, AppExprs;
 
 attribute monadRewritten<AppExpr>, merrors, mDownSubst, mUpSubst occurs on AppExpr;
 attribute monadRewritten<AppExprs>, merrors, mDownSubst, mUpSubst occurs on AppExprs;

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -1203,6 +1203,8 @@ concrete production ifThen
 top::Expr ::= 'if' e1::Expr 'then' e2::Expr 'end' --this is easier than anything else to do
 {
   top.unparse = "if " ++ e1.unparse  ++ " then " ++ e2.unparse ++ " end";
+  propagate config, grammarName, compiledGrammars, frame, env, flowEnv, finalSubst, originRules;
+
   top.merrors <-
       if isMonad(e1.mtyperep, top.env) && monadsMatch(top.expectedMonad, e1.mtyperep, top.mDownSubst).fst
       then if monadsMatch(top.expectedMonad, e1.mtyperep, top.mDownSubst).fst
@@ -1243,6 +1245,9 @@ top::Expr ::= 'if' e1::Expr 'then' e2::Expr 'end' --this is easier than anything
   e2.expectedMonad = if isMonad(e1.mtyperep, top.env) && monadsMatch(top.expectedMonad, e1.mtyperep, top.mDownSubst).fst
                      then e1.mtyperep
                      else top.expectedMonad;
+  
+  e1.isRoot = false;
+  e2.isRoot = false;
 
   forwards to ifThenElse('if', e1, 'then', e2, 'else', monadFail(top.location), location=top.location);
 }
@@ -1992,7 +1997,7 @@ top::AppExpr ::= e::Expr
   top.monadRewritten = presentAppExpr(e.monadRewritten, location=top.location);
 }
 
-propagate mDownSubst, mUpSubst on AppExprs;
+propagate monadArgumentsAllowed, mDownSubst, mUpSubst on AppExprs;
 
 aspect production snocAppExprs
 top::AppExprs ::= es::AppExprs ',' e::AppExpr

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -185,7 +185,6 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   nes.finalSubst = top.finalSubst;
   nes.downSubst = top.downSubst;
   nes.originRules = top.originRules;
-  nes.isRoot = false;
   nes.appExprTypereps = reverse(performSubstitution(ne.mtyperep, ne.mUpSubst).inputTypes);
   nes.appExprApplied = ne.unparse;
   nes.monadArgumentsAllowed = acceptableMonadFunction(e);

--- a/grammars/silver/compiler/extension/implicit_monads/PatternTypes.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/PatternTypes.sv
@@ -3,6 +3,8 @@ grammar silver:compiler:extension:implicit_monads;
 aspect production prodAppPattern
 top::Pattern ::= prod::QName '(' ps::PatternList ')'
 {
+  propagate env;
+
   -- TODO: is this right?  Seems like we should unify with ps pattern types?
   top.patternType = prod.lookupValue.typeScheme.typerep.outputType;
 } 

--- a/grammars/silver/compiler/extension/implicit_monads/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/PrimitiveMatch.sv
@@ -265,7 +265,7 @@ top::PrimPattern ::= qn::QName '(' ns::VarBinders ')' arr::Arrow_kwd e::Expr
   ne.config = top.config;
   ne.flowEnv = top.flowEnv;
   ne.originRules = top.originRules;
-  ne.isRoot = top.isRoot;
+  ne.isRoot = false;
 
   ne.finalSubst = top.finalSubst;
   ne.downSubst = top.mDownSubst;

--- a/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
@@ -13,6 +13,7 @@ concrete production emptyAttributeDef
 top::ProductionStmt ::= 'implicit' dl::DefLHS '.' attr::QNameAttrOccur '=' ';'
 {
   top.unparse = "\timplicit " ++ dl.unparse ++ "." ++ attr.unparse ++ " = ;";
+  propagate grammarName, compiledGrammars, config, frame, env, flowEnv, finalSubst, originRules;
 
   top.productionAttributes := [];
   top.defs := [];
@@ -54,6 +55,7 @@ concrete production implicitAttributeDef
 top::ProductionStmt ::= 'implicit' dl::DefLHS '.' attr::QNameAttrOccur '=' e::Expr ';'
 {
   top.unparse = "\timplicit" ++ dl.unparse ++ "." ++ attr.unparse ++ " = ;";
+  propagate grammarName, compiledGrammars, config, frame, env, flowEnv, finalSubst, originRules;
 
   top.productionAttributes := [];
   top.defs := [];
@@ -93,6 +95,7 @@ top::ProductionStmt ::= 'restricted' dl::DefLHS '.' attr::QNameAttrOccur '=' e::
 {
   e.downSubst = top.downSubst;
   top.unparse = "\trestricted" ++ dl.unparse ++ "." ++ attr.unparse ++ " = ;";
+  propagate grammarName, compiledGrammars, config, frame, env, flowEnv, finalSubst, originRules;
 
   top.productionAttributes := [];
   top.defs := [];
@@ -132,6 +135,7 @@ concrete production unrestrictedAttributeDef
 top::ProductionStmt ::= 'unrestricted' dl::DefLHS '.' attr::QNameAttrOccur '=' e::Expr ';'
 {
   top.unparse = "\tunrestricted" ++ dl.unparse ++ "." ++ attr.unparse ++ " = ;";
+  propagate grammarName, compiledGrammars, config, frame, env, flowEnv, finalSubst, originRules;
 
   top.productionAttributes := [];
   top.defs := [];
@@ -188,9 +192,9 @@ abstract production restrictedSynAttributeDef
 top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
 {
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
+  propagate grammarName, compiledGrammars, config, frame, env, flowEnv, finalSubst, originRules;
 
   e.downSubst = top.downSubst;
-  e.originRules = top.originRules;
   e.isRoot = true;
 
   top.containsPluck = false;
@@ -212,9 +216,9 @@ abstract production restrictedInhAttributeDef
 top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
 {
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
+  propagate grammarName, compiledGrammars, config, frame, env, flowEnv, finalSubst, originRules;
 
   e.downSubst = top.downSubst;
-  e.originRules = top.originRules;
   e.isRoot = true;
 
   top.containsPluck = false;
@@ -239,12 +243,11 @@ abstract production implicitSynAttributeDef
 top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
 {
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
+  propagate grammarName, compiledGrammars, config, frame, env, flowEnv, originRules;
 
   e.downSubst = top.downSubst;
   e.mDownSubst = top.downSubst;
   e.finalSubst = e.mUpSubst;
-  e.env = top.env;
-  e.originRules = top.originRules;
   e.isRoot = true;
 
   e.expectedMonad = attr.typerep;
@@ -269,12 +272,11 @@ abstract production implicitInhAttributeDef
 top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
 {
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
+  propagate grammarName, compiledGrammars, config, frame, env, flowEnv, originRules;
 
   e.downSubst = top.downSubst;
   e.mDownSubst = top.downSubst;
   e.finalSubst = e.mUpSubst;
-  e.env = top.env;
-  e.originRules = top.originRules;
   e.isRoot = true;
 
   e.expectedMonad = attr.typerep;

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -33,7 +33,7 @@ propagate errors, freeVars on MRuleList;
 -- Turns MRuleList (of MatchRules) into [AbstractMatchRule]
 synthesized attribute matchRuleList :: [AbstractMatchRule];
 -- Notification of the number of expressions being matched upon
-autocopy attribute matchRulePatternSize :: Integer;
+inherited attribute matchRulePatternSize :: Integer;
 
 -- P -> E
 nonterminal MatchRule with location, config, unparse, env, frame, errors, freeVars, matchRuleList, matchRulePatternSize;

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -28,7 +28,7 @@ terminal Matches_kwd 'matches' lexer classes {KEYWORD};
 
 -- MR | ...
 nonterminal MRuleList with location, config, unparse, env, frame, errors, freeVars, matchRuleList, matchRulePatternSize;
-propagate errors, freeVars on MRuleList;
+propagate config, frame, env, errors, freeVars, matchRulePatternSize on MRuleList;
 
 -- Turns MRuleList (of MatchRules) into [AbstractMatchRule]
 synthesized attribute matchRuleList :: [AbstractMatchRule];
@@ -50,7 +50,7 @@ synthesized attribute hasCondition::Boolean;
 
 -- P , ...
 nonterminal PatternList with location, config, unparse, patternList, env, frame, errors, patternVars, patternVarEnv;
-propagate errors on PatternList;
+propagate config, frame, env, errors on PatternList;
 
 -- Turns PatternList into [Pattern]
 synthesized attribute patternList :: [Decorated Pattern];
@@ -73,7 +73,7 @@ concrete production caseExpr_c
 top::Expr ::= 'case' es::Exprs 'of' Opt_Vbar_t ml::MRuleList 'end'
 {
   top.unparse = "case " ++ es.unparse ++ " of " ++ ml.unparse ++ " end";
-  propagate freeVars;
+  propagate config, frame, env, freeVars;
 
   ml.matchRulePatternSize = length(es.rawExprs);
   top.errors <- ml.errors;
@@ -98,6 +98,7 @@ top::Expr ::= es::[Expr] ml::[AbstractMatchRule] complete::Boolean failExpr::Exp
     "(case " ++ implode(", ", map((.unparse), es)) ++ " of " ++ 
     implode(" | ", map((.unparse), ml)) ++ " | _ -> " ++ failExpr.unparse ++
     " end :: " ++ prettyType(retType) ++ ")";
+  propagate frame;
   top.freeVars := concat(map(getFreeVars(top.frame, _), es) ++ map(getFreeVars(top.frame, _), ml) ++ [failExpr.freeVars]);
 
   {-Checking Pattern Completeness
@@ -1058,6 +1059,8 @@ concrete production matchRule_c
 top::MatchRule ::= pt::PatternList '->' e::Expr
 {
   top.unparse = pt.unparse ++ " -> " ++ e.unparse;
+  propagate frame, config, env;
+
   top.errors := pt.errors; -- e.errors is examined later, after transformation.
   top.freeVars := ts:removeAll(pt.patternVars, e.freeVars);
   
@@ -1074,6 +1077,8 @@ concrete production matchRuleWhen_c
 top::MatchRule ::= pt::PatternList 'when' cond::Expr '->' e::Expr
 {
   top.unparse = pt.unparse ++ " when " ++ cond.unparse ++ " -> " ++ e.unparse;
+  propagate frame, config, env;
+
   top.errors := pt.errors; -- e.errors is examined later, after transformation, as is cond.errors
   top.freeVars := ts:removeAll(pt.patternVars, cond.freeVars ++ e.freeVars);
   
@@ -1090,6 +1095,8 @@ concrete production matchRuleWhenMatches_c
 top::MatchRule ::= pt::PatternList 'when' cond::Expr 'matches' p::Pattern '->' e::Expr
 {
   top.unparse = pt.unparse ++ " when " ++ cond.unparse ++ " matches " ++ p.unparse ++ " -> " ++ e.unparse;
+  propagate frame, config, env;
+
   top.errors := pt.errors; -- e.errors is examined later, after transformation, as is cond.errors
   top.freeVars := ts:removeAll(pt.patternVars, cond.freeVars ++ ts:removeAll(p.patternVars, e.freeVars));
   
@@ -1117,6 +1124,8 @@ top::AbstractMatchRule ::= pl::[Decorated Pattern]
     | nothing() -> ""
     end ++
     " -> " ++ e.unparse;
+  propagate frame;
+
   top.freeVars := ts:removeAll(concat(map((.patternVars), pl)),
     case cond of
     | just((e1, just(p))) -> getFreeVars(top.frame, e1) ++ ts:removeAll(p.patternVars, e.freeVars)
@@ -1167,6 +1176,7 @@ top::PatternList ::= p::Pattern ',' ps1::PatternList
   top.unparse = p.unparse ++ (if ps1.unparse == "" then "" else ", " ++ ps1.unparse);
 
   top.patternVars = p.patternVars ++ ps1.patternVars;
+  p.patternVarEnv = top.patternVarEnv;
   ps1.patternVarEnv = p.patternVarEnv ++ p.patternVars;
   
   top.patternList = p :: ps1.patternList;

--- a/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
@@ -6,6 +6,7 @@ import silver:compiler:modification:list only LSqr_t, RSqr_t;
  - The forms of syntactic patterns that are permissible in (nested) case expresssions.
  -}
 nonterminal Pattern with location, config, unparse, env, frame, errors, patternVars, patternVarEnv, patternIsVariable, patternVariableName, patternSubPatternList, patternNamedSubPatternList, patternSortKey, isPrimitivePattern, isBoolPattern, isListPattern, patternTypeName;
+propagate config, frame, env, errors on Pattern;
 
 {--
  - The names of all var patterns in the pattern.
@@ -70,7 +71,6 @@ concrete production prodAppPattern_named
 top::Pattern ::= prod::QName '(' ps::PatternList ',' nps::NamedPatternList ')'
 {
   top.unparse = prod.unparse ++ "(" ++ ps.unparse ++ ")";
-  top.errors := ps.errors ++ nps.errors;
 
   local parms :: Integer = prod.lookupValue.typeScheme.arity;
 
@@ -79,6 +79,7 @@ top::Pattern ::= prod::QName '(' ps::PatternList ',' nps::NamedPatternList ')'
     else [err(prod.location, prod.name ++ " has " ++ toString(parms) ++ " parameters but " ++ toString(length(ps.patternList)) ++ " patterns were provided")];
   
   top.patternVars = ps.patternVars ++ nps.patternVars;
+  ps.patternVarEnv = top.patternVarEnv;
   nps.patternVarEnv = ps.patternVarEnv ++ ps.patternVars;
 
   top.patternIsVariable = false;
@@ -112,7 +113,6 @@ concrete production wildcPattern
 top::Pattern ::= '_'
 {
   top.unparse = "_";
-  top.errors := [];
 
   top.patternVars = [];
   top.patternIsVariable = true;
@@ -136,7 +136,6 @@ concrete production varPattern
 top::Pattern ::= v::Name
 {
   top.unparse = v.name;
-  top.errors := [];
   top.errors <-
     if contains(v.name, top.patternVarEnv)
     then [err(v.location, "Duplicate pattern variable " ++ v.name)]
@@ -171,7 +170,7 @@ abstract production errorPattern
 top::Pattern ::= msg::[Message]
 {
   top.unparse = s"{-${messagesToString(msg)}-}";
-  top.errors := msg;
+  top.errors <- msg;
 
   top.patternVars = [];
   top.patternIsVariable = true;
@@ -212,7 +211,6 @@ concrete production intPattern
 top::Pattern ::= num::Int_t
 {
   top.unparse = num.lexeme;
-  top.errors := [];
   
   top.patternVars = [];
   top.patternSubPatternList = [];
@@ -227,7 +225,6 @@ concrete production fltPattern
 top::Pattern ::= num::Float_t
 {
   top.unparse = num.lexeme;
-  top.errors := [];
   
   top.patternVars = [];
   top.patternSubPatternList = [];
@@ -242,7 +239,6 @@ concrete production strPattern
 top::Pattern ::= str::String_t
 {
   top.unparse = str.lexeme;
-  top.errors := [];
   
   top.patternVars = [];
   top.patternSubPatternList = [];
@@ -257,7 +253,6 @@ concrete production truePattern
 top::Pattern ::= 'true'
 {
   top.unparse = "true";
-  top.errors := [];
   
   top.patternVars = [];
   top.patternSubPatternList = [];
@@ -272,7 +267,6 @@ concrete production falsePattern
 top::Pattern ::= 'false'
 {
   top.unparse = "false";
-  top.errors := [];
   
   top.patternVars = [];
   top.patternSubPatternList = [];
@@ -287,7 +281,6 @@ abstract production nilListPattern
 top::Pattern ::= '[' ']'
 {
   top.unparse = "[]";
-  top.errors := [];
   
   top.patternVars = [];
   top.patternSubPatternList = [];
@@ -302,7 +295,6 @@ concrete production consListPattern
 top::Pattern ::= hp::Pattern '::' tp::Pattern
 {
   top.unparse = hp.unparse ++ "::" ++ tp.unparse;
-  top.errors := hp.errors ++ tp.errors;
   
   top.patternVars = hp.patternVars ++ tp.patternVars;
   hp.patternVarEnv = top.patternVarEnv;
@@ -346,23 +338,24 @@ top::PatternList ::=
 synthesized attribute namedPatternList::[Pair<String Decorated Pattern>];
 
 nonterminal NamedPatternList with location, config, unparse, frame, env, errors, patternVars, patternVarEnv, namedPatternList;
+propagate config, frame, env, errors on NamedPatternList;
 
 concrete production namedPatternList_one
 top::NamedPatternList ::= p::NamedPattern
 {
   top.unparse = p.unparse;
-  top.errors := p.errors;
 
   top.patternVars = p.patternVars;
+  p.patternVarEnv = top.patternVarEnv;
   top.namedPatternList = p.namedPatternList;
 }
 concrete production namedPatternList_more
 top::NamedPatternList ::= p::NamedPattern ',' ps::NamedPatternList
 {
   top.unparse = p.unparse ++ ", " ++ ps.unparse;
-  top.errors := p.errors ++ ps.errors;
 
   top.patternVars = p.patternVars ++ ps.patternVars;
+  p.patternVarEnv = top.patternVarEnv;
   ps.patternVarEnv = p.patternVarEnv ++ p.patternVars;
   top.namedPatternList = p.namedPatternList ++ ps.namedPatternList;
 }
@@ -372,19 +365,18 @@ abstract production namedPatternList_nil
 top::NamedPatternList ::=
 {
   top.unparse = "";
-  top.errors := [];
 
   top.patternVars = [];
   top.namedPatternList = [];
 }
 
 nonterminal NamedPattern with location, config, unparse, frame, env, errors, patternVars, patternVarEnv, namedPatternList;
+propagate config, frame, env, patternVarEnv, errors on NamedPattern;
 
 concrete production namedPattern
 top::NamedPattern ::= qn::QName '=' p::Pattern
 {
   top.unparse = s"${qn.unparse}=${p.unparse}";
-  top.errors := p.errors;
   
   -- TODO: Error checking for annotation patterns is a bit broken.
   -- We can check that it is an annotation here, but any other

--- a/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
+++ b/grammars/silver/compiler/extension/patternmatching/PatternTypes.sv
@@ -14,7 +14,7 @@ synthesized attribute patternVars :: [String];
 {--
  - The names of all var patterns seen so far.
  -}
-autocopy attribute patternVarEnv :: [String];
+inherited attribute patternVarEnv :: [String];
 {--
  - False if it actually matches anything specific, true if it's a variable/wildcard.
  -}

--- a/grammars/silver/compiler/extension/regex/Regex.sv
+++ b/grammars/silver/compiler/extension/regex/Regex.sv
@@ -26,7 +26,7 @@ concrete production matches
 top::Expr ::= e::Expr '=~' r::Expr
 {
   top.unparse = s"(${e.unparse}) =~ (${r.unparse})";
-  propagate freeVars;
+  propagate frame, freeVars;
   forwards to
     if null(getValueDcl("silver:regex:matches", top.env))
     then errorExpr([err(top.location, "Use of regexes requires import of silver:regex")], location=top.location)

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -566,7 +566,6 @@ top::Expr ::= '[' es::Exprs ']'
   decEs.env = top.env;
   decEs.flowEnv = top.flowEnv;
   decEs.boundVars = top.boundVars;
-  decEs.isRoot = top.isRoot;
   decEs.originRules = top.originRules;
 
   top.transform = listASTExpr(decEs.transform);
@@ -601,7 +600,6 @@ top::Expr ::= 'case' es::Exprs 'of' o::Opt_Vbar_t ml::MRuleList 'end'
   decEs.env = top.env;
   decEs.flowEnv = top.flowEnv;
   decEs.boundVars = top.boundVars;
-  decEs.isRoot = top.isRoot;
   decEs.originRules = top.originRules;
   
   top.transform =

--- a/grammars/silver/compiler/extension/rewriting/Pattern.sv
+++ b/grammars/silver/compiler/extension/rewriting/Pattern.sv
@@ -40,6 +40,9 @@ synthesized attribute wrappedMatchRuleList :: [AbstractMatchRule] occurs on MRul
 inherited attribute decRuleExprsIn::[(String, Decorated Expr with {decorate, boundVars})] occurs on MRuleList, MatchRule;
 inherited attribute ruleIndex::Integer occurs on MRuleList, MatchRule;
 
+propagate decRuleExprsIn on MRuleList;
+propagate namedTypesHaveUniversalVars on NamedPatternList, NamedPattern;
+
 aspect production mRuleList_one
 top::MRuleList ::= m::MatchRule
 {

--- a/grammars/silver/compiler/extension/rewriting/Pattern.sv
+++ b/grammars/silver/compiler/extension/rewriting/Pattern.sv
@@ -33,11 +33,11 @@ attribute transform<Strategy> occurs on MRuleList, MatchRule;
 synthesized attribute isPolymorphic :: Boolean occurs on MRuleList, MatchRule, PatternList, Pattern, NamedPatternList, NamedPattern;
 inherited attribute typeHasUniversalVars :: Boolean occurs on Pattern;
 inherited attribute typesHaveUniversalVars :: [Boolean] occurs on PatternList;
-autocopy attribute namedTypesHaveUniversalVars :: [(String, Boolean)] occurs on NamedPatternList, NamedPattern;
+inherited attribute namedTypesHaveUniversalVars :: [(String, Boolean)] occurs on NamedPatternList, NamedPattern;
 
 synthesized attribute wrappedMatchRuleList :: [AbstractMatchRule] occurs on MRuleList, MatchRule;
 
-autocopy attribute decRuleExprsIn::[(String, Decorated Expr with {decorate, boundVars})] occurs on MRuleList, MatchRule;
+inherited attribute decRuleExprsIn::[(String, Decorated Expr with {decorate, boundVars})] occurs on MRuleList, MatchRule;
 inherited attribute ruleIndex::Integer occurs on MRuleList, MatchRule;
 
 aspect production mRuleList_one

--- a/grammars/silver/compiler/extension/strategyattr/ConcreteSyntax.sv
+++ b/grammars/silver/compiler/extension/strategyattr/ConcreteSyntax.sv
@@ -209,7 +209,7 @@ concrete productions top::StrategyExpr_c
   s.givenGenName = top.givenGenName ++ "_outermost_arg";
 }
 
-autocopy attribute index::Integer;
+inherited attribute index::Integer;
 
 nonterminal StrategyExprs_c with location, index, givenGenName, unparse, ast<StrategyExprs>;
 concrete productions top::StrategyExprs_c

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -4,6 +4,8 @@ abstract production strategyAttributeDcl
 top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] recVarTotalEnv::[Pair<String Boolean>] e::StrategyExpr
 {
   top.unparse = (if isTotal then "" else "partial ") ++ "strategy attribute " ++ a.unparse ++ "=" ++ e.unparse ++ ";";
+  propagate grammarName, config, env, flowEnv;
+
   top.occursDefs := [];
   top.specDefs := [];
   top.refDefs := [];
@@ -13,7 +15,7 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
   
   -- Define these directly to avoid circular dependencies,
   -- since the forward contributes to the env.
-  propagate errors, moduleNames;
+  propagate compiledGrammars, errors, moduleNames;
   
   top.errors <-
     if length(getAttrDclAll(fName, top.env)) > 1
@@ -58,6 +60,8 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
 abstract production strategyAttributionDcl
 top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
+  propagate grammarName, env, flowEnv;
+
   production attribute localErrors::[Message] with ++;
   localErrors :=
     attl.errors ++ attl.errorsTyVars ++ nt.lookupType.errors ++ nttl.errors ++ nttl.errorsTyVars;

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -145,10 +145,12 @@ flowtype StrategyExprs =
   attrRefNames {env, recVarNameEnv, givenInputElements},
   containsFail {}, allId {}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate};
 
+propagate grammarName, config, compiledGrammars, env, flowEnv, outerAttr, partialRefs, totalRefs, containsTraversal on StrategyExpr, StrategyExprs;
+propagate frame on StrategyExpr excluding allTraversal, someTraversal, oneTraversal, prodTraversal;
 propagate errors on StrategyExpr, StrategyExprs excluding partialRef, totalRef, rewriteRule;
 propagate containsFail, allId on StrategyExprs;
-propagate freeRecVars on StrategyExpr, StrategyExprs excluding recComb;
-propagate partialRefs, totalRefs, containsTraversal on StrategyExpr, StrategyExprs;
+propagate recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, freeRecVars on StrategyExpr, StrategyExprs excluding recComb;
+propagate inlinedStrategies on StrategyExpr, StrategyExprs excluding inlined;
 propagate genericSimplify on StrategyExprs;
 propagate prodStep on MRuleList;
 propagate genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize on StrategyExpr;
@@ -320,7 +322,6 @@ top::StrategyExpr ::= s::StrategyExpr
   top.containsTraversal <- true;
 
   s.isOutermost = false;
-  s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
   local sBaseName::String = last(explode(":", sName));
   -- pair(child name, attr occurs on child)
@@ -410,7 +411,6 @@ top::StrategyExpr ::= s::StrategyExpr
   top.containsTraversal <- true;
 
   s.isOutermost = false;
-  s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
   -- pair(child name, attr occurs on child)
   local childAccesses::[Pair<String Boolean>] =
@@ -491,7 +491,6 @@ top::StrategyExpr ::= s::StrategyExpr
   top.containsTraversal <- true;
   
   s.isOutermost = false;
-  s.frame = error("No frame for traversal strategies");  -- TODO: This equation shouldn't exist, but frame is an autocopy
   
   local sBaseName::String = last(explode(":", sName));
   -- pair(child name, attr occurs on child)
@@ -890,6 +889,7 @@ abstract production nameRef
 top::StrategyExpr ::= id::QName
 {
   top.unparse = id.unparse;
+  propagate env;
   
   -- Forwarding depends on env here, these must be computed without env
   propagate liftedStrategies;

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -7,12 +7,12 @@ import silver:compiler:driver:util;
 
 annotation genName::String; -- Used to generate the names of lifted strategy attributes
 
-autocopy attribute recVarNameEnv::[Pair<String String>]; -- name, (isTotal, genName)
-autocopy attribute recVarTotalEnv::[Pair<String Boolean>]; -- name, (isTotal, genName)
-autocopy attribute recVarTotalNoEnvEnv::[Pair<String Boolean>]; -- same as above but doesn't depend on env
+inherited attribute recVarNameEnv::[Pair<String String>]; -- name, (isTotal, genName)
+inherited attribute recVarTotalEnv::[Pair<String Boolean>]; -- name, (isTotal, genName)
+inherited attribute recVarTotalNoEnvEnv::[Pair<String Boolean>]; -- same as above but doesn't depend on env
 inherited attribute isOutermost::Boolean;
-autocopy attribute outerAttr::String;
-autocopy attribute inlinedStrategies::[String];
+inherited attribute outerAttr::String;
+inherited attribute inlinedStrategies::[String];
 type LiftedInhs = {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr, isOutermost};
 monoid attribute liftedStrategies::[(String, Decorated StrategyExpr with LiftedInhs)];
 synthesized attribute attrRefName::Maybe<String>;

--- a/grammars/silver/compiler/extension/templating/StringTemplating.sv
+++ b/grammars/silver/compiler/extension/templating/StringTemplating.sv
@@ -36,7 +36,7 @@ production stringAppendCall
 top::Expr ::= a::Expr b::Expr
 {
   top.unparse = s"${a.unparse} ++ ${b.unparse}";
-  propagate freeVars;
+  propagate grammarName, config, compiledGrammars, frame, env, flowEnv, finalSubst, originRules, freeVars;
 
   -- TODO: We really need eagerness analysis in Silver.
   -- Otherwise the translation for a large string template block contains
@@ -46,6 +46,9 @@ top::Expr ::= a::Expr b::Expr
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
   
   thread downSubst, upSubst on top, a, b, forward;
+
+  a.isRoot = false;
+  b.isRoot = false;
   
   forwards to
     mkStrFunctionInvocation(

--- a/grammars/silver/compiler/extension/testing/EqualityTest.sv
+++ b/grammars/silver/compiler/extension/testing/EqualityTest.sv
@@ -23,6 +23,7 @@ ag::AGDcl ::= kwd::'equalityTest'
 {
   ag.unparse = "equalityTest (" ++ value.unparse ++ "," ++ expected.unparse ++ ",\n" ++ 
           "              " ++ valueType.unparse ++ ", " ++ testSuite.unparse ++ ");\n";
+  propagate grammarName, compiledGrammars, config, env, flowEnv;
 
   local attribute errCheck1 :: TypeCheck; 
   local attribute errCheck2 :: TypeCheck; 

--- a/grammars/silver/compiler/extension/testing/WrongCode.sv
+++ b/grammars/silver/compiler/extension/testing/WrongCode.sv
@@ -18,6 +18,7 @@ concrete production wrongDecl
 top::AGDcl ::= 'wrongCode' s::String_t '{' ags::AGDcls '}'
 {
   top.unparse = "wrongCode" ++ s.lexeme ++ "{" ++ ags.unparse ++ "}";
+  propagate grammarName, grammarDependencies, compiledGrammars, config, flowEnv;
   
   top.errors := 
     if !containsMessage(substring(1, length(s.lexeme) - 1, s.lexeme), 2, ags.errors)
@@ -34,6 +35,7 @@ concrete production warnDecl
 top::AGDcl ::= 'warnCode' s::String_t '{' ags::AGDcls '}'
 {
   top.unparse = "warnCode" ++ s.lexeme ++ "{" ++ ags.unparse ++ "}";
+  propagate grammarName, grammarDependencies, compiledGrammars, config, env, flowEnv;
   
   top.errors := 
     if !containsMessage(substring(1, length(s.lexeme) - 1, s.lexeme), 1, ags.errors)
@@ -56,6 +58,7 @@ concrete production noWarnDecl
 top::AGDcl ::= 'noWarnCode' s::String_t '{' ags::AGDcls '}'
 {
   top.unparse = "noWarnCode " ++ s.lexeme ++ " {" ++ ags.unparse ++ "}";
+  propagate grammarName, grammarDependencies, compiledGrammars, config, env, flowEnv;
 
   {-
     I think we want the errors from ags in any case.  This production
@@ -77,6 +80,7 @@ concrete production wrongFlowDecl
 top::AGDcl ::= 'wrongFlowCode' s::String_t '{' ags::AGDcls '}'
 {
   top.unparse = "wrongFlowCode" ++ s.lexeme ++ "{" ++ ags.unparse ++ "}";
+  propagate grammarName, grammarDependencies, compiledGrammars, config, flowEnv;
   
   top.errors := 
     if !containsMessage(substring(1, length(s.lexeme) - 1, s.lexeme), 2, ags.errors)

--- a/grammars/silver/compiler/extension/treegen/Arbitrary.sv
+++ b/grammars/silver/compiler/extension/treegen/Arbitrary.sv
@@ -21,6 +21,7 @@ concrete production generatorDcl
 top::AGDcl ::= 'generator' n::Name '::' t::TypeExpr '{' grammars::GeneratorComponents '}'
 {
   top.unparse = s"generator ${n.unparse} :: ${t.unparse} { ${grammars.unparse} }";
+  propagate config, grammarName, compiledGrammars, grammarDependencies, env, flowEnv;
 
   -- Compute the defs exported by the specified grammars
   local med::ModuleExportedDefs =
@@ -85,7 +86,7 @@ top::AGDcl ::= 'generator' n::Name '::' t::TypeExpr '{' grammars::GeneratorCompo
 nonterminal GeneratorComponents with config, grammarName, location, unparse, errors, moduleNames, compiledGrammars, grammarDependencies;
 nonterminal GeneratorComponent with config, grammarName, location, unparse, errors, moduleNames, compiledGrammars, grammarDependencies;
 
-propagate errors, moduleNames on GeneratorComponents, GeneratorComponent;
+propagate config, grammarName, compiledGrammars, grammarDependencies, env, errors, moduleNames on GeneratorComponents, GeneratorComponent;
 
 concrete production nilGeneratorComponent
 top::GeneratorComponents ::=

--- a/grammars/silver/compiler/extension/treegen/TerminalGen.sv
+++ b/grammars/silver/compiler/extension/treegen/TerminalGen.sv
@@ -16,7 +16,7 @@ concrete production genArbTerminalNoLocExpr
 top::Expr ::= 'genArbTerminal' '(' te::TypeExpr ',' '_' ')'
 {
   top.unparse = s"genArbTerminal(${te.unparse}, _)";
-  propagate freeVars;
+  propagate grammarName, env, flowEnv, freeVars;
   
   local regex::Regex =
     case getTypeDcl(te.typerep.typeName, top.env) of

--- a/grammars/silver/compiler/extension/tuple/Tuple.sv
+++ b/grammars/silver/compiler/extension/tuple/Tuple.sv
@@ -46,7 +46,8 @@ top::Expr ::= tuple::Expr '.' a::IntConst
 {
 
   -- Forward gets the substitution context of the tuple
-  propagate grammarName, config, frame, env, flowEnv, downSubst, upSubst, freeVars, originRules;
+  propagate grammarName, config, compiledGrammars, frame, env, flowEnv, downSubst, upSubst, finalSubst, freeVars, originRules;
+  tuple.isRoot = false;
 
   local accessIndex::Integer = toInteger(a.lexeme);
 

--- a/grammars/silver/compiler/extension/tuple/Tuple.sv
+++ b/grammars/silver/compiler/extension/tuple/Tuple.sv
@@ -46,7 +46,7 @@ top::Expr ::= tuple::Expr '.' a::IntConst
 {
 
   -- Forward gets the substitution context of the tuple
-  propagate downSubst, upSubst, freeVars;
+  propagate grammarName, config, frame, env, flowEnv, downSubst, upSubst, freeVars, originRules;
 
   local accessIndex::Integer = toInteger(a.lexeme);
 

--- a/grammars/silver/compiler/langserver/ReferenceLocations.sv
+++ b/grammars/silver/compiler/langserver/ReferenceLocations.sv
@@ -82,6 +82,18 @@ aspect attributeRefLocs on AGDcl using := of
 | strategyAttributeDcl(_, _, _, _, e) -> e.attributeRefLocs
 end;
 
+aspect production propagateOnNTListDcl
+top::AGDcl ::= attrs::NameList nts::NameList ps::ProdNameList
+{
+  propagate grammarName, env, flowEnv;
+}
+
+aspect production tcMonoidAttributeDcl
+top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs _ te::TypeExpr ';'
+{
+  propagate grammarName, env, flowEnv;
+}
+
 aspect attributeRefLocs on Constraint using <- of
 | inhOccursConstraint(_, at, _, _, _, _) -> if at.lookupAttribute.found then [(at.location, at.lookupAttribute.dcl)] else []
 | synOccursConstraint(_, at, _, _, _, _, _) -> if at.lookupAttribute.found then [(at.location, at.lookupAttribute.dcl)] else []

--- a/grammars/silver/compiler/metatranslation/Translation.sv
+++ b/grammars/silver/compiler/metatranslation/Translation.sv
@@ -33,6 +33,8 @@ flowtype translation {givenLocation} on AST, ASTs, NamedASTs, NamedAST;
 flowtype patternTranslation {givenLocation} on AST, ASTs;
 flowtype foundLocation {} on ASTs, NamedASTs, NamedAST;
 
+propagate givenLocation on AST, ASTs, NamedASTs, NamedAST excluding nonterminalAST;
+
 attribute givenLocation, translation<Expr>, patternTranslation<Pattern> occurs on AST;
 
 aspect production nonterminalAST

--- a/grammars/silver/compiler/metatranslation/Translation.sv
+++ b/grammars/silver/compiler/metatranslation/Translation.sv
@@ -27,7 +27,7 @@ Pattern ::= loc::Location ast::AST
 synthesized attribute translation<a>::a;
 synthesized attribute patternTranslation<a>::a;
 synthesized attribute foundLocation::Maybe<Location>;
-autocopy attribute givenLocation::Location;
+inherited attribute givenLocation::Location;
 
 flowtype translation {givenLocation} on AST, ASTs, NamedASTs, NamedAST;
 flowtype patternTranslation {givenLocation} on AST, ASTs;

--- a/grammars/silver/compiler/modification/autocopyattr/AutoCopy.sv
+++ b/grammars/silver/compiler/modification/autocopyattr/AutoCopy.sv
@@ -6,6 +6,7 @@ concrete production attributeDclAuto
 top::AGDcl ::= 'autocopy' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
   top.unparse = "autocopy attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
+  propagate grammarName, flowEnv;
 
   production attribute fName :: String;
   fName = top.grammarName ++ ":" ++ a.name;

--- a/grammars/silver/compiler/modification/copper/ActionCode.sv
+++ b/grammars/silver/compiler/modification/copper/ActionCode.sv
@@ -6,6 +6,7 @@ concrete production concreteProductionDclAction
 top::AGDcl ::= 'concrete' 'production' id::Name ns::ProductionSignature pm::ProductionModifiers body::ProductionBody 'action' acode::ActionCode_c
 {
   top.unparse = forward.unparse ++ "action " ++ acode.unparse;
+  propagate config, grammarName, compiledGrammars;
 
   production fName :: String = top.grammarName ++ ":" ++ id.name;
 
@@ -50,7 +51,7 @@ top::ActionCode_c ::= '{' stmts::ProductionStmts '}'
 {
   top.unparse = "{\n" ++ stmts.unparse ++ "}\n";
   top.defs := flatMap(hackTransformLocals, stmts.defs);
-  propagate flowDefs;
+  propagate config, grammarName, compiledGrammars, env, frame, flowDefs, flowEnv;
 
   top.actionCode =
     -- action code translation goes in the env/syntax AST, so we might demand it

--- a/grammars/silver/compiler/modification/copper/ActionCode.sv
+++ b/grammars/silver/compiler/modification/copper/ActionCode.sv
@@ -6,7 +6,7 @@ concrete production concreteProductionDclAction
 top::AGDcl ::= 'concrete' 'production' id::Name ns::ProductionSignature pm::ProductionModifiers body::ProductionBody 'action' acode::ActionCode_c
 {
   top.unparse = forward.unparse ++ "action " ++ acode.unparse;
-  propagate config, grammarName, compiledGrammars;
+  propagate config, grammarName, compiledGrammars, flowEnv;
 
   production fName :: String = top.grammarName ++ ":" ++ id.name;
 

--- a/grammars/silver/compiler/modification/copper/CustomLayout.sv
+++ b/grammars/silver/compiler/modification/copper/CustomLayout.sv
@@ -7,6 +7,7 @@ concrete production productionModifierLayout
 top::ProductionModifier ::= 'layout' '{' terms::TermList '}'
 {
   top.unparse = "layout {" ++ terms.unparse ++ "}";
+  propagate env;
 
   top.productionModifiers := [prodLayout(terms.termList)];
   top.errors := terms.errors;
@@ -25,6 +26,7 @@ concrete production nonterminalModifierLayout
 top::NonterminalModifier ::= 'layout' '{' terms::TermList '}'
 {
   top.unparse = "layout {" ++ terms.unparse ++ "}";
+  propagate env;
   
   top.nonterminalModifiers := [ntLayout(terms.termList)];
   top.errors := terms.errors;

--- a/grammars/silver/compiler/modification/copper/DisambiguationGroup.sv
+++ b/grammars/silver/compiler/modification/copper/DisambiguationGroup.sv
@@ -6,9 +6,9 @@ concrete production disambiguationGroupDcl
 top::AGDcl ::= 'disambiguate' terms::TermList acode::ActionCode_c
 {
   top.unparse = "disambiguate " ++ terms.unparse ++ " " ++ acode.unparse;
+  propagate config, grammarName, compiledGrammars, errors;
 
-  top.errors := terms.errors ++ acode.errors;
-
+  terms.env = top.env;
   acode.env = newScopeEnv(disambiguationActionVars ++ acode.defs ++ terms.defs, top.env);
 
   -- Give the group a name, deterministically, based on line number

--- a/grammars/silver/compiler/modification/copper/LexerClass.sv
+++ b/grammars/silver/compiler/modification/copper/LexerClass.sv
@@ -43,7 +43,7 @@ closed nonterminal LexerClassModifier with config, location, unparse, lexerClass
 
 monoid attribute lexerClassModifiers :: [SyntaxLexerClassModifier];
 
-propagate errors on LexerClassModifiers, LexerClassModifier;
+propagate config, grammarName, compiledGrammars, env, flowEnv, errors on LexerClassModifiers, LexerClassModifier;
 propagate lexerClassModifiers, superClasses on LexerClassModifiers;
 
 abstract production lexerClassModifiersNone

--- a/grammars/silver/compiler/modification/copper/LexerClass.sv
+++ b/grammars/silver/compiler/modification/copper/LexerClass.sv
@@ -18,6 +18,7 @@ concrete production lexerClassDecl
 top::AGDcl ::= 'lexer' 'class' id::Name modifiers::LexerClassModifiers ';'
 {
   top.unparse = "lexer class " ++ id.name ++ modifiers.unparse ++ ";";
+  propagate config, grammarName, compiledGrammars, env;
 
   production attribute fName :: String;
   fName = top.grammarName ++ ":" ++ id.name;
@@ -43,8 +44,9 @@ closed nonterminal LexerClassModifier with config, location, unparse, lexerClass
 
 monoid attribute lexerClassModifiers :: [SyntaxLexerClassModifier];
 
-propagate config, grammarName, compiledGrammars, env, flowEnv, errors on LexerClassModifiers, LexerClassModifier;
-propagate lexerClassModifiers, superClasses on LexerClassModifiers;
+propagate config, grammarName, compiledGrammars, flowEnv, errors on LexerClassModifiers, LexerClassModifier;
+propagate env, lexerClassModifiers, superClasses on LexerClassModifiers;
+propagate env on LexerClassModifier excluding lexerClassModifierDisambiguate;
 
 abstract production lexerClassModifiersNone
 top::LexerClassModifiers ::= 

--- a/grammars/silver/compiler/modification/copper/ParserAttributes.sv
+++ b/grammars/silver/compiler/modification/copper/ParserAttributes.sv
@@ -4,13 +4,13 @@ concrete production attributeDclParser
 top::AGDcl ::= 'parser' 'attribute' a::Name '::' te::TypeExpr 'action' acode::ActionCode_c ';'
 {
   top.unparse = "parser attribute " ++ a.name ++ " :: " ++ te.unparse ++ " action " ++ acode.unparse ++ " ;" ;
+  propagate config, grammarName, compiledGrammars, env, errors;
 
   production attribute fName :: String;
   fName = top.grammarName ++ ":" ++ a.name;
 
   top.defs := [parserAttrDef(top.grammarName, a.location, fName, te.typerep)];
 
-  propagate errors;
   top.errors <- if length(getValueDclAll(fName, top.env)) > 1
                 then [err(a.location, "Attribute '" ++ fName ++ "' is already bound.")]
                 else [];
@@ -36,13 +36,13 @@ concrete production attributeAspectParser
 top::AGDcl ::= 'aspect' 'parser' 'attribute' a::QName 'action' acode::ActionCode_c ';'
 {
   top.unparse = "aspect parser attribute " ++ a.name ++ " action " ++ acode.unparse ++ " ;" ;
+  propagate config, grammarName, compiledGrammars, env, errors;
 
   production attribute fName :: String;
   fName = a.lookupValue.dcl.fullName;
 
   top.defs := [];
 
-  propagate errors;
   top.errors <- if null(a.lookupValue.dcls)
                 then [err(a.location, "Undefined attribute '" ++ a.name ++ "'.")]
                 else [];

--- a/grammars/silver/compiler/modification/copper/ParserAttributes.sv
+++ b/grammars/silver/compiler/modification/copper/ParserAttributes.sv
@@ -4,7 +4,7 @@ concrete production attributeDclParser
 top::AGDcl ::= 'parser' 'attribute' a::Name '::' te::TypeExpr 'action' acode::ActionCode_c ';'
 {
   top.unparse = "parser attribute " ++ a.name ++ " :: " ++ te.unparse ++ " action " ++ acode.unparse ++ " ;" ;
-  propagate config, grammarName, compiledGrammars, env, errors;
+  propagate config, grammarName, compiledGrammars, errors;
 
   production attribute fName :: String;
   fName = top.grammarName ++ ":" ++ a.name;
@@ -23,6 +23,8 @@ top::AGDcl ::= 'parser' 'attribute' a::Name '::' te::TypeExpr 'action' acode::Ac
   local myFlowGraph :: ProductionGraph = 
     constructAnonymousGraph(acode.flowDefs, top.env, myProds, myFlow);
 
+  te.env = top.env;
+
   acode.frame = actionContext(myFlowGraph, sourceGrammar=top.grammarName);
   acode.env = newScopeEnv(acode.defs, top.env);
   
@@ -36,7 +38,7 @@ concrete production attributeAspectParser
 top::AGDcl ::= 'aspect' 'parser' 'attribute' a::QName 'action' acode::ActionCode_c ';'
 {
   top.unparse = "aspect parser attribute " ++ a.name ++ " action " ++ acode.unparse ++ " ;" ;
-  propagate config, grammarName, compiledGrammars, env, errors;
+  propagate config, grammarName, compiledGrammars, errors;
 
   production attribute fName :: String;
   fName = a.lookupValue.dcl.fullName;
@@ -53,6 +55,8 @@ top::AGDcl ::= 'aspect' 'parser' 'attribute' a::QName 'action' acode::ActionCode
 
   local myFlowGraph :: ProductionGraph = 
     constructAnonymousGraph(acode.flowDefs, top.env, myProds, myFlow);
+
+  a.env = top.env;
 
   acode.frame = actionContext(myFlowGraph, sourceGrammar=top.grammarName);
   acode.env = newScopeEnv(acode.defs, top.env);

--- a/grammars/silver/compiler/modification/copper/ParserDcl.sv
+++ b/grammars/silver/compiler/modification/copper/ParserDcl.sv
@@ -11,7 +11,7 @@ top::AGDcl ::= 'parser' n::Name '::' t::TypeExpr '{' m::ParserComponents '}'
 {
   top.unparse = "parser " ++ m.unparse ++ ";"; -- TODO?
   
-  propagate errors, moduleNames;
+  propagate config, grammarName, compiledGrammars, errors, moduleNames;
 
   -- Right now parsers masquerade as functions. This is probably fine.
   -- Only bug is that you can aspect it, but it's pointless to do so, you can't affect anything.
@@ -24,6 +24,7 @@ top::AGDcl ::= 'parser' n::Name '::' t::TypeExpr '{' m::ParserComponents '}'
   production med :: ModuleExportedDefs =
     moduleExportedDefs(top.location, top.compiledGrammars, m.grammarDependencies, m.moduleNames, []);
   
+  t.env = top.env;
   m.env = appendEnv(toEnv(med.defs), top.env);
   
   production fName :: String = top.grammarName ++ ":" ++ n.name;
@@ -47,7 +48,7 @@ top::AGDcl ::= 'parser' n::Name '::' t::TypeExpr '{' m::ParserComponents '}'
 
 nonterminal ParserComponents with config, env, flowEnv, grammarName, location, unparse, errors, moduleNames, compiledGrammars, grammarDependencies, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles;
 
-propagate errors, moduleNames, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles on ParserComponents;
+propagate config, env, flowEnv, grammarName, compiledGrammars, grammarDependencies, errors, moduleNames, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles on ParserComponents;
 
 concrete production nilParserComponent
 top::ParserComponents ::=
@@ -63,7 +64,7 @@ top::ParserComponents ::= c1::ParserComponent  c2::ParserComponents
 
 closed nonterminal ParserComponent with config, env, flowEnv, grammarName, location, unparse, errors, moduleNames, compiledGrammars, grammarDependencies, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles;
 
-propagate errors, moduleNames, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles on ParserComponent;
+propagate config, env, flowEnv, grammarName, compiledGrammars, grammarDependencies, errors, moduleNames, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles on ParserComponent;
 
 aspect default production
 top::ParserComponent ::=
@@ -84,7 +85,7 @@ inherited attribute componentGrammarName::String;
 {-- Have special env built from just this parser component and the global env -}
 nonterminal ParserComponentModifiers with config, env, flowEnv, grammarName, componentGrammarName, compiledGrammars, grammarDependencies, location, unparse, errors, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles;
 
-propagate errors, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles on ParserComponentModifiers;
+propagate config, env, flowEnv, grammarName, componentGrammarName, compiledGrammars, grammarDependencies, errors, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles on ParserComponentModifiers;
 
 concrete production nilParserComponentModifier
 top::ParserComponentModifiers ::=
@@ -100,7 +101,7 @@ top::ParserComponentModifiers ::= h::ParserComponentModifier t::ParserComponentM
 
 nonterminal ParserComponentModifier with config, env, flowEnv, grammarName, componentGrammarName, compiledGrammars, grammarDependencies, location, unparse, errors, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles;
 
-propagate errors, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles on ParserComponentModifier;
+propagate config, env, flowEnv, grammarName, componentGrammarName, compiledGrammars, grammarDependencies, errors, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles on ParserComponentModifier;
 
 aspect default production
 top::ParserComponentModifier ::=

--- a/grammars/silver/compiler/modification/copper/ParserDcl.sv
+++ b/grammars/silver/compiler/modification/copper/ParserDcl.sv
@@ -79,7 +79,7 @@ top::ParserComponent ::= m::ModuleName mods::ParserComponentModifiers ';'
   mods.componentGrammarName = head(m.moduleNames);
 }
 
-autocopy attribute componentGrammarName::String;
+inherited attribute componentGrammarName::String;
 
 {-- Have special env built from just this parser component and the global env -}
 nonterminal ParserComponentModifiers with config, env, flowEnv, grammarName, componentGrammarName, compiledGrammars, grammarDependencies, location, unparse, errors, terminalPrefixes, grammarTerminalPrefixes, syntaxAst, genFiles;

--- a/grammars/silver/compiler/modification/copper/Prefix.sv
+++ b/grammars/silver/compiler/modification/copper/Prefix.sv
@@ -22,7 +22,7 @@ inherited attribute prefixedGrammars::[String];
 synthesized attribute terminalPrefix::String;
 nonterminal TerminalPrefix with config, env, flowEnv, grammarName, componentGrammarName, compiledGrammars, prefixedTerminals, prefixedGrammars, location, unparse, errors, syntaxAst, genFiles, terminalPrefix;
 
-propagate errors, syntaxAst, genFiles on TerminalPrefix;
+propagate config, env, flowEnv, grammarName, componentGrammarName, compiledGrammars, errors, syntaxAst, genFiles on TerminalPrefix;
 
 concrete production nameTerminalPrefix
 top::TerminalPrefix ::= s::QName
@@ -92,8 +92,7 @@ top::TerminalModifier ::= terms::[String]  grams::[String]
 synthesized attribute prefixItemNames::[String];
 synthesized attribute isAllMarking::Boolean;
 nonterminal TerminalPrefixItems with config, env, grammarName, componentGrammarName, compiledGrammars, grammarDependencies, location, unparse, errors, prefixItemNames, isAllMarking;
-
-propagate errors on TerminalPrefixItems;
+propagate config, env, grammarName, componentGrammarName, compiledGrammars, errors on TerminalPrefixItems;
 
 concrete production consTerminalPrefixItem
 top::TerminalPrefixItems ::= t::TerminalPrefixItem ',' ts::TerminalPrefixItems
@@ -129,6 +128,7 @@ top::TerminalPrefixItems ::=
 }
 
 nonterminal TerminalPrefixItem with config, env, grammarName, componentGrammarName, compiledGrammars, location, unparse, errors, prefixItemNames;
+propagate config, env, grammarName, componentGrammarName, compiledGrammars on TerminalPrefixItem;
 
 concrete production qNameTerminalPrefixItem
 top::TerminalPrefixItem ::= t::QName
@@ -143,6 +143,7 @@ top::TerminalPrefixItem ::= t::QName
 concrete production easyTerminalRefTerminalPrefixItem
 top::TerminalPrefixItem ::= t::EasyTerminalRef
 {
+  propagate env;
   forwards to
     qNameTerminalPrefixItem(
       qName(top.location, head(t.dcls).fullName),

--- a/grammars/silver/compiler/modification/copper/Prefix.sv
+++ b/grammars/silver/compiler/modification/copper/Prefix.sv
@@ -17,8 +17,8 @@ top::ParserComponentModifier ::= 'prefix' ts::TerminalPrefixItems 'with' s::Term
   s.prefixedGrammars = if ts.isAllMarking then [top.componentGrammarName] else [];
 }
 
-autocopy attribute prefixedTerminals::[String];
-autocopy attribute prefixedGrammars::[String];
+inherited attribute prefixedTerminals::[String];
+inherited attribute prefixedGrammars::[String];
 synthesized attribute terminalPrefix::String;
 nonterminal TerminalPrefix with config, env, flowEnv, grammarName, componentGrammarName, compiledGrammars, prefixedTerminals, prefixedGrammars, location, unparse, errors, syntaxAst, genFiles, terminalPrefix;
 

--- a/grammars/silver/compiler/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/compiler/modification/copper/ProductionStmt.sv
@@ -173,7 +173,7 @@ concrete production blockStmt
 top::ProductionStmt ::= '{' stmts::ProductionStmts '}'
 {
   top.unparse = "\t{\n" ++ stmts.unparse ++ "\n\t}";
-  propagate config, grammarName, compiledGrammars, env, frame, finalSubst;
+  propagate config, grammarName, compiledGrammars, env, frame, errors, finalSubst;
   
   top.errors <-
     if !top.frame.permitActions
@@ -192,7 +192,7 @@ concrete production ifElseStmt
 top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt 'else' el::ProductionStmt
 {
   top.unparse = "\t" ++ "if (" ++ condition.unparse ++ ") " ++ th.unparse ++ "\nelse " ++ el.unparse;
-  propagate config, grammarName, compiledGrammars, env, frame, originRules;
+  propagate config, grammarName, compiledGrammars, env, frame, errors;
 
   top.errors <-
     if !top.frame.permitActions
@@ -203,10 +203,14 @@ top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt 'else' e
 
   condition.originRules = [];
   condition.isRoot = false;
+  th.originRules = [];
+  el.originRules = [];
 
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
   thread downSubst, upSubst on top, condition, errCheck1, top;
+
+  condition.finalSubst = condition.upSubst;
   
   th.downSubst = top.downSubst;
   th.finalSubst = th.upSubst;

--- a/grammars/silver/compiler/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/compiler/modification/copper/ProductionStmt.sv
@@ -23,13 +23,13 @@ concrete production pluckDef
 top::ProductionStmt ::= 'pluck' e::Expr ';'
 {
   top.unparse = "pluck " ++ e.unparse ++ ";";
+  propagate config, grammarName, compiledGrammars, env, frame, errors, finalSubst;
 
   -- Cast to integer is required, because that's secretly the real type of the
   -- result, but our type system only calls it an Object at the moment.
   -- Perhaps this problem can be resolved by using a proper type in this situation.
   top.translation = "return (Integer)(" ++ e.translation ++ ");\n";
 
-  propagate errors;
   top.errors <-
     if !top.frame.permitPluck
     then [err(top.location, "'pluck' allowed only in disambiguation-group parser actions.")]
@@ -57,10 +57,10 @@ concrete production printStmt
 top::ProductionStmt ::= 'print' e::Expr ';'
 {
   top.unparse = "print " ++ e.unparse ++ ";";
+  propagate config, grammarName, compiledGrammars, env, frame, errors, finalSubst;
 
   top.translation = "System.err.println(" ++ e.translation ++ ");\n";
 
-  propagate errors;
   top.errors <-
     if !top.frame.permitActions
     then [err(top.location, "'print' statement allowed only in parser action blocks. You may be looking for print(String,IO) :: IO.")]
@@ -90,8 +90,8 @@ abstract production parserAttributeValueDef
 top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
+  propagate config, grammarName, compiledGrammars, env, frame, errors, finalSubst;
 
-  propagate errors;
   top.errors <-
     if !top.frame.permitActions
     then [err(top.location, "Assignment to parser attributes only permitted in parser action blocks")]
@@ -117,8 +117,8 @@ concrete production pushTokenStmt
 top::ProductionStmt ::= 'pushToken' '(' val::QName ',' lexeme::Expr ')' ';'
 {
   top.unparse = "\t" ++ "pushToken(" ++ val.unparse ++ ", " ++ lexeme.unparse ++ ");";
+  propagate config, grammarName, compiledGrammars, env, frame, errors, finalSubst;
 
-  propagate errors;
   top.errors <-
     if !top.frame.permitActions
     then [err(top.location, "Tokens may only be pushed in action blocks")]
@@ -144,8 +144,8 @@ concrete production insertSemanticTokenStmt
 top::ProductionStmt ::= 'insert' 'semantic' 'token' n::QNameType 'at' loc::Expr ';'
 {
   top.unparse = "\t" ++ "insert semantic token " ++ n.unparse ++ " at " ++ loc.unparse ++ ";";
+  propagate config, grammarName, compiledGrammars, env, frame, errors, finalSubst;
 
-  propagate errors;
   top.errors <-
     if !top.frame.permitActions
     then [err(top.location, "Semantic tokens may only be inserted in action blocks")]
@@ -173,8 +173,8 @@ concrete production blockStmt
 top::ProductionStmt ::= '{' stmts::ProductionStmts '}'
 {
   top.unparse = "\t{\n" ++ stmts.unparse ++ "\n\t}";
+  propagate config, grammarName, compiledGrammars, env, frame, finalSubst;
   
-  propagate errors;
   top.errors <-
     if !top.frame.permitActions
     then [err(top.location, "Block statement is only permitted in action blocks")]
@@ -183,6 +183,7 @@ top::ProductionStmt ::= '{' stmts::ProductionStmts '}'
   top.translation = stmts.translation;
   
   stmts.downSubst = top.downSubst;
+  stmts.originRules = [];
   top.upSubst = error("Shouldn't ever be needed anywhere. (Should only ever be fed back here as top.finalSubst)");
   -- Of course, this means do not use top.finalSubst here!
 }
@@ -191,8 +192,8 @@ concrete production ifElseStmt
 top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt 'else' el::ProductionStmt
 {
   top.unparse = "\t" ++ "if (" ++ condition.unparse ++ ") " ++ th.unparse ++ "\nelse " ++ el.unparse;
+  propagate config, grammarName, compiledGrammars, env, frame, originRules;
 
-  propagate errors;
   top.errors <-
     if !top.frame.permitActions
     then [err(top.location, "If statement is only permitted in action blocks")]
@@ -251,10 +252,10 @@ abstract production termAttrValueValueDef
 top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 {
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
+  propagate config, grammarName, compiledGrammars, env, frame, errors, finalSubst;
 
   -- these values should only ever be in scope when it's valid to use them
-  propagate errors;
-  
+
   top.errors <-
     if val.name != "lexeme" then [] else
     [err(val.location, "lexeme is not reassignable.")];

--- a/grammars/silver/compiler/modification/copper/TermList.sv
+++ b/grammars/silver/compiler/modification/copper/TermList.sv
@@ -9,7 +9,7 @@ nonterminal TermList with config, grammarName, unparse, location, termList, defs
 
 monoid attribute termList :: [String];
 
-propagate errors, termList on TermList;
+propagate config, grammarName, env, errors, termList on TermList;
 
 concrete production termListOne
 terms::TermList ::= t::QName

--- a/grammars/silver/compiler/modification/copper/TerminalDcl.sv
+++ b/grammars/silver/compiler/modification/copper/TerminalDcl.sv
@@ -12,33 +12,34 @@ concrete production terminalModifierDominates
 top::TerminalModifier ::= 'dominates' terms::TermPrecs
 {
   top.unparse = "dominates { " ++ terms.unparse ++ " } ";
+  propagate env, errors;
 
   top.terminalModifiers := [termDominates(terms.precTermList)];
-  propagate errors;
 }
 
 concrete production terminalModifierSubmitsTo
 top::TerminalModifier ::= 'submits' 'to' terms::TermPrecs
 {
   top.unparse = "submits to { " ++ terms.unparse ++ " } " ;
+  propagate env, errors;
 
   top.terminalModifiers := [termSubmits(terms.precTermList)];
-  propagate errors;
 }
 
 concrete production terminalModifierClassSpec
 top::TerminalModifier ::= 'lexer' 'classes' cl::LexerClasses
 {
   top.unparse = "lexer classes { " ++ cl.unparse ++ " } " ;
+  propagate env, errors;
 
   top.terminalModifiers := [termClasses(cl.lexerClasses)];
-  propagate errors;
 }
 
 concrete production terminalModifierActionCode
 top::TerminalModifier ::= 'action' acode::ActionCode_c
 {
   top.unparse = "action " ++ acode.unparse;
+  propagate config, grammarName, compiledGrammars, flowEnv, errors;
 
   top.terminalModifiers := [termAction(acode.actionCode)];
 
@@ -51,14 +52,12 @@ top::TerminalModifier ::= 'action' acode::ActionCode_c
 
   acode.frame = actionContext(myFlowGraph, sourceGrammar=top.grammarName);
   acode.env = newScopeEnv(terminalActionVars ++ acode.defs, top.env);
-  
-  propagate errors;
 }
 
 monoid attribute precTermList :: [String];
 
 nonterminal TermPrecs with config, grammarName, unparse, location, precTermList, errors, env;
-propagate errors, precTermList on TermPrecs;
+propagate config, grammarName, env, errors, precTermList on TermPrecs;
 
 concrete production termPrecsOne
 top::TermPrecs ::= t::QName
@@ -81,7 +80,7 @@ top::TermPrecs ::= terms::TermPrecList
 }
 
 nonterminal TermPrecList with config, grammarName, unparse, location, precTermList, errors, env;
-propagate errors, precTermList on TermPrecList;
+propagate config, grammarName, env, errors, precTermList on TermPrecList;
 
 abstract production termPrecList
 top::TermPrecList ::= h::QName t::TermPrecList
@@ -126,7 +125,7 @@ top::TermPrecList ::= t::QName ',' terms_tail::TermPrecList
 }
 
 nonterminal LexerClasses with location, config, unparse, lexerClasses, errors, env;
-propagate errors, lexerClasses on LexerClasses;
+propagate config, env, errors, lexerClasses on LexerClasses;
 
 concrete production lexerClassesOne
 top::LexerClasses ::= n::QName
@@ -149,7 +148,7 @@ top::LexerClasses ::= cls::LexerClassList
 }
 
 nonterminal LexerClassList with location, config, unparse, lexerClasses, errors, env;
-propagate errors, lexerClasses on LexerClassList;
+propagate config, env, errors, lexerClasses on LexerClassList;
 
 concrete production lexerClassListOne
 top::LexerClassList ::= n::QName

--- a/grammars/silver/compiler/modification/copper_mda/Analysis.sv
+++ b/grammars/silver/compiler/modification/copper_mda/Analysis.sv
@@ -16,7 +16,7 @@ top::AGDcl ::= 'copper_mda' testname::Name '(' orig::QName ')' '{' m::ParserComp
 {
   top.unparse = "";
   
-  propagate errors, moduleNames;
+  propagate config, grammarName, compiledGrammars, grammarDependencies, env, flowEnv, errors, moduleNames;
   
   top.errors <- orig.lookupValue.errors;
   

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -58,7 +58,7 @@ top::AspectDefaultProductionSignature ::= lhs::Name '::' te::TypeExpr '::='
       namedSignatureElement(lhs.name, te.typerep),
       foldNamedSignatureElements(annotationsForNonterminal(te.typerep, top.env)));
 
-  propagate config, grammarName, compiledGrammars, errors, lexicalTypeVariables, lexicalTyVarKinds;
+  propagate config, grammarName, env, compiledGrammars, errors, lexicalTypeVariables, lexicalTyVarKinds, flowEnv;
 
   local checkNT::TypeCheck = checkNonterminal(top.env, false, te.typerep);
   checkNT.downSubst = emptySubst();

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -20,7 +20,7 @@ top::AGDcl ::= 'aspect' 'default' 'production' ns::AspectDefaultProductionSignat
 
   top.defs := [];
 
-  propagate errors, flowDefs;
+  propagate config, grammarName, compiledGrammars, errors;
   
   local sigDefs :: [Def] = addNewLexicalTyVars(top.grammarName, top.location, ns.lexicalTyVarKinds, ns.lexicalTypeVariables);
 
@@ -58,7 +58,7 @@ top::AspectDefaultProductionSignature ::= lhs::Name '::' te::TypeExpr '::='
       namedSignatureElement(lhs.name, te.typerep),
       foldNamedSignatureElements(annotationsForNonterminal(te.typerep, top.env)));
 
-  propagate errors, lexicalTypeVariables, lexicalTyVarKinds;
+  propagate config, grammarName, compiledGrammars, errors, lexicalTypeVariables, lexicalTyVarKinds;
 
   local checkNT::TypeCheck = checkNonterminal(top.env, false, te.typerep);
   checkNT.downSubst = emptySubst();

--- a/grammars/silver/compiler/modification/ffi/FunctionDcl.sv
+++ b/grammars/silver/compiler/modification/ffi/FunctionDcl.sv
@@ -8,7 +8,8 @@ nonterminal FFIDef with config, location, grammarName, errors, env, unparse;
 concrete production functionDclFFI
 top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody 'foreign' '{' ffidefs::FFIDefs '}'
 {
-  top.unparse = "function " ++ id.unparse ++ "\n" ++ ns.unparse ++ "\n" ++ body.unparse ++ " foreign {\n" ++ ffidefs.unparse ++ "}"; 
+  top.unparse = "function " ++ id.unparse ++ "\n" ++ ns.unparse ++ "\n" ++ body.unparse ++ " foreign {\n" ++ ffidefs.unparse ++ "}";
+  propagate grammarName, flowEnv;
 
   production fName :: String = top.grammarName ++ ":" ++ id.name;
   production namedSig :: NamedSignature = ns.namedSignature;

--- a/grammars/silver/compiler/modification/ffi/TypeDcl.sv
+++ b/grammars/silver/compiler/modification/ffi/TypeDcl.sv
@@ -42,7 +42,7 @@ top::AGDcl ::= 'type' id::Name tl::BracketedOptTypeExprs 'foreign' '=' trans::St
 
   top.defs := [typeAliasDef(top.grammarName, id.location, fName, [], tl.freeVariables, foreignType(fName, transType, tl.types))];
 
-  propagate errors, flowDefs;
+  propagate grammarName, errors, flowDefs, flowEnv;
   top.errors <- tl.errorsTyVars;
   
   -- Put the variables listed on the rhs in the environment FOR TL ONLY, so they're all "declared"

--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -24,7 +24,7 @@ top::Expr ::= params::ProductionRHS e::Expr
   top.unparse = "\\ " ++ params.unparse ++ " -> " ++ e.unparse;
   top.freeVars := ts:removeAll(params.lambdaBoundVars, e.freeVars);
   
-  propagate errors;
+  propagate config, grammarName, compiledGrammars, errors, originRules;
   
   top.typerep = appTypes(functionType(length(params.inputElements), []), map((.typerep), params.inputElements) ++ [e.typerep]);
 
@@ -35,14 +35,15 @@ top::Expr ::= params::ProductionRHS e::Expr
       top.grammarName, top.location, params.lexicalTyVarKinds,
       filter(\ tv::String -> null(getTypeDcl(tv, top.env)), nub(params.lexicalTypeVariables)));
 
-  propagate downSubst, upSubst;
-  propagate flowDeps, flowDefs;
+  propagate downSubst, upSubst, finalSubst;
+  propagate flowDeps, flowDefs, flowEnv;
   
   params.env = newScopeEnv(sigDefs, top.env);
   params.givenLambdaParamIndex = 0;
   params.givenLambdaId = genInt();
   e.env = params.env;
   e.frame = inLambdaContext(top.frame, sourceGrammar=top.frame.sourceGrammar); --TODO: Is this sourceGrammar correct?
+  e.isRoot = false;
 }
 
 monoid attribute lambdaDefs::[Def];

--- a/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
@@ -58,4 +58,3 @@ top::Expr ::= q::PartiallyDecorated QName
   top.translation = s"common.Util.<${finalType(top).transType}>demandIndex(lambda_${toString(q.lookupValue.dcl.lambdaId)}_args, ${toString(q.lookupValue.dcl.lambdaParamIndex)})";
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
 }
-

--- a/grammars/silver/compiler/modification/let_fix/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/Let.sv
@@ -44,14 +44,15 @@ top::Expr ::= la::AssignExpr  e::Expr
   top.unparse = "let " ++ la.unparse ++ " in " ++ e.unparse ++ " end";
   top.freeVars := ts:removeAll(la.boundNames, e.freeVars);
   
-  propagate errors;
+  propagate config, grammarName, compiledGrammars, frame, errors, originRules;
   
   top.typerep = e.typerep;
 
-  propagate downSubst, upSubst;
+  propagate downSubst, upSubst, finalSubst;
   
   -- Semantics for the moment is these are not mutually recursive,
   -- so la does NOT get new environment, only e. Thus, la.defs can depend on downSubst...
+  la.env = top.env;
   e.env = newScopeEnv(la.defs, top.env);
 }
 
@@ -61,7 +62,7 @@ nonterminal AssignExpr with location, config, grammarName, env, compiledGrammars
                             unparse, defs, errors, boundNames, freeVars, upSubst, 
                             downSubst, finalSubst, frame, isRoot, originRules;
 
-propagate errors, defs on AssignExpr;
+propagate config, grammarName, compiledGrammars, frame, env, errors, defs, finalSubst, originRules on AssignExpr;
 
 abstract production appendAssignExpr
 top::AssignExpr ::= a1::AssignExpr a2::AssignExpr

--- a/grammars/silver/compiler/modification/let_fix/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/Let.sv
@@ -45,6 +45,7 @@ top::Expr ::= la::AssignExpr  e::Expr
   top.freeVars := ts:removeAll(la.boundNames, e.freeVars);
   
   propagate config, grammarName, compiledGrammars, frame, errors, originRules;
+  e.isRoot = false;
   
   top.typerep = e.typerep;
 
@@ -60,7 +61,7 @@ monoid attribute boundNames::[String];
 
 nonterminal AssignExpr with location, config, grammarName, env, compiledGrammars, 
                             unparse, defs, errors, boundNames, freeVars, upSubst, 
-                            downSubst, finalSubst, frame, isRoot, originRules;
+                            downSubst, finalSubst, frame, originRules;
 
 propagate config, grammarName, compiledGrammars, frame, env, errors, defs, finalSubst, originRules on AssignExpr;
 
@@ -114,6 +115,8 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
     if errCheck1.typeerror
     then [err(id.location, "Value " ++ id.name ++ " declared with type " ++ errCheck1.rightpp ++ " but the expression being assigned to it has type " ++ errCheck1.leftpp)]
     else [];
+
+  e.isRoot = false;
 }
 
 abstract production lexicalLocalReference

--- a/grammars/silver/compiler/modification/list/List.sv
+++ b/grammars/silver/compiler/modification/list/List.sv
@@ -10,6 +10,7 @@ concrete production listTypeExpr
 top::TypeExpr ::= '[' te::TypeExpr ']'
 {
   top.unparse = "[" ++ te.unparse ++ "]";
+  propagate grammarName, env, flowEnv;
 
   top.typerep = listType(te.typerep);
   

--- a/grammars/silver/compiler/modification/list/Type.sv
+++ b/grammars/silver/compiler/modification/list/Type.sv
@@ -6,7 +6,7 @@ grammar silver:compiler:modification:list;
 abstract production listType
 top::Type ::= el::Type
 {
-  propagate substituted, flatRenamed;
+  propagate substitution, substituted, flatRenamed, boundVariables;
   top.typepp = "[" ++ el.typepp ++ "]";
 
   forwards to appType(listCtrType(), el);

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -31,8 +31,8 @@ nonterminal PrimPattern with
   downSubst, upSubst, finalSubst,
   scrutineeType, returnType, translation, isRoot, originRules;
 
-autocopy attribute scrutineeType :: Type;
-autocopy attribute returnType :: Type;
+inherited attribute scrutineeType :: Type;
+inherited attribute returnType :: Type;
 
 propagate errors on PrimPatterns, PrimPattern;
 propagate freeVars on PrimPatterns, PrimPattern excluding prodPatternNormal, prodPatternGadt, conslstPattern;

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -24,12 +24,12 @@ nonterminal PrimPatterns with
   config, grammarName, env, compiledGrammars, frame,
   location, unparse, errors, freeVars,
   downSubst, upSubst, finalSubst,
-  scrutineeType, returnType, translation, isRoot, originRules;
+  scrutineeType, returnType, translation, originRules;
 nonterminal PrimPattern with 
   config, grammarName, env, compiledGrammars, frame,
   location, unparse, errors, freeVars,
   downSubst, upSubst, finalSubst,
-  scrutineeType, returnType, translation, isRoot, originRules;
+  scrutineeType, returnType, translation, originRules;
 
 inherited attribute scrutineeType :: Type;
 inherited attribute returnType :: Type;

--- a/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
@@ -31,7 +31,8 @@ flowtype errors {decorate, receivedDeps} on VarBinders, VarBinder;
 flowtype defs {decorate} on VarBinders, VarBinder;
 flowtype boundNames {} on VarBinders, VarBinder;
 
-propagate errors, defs, boundNames on VarBinders, VarBinder;
+propagate config, grammarName, env, compiledGrammars, frame, errors, defs, boundNames, finalSubst, flowEnv, matchingAgainst
+  on VarBinders, VarBinder;
 
 --- Types of each child
 inherited attribute bindingTypes :: [Type];

--- a/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
@@ -45,7 +45,7 @@ inherited attribute bindingName :: String;
 synthesized attribute flowProjections :: [PatternVarProjection];
 
 -- The DclInfo of the production we're matching against
-autocopy attribute matchingAgainst :: Maybe<ValueDclInfo>;
+inherited attribute matchingAgainst :: Maybe<ValueDclInfo>;
 
 synthesized attribute varBinderCount :: Integer;
 

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -10,7 +10,7 @@ synthesized attribute contextSigElems :: [String] occurs on Contexts;
 synthesized attribute contextSigElem :: String occurs on Context;
 -- Track what children with inh occurs-on contexts need to have indices generated
 monoid attribute contextInhOccurs :: [(Type, String)] occurs on NamedSignature, Contexts, Context;
-autocopy attribute sigInhOccurs :: [(Type, String)] occurs on NamedSignatureElements, NamedSignatureElement;
+inherited attribute sigInhOccurs :: [(Type, String)] occurs on NamedSignatureElements, NamedSignatureElement;
 synthesized attribute inhOccursContextTypes :: [Type] occurs on NamedSignature;
 monoid attribute inhOccursIndexDecls :: String occurs on NamedSignature, Contexts, Context;
 -- Track what children can be used to resolve contexts at runtime

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -46,6 +46,8 @@ synthesized attribute annoNameElem :: String occurs on NamedSignatureElement;
 -- "if (name.equals("signame")) { return getAnno_signame(); }"
 synthesized attribute annoLookupElem :: String occurs on NamedSignatureElement;
 
+propagate sigInhOccurs on NamedSignatureElements, NamedSignatureElement;
+
 aspect production namedSignature
 top::NamedSignature ::= fn::String ctxs::Contexts ie::NamedSignatureElements oe::NamedSignatureElement np::NamedSignatureElements
 {

--- a/grammars/silver/compiler/translation/java/type/Type.sv
+++ b/grammars/silver/compiler/translation/java/type/Type.sv
@@ -13,7 +13,7 @@ synthesized attribute transCovariantType :: String;
 -- the <> part of the type!! e.g. "Foo<Bar>.class" is illegal, should be "Foo.class"
 synthesized attribute transClassType :: String;
 -- An environment mapping skolem constants to their runtime representation translations
-autocopy attribute skolemTypeReps :: [(TyVar, String)];
+inherited attribute skolemTypeReps :: [(TyVar, String)];
 -- The runtime representation of a type, where all skolems are replaced with their provided representations, used for reification
 synthesized attribute transTypeRep :: String;
 -- A valid Java identifier, unique to the type

--- a/grammars/silver/compiler/translation/java/type/Type.sv
+++ b/grammars/silver/compiler/translation/java/type/Type.sv
@@ -48,6 +48,7 @@ String ::= te::Type tvs::[TyVar]
 }
 
 attribute transType, transCovariantType, transClassType, transTypeRep, skolemTypeReps, transTypeName occurs on Type;
+propagate skolemTypeReps on Type;
 
 aspect default production
 top::Type ::=

--- a/grammars/silver/langutil/pp/Document.sv
+++ b/grammars/silver/langutil/pp/Document.sv
@@ -150,8 +150,8 @@ nonterminal Document with indent, width,
                           result, horizontals,
 			  compareTo, isEqual;
 
-autocopy attribute indent :: Integer;
-autocopy attribute width :: Integer;
+inherited attribute indent :: Integer;
+inherited attribute width :: Integer;
 
 -- The scanning process
 inherited attribute inPosition :: Integer;

--- a/grammars/silver/langutil/pp/Document.sv
+++ b/grammars/silver/langutil/pp/Document.sv
@@ -152,6 +152,7 @@ nonterminal Document with indent, width,
 
 inherited attribute indent :: Integer;
 inherited attribute width :: Integer;
+propagate indent, width on Document;
 
 -- The scanning process
 inherited attribute inPosition :: Integer;

--- a/grammars/silver/rewrite/AST.sv
+++ b/grammars/silver/rewrite/AST.sv
@@ -21,6 +21,8 @@ attribute someResult<AST> occurs on AST;
 attribute oneResult<AST> occurs on AST;
 attribute traversalResult<AST> occurs on AST;
 
+propagate givenStrategy on AST, ASTs, NamedASTs, NamedAST;
+
 aspect default production
 top::AST ::=
 {
@@ -59,6 +61,8 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
       just(nonterminalAST(prodName, children, annotationsResult))
     | nothing(), nothing() -> nothing()
     end;
+  children.childStrategies = top.childStrategies;
+  annotations.annotationStrategies = top.annotationStrategies;
   top.traversalResult =
     do {
       if prodName != top.productionName then nothing() else just(unit());
@@ -216,6 +220,7 @@ top::NamedASTs ::= h::NamedAST t::NamedASTs
     | nothing(), just(tResult) -> just(consNamedAST(h, tResult))
     | nothing(), nothing() -> nothing()
     end;
+  propagate annotationStrategies;
   top.traversalResult =
     do {
       hResult::NamedAST <- h.traversalResult;

--- a/grammars/silver/rewrite/AST.sv
+++ b/grammars/silver/rewrite/AST.sv
@@ -2,14 +2,14 @@ grammar silver:rewrite;
 
 exports silver:reflect; -- Needed by the extension, so just export it here.
 
-autocopy attribute givenStrategy::Strategy occurs on AST, ASTs, NamedASTs, NamedAST;
+inherited attribute givenStrategy::Strategy occurs on AST, ASTs, NamedASTs, NamedAST;
 synthesized attribute allResult<a>::Maybe<a>;
 synthesized attribute someResult<a>::Maybe<a>;
 synthesized attribute oneResult<a>::Maybe<a>;
 
 inherited attribute productionName::String occurs on AST;
-autocopy attribute childStrategies::[Strategy] occurs on AST, ASTs;
-autocopy attribute annotationStrategies::[Pair<String Strategy>] occurs on AST, NamedASTs, NamedAST;
+inherited attribute childStrategies::[Strategy] occurs on AST, ASTs;
+inherited attribute annotationStrategies::[Pair<String Strategy>] occurs on AST, NamedASTs, NamedAST;
 synthesized attribute traversalResult<a>::Maybe<a>;
 inherited attribute headStrategy::Strategy occurs on AST;
 inherited attribute tailStrategy::Strategy occurs on AST;

--- a/grammars/silver/rewrite/ASTExpr.sv
+++ b/grammars/silver/rewrite/ASTExpr.sv
@@ -7,6 +7,7 @@ inherited attribute substitutionEnv::[Pair<String AST>];
 synthesized attribute value::AST;
 
 nonterminal ASTExpr with pp, substitutionEnv, value;
+propagate substitutionEnv on ASTExpr excluding letASTExpr, matchASTExpr;
 
 -- AST constructors
 abstract production prodCallASTExpr
@@ -348,6 +349,7 @@ top::ASTExpr ::= a::NamedASTExprs body::ASTExpr
 {
   top.pp = pp"let ${ppImplode(pp", ", a.pps)} in ${body.pp} end";
   top.value = body.value;
+  a.substitutionEnv = top.substitutionEnv;
   body.substitutionEnv =
     map(\ n::NamedAST -> case n of namedAST(n, a) -> pair(n, a) end, a.namedValues) ++ top.substitutionEnv;
 }
@@ -426,8 +428,10 @@ top::ASTExpr ::= e::ASTExpr pattern::ASTPattern res::ASTExpr fail::ASTExpr
 {
   top.pp = pp"case ${e.pp} of ${pattern.pp} -> ${res.pp} | _ -> ${fail.pp} end";
   
+  e.substitutionEnv = top.substitutionEnv;
   pattern.matchWith = e.value;
   res.substitutionEnv = pattern.substitution.fromJust ++ top.substitutionEnv;
+  fail.substitutionEnv = top.substitutionEnv;
   top.value = if pattern.substitution.isJust then res.value else fail.value;
 }
 
@@ -451,6 +455,7 @@ synthesized attribute values::[AST];
 synthesized attribute appValues::[Maybe<AST>];
 
 nonterminal ASTExprs with pps, astExprs, substitutionEnv, values, appValues;
+propagate substitutionEnv on ASTExprs;
 
 abstract production consASTExpr
 top::ASTExprs ::= h::ASTExpr t::ASTExprs
@@ -488,6 +493,7 @@ synthesized attribute namedValues::[NamedAST];
 synthesized attribute namedAppValues::[Pair<String Maybe<AST>>];
 
 nonterminal NamedASTExprs with pps, substitutionEnv, namedValues, namedAppValues;
+propagate substitutionEnv on NamedASTExprs;
 
 abstract production consNamedASTExpr
 top::NamedASTExprs ::= h::NamedASTExpr t::NamedASTExprs
@@ -519,6 +525,7 @@ synthesized attribute namedValue::NamedAST;
 synthesized attribute namedAppValue::Pair<String Maybe<AST>>;
 
 nonterminal NamedASTExpr with pp, substitutionEnv, namedValue, namedAppValue;
+propagate substitutionEnv on NamedASTExpr;
 
 abstract production namedASTExpr
 top::NamedASTExpr ::= n::String v::ASTExpr

--- a/grammars/silver/rewrite/ASTExpr.sv
+++ b/grammars/silver/rewrite/ASTExpr.sv
@@ -3,7 +3,7 @@ grammar silver:rewrite;
 imports silver:langutil;
 imports silver:langutil:pp;
 
-autocopy attribute substitutionEnv::[Pair<String AST>];
+inherited attribute substitutionEnv::[Pair<String AST>];
 synthesized attribute value::AST;
 
 nonterminal ASTExpr with pp, substitutionEnv, value;


### PR DESCRIPTION
# Changes
* Replace all autocopy attributes with inherited attributes, and add propagate declarations as needed.
* Fix some incorrect equations for `isRoot`, which probably should never have been an autocopy in the first place.
* Improve strategy attribute flow types by removing some undesirable autocopy equations.

# Documentation
None needed, really?  This change makes the code more explicit.  
