### PR TITLE
Misc cleanup in origins translation and runtime

### DIFF
--- a/grammars/silver/compiler/translation/java/core/Origins.sv
+++ b/grammars/silver/compiler/translation/java/core/Origins.sv
@@ -43,7 +43,7 @@ function makeOriginContextRef
 String ::= top::Decorated Expr --need .frame anno
 {
   local rulesTrans :: [String] = (if top.config.tracingOrigins then [locRule] else []) ++ map((.translation), top.originRules);
-  local locRule :: String = s"new silver.core.PtraceNote(new common.StringCatter(\"${substitute("\"", "\\\"", top.location.unparse)}\"))";
+  local locRule :: String = s"new silver.core.PtraceNote(new common.StringCatter(\"${escapeString(top.location.unparse)}\"))";
 
   return if top.config.noOrigins then "null" 
          else if length(rulesTrans)==0 
@@ -74,9 +74,7 @@ function getSpecialCaseNoOrigins
     -- These are forced to be untracked to prevent circularity
     "silver:core:OriginInfo",
     "silver:core:OriginInfoType",
-    "silver:core:OriginNote",
-    -- List is special(TM) because of it's special(TM) quasi-extension translation specialization
-    "silver:core:List"
+    "silver:core:OriginNote"
   ];
   return names;
 }

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -290,6 +290,7 @@ ${makeTyVarDecls(3, namedSig.typerep.freeVariables)}
 """)];
 
   local otImpl :: String = if wantsTracking then s"""
+    @Override
     public ${fnnt} duplicate(common.Node redex, common.ConsCell notes) {
         if (redex == null || ${if top.config.noRedex then "true" else "false"}) {
             return new ${className}(${implode(", ",
@@ -304,6 +305,7 @@ ${makeTyVarDecls(3, namedSig.typerep.freeVariables)}
         }
     }
 
+    @Override
     public ${fnnt} copy(common.Node redex, common.ConsCell redexNotes) {
         Object origin;
         common.ConsCell originNotes;
@@ -329,6 +331,7 @@ ${makeTyVarDecls(3, namedSig.typerep.freeVariables)}
           map(copyAnno, namedSig.namedInputElements))});
     }
 
+    @Override
     public ${fnnt} duplicateForForwarding(common.Node redex, String note) {
         return new ${className}(${implode(", ",
           "new PoriginOriginInfo(common.OriginsUtil.SET_AT_FORWARDING_OIT, this, new common.ConsCell(new silver.core.PoriginDbgNote(new common.StringCatter(note)), common.ConsCell.nil), true)" ::

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -48,9 +48,6 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
                                   | _ -> "null"
                                   end);
 
-  local commaIfKids :: String = if length(namedSig.inputElements)!=0 then "," else "";
-  local commaIfAnnos :: String = if length(namedSig.namedInputElements)!=0 then "," else "";
-  local commaIfContexts :: String = if length(namedSig.contexts)!=0 then "," else "";
   local commaIfAny :: String = if length(namedSig.inputElements)!=0 || length(namedSig.namedInputElements)!=0 || length(namedSig.contexts)!=0 then "," else "";
 
   local contexts::Contexts = foldContexts(namedSig.contexts);
@@ -90,7 +87,7 @@ ${namedSig.childStatic}
     }
 
     public ${className}(final NOriginInfo origin ${commaIfAny} ${namedSig.javaSignature}) {
-        super(${if wantsTracking then "origin"++commaIfAnnos else ""}${implode(", ", map((.annoRefElem), namedSig.namedInputElements))});
+        super(${implode(", ", (if wantsTracking then ["origin"] else []) ++ map((.annoRefElem), namedSig.namedInputElements))});
 ${implode("", map(makeChildAssign, namedSig.inputElements))}
 ${contexts.contextInitTrans}
     }
@@ -151,7 +148,10 @@ ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInh
     public common.Node evalForward(final common.DecoratedNode context) {
         ${if null(body.uniqueSignificantExpression) 
           then s"throw new common.exceptions.SilverInternalError(\"Production ${fName} erroneously claimed to forward\")"
-          else s"return ((common.Node)${head(body.uniqueSignificantExpression).translation}${if wantsTracking && !top.config.noRedex  then s".duplicateForForwarding(context.undecorate(), \"${substitute("\"", "\\\"", hackUnparse(head(body.uniqueSignificantExpression).location))}\")" else ""})"};
+          else s"return ((common.Node)${head(body.uniqueSignificantExpression).translation}${
+            if wantsTracking && !top.config.noRedex
+            then s".duplicateForForwarding(context.undecorate(), \"${escapeString(hackUnparse(head(body.uniqueSignificantExpression).location))}\")"
+            else ""})"};
     }
 
     @Override
@@ -248,7 +248,7 @@ ${body.translation}
         public String getName(){ return "${fName}"; }
         public common.RTTIManager.Nonterminalton<${fnnt}> getNonterminalton(){ return ${fnnt}.nonterminalton; }
 
-        public String getTypeUnparse() { return "${substitute("\"", "\\\"", substitute("\\", "\\\\", ns.unparse))}"; }
+        public String getTypeUnparse() { return "${escapeString(ns.unparse)}"; }
         public int getChildCount() { return ${toString(length(namedSig.inputElements))}; }
         public int getAnnoCount() { return ${toString(length(namedSig.namedInputElements))}; }
 
@@ -290,22 +290,24 @@ ${makeTyVarDecls(3, namedSig.typerep.freeVariables)}
 """)];
 
   local otImpl :: String = if wantsTracking then s"""
-    public ${fnnt} duplicate(Object redex, Object notes) {
+    public ${fnnt} duplicate(common.Node redex, common.ConsCell notes) {
         if (redex == null || ${if top.config.noRedex then "true" else "false"}) {
-            return new ${className}(new PoriginOriginInfo(common.OriginsUtil.SET_AT_NEW_OIT, this, notes, true) ${commaIfKids}
-                ${implode(", ", map(dupChild, namedSig.inputElements))} ${commaIfAnnos} ${implode(", ", map(dupAnno, namedSig.namedInputElements))});
+            return new ${className}(${implode(", ",
+              "new PoriginOriginInfo(common.OriginsUtil.SET_AT_NEW_OIT, this, notes, true)" ::
+              map(dupChild, namedSig.inputElements) ++
+              map(dupAnno, namedSig.namedInputElements))});
         } else {
-            return new ${className}(new PoriginAndRedexOriginInfo(common.OriginsUtil.SET_AT_NEW_OIT, this, notes, redex, notes, true) ${commaIfKids}
-                ${implode(", ", map(dupChild, namedSig.inputElements))} ${commaIfAnnos} ${implode(", ", map(dupAnno, namedSig.namedInputElements))});
+            return new ${className}(${implode(", ",
+              "new PoriginAndRedexOriginInfo(common.OriginsUtil.SET_AT_NEW_OIT, this, notes, redex, notes, true)" ::
+              map(dupChild, namedSig.inputElements) ++
+              map(dupAnno, namedSig.namedInputElements))});
         }
     }
 
-    public ${fnnt} duplicate(common.OriginContext oc) {
-        return this.duplicate(oc.lhs, oc.rulesAsSilverList());
-    }
-
-    public ${fnnt} copy(Object newRedex, Object newRule) {
-        Object origin, originNotes, newlyConstructed;
+    public ${fnnt} copy(common.Node redex, common.ConsCell redexNotes) {
+        Object origin;
+        common.ConsCell originNotes;
+        Boolean newlyConstructed;
         Object roi = this.origin;
         if (roi instanceof PoriginOriginInfo) {
             PoriginOriginInfo oi = (PoriginOriginInfo)roi;
@@ -321,17 +323,17 @@ ${makeTyVarDecls(3, namedSig.typerep.freeVariables)}
             return this;
         }
 
-        if (newRedex instanceof common.DecoratedNode) newRedex = ((common.DecoratedNode)newRedex).undecorate();
-
-        Object redex = ((common.Node)newRedex);
-        Object redexNotes = newRule;
-        return new ${className}(new PoriginAndRedexOriginInfo(common.OriginsUtil.SET_AT_ACCESS_OIT, origin, originNotes, redex, redexNotes, newlyConstructed) ${commaIfKids}
-            ${implode(", ", map(copyChild, namedSig.inputElements))} ${commaIfAnnos} ${implode(", ", map(copyAnno, namedSig.namedInputElements))});
+        return new ${className}(${implode(", ",
+          "new PoriginAndRedexOriginInfo(common.OriginsUtil.SET_AT_ACCESS_OIT, origin, originNotes, redex, redexNotes, newlyConstructed)" ::
+          map(copyChild, namedSig.inputElements) ++
+          map(copyAnno, namedSig.namedInputElements))});
     }
 
-    public ${fnnt} duplicateForForwarding(Object redex, String note) {
-        return new ${className}(new PoriginOriginInfo(common.OriginsUtil.SET_AT_FORWARDING_OIT, this, new common.ConsCell(new silver.core.PoriginDbgNote(new common.StringCatter(note)), common.ConsCell.nil), true) ${commaIfKids}
-            ${implode(", ", map(copyChild, namedSig.inputElements))} ${commaIfAnnos} ${implode(", ", map(copyAnno, namedSig.namedInputElements))});
+    public ${fnnt} duplicateForForwarding(common.Node redex, String note) {
+        return new ${className}(${implode(", ",
+          "new PoriginOriginInfo(common.OriginsUtil.SET_AT_FORWARDING_OIT, this, new common.ConsCell(new silver.core.PoriginDbgNote(new common.StringCatter(note)), common.ConsCell.nil), true)" ::
+          map(copyChild, namedSig.inputElements) ++
+          map(copyAnno, namedSig.namedInputElements))});
     }
 
     """ else "";

--- a/runtime/java/src/common/Tracked.java
+++ b/runtime/java/src/common/Tracked.java
@@ -5,11 +5,13 @@ import silver.core.NOriginInfo;
 public interface Tracked {
 	public abstract NOriginInfo getOrigin();
 
-	public abstract Object duplicate(Object redex, Object rule);
+	public abstract Object duplicate(Node redex, ConsCell notes);
 
-	public abstract Object duplicate(OriginContext oc);
+	public default Object duplicate(OriginContext oc) {
+		return this.duplicate(oc.lhs, oc.rulesAsSilverList());
+	}
 
-	public abstract Object duplicateForForwarding(Object redex, String note);
+	public abstract Object duplicateForForwarding(Node redex, String note);
 
-	public abstract Object copy(Object redex, Object rule);
+	public abstract Object copy(Node redex, ConsCell redexNotes);
 }

--- a/runtime/java/src/common/Tracked.java
+++ b/runtime/java/src/common/Tracked.java
@@ -5,13 +5,13 @@ import silver.core.NOriginInfo;
 public interface Tracked {
 	public abstract NOriginInfo getOrigin();
 
-	public abstract Object duplicate(Node redex, ConsCell notes);
+	public abstract Tracked duplicate(Node redex, ConsCell notes);
 
-	public default Object duplicate(OriginContext oc) {
+	public default Tracked duplicate(OriginContext oc) {
 		return this.duplicate(oc.lhs, oc.rulesAsSilverList());
 	}
 
-	public abstract Object duplicateForForwarding(Node redex, String note);
+	public abstract Tracked duplicateForForwarding(Node redex, String note);
 
-	public abstract Object copy(Node redex, ConsCell redexNotes);
+	public abstract Tracked copy(Node redex, ConsCell redexNotes);
 }


### PR DESCRIPTION
# Changes
* Make the types of the `Tracked` methods more specific
* Move implementation of `duplicate(OriginContext)` to the `Tracked` interface
* Better use of `implode` in translation
* Other misc cleanup

# Documentation
I updated some outdated documentation on the website.