### PR TITLE
Fix bugs in MDA failure handling

### DIFF
--- a/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
@@ -32,11 +32,12 @@ top::DriverAction ::= spec::MdaSpec  compiledGrammars::EnvTree<Decorated RootSpe
       mkdir(outDir);
       eprintln("Running MDA for " ++ spec.fullName ++ ".");
       ret::Integer <- copper:compileParserBean(specCstAst.copperParser,
-        makeName(spec.sourceGrammar), parserName, true, "", false, "", false);
-      case nativeSerialize(new(specCstAst)) of
-      | left(e) -> error("BUG: specCstAst was not serializable; hopefully this was caused by the most recent change to the copper_mda modification: " ++ e)
-      | right(dump) -> writeBinaryFile(dumpFile, dump)
-      end;
+        makeName(spec.sourceGrammar), parserName, true, "", false, parserName ++ ".html", false);
+      when_(ret == 0,
+        case nativeSerialize(new(specCstAst)) of
+        | left(e) -> error("BUG: specCstAst was not serializable; hopefully this was caused by the most recent change to the copper_mda modification: " ++ e)
+        | right(dump) -> writeBinaryFile(dumpFile, dump)
+        end);
       return ret;
     } else do {
       -- Should this be stderr?


### PR DESCRIPTION
# Changes
* An empty string was being passed as the HTML dump file name, causing a crash when trying to create a dump after a failure
* Only write out the serialized MDA spec when the test passed.  Otherwise a failing test is seen as up to date and is skipped in subsequent builds.

# Documentation
This is a minor bug fix, not really needed.