### PR TITLE
Fix #713, actually delete old generated files

### DIFF
--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -246,7 +246,8 @@ IO<()> ::= silverGen::String keepFiles::[String] r::Decorated RootSpec
         exit(-5);
       });
     });
-    oldSrcFiles::[String] <- listContents(srcPath);
+    srcDirContents::[String] <- listContents(srcPath);
+    oldSrcFiles::[String] <- filterM(isFile, map(append(srcPath, _), srcDirContents));
     deleteFiles(removeAll(keepFiles, oldSrcFiles));
     deleteDirFiles(binPath);
     writeFiles(srcPath, r.genFiles);

--- a/grammars/silver/core/List.sv
+++ b/grammars/silver/core/List.sv
@@ -173,6 +173,29 @@ function filter
 }
 
 @{--
+ - Monadic (actually Applicative) version of filter
+ -
+ - @param f  The filter function
+ - @param lst  The input list to filter
+ - @return  Only those elements of 'lst' that 'f' returns true for, in the
+ -   same order as they appeared in 'lst'
+ -}
+function filterM
+Applicative m =>
+m<[a]> ::= f::(m<Boolean> ::= a) lst::[a]
+{
+  return
+    case lst of
+    | [] -> pure([])
+    | h :: t -> do {
+        cond::Boolean <- f(h);
+        rest::[a] <- filterM(f, t);
+        return if cond then h :: rest else rest;
+      }
+    end;
+}
+
+@{--
  - Partition a list in two
  -
  - @param f  Decision function


### PR DESCRIPTION
# Changes
Fixes #713 - apparently we were trying to delete the short names of old generated files, not their full paths, which wasn't actually deleting anything.  Note that #675 is still an issue, where generated files persist from deleted grammars or grammars not included in the build.  

Also add a monadic version of `filter`, present in Haskell's standard lib.

# Documentation
Added a doc comment for `filterM`.
