### PR TITLE
Remove ableJ14 from the Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,7 +120,7 @@ melt.trynode('silver') {
 
   stage("Integration") {
     // Projects with 'develop' as main branch, we'll try to build specific branch names if they exist
-    def github_projects = ["/melt-umn/ableC", "/melt-umn/Oberon0", "/melt-umn/ableJ14", "/melt-umn/meta-ocaml-lite",
+    def github_projects = ["/melt-umn/ableC", "/melt-umn/Oberon0", "/melt-umn/meta-ocaml-lite",
                            "/melt-umn/lambda-calculus", "/melt-umn/rewriting-regex-matching", "/melt-umn/rewriting-optimization-demo",
                            "/internal/ring", "/melt-umn/caml-light"]
     // Specific other jobs to build


### PR DESCRIPTION
# Changes
AbleJ14 is no longer supported, since it includes `autocopy` and Silver does not, so this removes it from the Jenkins build process.

# Documentation
This does not require documentation in Silver as it only changes Jenkins.  The README in the ableJ repository notes it is legacy code and no longer compiles under the latest version of Silver.