### PR TITLE
Allow specifying an arbitrary branch name from which to copy jars in OVERRIDE_JARS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,19 @@ melt.trynode('silver') {
       def source = params.OVERRIDE_JARS
       if (source == 'develop') {
         source = "${silver.SILVER_WORKSPACE}/jars"
+      } else {
+        String branchJob = "/melt-umn/silver/${hudson.Util.rawEncode(source)}"
+        if(melt.doesJobExist(branchJob)) {
+          // Obtain jars from specified branch
+          melt.annotate("Jars overidden from branch.")
+          copyArtifacts(projectName: branchJob, selector: lastCompleted())
+        } else {
+          // Obtain jars from specified location
+          melt.annotate("Jars overridden from path.")
+          sh "mkdir -p jars"
+          sh "cp ${source}/* jars/"
+        }
       }
-      // Obtain jars from specified location
-      sh "mkdir -p jars"
-      sh "cp ${source}/* jars/"
-      melt.annotate("Jars overridden.")
     } else {
       // We start by obtaining normal jars, but we potentially overwrite them:
       // (This is the least annoying way to go about this...)


### PR DESCRIPTION
# Changes
This avoids needing to run `upload-override-jars` when the desired jars are from another branch that has built on Jenkins.

# Documentation
Added a comment to the Jenkinsfile
