### PR TITLE
Renaming of partially decorated references to unique references

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -19,7 +19,7 @@ top::Expr ::=
 }
 
 aspect production productionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   contexts.contextLoc = q.location;
   contexts.contextSource = "the use of " ++ q.name;
@@ -28,7 +28,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production functionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   contexts.contextLoc = q.location;
   contexts.contextSource = "the use of " ++ q.name;
@@ -37,7 +37,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production globalValueReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   contexts.contextLoc = q.location;
   contexts.contextSource = "the use of " ++ q.name;
@@ -46,7 +46,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production classMemberReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   instHead.contextLoc = q.location;
   instHead.contextSource = "the use of " ++ q.name;
@@ -80,7 +80,7 @@ top::Expr ::= e::Expr '.' q::QNameAttrOccur
 }
 
 aspect production undecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   -- We might have gotten here via a 'ntOrDec' type. So let's make certain we're UNdecorated,
   -- ensuring that type's specialization, otherwise we could end up in trouble!
@@ -98,7 +98,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production accessBouncer
-top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= target::(Expr ::= Decorated! Expr  Decorated! QNameAttrOccur  Location) e::Expr  q::Decorated! QNameAttrOccur
 {
   propagate upSubst, downSubst, finalSubst;
 }
@@ -118,7 +118,7 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production decoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   -- We might have gotten here via a 'ntOrDec' type. So let's make certain we're decorated,
   -- ensuring that type's specialization, otherwise we could end up in trouble!
@@ -362,7 +362,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
   errCheck1 = checkDecorable(top.env, e.typerep);
   top.errors <-
        if errCheck1.typeerror
-       then [err(top.location, "Operand to decorate must be a nonterminal or partially decorated type.  Instead it is of type " ++ errCheck1.leftpp)]
+       then [err(top.location, "Operand to decorate must be a nonterminal or unique reference type.  Instead it is of type " ++ errCheck1.leftpp)]
        else [];
 }
 
@@ -373,10 +373,10 @@ top::Expr ::= '@' e::Expr
 
   thread downSubst, upSubst on top, e, errCheck1, top;
 
-  errCheck1 = check(e.typerep, partiallyDecoratedType(freshType(), inhSetType([])));
+  errCheck1 = check(e.typerep, uniqueDecoratedType(freshType(), inhSetType([])));
   top.errors <-
        if errCheck1.typeerror
-       then [err(top.location, "Operand to @ must be partially decorated with no attributes.  Instead it is of type " ++ errCheck1.leftpp)]
+       then [err(top.location, "Operand to @ must be a unique reference with no inherited attributes.  Instead it is of type " ++ errCheck1.leftpp)]
        else [];
 }
 

--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
@@ -117,7 +117,7 @@ top::ProductionStmt ::= 'return' e::Expr ';'
 }
 
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
@@ -131,7 +131,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 }
 
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 
@@ -145,23 +145,23 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 }
 
 aspect production errorAttributeDef
-top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= msg::[Message] dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   propagate downSubst, upSubst, finalSubst;
 }
 
 aspect production childDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   top.errors <- if isDecorable(top.typerep, top.env) then []
-                else [err(top.location, s"Inherited attributes can only be defined on (undecorated) nonterminal and partially decorated types, not ${prettyType(top.typerep)}.")];
+                else [err(top.location, s"Inherited attributes can only be defined on (undecorated) nonterminal and unique decorated types, not ${prettyType(top.typerep)}.")];
 }
 
 aspect production localDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   top.errors <- if isDecorable(top.typerep, top.env) then []
-                else [err(top.location, s"Inherited attributes can only be defined on (undecorated) nonterminal and partially decorated types, not ${prettyType(top.typerep)}.")];
+                else [err(top.location, s"Inherited attributes can only be defined on (undecorated) nonterminal and unique decorated types, not ${prettyType(top.typerep)}.")];
 }
 
 aspect production localAttributeDcl
@@ -177,7 +177,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
 }
 
 aspect production localValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
 

--- a/grammars/silver/compiler/analysis/uniqueness/Expr.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Expr.sv
@@ -15,85 +15,85 @@ top::Expr ::= msg::[Message]
 }
 
 aspect production errorReference
-top::Expr ::= msg::[Message]  q::PartiallyDecorated QName
+top::Expr ::= msg::[Message]  q::Decorated! QName
 {
   top.isUnique = false;
 }
 
 aspect production childReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.isUnique = finalType(top).isUnique;
 }
 
 aspect production localReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.isUnique = finalType(top).isUnique;
 }
 
 aspect production lhsReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.isUnique = false;
 }
 
 aspect production forwardReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.isUnique = false;
 }
 
 aspect production productionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.isUnique = false;
 }
 
 aspect production functionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.isUnique = false;
 }
 
 aspect production classMemberReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.isUnique = false;
 }
 
 aspect production globalValueReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.isUnique = false;
 }
 
 aspect production errorApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs annos::Decorated! AnnoAppExprs
 {
   top.isUnique = false;
 }
 
 aspect production functionInvocation
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs annos::Decorated! AnnoAppExprs
 {
   top.isUnique = e.isUnique || es.isUnique;
 }
 
 aspect production partialApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs annos::Decorated! AnnoAppExprs
 {
   top.isUnique = e.isUnique || es.isUnique;
 }
 
 aspect production errorAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.isUnique = false;
 }
 
 aspect production errorDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.isUnique = false;
 }
@@ -105,25 +105,25 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.isUnique = false;
 }
 
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.isUnique = false;
 }
 
 aspect production terminalAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.isUnique = false;
 }
 
 aspect production annoAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.isUnique = false;
 }
@@ -283,7 +283,7 @@ top::AppExprs ::=
 }
 
 aspect production exprRef
-top::Expr ::= e::PartiallyDecorated Expr
+top::Expr ::= e::Decorated! Expr
 {
   top.isUnique = e.isUnique;
 }

--- a/grammars/silver/compiler/analysis/uniqueness/Type.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Type.sv
@@ -5,6 +5,6 @@ imports silver:compiler:definition:type;
 attribute isUnique occurs on Type;
 
 aspect isUnique on Type of
-| partiallyDecoratedType(_, _) -> true
+| uniqueDecoratedType(_, _) -> true
 | _ -> false
 end;

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -62,9 +62,9 @@ Boolean ::= f::([FlowDef] ::= String)  attr::String
 }
 
 {--
- - Given a name of a child, return whether it has a fully decorated nonterminal
+ - Given a name of a child, return whether it has a normal decorated nonterminal
  - type (covered by the more specific checks on accesses from references) or a
- - partially decorated nonterminal type decorated with the attr.
+ - unique decorated nonterminal type decorated with the attr.
  - True if nonsensicle.
  -}
 function sigAttrViaReference
@@ -75,9 +75,9 @@ Boolean ::= sigName::String  attrName::String  ns::NamedSignature  e::Decorated 
 }
 
 {--
- - Given a name of a local, return whether it has a fully decorated nonterminal
+ - Given a name of a local, return whether it has a normal decorated nonterminal
  - type (covered by the more specific checks on accesses from references) or a
- - partially decorated nonterminal type decorated with the attr.
+ - unique decorated nonterminal type decorated with the attr.
  - True if nonsensicle.
  -}
 function localAttrViaReference
@@ -241,7 +241,7 @@ top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
 }
 
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
@@ -261,7 +261,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 }
 
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local transitiveDeps :: [FlowVertex] = 
     expandGraph(e.flowDeps, top.frame.flowGraph);
@@ -277,7 +277,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 
 ----- WARNING TODO BEGIN MASSIVE COPY & PASTE SESSION
 aspect production synBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
@@ -296,7 +296,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     else [];
 }
 aspect production synAppendColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
@@ -315,7 +315,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     else [];
 }
 aspect production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local transitiveDeps :: [FlowVertex] =
     expandGraph(e.flowDeps, top.frame.flowGraph);
@@ -327,7 +327,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     else [];
 }
 aspect production inhAppendColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local transitiveDeps :: [FlowVertex] = 
     expandGraph(e.flowDeps, top.frame.flowGraph);
@@ -408,7 +408,7 @@ top::ProductionStmt ::= 'undecorates' 'to' e::Expr ';'
 }
 
 aspect production localValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   local transitiveDeps :: [FlowVertex] =
     expandGraph(e.flowDeps, top.frame.flowGraph);
@@ -448,7 +448,7 @@ top::ProductionStmt ::= 'attachNote' e::Expr ';'
 -- Partially skipping `appendCollectionValueDef`: it likewise forwards
 -- But we do have a special "exceeds check" to do here:
 aspect production appendCollectionValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   local productionFlowGraph :: ProductionGraph = top.frame.flowGraph;
   local transitiveDeps :: [FlowVertex] = expandGraph(e.flowDeps, productionFlowGraph);
@@ -485,7 +485,7 @@ Step 2: Let's go check on expressions. This has two purposes:
 -}
 
 aspect production childReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -496,7 +496,7 @@ top::Expr ::= q::PartiallyDecorated QName
     else [];
 }
 aspect production lhsReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -506,7 +506,7 @@ top::Expr ::= q::PartiallyDecorated QName
     else [];
 }
 aspect production localReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -517,7 +517,7 @@ top::Expr ::= q::PartiallyDecorated QName
     else [];
 }
 aspect production forwardReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
@@ -534,7 +534,7 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   -- oh no again
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
@@ -624,7 +624,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   -- In this case, ONLY check for references.
   -- The transitive deps error will be less difficult to figure out when there's

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
@@ -25,7 +25,7 @@ Either<String  Decorated CmdArgs> ::= args::[String]
 }
 
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur e::Expr
 {
   local exportedBy :: [String] = 
     if top.frame.hasPartialSignature
@@ -48,7 +48,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 }
 
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local exportedBy :: [String] = 
     case dl of
@@ -71,7 +71,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     then [mwdaWrn(top.config, top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName)]
     else [];
 
-  -- Check that if there is a partially decorated reference taken to this decoration site,
+  -- Check that if there is a unique reference taken to this decoration site,
   -- we aren't defining an equation that isn't in that reference type (Decorated Foo with only {...}).
   top.errors <-
     if dl.found && attr.found
@@ -79,7 +79,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     then flatMap(
       \ refSite::(String, Location, [String]) ->
         if contains(attr.attrDcl.fullName, refSite.3) then []
-        else [mwdaWrn(top.config, top.location, "Attribute " ++ attr.name ++ " with an equation on " ++ dl.name ++ " is not in the partially decorated reference taken at " ++ refSite.1 ++ ":" ++ refSite.2.unparse ++ " with only " ++ implode(", ", refSite.3))],
+        else [mwdaWrn(top.config, top.location, "Attribute " ++ attr.name ++ " with an equation on " ++ dl.name ++ " is not in the unique reference taken at " ++ refSite.1 ++ ":" ++ refSite.2.unparse ++ " with only " ++ implode(", ", refSite.3))],
       case dl of
       | childDefLHS(q) -> getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv)
       | localDefLHS(q) -> getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv)
@@ -92,7 +92,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 --- FROM COLLECTIONS
 
 aspect production synBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local exportedBy :: [String] = 
     if top.frame.hasPartialSignature
@@ -114,7 +114,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     else [];
 }
 aspect production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local exportedBy :: [String] = 
     case dl of
@@ -137,7 +137,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     then [mwdaWrn(top.config, top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName)]
     else [];
 
-  -- Check that if there is a partially decorated reference taken to this decoration site,
+  -- Check that if there is a unique reference taken to this decoration site,
   -- we aren't defining an equation that isn't in that reference type (Decorated Foo with only {...}).
   top.errors <-
     if dl.found && attr.found
@@ -145,7 +145,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     then flatMap(
       \ refSite::(String, Location, [String]) ->
         if contains(attr.attrDcl.fullName, refSite.3) then []
-        else [mwdaWrn(top.config, top.location, "Attribute " ++ attr.name ++ " with an equation for " ++ dl.name ++ " is not in the partially decorated reference taken at " ++ refSite.1 ++ ":" ++ refSite.2.unparse ++ " with only " ++ implode(", ", refSite.3))],
+        else [mwdaWrn(top.config, top.location, "Attribute " ++ attr.name ++ " with an equation for " ++ dl.name ++ " is not in the unique reference taken at " ++ refSite.1 ++ ":" ++ refSite.2.unparse ++ " with only " ++ implode(", ", refSite.3))],
       case dl of
       | childDefLHS(q) -> getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv)
       | localDefLHS(q) -> getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv)
@@ -166,92 +166,92 @@ top::ExprLHSExpr ::= attr::QNameAttrOccur
 
 -- These checks live here for now, since they are related to duplicate equations:
 aspect production childReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
-  local partialRefs::[(String, Location, [String])] = getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv);
+  local uniqueRefs::[(String, Location, [String])] = getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv);
   top.errors <-
     case finalTy, refSet of
-    | partiallyDecoratedType(_, _), just(inhs) when top.config.warnEqdef && q.lookupValue.found ->
+    | uniqueDecoratedType(_, _), just(inhs) when top.config.warnEqdef && q.lookupValue.found ->
       case getMaxRefSet(q.lookupValue.typeScheme.typerep, top.env) of
       | just(origInhs) ->
         if all(map(contains(_, inhs), origInhs)) then []
-        else [mwdaWrn(top.config, top.location, s"Partially decorated reference of type ${prettyType(finalTy)} does not contain all attributes in the reference set of ${q.name}'s type ${prettyType(q.lookupValue.typeScheme.monoType)}")]
-      | nothing() -> [mwdaWrn(top.config, top.location, s"Cannot take a partially decorated reference to ${q.name} of type ${prettyType(q.lookupValue.typeScheme.monoType)}, as the reference set is not bounded")]
+        else [mwdaWrn(top.config, top.location, s"Unique reference of type ${prettyType(finalTy)} does not contain all attributes in the reference set of ${q.name}'s type ${prettyType(q.lookupValue.typeScheme.monoType)}")]
+      | nothing() -> [mwdaWrn(top.config, top.location, s"Cannot take a unique reference to ${q.name} of type ${prettyType(q.lookupValue.typeScheme.monoType)}, as the reference set is not bounded")]
       end ++
       -- Check that we are exported by the decoration site.
       if q.lookupValue.found && top.config.warnEqdef
       && !isExportedBy(top.grammarName, [q.lookupValue.dcl.sourceGrammar], top.compiledGrammars)
-      then [mwdaWrn(top.config, top.location, s"Orphaned partially decorated reference to ${q.lookupValue.fullName} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
+      then [mwdaWrn(top.config, top.location, s"Orphaned unique reference to ${q.lookupValue.fullName} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
       -- Check that there is at most one partial reference taken to this decoration site.
       -- TODO: This check isn't actually sufficent for well-definedness (e.g. wrapping this ref in
       -- a term and decorating that more than once), need some sort of "linearity analysis".
-      -- TODO: This check is overly conservative, it flags partially decorated references in mutually exclusive positions:
-      {-else if length(partialRefs) > 1
-      then [mwdaWrn(top.config, top.location, s"Multiple partially decorated references taken to ${q.name} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]-}
+      -- TODO: This check is overly conservative, it flags unique references in mutually exclusive positions:
+      {-else if length(uniqueRefs) > 1
+      then [mwdaWrn(top.config, top.location, s"Multiple unique references taken to ${q.name} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]-}
       else []
     | _, _ -> []
     end;
 }
 aspect production localReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
-  local partialRefs::[(String, Location, [String])] = getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv);
+  local uniqueRefs::[(String, Location, [String])] = getPartialRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv);
   top.errors <-
     case finalTy, refSet of
-    | partiallyDecoratedType(_, _), just(inhs) when top.config.warnEqdef && q.lookupValue.found ->
+    | uniqueDecoratedType(_, _), just(inhs) when top.config.warnEqdef && q.lookupValue.found ->
       case getMaxRefSet(q.lookupValue.typeScheme.typerep, top.env) of
       | just(origInhs) ->
         if all(map(contains(_, inhs), origInhs)) then []
-        else [mwdaWrn(top.config, top.location, s"Partially decorated reference of type ${prettyType(finalTy)} does not contain all attributes in the reference set of ${q.name}'s type ${prettyType(q.lookupValue.typeScheme.monoType)}")]
-      | nothing() -> [mwdaWrn(top.config, top.location, s"Cannot take a partially decorated reference to ${q.name} of type ${prettyType(q.lookupValue.typeScheme.monoType)}, as the reference set is not bounded")]
+        else [mwdaWrn(top.config, top.location, s"Unique reference of type ${prettyType(finalTy)} does not contain all attributes in the reference set of ${q.name}'s type ${prettyType(q.lookupValue.typeScheme.monoType)}")]
+      | nothing() -> [mwdaWrn(top.config, top.location, s"Cannot take a unique reference to ${q.name} of type ${prettyType(q.lookupValue.typeScheme.monoType)}, as the reference set is not bounded")]
       end ++
       -- Check that we are exported by the decoration site/
       if q.lookupValue.found && top.config.warnEqdef
       && !isExportedBy(top.grammarName, [q.lookupValue.dcl.sourceGrammar], top.compiledGrammars)
-      then [mwdaWrn(top.config, top.location, s"Orphaned partially decorated reference to ${q.lookupValue.fullName} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
+      then [mwdaWrn(top.config, top.location, s"Orphaned unique reference to ${q.lookupValue.fullName} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
       -- Check that there is at most one partial reference taken to this decoration site.
       -- TODO: This check isn't actually sufficent for well-definedness (e.g. wrapping this ref in
       -- a term and decorating that more than once), need some sort of "linearity analysis".
-      -- TODO: This check is overly conservative, it flags partially decorated references in mutually exclusive positions:
-      {-else if length(partialRefs) > 1
-      then [mwdaWrn(top.config, top.location, s"Multiple partially decorated references taken to ${q.name} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]-}
+      -- TODO: This check is overly conservative, it flags unique references in mutually exclusive positions:
+      {-else if length(uniqueRefs) > 1
+      then [mwdaWrn(top.config, top.location, s"Multiple unique references taken to ${q.name} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]-}
       else []
     | _, _ -> []
     end;
 }
 aspect production lhsReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
     case finalTy of
-    | partiallyDecoratedType(_, _) when top.config.warnEqdef ->
-      [mwdaWrn(top.config, top.location, s"Cannot take a partially decorated reference of type ${prettyType(finalTy)} to ${q.name}.")]
+    | uniqueDecoratedType(_, _) when top.config.warnEqdef ->
+      [mwdaWrn(top.config, top.location, s"Cannot take a unique reference of type ${prettyType(finalTy)} to ${q.name}.")]
     | _ -> []
     end;
 }
 aspect production forwardReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
     case finalTy of
-    | partiallyDecoratedType(_, _) when top.config.warnEqdef ->
-      [mwdaWrn(top.config, top.location, s"Cannot take a partially decorated reference of type ${prettyType(finalTy)} to the forward tree.")]
+    | uniqueDecoratedType(_, _) when top.config.warnEqdef ->
+      [mwdaWrn(top.config, top.location, s"Cannot take a unique reference of type ${prettyType(finalTy)} to the forward tree.")]
     | _ -> []
     end;
 }
 aspect production lexicalLocalReference
-top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::Decorated! QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.errors <-
     case finalTy, q.lookupValue.typeScheme.monoType of
-    | partiallyDecoratedType(_, _), partiallyDecoratedType(_, _) -> []  -- TODO: Need linearity analysis...
-    | partiallyDecoratedType(_, _), _ when top.config.warnEqdef ->
-      [mwdaWrn(top.config, top.location, s"${q.name} was not bound as a partially decorated reference, but here it is used with type ${prettyType(finalTy)}.")]
+    | uniqueDecoratedType(_, _), uniqueDecoratedType(_, _) -> []  -- TODO: Need linearity analysis...
+    | uniqueDecoratedType(_, _), _ when top.config.warnEqdef ->
+      [mwdaWrn(top.config, top.location, s"${q.name} was not bound as a unique reference, but here it is used with type ${prettyType(finalTy)}.")]
     | _, _ -> []
     end;
 }

--- a/grammars/silver/compiler/definition/core/DclInfo.sv
+++ b/grammars/silver/compiler/definition/core/DclInfo.sv
@@ -5,36 +5,36 @@ import silver:compiler:modification:copper only terminalIdReference;
 {--
  - The production a variable reference should forward to for this type of value
  -}
-synthesized attribute refDispatcher :: (Expr ::= PartiallyDecorated QName  Location) occurs on ValueDclInfo;
+synthesized attribute refDispatcher :: (Expr ::= Decorated! QName  Location) occurs on ValueDclInfo;
 {--
  - The production an "assignment" should forward to for this type of value
  -}
-synthesized attribute defDispatcher :: (ProductionStmt ::= PartiallyDecorated QName  Expr  Location) occurs on ValueDclInfo;
+synthesized attribute defDispatcher :: (ProductionStmt ::= Decorated! QName  Expr  Location) occurs on ValueDclInfo;
 {--
  - The production an "equation" left hand side should forward to for this type of value (i.e. the 'x' in 'x.a = e')
  -}
-synthesized attribute defLHSDispatcher :: (DefLHS ::= PartiallyDecorated QName  Location) occurs on ValueDclInfo;
+synthesized attribute defLHSDispatcher :: (DefLHS ::= Decorated! QName  Location) occurs on ValueDclInfo;
 
 {--
  - The handler for 'x.a' for 'a', given that 'x' is DECORATED.
  - @see accessDispather in TypeExp.sv, for the first step in that process...
  - @see decoratedAccessHandler production for where this is used
  -}
-synthesized attribute decoratedAccessHandler :: (Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) occurs on AttributeDclInfo;
+synthesized attribute decoratedAccessHandler :: (Expr ::= Decorated! Expr  Decorated! QNameAttrOccur  Location) occurs on AttributeDclInfo;
 {--
  - The handler for 'x.a' for 'a', given that 'x' is UNdecorated.
  - @see accessDispather in TypeExp.sv, for the first step in that process...
  - @see undecoratedAccessHandler production for where this is used
  -}
-synthesized attribute undecoratedAccessHandler :: (Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) occurs on AttributeDclInfo;
+synthesized attribute undecoratedAccessHandler :: (Expr ::= Decorated! Expr  Decorated! QNameAttrOccur  Location) occurs on AttributeDclInfo;
 {--
  - The production an "equation" should forward to for this type of attribute (i.e. the 'a' in 'x.a = e')
  -}
-synthesized attribute attrDefDispatcher :: (ProductionStmt ::= PartiallyDecorated DefLHS  PartiallyDecorated QNameAttrOccur  Expr  Location) occurs on AttributeDclInfo;
+synthesized attribute attrDefDispatcher :: (ProductionStmt ::= Decorated! DefLHS  Decorated! QNameAttrOccur  Expr  Location) occurs on AttributeDclInfo;
 {--
  - The production an "occurs on" decl should forward to for this type of attribute (for extension use, defaultAttributionDcl for all syn/inh attrs.)
  -}
-synthesized attribute attributionDispatcher :: (AGDcl ::= PartiallyDecorated QName  BracketedOptTypeExprs  QName  BracketedOptTypeExprs  Location) occurs on AttributeDclInfo;
+synthesized attribute attributionDispatcher :: (AGDcl ::= Decorated! QName  BracketedOptTypeExprs  QName  BracketedOptTypeExprs  Location) occurs on AttributeDclInfo;
 
 -- -- non-interface values
 aspect production childDcl
@@ -131,7 +131,7 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
   top.decoratedAccessHandler = accessBounceUndecorate(annoAccessHandler(_, _, location=_), _, _, location=_);
   top.undecoratedAccessHandler = annoAccessHandler(_, _, location=_);
   top.attrDefDispatcher =
-    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, "Annotations are not defined as equations within productions")], dl, attr, e, location=l);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
 }

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -97,7 +97,7 @@ top::Expr ::= q::QName
 }
 
 abstract production errorReference
-top::Expr ::= msg::[Message]  q::PartiallyDecorated QName
+top::Expr ::= msg::[Message]  q::Decorated! QName
 {
   undecorates to errorExpr(msg, location=top.location);
   top.unparse = q.unparse;
@@ -109,7 +109,7 @@ top::Expr ::= msg::[Message]  q::PartiallyDecorated QName
 
 -- TODO: We should separate this out, even, to be "nonterminal/decorable" and "as-is"
 abstract production childReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -121,7 +121,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production lhsReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -132,7 +132,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production localReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -144,7 +144,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production forwardReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -158,7 +158,7 @@ top::Expr ::= q::PartiallyDecorated QName
 -- Later on, we do *not* distinguish for application.
 
 abstract production productionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -177,7 +177,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production functionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -196,7 +196,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production classMemberReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -228,7 +228,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production globalValueReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -314,7 +314,7 @@ top::Expr ::= e::Expr '(' ')'
 }
 
 abstract production errorApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   undecorates to application(e, '(', es, ',', anns, ')', location=top.location);
   top.unparse = e.unparse ++ "(" ++ es.unparse ++ "," ++ anns.unparse ++ ")";
@@ -332,7 +332,7 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::P
 -- We don't distinguish anymore at this point. A production reference
 -- becomes a function, effectively.
 abstract production functionApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   undecorates to application(e, '(', es, ',', anns, ')', location=top.location);
   top.unparse = e.unparse ++ "(" ++ es.unparse ++ "," ++ anns.unparse ++ ")";
@@ -345,7 +345,7 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::P
 }
 
 abstract production functionInvocation
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   undecorates to application(e, '(', es, ',', anns, ')', location=top.location);
   top.unparse = e.unparse ++ "(" ++ es.unparse ++ "," ++ anns.unparse ++ ")";
@@ -356,7 +356,7 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::P
 }
 
 abstract production partialApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   undecorates to application(e, '(', es, ',', anns, ')', location=top.location);
   top.unparse = e.unparse ++ "(" ++ es.unparse ++ "," ++ anns.unparse ++ ")";
@@ -413,7 +413,7 @@ top::Expr ::= e::Expr '.' q::QNameAttrOccur
 }
 
 abstract production errorAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   top.unparse = e.unparse ++ "." ++ q.unparse;
@@ -429,7 +429,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 abstract production annoAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   top.unparse = e.unparse ++ "." ++ q.unparse;
@@ -441,7 +441,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 abstract production terminalAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   top.unparse = e.unparse ++ "." ++ q.unparse;
@@ -466,7 +466,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 abstract production undecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   top.unparse = e.unparse ++ "." ++ q.unparse;
@@ -483,7 +483,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
  - This production is intended to permit that.
  -}
 abstract production accessBouncer
-top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= target::(Expr ::= Decorated! Expr  Decorated! QNameAttrOccur  Location) e::Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   top.unparse = e.unparse ++ "." ++ q.unparse;
@@ -494,21 +494,21 @@ top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNam
   forwards to target(e, q, top.location);
 }
 abstract production accessBounceDecorate
-top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= target::(Expr ::= Decorated! Expr  Decorated! QNameAttrOccur  Location) e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   forwards to accessBouncer(target, decorateExprWithEmpty('decorate', exprRef(e, location=top.location), 'with', '{', '}', location=top.location), q, location=top.location);
 }
 -- Note that this performs the access on the term that was originally decorated, rather than properly undecorating.
 abstract production accessBounceUndecorate
-top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= target::(Expr ::= Decorated! Expr  Decorated! QNameAttrOccur  Location) e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   forwards to accessBouncer(target, mkStrFunctionInvocation(top.location, "silver:core:getTermThatWasDecorated", [exprRef(e, location=top.location)]), q, location=top.location);
 }
 
 abstract production decoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   top.unparse = e.unparse ++ "." ++ q.unparse;
@@ -523,7 +523,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 abstract production synDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   top.unparse = e.unparse ++ "." ++ q.unparse;
@@ -532,7 +532,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 abstract production inhDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   top.unparse = e.unparse ++ "." ++ q.unparse;
@@ -542,7 +542,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 
 -- TODO: change name. really "unknownDclAccessHandler"
 abstract production errorDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);
   top.unparse = e.unparse ++ "." ++ q.unparse;
@@ -567,7 +567,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
   production eType::Type = performSubstitution(e.typerep, inh.downSubst);  -- Specialize e.typerep
   production ntType::Type = if eType.isDecorated then eType.decoratedType else eType;
 
-  -- TODO: This _could_ be partiallyDecoratedType, but we use decorate in a ton of places where we expect a decoratedType
+  -- TODO: This _could_ be uniqueDecoratedType, but we use decorate in a ton of places where we expect a decoratedType
   top.typerep = decoratedType(ntType, inhSetType(sort(nub(inh.suppliedInhs ++ eType.inhSetMembers))));
   e.isRoot = false;
   
@@ -1244,7 +1244,7 @@ AnnoExpr ::= p::Pair<String Expr>
  - references to those children.
  -}
 abstract production exprRef
-top::Expr ::= e::PartiallyDecorated Expr
+top::Expr ::= e::Decorated! Expr
 {
   undecorates to e;
 

--- a/grammars/silver/compiler/definition/core/OccursDcl.sv
+++ b/grammars/silver/compiler/definition/core/OccursDcl.sv
@@ -1,7 +1,7 @@
 grammar silver:compiler:definition:core;
 
 abstract production defaultAttributionDcl
-top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   undecorates to attributionDcl('attribute', at, attl, 'occurs', 'on', nt, nttl, ';', location=top.location); 
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
@@ -127,7 +127,7 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
 }
 
 abstract production errorAttributionDcl
-top::AGDcl ::= msg::[Message] at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= msg::[Message] at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   undecorates to errorAGDcl(msg, location=top.location); 
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -304,7 +304,7 @@ top::ProductionStmt ::= dl::DefLHS '.' attr::QNameAttrOccur '=' e::Expr ';'
 {- This is a helper that exist primarily to decorate 'e' and add its error messages to the list.
    Invariant: msg should not be null! -}
 abstract production errorAttributeDef
-top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= msg::[Message] dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   undecorates to errorProductionStmt(msg, location=top.location);
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
@@ -315,7 +315,7 @@ top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::Part
 }
 
 abstract production synthesizedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   undecorates to attributeDef(dl, '.', attr, '=', e, ';', location=top.location);
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
@@ -324,7 +324,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 }
 
 abstract production inheritedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   undecorates to attributeDef(dl, '.', attr, '=', e, ';', location=top.location);
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
@@ -349,7 +349,7 @@ top::DefLHS ::= q::QName
 }
 
 abstract production errorDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   undecorates to concreteDefLHS(q, location=top.location);
   top.name = q.name;
@@ -369,7 +369,7 @@ top::DefLHS ::= q::'forward'
 }
 
 abstract production childDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   undecorates to concreteDefLHS(q, location=top.location);
   top.name = q.name;
@@ -386,7 +386,7 @@ top::DefLHS ::= q::PartiallyDecorated QName
 }
 
 abstract production lhsDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   undecorates to concreteDefLHS(q, location=top.location);
   top.name = q.name;
@@ -403,7 +403,7 @@ top::DefLHS ::= q::PartiallyDecorated QName
 }
 
 abstract production localDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   undecorates to concreteDefLHS(q, location=top.location);
   top.name = q.name;
@@ -420,7 +420,7 @@ top::DefLHS ::= q::PartiallyDecorated QName
 }
 
 abstract production forwardDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   undecorates to concreteDefLHS(q, location=top.location);
   top.name = q.name;
@@ -456,7 +456,7 @@ top::ProductionStmt ::= val::QName '=' e::Expr ';'
 }
 
 abstract production errorValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   undecorates to valueEq(val, '=', e, ';', location=top.location);
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
@@ -469,7 +469,7 @@ top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 }
 
 abstract production localValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   undecorates to valueEq(val, '=', e, ';', location=top.location);
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";

--- a/grammars/silver/compiler/definition/core/Type.sv
+++ b/grammars/silver/compiler/definition/core/Type.sv
@@ -1,10 +1,10 @@
 grammar silver:compiler:definition:core;
 
 -- LHS type gives this to 'application' for "foo(...)" calls.
-synthesized attribute applicationDispatcher :: (Expr ::= PartiallyDecorated Expr  PartiallyDecorated AppExprs  PartiallyDecorated AnnoAppExprs  Location);
+synthesized attribute applicationDispatcher :: (Expr ::= Decorated! Expr  Decorated! AppExprs  Decorated! AnnoAppExprs  Location);
 -- LHS type gives this to 'access' for "foo.some" accesses.
 -- (See DclInfo for the next step)
-synthesized attribute accessHandler :: (Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location);
+synthesized attribute accessHandler :: (Expr ::= Decorated! Expr  Decorated! QNameAttrOccur  Location);
 
 -- Used for poor man's type classes
 -- TODO: Finish removing these and replace with real type classes
@@ -71,7 +71,7 @@ top::Type ::= te::Type _
   top.accessHandler = decoratedAccessHandler(_, _, location=_);
 }
 
-aspect production partiallyDecoratedType
+aspect production uniqueDecoratedType
 top::Type ::= te::Type _
 {
   top.accessHandler = decoratedAccessHandler(_, _, location=_);

--- a/grammars/silver/compiler/definition/env/Context.sv
+++ b/grammars/silver/compiler/definition/env/Context.sv
@@ -262,7 +262,7 @@ Boolean ::= a::Type b::Type
       (isMoreSpecific(c1, c2) || isMoreSpecific(a1, a2)) && !(isMoreSpecific(c2, c1) || isMoreSpecific(a2, a1))
     | decoratedType(t1, i1), decoratedType(t2, i2) ->
       (isMoreSpecific(t1, t2) || isMoreSpecific(i1, i2)) && !(isMoreSpecific(t2, t1) || isMoreSpecific(i2, i1))
-    | partiallyDecoratedType(t1, i1), partiallyDecoratedType(t2, i2) ->
+    | uniqueDecoratedType(t1, i1), uniqueDecoratedType(t2, i2) ->
       (isMoreSpecific(t1, t2) || isMoreSpecific(i1, i2)) && !(isMoreSpecific(t2, t1) || isMoreSpecific(i2, i1))
     | _, _ -> false
     end;

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -225,7 +225,7 @@ Boolean ::= t::Type e::Decorated Env
     case t of
     | skolemType(_) -> !null(searchEnvTree(t.typeName, e.occursTree))
     | varType(_) -> !null(searchEnvTree(t.typeName, e.occursTree))  -- Can happen when pattern matching on a prod with occurs contexts
-    | partiallyDecoratedType(nt, _) -> isDecorable(nt, e)
+    | uniqueDecoratedType(nt, _) -> isDecorable(nt, e)
     | _ -> t.isNonterminal
     end;
 }
@@ -324,7 +324,7 @@ function getMinRefSet
   return
     case t of
     | decoratedType(_, i) -> getMinInhSetMembers([], i, e).fst
-    | partiallyDecoratedType(_, i) -> getMinInhSetMembers([], i, e).fst
+    | uniqueDecoratedType(_, i) -> getMinInhSetMembers([], i, e).fst
     | _ -> []
     end;
 }
@@ -359,7 +359,7 @@ Maybe<[String]> ::= t::Type e::Decorated Env
   return
     case t of
     | decoratedType(_, i) -> getMaxInhSetMembers([], i, e).fst
-    | partiallyDecoratedType(_, i) -> getMaxInhSetMembers([], i, e).fst
+    | uniqueDecoratedType(_, i) -> getMaxInhSetMembers([], i, e).fst
     | _ -> just([])
     end;
 }

--- a/grammars/silver/compiler/definition/env/Type.sv
+++ b/grammars/silver/compiler/definition/env/Type.sv
@@ -57,7 +57,7 @@ top::Type ::= te::Type _
   top.typeName = te.typeName;
 }
 
-aspect production partiallyDecoratedType
+aspect production uniqueDecoratedType
 top::Type ::= te::Type _
 {
   top.typeName = te.typeName;

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -10,8 +10,8 @@ grammar silver:compiler:definition:flow:ast;
  -  - extraEq (handling collections '<-')
  - which the thesis does not address.
  -}
-nonterminal FlowDef with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, prodTreeContribs, prodGraphContribs, flowEdges, localInhTreeContribs, suspectFlowEdges, hostSynTreeContribs, nonSuspectContribs, localTreeContribs, partialRefContribs;
-nonterminal FlowDefs with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, prodTreeContribs, prodGraphContribs, localInhTreeContribs, hostSynTreeContribs, nonSuspectContribs, localTreeContribs, partialRefContribs;
+nonterminal FlowDef with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, prodTreeContribs, prodGraphContribs, flowEdges, localInhTreeContribs, suspectFlowEdges, hostSynTreeContribs, nonSuspectContribs, localTreeContribs, uniqueRefContribs;
+nonterminal FlowDefs with synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, prodTreeContribs, prodGraphContribs, localInhTreeContribs, hostSynTreeContribs, nonSuspectContribs, localTreeContribs, uniqueRefContribs;
 
 {-- lookup (production, attribute) to find synthesized equations
  - Used to ensure a necessary lhs.syn equation exists.
@@ -67,9 +67,9 @@ monoid attribute hostSynTreeContribs :: [Pair<String FlowDef>];
 monoid attribute nonSuspectContribs :: [Pair<String [String]>];
 
 {-- A list of decoration sites where partial references are taken, and the attributes on those partial references -}
-monoid attribute partialRefContribs :: [(String, String, Location, [String])];
+monoid attribute uniqueRefContribs :: [(String, String, Location, [String])];
 
-propagate synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, localInhTreeContribs, localTreeContribs, prodTreeContribs, prodGraphContribs, hostSynTreeContribs, nonSuspectContribs, partialRefContribs
+propagate synTreeContribs, inhTreeContribs, defTreeContribs, fwdTreeContribs, fwdInhTreeContribs, localInhTreeContribs, localTreeContribs, prodTreeContribs, prodGraphContribs, hostSynTreeContribs, nonSuspectContribs, uniqueRefContribs
   on FlowDefs;
 
 abstract production consFlow
@@ -100,7 +100,7 @@ top::FlowDef ::=
   top.hostSynTreeContribs := [];
   top.nonSuspectContribs := [];
   top.suspectFlowEdges = []; -- flowEdges is required, but suspect is typically not!
-  top.partialRefContribs := [];
+  top.uniqueRefContribs := [];
   -- require prodGraphContibs, flowEdges
 }
 
@@ -358,8 +358,8 @@ top::PatternVarProjection ::= child::String  typeName::String  patternVar::Strin
 }
 
 {--
- - The taking of a partially decorated reference to a child or local/production attribute.
- - Since taking a partially decorated reference means that inherited equations
+ - The taking of a unique reference to a child or local/production attribute.
+ - Since taking a unique reference means that inherited equations
  - on the decoration site for attributes not in the reference set are forbidden,
  - this info tracks what decoration sites have partial references taken.
  -
@@ -369,10 +369,10 @@ top::PatternVarProjection ::= child::String  typeName::String  patternVar::Strin
  - @param loc   the location of where the reference was taken
  - @param attrs the attributes in the type of the taken reference
  -}
-abstract production partialRef
+abstract production uniqueRef
 top::FlowDef ::= prod::String  fName::String  gram::String  loc::Location  attrs::[String]
 {
-  top.partialRefContribs := [(crossnames(prod, fName), gram, loc, attrs)];
+  top.uniqueRefContribs := [(crossnames(prod, fName), gram, loc, attrs)];
   top.prodGraphContribs := [];
   top.flowEdges = [];
 }

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -40,7 +40,7 @@ top::Expr ::=
 }
 
 aspect production childReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   -- Note that q should find the actual type written in the signature, and so
   -- isDecorable on that indeed tells us whether it's something autodecorated.
@@ -58,14 +58,14 @@ top::Expr ::= q::PartiallyDecorated QName
 
   top.flowDefs <-
     case finalTy, refSet of
-    | partiallyDecoratedType(_, _), just(inhs)
+    | uniqueDecoratedType(_, _), just(inhs)
       when isExportedBy(top.grammarName, [q.lookupValue.dcl.sourceGrammar], top.compiledGrammars) ->
-      [partialRef(top.frame.fullName, q.lookupValue.fullName, top.grammarName, q.location, inhs)]
+      [uniqueRef(top.frame.fullName, q.lookupValue.fullName, top.grammarName, q.location, inhs)]
     | _, _ -> []
     end;
 }
 aspect production lhsReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   -- Always a decorable type, so just check how it's being used:
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
@@ -80,7 +80,7 @@ top::Expr ::= q::PartiallyDecorated QName
     else noVertex();
 }
 aspect production localReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   -- Again, q give the actual type written.
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
@@ -98,14 +98,14 @@ top::Expr ::= q::PartiallyDecorated QName
 
   top.flowDefs <-
     case finalTy, refSet of
-    | partiallyDecoratedType(_, _), just(inhs)
+    | uniqueDecoratedType(_, _), just(inhs)
       when isExportedBy(top.grammarName, [q.lookupValue.dcl.sourceGrammar], top.compiledGrammars) ->
-      [partialRef(top.frame.fullName, q.lookupValue.fullName, top.grammarName, q.location, inhs)]
+      [uniqueRef(top.frame.fullName, q.lookupValue.fullName, top.grammarName, q.location, inhs)]
     | _, _ -> []
     end;
 }
 aspect production forwardReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   -- Again, always a decorable type.
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
@@ -134,7 +134,7 @@ top::Expr ::= e::Expr '.' q::QNameAttrOccur
 }
 
 aspect production accessBouncer
-top::Expr ::= target::(Expr ::= PartiallyDecorated Expr  PartiallyDecorated QNameAttrOccur  Location) e::Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= target::(Expr ::= Decorated! Expr  Decorated! QNameAttrOccur  Location) e::Expr  q::Decorated! QNameAttrOccur
 {
   propagate flowEnv;
 }
@@ -152,7 +152,7 @@ top::Expr ::= e::Expr '.' 'forward'
 -- Note that below we IGNORE the flow deps of the lhs if we know what it is
 -- this is because by default the lhs will have 'taking ref' flow deps (see above)
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.flowDeps := 
     case e.flowVertexInfo of
@@ -161,7 +161,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
     end;
 }
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.flowDeps :=
     case e.flowVertexInfo of
@@ -223,7 +223,7 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e1::Expr ';'
 }
 
 aspect production exprRef
-top::Expr ::= e::PartiallyDecorated Expr
+top::Expr ::= e::Decorated! Expr
 {
   top.flowVertexInfo = e.flowVertexInfo;
 }
@@ -239,7 +239,7 @@ top::Expr ::= la::AssignExpr  e::Expr
 }
 
 aspect production lexicalLocalReference
-top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::Decorated! QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   -- Because of the auto-undecorate behavior, we need to check for the case
   -- where `t` should be equivalent to `new(t)` and report accoringly.

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -14,7 +14,7 @@ monoid attribute flowDefs :: [FlowDef];
 monoid attribute specDefs :: [(String, String, [String], [String])];  -- (nt, attr, [inhs], [referenced flow specs])
 monoid attribute refDefs :: [(String, [String])];
 
-nonterminal FlowEnv with synTree, inhTree, defTree, fwdTree, prodTree, fwdInhTree, refTree, partialRefTree, localInhTree, localTree, nonSuspectTree, hostSynTree, specTree, prodGraphTree;
+nonterminal FlowEnv with synTree, inhTree, defTree, fwdTree, prodTree, fwdInhTree, refTree, uniqueRefTree, localInhTree, localTree, nonSuspectTree, hostSynTree, specTree, prodGraphTree;
 
 annotation synTree :: EnvTree<FlowDef>;
 annotation inhTree :: EnvTree<FlowDef>;
@@ -23,7 +23,7 @@ annotation fwdTree :: EnvTree<FlowDef>;
 annotation fwdInhTree :: EnvTree<FlowDef>;
 annotation prodTree :: EnvTree<FlowDef>;
 annotation refTree :: EnvTree<[String]>;
-annotation partialRefTree :: EnvTree<(String, Location, [String])>;
+annotation uniqueRefTree :: EnvTree<(String, Location, [String])>;
 annotation localInhTree ::EnvTree<FlowDef>;
 annotation localTree :: EnvTree<FlowDef>;
 annotation nonSuspectTree :: EnvTree<[String]>;
@@ -48,7 +48,7 @@ FlowEnv ::=
     fwdInhTree = directBuildTree(d.fwdInhTreeContribs),
     prodTree = directBuildTree(d.prodTreeContribs),
     refTree = directBuildTree(refContribs),
-    partialRefTree = directBuildTree(d.partialRefContribs),
+    uniqueRefTree = directBuildTree(d.uniqueRefContribs),
     localInhTree = directBuildTree(d.localInhTreeContribs),
     localTree = directBuildTree(d.localTreeContribs),
     nonSuspectTree = directBuildTree(d.nonSuspectContribs),
@@ -114,11 +114,11 @@ function getInhsForNtRef
   return searchEnvTree(nt, e.refTree);
 }
 
--- partially decorated references taken for a child/local/production attribute
+-- unique references taken for a child/local/production attribute
 function getPartialRefs
 [(String, Location, [String])] ::= prod::String  fName::String  e::FlowEnv
 {
-  return searchEnvTree(crossnames(prod, fName), e.partialRefTree);
+  return searchEnvTree(crossnames(prod, fName), e.uniqueRefTree);
 }
 
 -- implicit forward syn copy equations that are allowed to affect the flow type

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -65,12 +65,12 @@ top::ProductionStmt ::= dl::DefLHS '.' attr::QNameAttrOccur '=' e::Expr ';'
   propagate flowEnv;
 }
 aspect production errorAttributeDef
-top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= msg::[Message] dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   propagate flowEnv;
 }
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
@@ -86,7 +86,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
       [defaultSynEq(top.frame.lhsNtName, attr.attrDcl.fullName, e.flowDeps)];
 }
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   top.flowDefs <-
     case dl of
@@ -98,7 +98,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 }
 
 aspect production localValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   -- TODO: So, I'm just going to assume for the moment that we're always allowed to define the eq for a local...
   -- technically, it's possible to break this if you declare it in one grammar, but define it in another, but
@@ -113,7 +113,7 @@ top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 -- FROM COLLECTIONS TODO
 
 aspect production synAppendColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- <- -} e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  {- <- -} e::Expr
 {
   local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
@@ -125,7 +125,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 }
 
 aspect production inhAppendColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- <- -} e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  {- <- -} e::Expr
 {
   local vertex :: FlowVertex =
     case dl of
@@ -138,7 +138,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     [extraEq(top.frame.fullName, vertex, e.flowDeps, true)];
 }
 aspect production synBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
 
@@ -154,7 +154,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
       [defaultSynEq(top.frame.lhsNtName, attr.attrDcl.fullName, e.flowDeps)];
 }
 aspect production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   top.flowDefs <-
     case dl of
@@ -167,7 +167,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 
 
 aspect production appendCollectionValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   local locDefGram :: String = hackGramFromQName(val.lookupValue);
   -- TODO: possible bug? this would include ":local" in the gram wouldn't it?

--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -215,10 +215,10 @@ top::Type ::= t::Type i::Type
   top.typepp = s"Decorated ${t.typepp} with ${i.typepp}";
 }
 
-aspect production partiallyDecoratedType
+aspect production uniqueDecoratedType
 top::Type ::= t::Type i::Type
 {
-  top.typepp = s"PartiallyDecorated ${t.typepp} with ${i.typepp}";
+  top.typepp = s"Decorated! ${t.typepp} with ${i.typepp}";
 }
 
 aspect production ntOrDecType

--- a/grammars/silver/compiler/definition/type/Type.sv
+++ b/grammars/silver/compiler/definition/type/Type.sv
@@ -261,13 +261,13 @@ top::Type ::= te::Type i::Type
 }
 
 {--
- - A *partially decorated* nonterminal type.
+ - A *unique decorated* nonterminal type.
  - Represents a reference with some exact set of provided inherited attributes,
  - may be decorated with additional attributes.
  - @param te  MUST be a 'nonterminalType' or 'varType'/'skolemType'
  - @param i  MUST have kind InhSet
  -}
-abstract production partiallyDecoratedType
+abstract production uniqueDecoratedType
 top::Type ::= te::Type i::Type
 {
   top.kindrep = starKind();
@@ -297,7 +297,7 @@ top::Type ::= te::Type i::Type
  -
  - @param nt  MUST be a 'nonterminalType'
  - @param inhs  The inh set that we're decorated with, or a free var if we don't care - MUST have kind InhSet
- - @param hidden  One of: (a) a type variable (b) 'nt' (c) 'decoratedType(nt, inhs)' (d) 'partiallyDecoratedType(nt, inhs)'
+ - @param hidden  One of: (a) a type variable (b) 'nt' (c) 'decoratedType(nt, inhs)' (d) 'uniqueDecoratedType(nt, inhs)'
  -                representing state: unspecialized, undecorated, or decorated.
  - @param defaultPartialDec  The default for what we are if we never specialize.
  - @param inhs  The default for what we're decorated with if we never specialize - MUST have kind InhSet

--- a/grammars/silver/compiler/definition/type/Unification.sv
+++ b/grammars/silver/compiler/definition/type/Unification.sv
@@ -153,14 +153,14 @@ top::Type ::= te::Type i::Type
     end;
 }
 
-aspect production partiallyDecoratedType
+aspect production uniqueDecoratedType
 top::Type ::= te::Type i::Type
 {
   top.unify = 
     case top.unifyWith of
-    | partiallyDecoratedType(ote, oi) -> composeSubst(unify(te, ote), unify(i, oi))
+    | uniqueDecoratedType(ote, oi) -> composeSubst(unify(te, ote), unify(i, oi))
     | ntOrDecType(_,_,_) -> errorSubst("dte-nodte: try again")
-    | _ -> errorSubst("Tried to unify partially decorated type with " ++ prettyType(top.unifyWith))
+    | _ -> errorSubst("Tried to unify unique decorated type with " ++ prettyType(top.unifyWith))
     end;
 }
 
@@ -180,7 +180,7 @@ top::Type ::= nt::Type inhs::Type hidden::Type
         -- Ensure compatibility between Decorated nonterminal types, then specialize ourselves
         unifyAllShortCircuit([ote, oi, top.unifyWith],
                              [nt,  inhs, hidden])
-    | partiallyDecoratedType(ote, oi) ->
+    | uniqueDecoratedType(ote, oi) ->
         -- Ensure compatibility between Decorated nonterminal types, then specialize ourselves
         unifyAllShortCircuit([ote, oi, top.unifyWith],
                              [nt,  inhs, hidden])

--- a/grammars/silver/compiler/definition/type/Util.sv
+++ b/grammars/silver/compiler/definition/type/Util.sv
@@ -20,9 +20,9 @@ monoid attribute freeFlexibleVars :: [TyVar] with [], setUnionTyVars;
 -- Also used by 'new()'
 synthesized attribute isDecorated :: Boolean;
 
--- Determines whether a type is a partially decorated nonterminal type
+-- Determines whether a type is a unique decorated nonterminal type
 -- Used in determining whether a type may be supplied with inherited attributes.
-synthesized attribute isPartiallyDecorated :: Boolean;
+synthesized attribute isUniqueDecorated :: Boolean;
 
 -- Determines whether a type is an (undecorated) nonterminal type
 -- Used in determining whether a type may be supplied with inherited attributes.
@@ -43,9 +43,9 @@ synthesized attribute defaultSpecialization :: Type;
 -- Used instead of unify() when we want to just know its decorated or undecorated
 synthesized attribute unifyInstanceNonterminal :: Substitution;
 synthesized attribute unifyInstanceDecorated :: Substitution;
-synthesized attribute unifyInstanceDecorable :: Substitution;  -- NT or partially decorated
+synthesized attribute unifyInstanceDecorable :: Substitution;  -- NT or unique decorated
 
-attribute arity, isError, isDecorated, isPartiallyDecorated, isNonterminal, isTerminal, asNtOrDecType, compareTo, isEqual occurs on PolyType;
+attribute arity, isError, isDecorated, isUniqueDecorated, isNonterminal, isTerminal, asNtOrDecType, compareTo, isEqual occurs on PolyType;
 
 aspect production monoType
 top::PolyType ::= ty::Type
@@ -53,7 +53,7 @@ top::PolyType ::= ty::Type
   top.arity = ty.arity;
   top.isError = ty.isError;
   top.isDecorated = ty.isDecorated;
-  top.isPartiallyDecorated = ty.isPartiallyDecorated;
+  top.isUniqueDecorated = ty.isUniqueDecorated;
   top.isNonterminal = ty.isNonterminal;
   top.isTerminal = ty.isTerminal;
   top.asNtOrDecType = ty.asNtOrDecType;
@@ -70,7 +70,7 @@ top::PolyType ::= bound::[TyVar] ty::Type
   top.arity = ty.arity;
   top.isError = ty.isError;
   top.isDecorated = ty.isDecorated;
-  top.isPartiallyDecorated = ty.isPartiallyDecorated;
+  top.isUniqueDecorated = ty.isUniqueDecorated;
   top.isNonterminal = ty.isNonterminal;
   top.isTerminal = ty.isTerminal;
   top.asNtOrDecType = error("Only mono types should be possibly-decorated");
@@ -88,7 +88,7 @@ top::PolyType ::= bound::[TyVar] contexts::[Context] ty::Type
   top.arity = ty.arity;
   top.isError = ty.isError;
   top.isDecorated = ty.isDecorated;
-  top.isPartiallyDecorated = ty.isPartiallyDecorated;
+  top.isUniqueDecorated = ty.isUniqueDecorated;
   top.isNonterminal = ty.isNonterminal;
   top.isTerminal = ty.isTerminal;
   top.asNtOrDecType = error("Only mono types should be possibly-decorated");
@@ -100,7 +100,7 @@ top::PolyType ::= bound::[TyVar] contexts::[Context] ty::Type
     top.compareTo.typerep == performRenaming(ty, eqSub);
 }
 
-attribute isError, inputTypes, outputType, namedTypes, arity, baseType, argTypes, isDecorated, isPartiallyDecorated, isNonterminal, isTerminal, isApplicable, decoratedType, asNtOrDecType, defaultSpecialization, inhSetMembers, freeSkolemVars, freeFlexibleVars, unifyInstanceNonterminal, unifyInstanceDecorated, unifyInstanceDecorable occurs on Type;
+attribute isError, inputTypes, outputType, namedTypes, arity, baseType, argTypes, isDecorated, isUniqueDecorated, isNonterminal, isTerminal, isApplicable, decoratedType, asNtOrDecType, defaultSpecialization, inhSetMembers, freeSkolemVars, freeFlexibleVars, unifyInstanceNonterminal, unifyInstanceDecorated, unifyInstanceDecorable occurs on Type;
 
 propagate freeSkolemVars, freeFlexibleVars on Type;
 
@@ -116,7 +116,7 @@ top::Type ::=
   top.inhSetMembers = [];
   
   top.isDecorated = false;
-  top.isPartiallyDecorated = false;
+  top.isUniqueDecorated = false;
   top.isNonterminal = false;
   top.isTerminal = false;
   top.isError = false;
@@ -230,11 +230,11 @@ top::Type ::= te::Type i::Type
   top.unifyInstanceDecorated = emptySubst();
 }
 
-aspect production partiallyDecoratedType
+aspect production uniqueDecoratedType
 top::Type ::= te::Type i::Type
 {
   top.isDecorated = true;
-  top.isPartiallyDecorated = true;
+  top.isUniqueDecorated = true;
   top.decoratedType = te;
   top.asNtOrDecType = ntOrDecType(te, freshInhSet(), freshType());
   top.inhSetMembers = i.inhSetMembers;

--- a/grammars/silver/compiler/definition/type/syntax/Terminals.sv
+++ b/grammars/silver/compiler/definition/type/syntax/Terminals.sv
@@ -14,6 +14,7 @@ disambiguate LCurly_t, InhSetLCurly_t { pluck LCurly_t; }
 
 terminal Boolean_tkwd    'Boolean'    lexer classes {TYPE,RESERVED};
 terminal Decorated_tkwd  'Decorated'  lexer classes {TYPE,RESERVED}, precedence=1;
+terminal UniqueDecorated_tkwd 'Decorated!' lexer classes {TYPE,RESERVED}, precedence=1;
 terminal PartiallyDecorated_tkwd 'PartiallyDecorated' lexer classes {TYPE,RESERVED}, precedence=1;
 terminal Float_tkwd      'Float'      lexer classes {TYPE,RESERVED};
 terminal Integer_tkwd    'Integer'    lexer classes {TYPE,RESERVED};

--- a/grammars/silver/compiler/definition/type/syntax/Terminals.sv
+++ b/grammars/silver/compiler/definition/type/syntax/Terminals.sv
@@ -15,7 +15,6 @@ disambiguate LCurly_t, InhSetLCurly_t { pluck LCurly_t; }
 terminal Boolean_tkwd    'Boolean'    lexer classes {TYPE,RESERVED};
 terminal Decorated_tkwd  'Decorated'  lexer classes {TYPE,RESERVED}, precedence=1;
 terminal UniqueDecorated_tkwd 'Decorated!' lexer classes {TYPE,RESERVED}, precedence=1;
-terminal PartiallyDecorated_tkwd 'PartiallyDecorated' lexer classes {TYPE,RESERVED}, precedence=1;
 terminal Float_tkwd      'Float'      lexer classes {TYPE,RESERVED};
 terminal Integer_tkwd    'Integer'    lexer classes {TYPE,RESERVED};
 terminal String_tkwd     'String'     lexer classes {TYPE,RESERVED};

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -57,7 +57,7 @@ flowtype typerep {grammarName, env, flowEnv} on TypeExpr, Signature;
 flowtype maybeType {grammarName, env, flowEnv} on SignatureLHS;
 flowtype types {grammarName, env, flowEnv} on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 
-propagate errors on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs excluding refTypeExpr, partialRefTypeExpr;
+propagate errors on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs excluding refTypeExpr, uniqueRefTypeExpr;
 propagate config, grammarName, env, flowEnv, lexicalTypeVariables, lexicalTyVarKinds
   on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate appLexicalTyVarKinds on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
@@ -346,10 +346,16 @@ top::TypeExpr ::= 'Decorated' t::TypeExpr
     end;
 }
 
-concrete production partialRefTypeExpr
+concrete production uniqueRefTypeExprOld
 top::TypeExpr ::= 'PartiallyDecorated' t::TypeExpr 'with' i::TypeExpr
 {
-  top.unparse = "PartiallyDecorated " ++ t.unparse ++ " with " ++ i.unparse;
+  forwards to uniqueRefTypeExpr('Decorated!', t, 'with', i, location=top.location);
+}
+
+concrete production uniqueRefTypeExpr
+top::TypeExpr ::= 'Decorated!' t::TypeExpr 'with' i::TypeExpr
+{
+  top.unparse = "Decorated! " ++ t.unparse ++ " with " ++ i.unparse;
   
   i.onNt = t.typerep;
 
@@ -360,7 +366,7 @@ top::TypeExpr ::= 'PartiallyDecorated' t::TypeExpr 'with' i::TypeExpr
     case t.typerep.baseType of
     | nonterminalType(_,_,_) -> []
     | skolemType(_) -> []
-    | _ -> [err(t.location, t.unparse ++ " is not a nonterminal, and cannot be PartiallyDecorated.")]
+    | _ -> [err(t.location, t.unparse ++ " is not a nonterminal, and cannot be Decorated!.")]
     end;
   top.errors <-
     if i.typerep.kindrep != inhSetKind()
@@ -375,10 +381,16 @@ top::TypeExpr ::= 'PartiallyDecorated' t::TypeExpr 'with' i::TypeExpr
     end;
 }
 
-concrete production partialRefDefaultTypeExpr
+concrete production uniqueRefDefaultTypeExprOld
 top::TypeExpr ::= 'PartiallyDecorated' t::TypeExpr
 {
-  top.unparse = "PartiallyDecorated " ++ t.unparse;
+  forwards to uniqueRefDefaultTypeExpr('Decorated!', t, location=top.location);
+}
+
+concrete production uniqueRefDefaultTypeExpr
+top::TypeExpr ::= 'Decorated!' t::TypeExpr
+{
+  top.unparse = "Decorated! " ++ t.unparse;
 
   top.typerep =
     partiallyDecoratedType(t.typerep,
@@ -387,8 +399,8 @@ top::TypeExpr ::= 'PartiallyDecorated' t::TypeExpr
   top.errors <-
     case t.typerep.baseType of
     | nonterminalType(_,_,_) -> []
-    | skolemType(_) -> [err(t.location, "polymorphic PartiallyDecorated types must specify an explicit reference set")]
-    | _ -> [err(t.location, t.unparse ++ " is not a nonterminal, and cannot be PartiallyDecorated.")]
+    | skolemType(_) -> [err(t.location, "polymorphic Decorated! types must specify an explicit reference set")]
+    | _ -> [err(t.location, t.unparse ++ " is not a nonterminal, and cannot be Decorated!.")]
     end;
 }
 

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -346,12 +346,6 @@ top::TypeExpr ::= 'Decorated' t::TypeExpr
     end;
 }
 
-concrete production uniqueRefTypeExprOld
-top::TypeExpr ::= 'PartiallyDecorated' t::TypeExpr 'with' i::TypeExpr
-{
-  forwards to uniqueRefTypeExpr('Decorated!', t, 'with', i, location=top.location);
-}
-
 concrete production uniqueRefTypeExpr
 top::TypeExpr ::= 'Decorated!' t::TypeExpr 'with' i::TypeExpr
 {
@@ -359,7 +353,7 @@ top::TypeExpr ::= 'Decorated!' t::TypeExpr 'with' i::TypeExpr
   
   i.onNt = t.typerep;
 
-  top.typerep = partiallyDecoratedType(t.typerep, i.typerepInhSet);
+  top.typerep = uniqueDecoratedType(t.typerep, i.typerepInhSet);
   
   top.errors := i.errorsInhSet ++ t.errors;
   top.errors <-
@@ -381,19 +375,13 @@ top::TypeExpr ::= 'Decorated!' t::TypeExpr 'with' i::TypeExpr
     end;
 }
 
-concrete production uniqueRefDefaultTypeExprOld
-top::TypeExpr ::= 'PartiallyDecorated' t::TypeExpr
-{
-  forwards to uniqueRefDefaultTypeExpr('Decorated!', t, location=top.location);
-}
-
 concrete production uniqueRefDefaultTypeExpr
 top::TypeExpr ::= 'Decorated!' t::TypeExpr
 {
   top.unparse = "Decorated! " ++ t.unparse;
 
   top.typerep =
-    partiallyDecoratedType(t.typerep,
+    uniqueDecoratedType(t.typerep,
       inhSetType(sort(concat(getInhsForNtRef(t.typerep.typeName, top.flowEnv)))));
   
   top.errors <-

--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:extension:autoattr;
 
-synthesized attribute propagateDispatcher :: (ProductionStmt ::= PartiallyDecorated QName  Location) occurs on AttributeDclInfo;
+synthesized attribute propagateDispatcher :: (ProductionStmt ::= Decorated! QName  Location) occurs on AttributeDclInfo;
 
 synthesized attribute emptyVal::Expr occurs on AttributeDclInfo;
 
@@ -54,7 +54,7 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type empty::Expr append:
   top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, location=_);
   top.attrDefDispatcher = 
-    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, attr.name ++ " is a monoid collection attribute, and you must use ':=' or '<-', not '='.")], dl, attr, e, location=l);
   top.attrBaseDefDispatcher = synBaseColAttributeDef(_, _, _, location=_);
   top.attrAppendDefDispatcher = synAppendColAttributeDef(_, _, _, location=_);

--- a/grammars/silver/compiler/extension/autoattr/Destruct.sv
+++ b/grammars/silver/compiler/extension/autoattr/Destruct.sv
@@ -21,7 +21,7 @@ top::AGDcl ::= 'destruct' 'attribute' inh::Name ';'
 }
 
 abstract production destructAttributionDcl
-top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   undecorates to attributionDcl('attribute', at, attl, 'occurs', 'on', nt, nttl, ';', location=top.location);
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
@@ -80,7 +80,7 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateDestruct
-top::ProductionStmt ::= attr::PartiallyDecorated QName
+top::ProductionStmt ::= attr::Decorated! QName
 {
   undecorates to propagateOneAttr(attr, location=top.location);
   top.unparse = s"propagate ${attr.unparse};";

--- a/grammars/silver/compiler/extension/autoattr/Equality.sv
+++ b/grammars/silver/compiler/extension/autoattr/Equality.sv
@@ -29,7 +29,7 @@ top::AGDcl ::= 'equality' 'attribute' syn::Name 'with' inh::QName ';'
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateEquality
-top::ProductionStmt ::= inh::String syn::PartiallyDecorated QName
+top::ProductionStmt ::= inh::String syn::Decorated! QName
 {
   undecorates to propagateOneAttr(syn, location=top.location);
   top.unparse = s"propagate ${syn.unparse};";

--- a/grammars/silver/compiler/extension/autoattr/Functor.sv
+++ b/grammars/silver/compiler/extension/autoattr/Functor.sv
@@ -21,7 +21,7 @@ top::AGDcl ::= 'functor' 'attribute' a::Name ';'
 }
 
 abstract production functorAttributionDcl
-top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   undecorates to attributionDcl('attribute', at, attl, 'occurs', 'on', nt, nttl, ';', location=top.location);
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
@@ -58,7 +58,7 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateFunctor
-top::ProductionStmt ::= attr::PartiallyDecorated QName
+top::ProductionStmt ::= attr::Decorated! QName
 {
   undecorates to propagateOneAttr(attr, location=top.location);
   top.unparse = s"propagate ${attr.unparse};";
@@ -107,7 +107,7 @@ Expr ::= loc::Location env::Decorated Env attrName::Decorated QName input::Named
   -- Check if the attribute occurs on the first child
   local attrOccursOnHead :: Boolean =
     !null(getOccursDcl(attrName.lookupAttribute.dcl.fullName, input.typerep.typeName, env));
-  local validTypeHead :: Boolean = isDecorable(input.typerep, env) && !input.typerep.isPartiallyDecorated;
+  local validTypeHead :: Boolean = isDecorable(input.typerep, env) && !input.typerep.isUniqueDecorated;
   
   return
     if validTypeHead && attrOccursOnHead

--- a/grammars/silver/compiler/extension/autoattr/Inherited.sv
+++ b/grammars/silver/compiler/extension/autoattr/Inherited.sv
@@ -1,7 +1,7 @@
 grammar silver:compiler:extension:autoattr;
 
 abstract production propagateInh
-top::ProductionStmt ::= attr::PartiallyDecorated QName
+top::ProductionStmt ::= attr::Decorated! QName
 {
   undecorates to propagateOneAttr(attr, location=top.location);
   top.unparse = s"propagate ${attr.unparse};";
@@ -11,7 +11,7 @@ top::ProductionStmt ::= attr::PartiallyDecorated QName
     filter(
       \ input::NamedSignatureElement ->
         isDecorable(input.typerep, top.env) &&
-        !input.typerep.isPartiallyDecorated &&  -- Don't copy on partially decorated children
+        !input.typerep.isUniqueDecorated &&  -- Don't copy on unique decorated children
         !null(getOccursDcl(attrFullName, input.typerep.typeName, top.env)),
       top.frame.signature.inputElements);
   forwards to

--- a/grammars/silver/compiler/extension/autoattr/Monoid.sv
+++ b/grammars/silver/compiler/extension/autoattr/Monoid.sv
@@ -116,7 +116,7 @@ top::Operation ::=
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateMonoid
-top::ProductionStmt ::= attr::PartiallyDecorated QName
+top::ProductionStmt ::= attr::Decorated! QName
 {
   undecorates to propagateOneAttr(attr, location=top.location);
   top.unparse = s"propagate ${attr.unparse};";

--- a/grammars/silver/compiler/extension/autoattr/Ordering.sv
+++ b/grammars/silver/compiler/extension/autoattr/Ordering.sv
@@ -36,7 +36,7 @@ top::AGDcl ::= 'ordering' 'attribute' keySyn::Name ',' syn::Name 'with' inh::QNa
  - Propagate a ordering key synthesized attribute on the enclosing production
  -}
 abstract production propagateOrderingKey
-top::ProductionStmt ::= syn::PartiallyDecorated QName
+top::ProductionStmt ::= syn::Decorated! QName
 {
   undecorates to propagateOneAttr(syn, location=top.location);
   top.unparse = s"propagate ${syn.unparse};";
@@ -52,7 +52,7 @@ top::ProductionStmt ::= syn::PartiallyDecorated QName
  - Propagate a ordering synthesized attribute on the enclosing production
  -}
 abstract production propagateOrdering
-top::ProductionStmt ::= inh::String keySyn::String syn::PartiallyDecorated QName
+top::ProductionStmt ::= inh::String keySyn::String syn::Decorated! QName
 {
   undecorates to propagateOneAttr(syn, location=top.location);
   top.unparse = s"propagate ${syn.unparse};";

--- a/grammars/silver/compiler/extension/autoattr/Propagate.sv
+++ b/grammars/silver/compiler/extension/autoattr/Propagate.sv
@@ -147,7 +147,7 @@ top::ProductionStmt ::= attr::QName
 }
 
 abstract production propagateError
-top::ProductionStmt ::= attr::PartiallyDecorated QName
+top::ProductionStmt ::= attr::Decorated! QName
 {
   undecorates to propagateOneAttr(attr, location=top.location);
   forwards to

--- a/grammars/silver/compiler/extension/autoattr/Threaded.sv
+++ b/grammars/silver/compiler/extension/autoattr/Threaded.sv
@@ -52,7 +52,7 @@ concrete productions top::Direction
   { top.reversed = true; }
 
 abstract production propagateThreadedInh
-top::ProductionStmt ::= rev::Boolean inh::PartiallyDecorated QName syn::String
+top::ProductionStmt ::= rev::Boolean inh::Decorated! QName syn::String
 {
   undecorates to propagateOneAttr(inh, location=top.location);
   top.unparse = s"propagate ${inh.unparse};";
@@ -64,7 +64,7 @@ top::ProductionStmt ::= rev::Boolean inh::PartiallyDecorated QName syn::String
       filter(
         \ ie::NamedSignatureElement ->
           isDecorable(ie.typerep, top.env) &&
-          !ie.typerep.isPartiallyDecorated &&  -- Don't thread on partially decorated children
+          !ie.typerep.isUniqueDecorated &&  -- Don't thread on unique decorated children
           !null(getOccursDcl(inh.lookupAttribute.fullName, ie.typerep.typeName, top.env)) &&
           !null(getOccursDcl(syn, ie.typerep.typeName, top.env)),
         if null(getOccursDcl(syn, top.frame.lhsNtName, top.env)) && !null(top.frame.signature.inputElements)
@@ -86,7 +86,7 @@ top::ProductionStmt ::= rev::Boolean inh::PartiallyDecorated QName syn::String
 }
 
 abstract production propagateThreadedSyn
-top::ProductionStmt ::= rev::Boolean inh::String syn::PartiallyDecorated QName
+top::ProductionStmt ::= rev::Boolean inh::String syn::Decorated! QName
 {
   undecorates to propagateOneAttr(syn, location=top.location);
   top.unparse = s"propagate ${syn.unparse};";
@@ -98,7 +98,7 @@ top::ProductionStmt ::= rev::Boolean inh::String syn::PartiallyDecorated QName
       filter(
         \ ie::NamedSignatureElement ->
           isDecorable(ie.typerep, top.env) &&
-          !ie.typerep.isPartiallyDecorated &&  -- Don't thread on partially decorated children
+          !ie.typerep.isUniqueDecorated &&  -- Don't thread on unique decorated children
           !null(getOccursDcl(inh, ie.typerep.typeName, top.env)) &&
           !null(getOccursDcl(syn.lookupAttribute.fullName, ie.typerep.typeName, top.env)),
         top.frame.signature.inputElements));

--- a/grammars/silver/compiler/extension/autoattr/Unification.sv
+++ b/grammars/silver/compiler/extension/autoattr/Unification.sv
@@ -32,7 +32,7 @@ top::AGDcl ::= 'unification' 'attribute' synPartial::Name ',' syn::Name 'with' i
 }
 
 abstract production unificationInhAttributionDcl
-top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   undecorates to attributionDcl('attribute', at, attl, 'occurs', 'on', nt, nttl, ';', location=top.location);
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
@@ -65,7 +65,7 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
 }
 
 abstract production propagateUnificationSynPartial
-top::ProductionStmt ::= inh::String synPartial::PartiallyDecorated QName syn::String
+top::ProductionStmt ::= inh::String synPartial::Decorated! QName syn::String
 {
   undecorates to propagateOneAttr(synPartial, location=top.location);
   top.unparse = s"propagate ${synPartial.unparse};";
@@ -102,7 +102,7 @@ top::ProductionStmt ::= inh::String synPartial::PartiallyDecorated QName syn::St
 }
 
 abstract production propagateUnificationSyn
-top::ProductionStmt ::= inh::String synPartial::String syn::PartiallyDecorated QName
+top::ProductionStmt ::= inh::String synPartial::String syn::Decorated! QName
 {
   undecorates to propagateOneAttr(syn, location=top.location);
   top.unparse = s"propagate ${syn.unparse};";

--- a/grammars/silver/compiler/extension/doc/core/AGDcl.sv
+++ b/grammars/silver/compiler/extension/doc/core/AGDcl.sv
@@ -201,7 +201,7 @@ top::AGDcl ::= 'type' id::Name tl::BracketedOptTypeExprs 'foreign' '=' trans::St
 
 
 aspect production defaultAttributionDcl
-top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.docForName = "";
   top.docUnparse = "";
@@ -292,7 +292,7 @@ top::AGDcl ::= n::Name
 }
 
 aspect production errorAttributionDcl
-top::AGDcl ::= msg::[Message] at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= msg::[Message] at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.docForName = "";
   top.docUnparse = "";

--- a/grammars/silver/compiler/extension/implicit_monads/CopperExpr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/CopperExpr.sv
@@ -6,7 +6,7 @@ grammar silver:compiler:extension:implicit_monads;
 -}
 
 aspect production actionChildReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
@@ -18,7 +18,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production pluckTerminalReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
@@ -30,7 +30,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production terminalIdReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
@@ -42,7 +42,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production parserAttributeReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;
@@ -54,7 +54,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production termAttrValueReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   top.mUpSubst = top.mDownSubst;

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -43,7 +43,7 @@ top::Expr ::= e::[Message]
 }
 
 aspect production errorReference
-top::Expr ::= msg::[Message]  q::PartiallyDecorated QName
+top::Expr ::= msg::[Message]  q::Decorated! QName
 {
   top.merrors := msg;
   propagate mDownSubst, mUpSubst;
@@ -53,7 +53,7 @@ top::Expr ::= msg::[Message]  q::PartiallyDecorated QName
 }
 
 aspect production childReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -67,7 +67,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production lhsReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -79,7 +79,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production localReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -93,7 +93,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production forwardReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -106,7 +106,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production productionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -118,7 +118,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production functionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -130,7 +130,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production classMemberReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -142,7 +142,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production globalValueReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;
@@ -269,7 +269,7 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 }
 
 aspect production functionInvocation
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   local t::Expr = application(e, '(', es, ',', anns, ')', location=top.location);
   t.mDownSubst = top.mDownSubst;
@@ -379,7 +379,7 @@ Expr ::= monadTysLocs::[Pair<Type Integer>] funargs::AppExprs monadType::Type wr
 
 
 aspect production partialApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   top.merrors := error("merrors not defined on partial applications");
   top.mUpSubst = error("mUpSubst not defined on partial applications");
@@ -391,7 +391,7 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::P
 }
 
 aspect production errorApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   top.merrors := [];
 
@@ -459,7 +459,7 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production errorAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
   e.expectedMonad = top.expectedMonad;
@@ -534,7 +534,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production annoAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
   e.expectedMonad = top.expectedMonad;
@@ -606,7 +606,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production terminalAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
   e.expectedMonad = top.expectedMonad;
@@ -655,7 +655,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
   e.expectedMonad = top.expectedMonad;
@@ -727,7 +727,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
   e.expectedMonad = top.expectedMonad;
@@ -799,7 +799,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production errorDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
   e.expectedMonad = top.expectedMonad;
@@ -985,10 +985,10 @@ top::Expr ::= '@' e::Expr
   e.mDownSubst = top.mDownSubst;
   errCheck1.downSubst = e.mUpSubst;
   top.mUpSubst = errCheck1.upSubst;
-  errCheck1 = check(e.typerep, partiallyDecoratedType(freshType(), inhSetType([])));
+  errCheck1 = check(e.typerep, uniqueDecoratedType(freshType(), inhSetType([])));
   top.merrors <-
        if errCheck1.typeerror
-       then [err(top.location, "Operand to @ must be partially decorated with no attributes.  Instead it is of type " ++ errCheck1.leftpp)]
+       then [err(top.location, "Operand to @ must be a unique reference with no inherited attributes.  Instead it is of type " ++ errCheck1.leftpp)]
        else [];
 }
 
@@ -2059,7 +2059,7 @@ top::AppExprs ::=
 
 
 aspect production exprRef
-top::Expr ::= e::PartiallyDecorated Expr
+top::Expr ::= e::Decorated! Expr
 {
   e.mDownSubst = top.mDownSubst;
   e.expectedMonad = top.expectedMonad;
@@ -2086,7 +2086,7 @@ top::Expr ::= 'disambiguationFailure'
 
 
 aspect production lexerClassReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.mUpSubst = top.mDownSubst;
   top.mtyperep = q.lookupValue.typeScheme.typerep;

--- a/grammars/silver/compiler/extension/implicit_monads/Lambda.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Lambda.sv
@@ -17,7 +17,7 @@ top::Expr ::= params::ProductionRHS e::Expr
 
 
 aspect production lambdaParamReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;

--- a/grammars/silver/compiler/extension/implicit_monads/Let.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Let.sv
@@ -134,7 +134,7 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
 
 
 aspect production lexicalLocalReference
-top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::Decorated! QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   top.merrors := [];
   propagate mDownSubst, mUpSubst;

--- a/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
@@ -49,9 +49,9 @@ top::ProductionStmt ::= 'implicit' dl::DefLHS '.' attr::QNameAttrOccur '=' ';'
 }
 
 
-global partialDefaultAttributeDef::(ProductionStmt ::= PartiallyDecorated DefLHS  PartiallyDecorated QNameAttrOccur  Expr  Location) =
-  \ dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr loc::Location ->
-    attributeDef(newPartial(dl), '.', newPartial(attr), '=', e, ';', location=loc);
+global partialDefaultAttributeDef::(ProductionStmt ::= Decorated! DefLHS  Decorated! QNameAttrOccur  Expr  Location) =
+  \ dl::Decorated! DefLHS attr::Decorated! QNameAttrOccur e::Expr loc::Location ->
+    attributeDef(newUnique(dl), '.', newUnique(attr), '=', e, ';', location=loc);
 
 concrete production implicitAttributeDef
 top::ProductionStmt ::= 'implicit' dl::DefLHS '.' attr::QNameAttrOccur '=' e::Expr ';'
@@ -193,7 +193,7 @@ function buildExplicitAttrErrors
 
 --productions for error checking on restricted attributes
 abstract production restrictedSynAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS attr::Decorated! QNameAttrOccur e::Expr
 {
   undecorates to attributeDef(dl, '.', attr, '=', e, ';', location=top.location);
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
@@ -219,7 +219,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated Q
 
 
 abstract production restrictedInhAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS attr::Decorated! QNameAttrOccur e::Expr
 {
   undecorates to attributeDef(dl, '.', attr, '=', e, ';', location=top.location);
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
@@ -248,7 +248,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated Q
 
 --productions for error checking on implicit attributes
 abstract production implicitSynAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS attr::Decorated! QNameAttrOccur e::Expr
 {
   undecorates to attributeDef(dl, '.', attr, '=', e, ';', location=top.location);
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
@@ -279,7 +279,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated Q
 
 
 abstract production implicitInhAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS attr::PartiallyDecorated QNameAttrOccur e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS attr::Decorated! QNameAttrOccur e::Expr
 {
   undecorates to attributeDef(dl, '.', attr, '=', e, ';', location=top.location);
   top.unparse = dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -26,7 +26,7 @@ top::Expr ::=
 }
 
 aspect production lexicalLocalReference
-top::Expr ::= q::PartiallyDecorated QName _ _
+top::Expr ::= q::Decorated! QName _ _
 {
   -- In regular pattern matching nonterminal values are always effectively decorated, but we are
   -- using the same typing behavior while matching on *undecorated* trees.  So when a variable is
@@ -74,7 +74,7 @@ top::Expr ::= q::PartiallyDecorated QName _ _
 }
 
 aspect production childReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
@@ -84,7 +84,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production lhsReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
@@ -94,7 +94,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production localReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
@@ -104,7 +104,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production forwardReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.transform =
     -- Explicitly undecorate the variable, if appropriate for the final expected type
@@ -114,7 +114,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production errorApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   top.transform = applyASTExpr(e.transform, es.transform, anns.transform);
   e.boundVars = top.boundVars;
@@ -123,7 +123,7 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::P
 }
 
 aspect production functionInvocation
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   top.transform =
     case e, es of
@@ -167,7 +167,7 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::P
 }
 
 aspect production partialApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs anns::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   top.transform = applyASTExpr(e.transform, es.transform, anns.transform);
   e.boundVars = top.boundVars;
@@ -198,7 +198,7 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production errorAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.transform =
     applyASTExpr(
@@ -213,7 +213,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production annoAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.transform =
     applyASTExpr(
@@ -228,7 +228,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production terminalAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.transform =
     applyASTExpr(
@@ -244,7 +244,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 
 
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   -- Flow analysis has no way to track what e is decorated with across reflect/reify,
   -- so if the inh set is unspecialized, assume that it has the reference set.
@@ -309,7 +309,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   -- Flow analysis has no way to track what e is decorated with across reflect/reify,
   -- so if the inh set is unspecialized, assume that it has the reference set.
@@ -332,7 +332,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production errorDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   -- Flow analysis has no way to track what e is decorated with across reflect/reify,
   -- so if the inh set is unspecialized, assume that it has the reference set.
@@ -555,7 +555,7 @@ aspect production fullList
 top::Expr ::= '[' es::Exprs ']'
 {
   -- TODO: Consider refactoring listtrans on Exprs to decorate the expressions here
-  -- before forwarding via partially decorated references.
+  -- before forwarding via unique references.
   local decEs::Exprs = es;
   decEs.downSubst = top.downSubst;
   decEs.finalSubst = top.finalSubst;
@@ -769,7 +769,7 @@ top::AnnoAppExprs ::=
 }
 
 aspect production exprRef
-top::Expr ::= e::PartiallyDecorated Expr
+top::Expr ::= e::Decorated! Expr
 {
   top.transform = e.transform;
   e.boundVars = top.boundVars;

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -58,7 +58,7 @@ top::AGDcl ::= isTotal::Boolean a::Name recVarNameEnv::[Pair<String String>] rec
 }
 
 abstract production strategyAttributionDcl
-top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   undecorates to attributionDcl('attribute', at, attl, 'occurs', 'on', nt, nttl, ';', location=top.location);
   propagate grammarName, env, flowEnv;
@@ -118,7 +118,7 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
  - @param attr  The name of the attribute to propagate
  -}
 abstract production propagateStrategy
-top::ProductionStmt ::= attr::PartiallyDecorated QName
+top::ProductionStmt ::= attr::Decorated! QName
 {
   undecorates to propagateOneAttr(attr, location=top.location);
   top.unparse = s"propagate ${attr.unparse}";

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -223,7 +223,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr 'with
 
 -- ERROR ON VALUE DEFS:
 abstract production errorCollectionValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   undecorates to valContainsBase(val, ':=', e, ';', location=top.location);
   top.errors <- [err(top.location, "The ':=' and '<-' operators can only be used for collections. " ++ val.name ++ " is not a collection.")];
@@ -234,7 +234,7 @@ top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
   forwards to errorValueDef(val, e, location=top.location);
 }
 abstract production errorColNormalValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   undecorates to valueEq(val, '=', e, ';', location=top.location);
   top.errors <- [err(top.location, val.name ++ " is a collection attribute, and you must use ':=' or '<-', not '='.")];
@@ -246,7 +246,7 @@ top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 -- NON-ERRORS for PRODUCTIONS
 
 abstract production baseCollectionValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   undecorates to valContainsBase(val, ':=', e, ';', location=top.location);
   top.unparse = "\t" ++ val.unparse ++ " := " ++ e.unparse ++ ";";
@@ -262,7 +262,7 @@ top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
   forwards to localValueDef(val, e, location=top.location);
 }
 abstract production appendCollectionValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   undecorates to valContainsAppend(val, '<-', e, ';', location=top.location);
   top.unparse = "\t" ++ val.unparse ++ " <- " ++ e.unparse ++ ";";
@@ -281,7 +281,7 @@ top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 -- NON-ERRORS for SYN ATTRS
 
 abstract production synBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   undecorates to attrContainsBase(dl, '.', attr, ':=', e, ';', location=top.location);
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " := " ++ e.unparse ++ ";";
@@ -302,7 +302,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     else [];
 }
 abstract production synAppendColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   undecorates to attrContainsAppend(dl, '.', attr, '<-', e, ';', location=top.location);
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " <- " ++ e.unparse ++ ";";
@@ -326,7 +326,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 -- NON-ERRORS for INHERITED ATTRS
 
 abstract production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   undecorates to attrContainsBase(dl, '.', attr, ':=', e, ';', location=top.location);
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " := " ++ e.unparse ++ ";";
@@ -347,7 +347,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
     else [];
 }
 abstract production inhAppendColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   undecorates to attrContainsAppend(dl, '.', attr, '<-', e, ';', location=top.location);
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " <- " ++ e.unparse ++ ";";

--- a/grammars/silver/compiler/modification/collection/DclInfo.sv
+++ b/grammars/silver/compiler/modification/collection/DclInfo.sv
@@ -3,11 +3,11 @@ grammar silver:compiler:modification:collection;
 attribute operation, attrBaseDefDispatcher, attrAppendDefDispatcher occurs on AttributeDclInfo;
 attribute operation, baseDefDispatcher, appendDefDispatcher occurs on ValueDclInfo;
 
-synthesized attribute attrBaseDefDispatcher :: (ProductionStmt ::= PartiallyDecorated DefLHS  PartiallyDecorated QNameAttrOccur  Expr  Location);
-synthesized attribute attrAppendDefDispatcher :: (ProductionStmt ::= PartiallyDecorated DefLHS  PartiallyDecorated QNameAttrOccur  Expr  Location);
+synthesized attribute attrBaseDefDispatcher :: (ProductionStmt ::= Decorated! DefLHS  Decorated! QNameAttrOccur  Expr  Location);
+synthesized attribute attrAppendDefDispatcher :: (ProductionStmt ::= Decorated! DefLHS  Decorated! QNameAttrOccur  Expr  Location);
 
-synthesized attribute baseDefDispatcher :: (ProductionStmt ::= PartiallyDecorated QName  Expr  Location);
-synthesized attribute appendDefDispatcher :: (ProductionStmt ::= PartiallyDecorated QName  Expr  Location);
+synthesized attribute baseDefDispatcher :: (ProductionStmt ::= Decorated! QName  Expr  Location);
+synthesized attribute appendDefDispatcher :: (ProductionStmt ::= Decorated! QName  Expr  Location);
 
 aspect default production
 top::AttributeDclInfo ::=
@@ -15,10 +15,10 @@ top::AttributeDclInfo ::=
   top.operation = error("Internal compiler error: must be defined for all collection attribute declarations");
   
   top.attrBaseDefDispatcher =
-    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, "The ':=' operator can only be used for collections. " ++ attr.name ++ " is not a collection.")], dl, attr, e, location=l);
   top.attrAppendDefDispatcher =
-    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, "The '<-' operator can only be used for collections. " ++ attr.name ++ " is not a collection.")], dl, attr, e, location=l);
 }
 
@@ -49,7 +49,7 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type o::Operation
   top.decoratedAccessHandler = synDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, location=_);
   top.attrDefDispatcher = 
-    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, attr.name ++ " is a collection attribute, and you must use ':=' or '<-', not '='.")], dl, attr, e, location=l);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
 
@@ -74,7 +74,7 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type o::Operation
   top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, location=_); -- TODO: above should probably be an error handler!
   top.attrDefDispatcher =
-    \ dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr  l::Location ->
+    \ dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr  l::Location ->
       errorAttributeDef([err(l, attr.name ++ " is a collection attribute, and you must use ':=' or '<-', not '='.")], dl, attr, e, location=l);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
 

--- a/grammars/silver/compiler/modification/collection/java/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/java/Collection.sv
@@ -187,7 +187,7 @@ public class ${className} extends common.CollectionAttribute {
 
 ---------- LOCALS ---
 aspect production baseCollectionValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   -- for locals, the CA object was created already
   top.translation = s"""
@@ -196,7 +196,7 @@ top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 """;
 }
 aspect production appendCollectionValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   -- for locals, the CA object was created already
   top.translation = s"""
@@ -207,7 +207,7 @@ top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
 
 ---------- SYNTHESIZED ----
 aspect production synBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- := -} e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  {- := -} e::Expr
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} := ${e.unparse}
@@ -217,7 +217,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 """;
 }
 aspect production synAppendColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- <- -} e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  {- <- -} e::Expr
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} <- ${e.unparse}
@@ -229,7 +229,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 
 ---------- INHERITED ----
 aspect production inhBaseColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- := -} e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  {- := -} e::Expr
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} := ${e.unparse}
@@ -239,7 +239,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 """;
 }
 aspect production inhAppendColAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  {- <- -} e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  {- <- -} e::Expr
 {
   top.translation = s"""
     // ${dl.unparse}.${attr.unparse} <- ${e.unparse}

--- a/grammars/silver/compiler/modification/copper/Expr.sv
+++ b/grammars/silver/compiler/modification/copper/Expr.sv
@@ -20,7 +20,7 @@ top::Expr ::= 'disambiguationFailure'
 }
 
 abstract production actionChildReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -38,7 +38,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production pluckTerminalReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -61,7 +61,7 @@ top::Expr ::= q::PartiallyDecorated QName
 -- thing.  Also having type classes would let us use a more specific type than generic TerminalId,
 -- and pluckTerminalReference wouldn't need to cheat with a fresh type.
 abstract production terminalIdReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -81,7 +81,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production lexerClassReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -102,7 +102,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production parserAttributeReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -123,7 +123,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 abstract production termAttrValueReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;

--- a/grammars/silver/compiler/modification/copper/ProductionStmt.sv
+++ b/grammars/silver/compiler/modification/copper/ProductionStmt.sv
@@ -87,7 +87,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
 }
 
 abstract production parserAttributeValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   undecorates to valueEq(val, '=', e, ';', location=top.location);
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";
@@ -235,7 +235,7 @@ top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt
 
 
 abstract production parserAttributeDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   undecorates to concreteDefLHS(q, location=top.location);
   top.name = q.name;
@@ -255,7 +255,7 @@ top::DefLHS ::= q::PartiallyDecorated QName
 }
 
 abstract production termAttrValueValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   undecorates to valueEq(val, '=', e, ';', location=top.location);
   top.unparse = "\t" ++ val.unparse ++ " = " ++ e.unparse ++ ";";

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -100,7 +100,7 @@ top::ValueDclInfo ::= fn::String ty::Type
 }
 
 abstract production defaultLhsDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   undecorates to concreteDefLHS(q, location=top.location);
   top.name = q.name;

--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -80,7 +80,7 @@ top::ProductionRHSElem ::= id::Name '::' t::TypeExpr
 }
 
 abstract production lambdaParamReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;

--- a/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
@@ -53,7 +53,7 @@ ${makeTyVarDecls(5, finTy.freeVariables)}
 }
 
 aspect production lambdaParamReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.translation = s"common.Util.<${finalType(top).transType}>demandIndex(lambda_${toString(q.lookupValue.dcl.lambdaId)}_args, ${toString(q.lookupValue.dcl.lambdaParamIndex)})";
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);

--- a/grammars/silver/compiler/modification/let_fix/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/Let.sv
@@ -122,7 +122,7 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
 }
 
 abstract production lexicalLocalReference
-top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::Decorated! QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   undecorates to baseExpr(q, location=top.location);
   top.unparse = q.unparse;
@@ -148,7 +148,7 @@ top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
     case q.lookupValue.typeScheme.monoType of
     | ntOrDecType(t, i, _) -> ntOrDecType(t, i, freshType())
     | decoratedType(t, i) -> ntOrDecType(t, i, freshType())
-    | partiallyDecoratedType(t, i) -> ntOrDecType(t, i, freshType())
+    | uniqueDecoratedType(t, i) -> ntOrDecType(t, i, freshType())
     | t -> t
     end;
 

--- a/grammars/silver/compiler/modification/let_fix/java/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/java/Let.sv
@@ -63,7 +63,7 @@ String ::= fn::String  et::String  ty::String
 }
 
 aspect production lexicalLocalReference
-top::Expr ::= q::PartiallyDecorated QName  fi::ExprVertexInfo  fd::[FlowVertex]
+top::Expr ::= q::Decorated! QName  fi::ExprVertexInfo  fd::[FlowVertex]
 {
   -- To account for a magic case where we generate a let expression with a type
   -- that is, for example, a ntOrDecType or something,

--- a/grammars/silver/compiler/modification/primitivepattern/Types.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/Types.sv
@@ -220,13 +220,13 @@ top::Type ::= te::Type i::Type
     end;
 }
 
-aspect production partiallyDecoratedType
+aspect production uniqueDecoratedType
 top::Type ::= te::Type i::Type
 {
   top.refine = 
     case top.refineWith of
-    | partiallyDecoratedType(oi, ote) -> composeSubst(refine(te, ote), refine(i, oi))
-    | _ -> errorSubst("Tried to refine partially decorated type with " ++ prettyType(top.refineWith))
+    | uniqueDecoratedType(oi, ote) -> composeSubst(refine(te, ote), refine(i, oi))
+    | _ -> errorSubst("Tried to refine unique decorated type with " ++ prettyType(top.refineWith))
     end;
 }
 

--- a/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
@@ -121,7 +121,7 @@ top::VarBinder ::= n::Name
   -- (We *DO NOT* want to substitute first... because that will turn the type
   -- variables into concrete types! and type variables in a production are
   -- NOT automatically decorated!)
-  -- Also, don't attempt to decorate already-partially-decorated types.
+  -- Also, don't attempt to decorate already-decorated types.
   local ty :: Type =
     if isDecorable(top.bindingType, top.env) && !top.bindingType.isDecorated
     then decoratedType(top.bindingType, freshInhSet())

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -57,14 +57,14 @@ top::Expr ::= msg::[Message]
 }
 
 aspect production errorReference
-top::Expr ::= msg::[Message]  q::PartiallyDecorated QName
+top::Expr ::= msg::[Message]  q::Decorated! QName
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
   top.lazyTranslation = top.translation;
 }
 
 aspect production childReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local childIDref :: String =
     top.frame.className ++ ".i_" ++ q.lookupValue.fullName;
@@ -88,7 +88,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production localReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.translation =
     if isDecorable(q.lookupValue.typeScheme.typerep, top.env)
@@ -108,7 +108,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production lhsReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.translation =
     if finalType(top).isDecorated
@@ -119,7 +119,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production forwardReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.translation =
     if finalType(top).isDecorated
@@ -131,7 +131,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production productionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   top.translation =
     if null(typeScheme.contexts)
@@ -148,7 +148,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production functionReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   -- functions, unlike productions, can return a type variable.
   -- as such, we have to cast it to the real inferred final type.
@@ -174,7 +174,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production classMemberReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local transContextMember::String =
     s"${instHead.transContext}.${makeInstanceMemberAccessorName(q.lookupValue.fullName)}(${implode(", ", contexts.transContexts)})";
@@ -190,7 +190,7 @@ top::Expr ::= q::PartiallyDecorated QName
 }
 
 aspect production globalValueReference
-top::Expr ::= q::PartiallyDecorated QName
+top::Expr ::= q::Decorated! QName
 {
   local directThunk :: String =
     s"${makeName(q.lookupValue.dcl.sourceGrammar)}.Init.global_${fullNameToShort(q.lookupValue.fullName)}" ++
@@ -204,14 +204,14 @@ top::Expr ::= q::PartiallyDecorated QName
     else s"${directThunk}.eval()";
 }
 aspect production errorApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs annos::Decorated! AnnoAppExprs
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
   top.lazyTranslation = top.translation;
 }
 
 aspect production functionInvocation
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs annos::Decorated! AnnoAppExprs
 {
   top.translation = e.invokeTranslation;
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
@@ -250,7 +250,7 @@ String ::= e::Decorated AnnoAppExprs
 function int2str String ::= i::Integer { return toString(i); }
 
 aspect production partialApplication
-top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::PartiallyDecorated AnnoAppExprs
+top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs annos::Decorated! AnnoAppExprs
 {
   local step1 :: String = e.translation;
   -- Note: we check for nullity of the index lists instead of use
@@ -279,14 +279,14 @@ top::Expr ::= e::PartiallyDecorated Expr es::PartiallyDecorated AppExprs annos::
 }
 
 aspect production errorAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
   top.lazyTranslation = top.translation;
 }
 
 aspect production errorDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
   top.lazyTranslation = top.translation;
@@ -300,7 +300,7 @@ top::Expr ::= e::Expr '.' 'forward'
 }
 
 aspect production synDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.translation = wrapAccessWithOT(top, s"${e.translation}.<${finalType(top).transType}>synthesized(${q.attrOccursIndex})");
 
@@ -319,7 +319,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production inhDecoratedAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.translation = wrapAccessWithOT(top, s"${e.translation}.<${finalType(top).transType}>inherited(${q.attrOccursIndex})");
 
@@ -331,7 +331,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production terminalAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   local accessor :: String =
     if q.name == "lexeme" || q.name == "location"
@@ -350,7 +350,7 @@ top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
 }
 
 aspect production annoAccessHandler
-top::Expr ::= e::PartiallyDecorated Expr  q::PartiallyDecorated QNameAttrOccur
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   -- Note that the transType is specific to the nonterminal we're accessing from.
   top.translation = s"((${finalType(top).transType})((${makeAnnoName(q.attrDcl.fullName)})${e.translation}).getAnno_${makeIdName(q.attrDcl.fullName)}())";
@@ -572,7 +572,7 @@ top::Exprs ::= e1::Expr ',' e2::Exprs
 }
 
 aspect production exprRef
-top::Expr ::= e::PartiallyDecorated Expr
+top::Expr ::= e::Decorated! Expr
 {
   top.translation = e.translation;
   top.lazyTranslation = e.lazyTranslation;

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -262,7 +262,7 @@ s"""private Object child_${n};
   top.childStaticElem =
     if lookupBy(typeNameEq, ty, top.sigInhOccurs).isJust
     then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[count_inh__ON__${ntType.transTypeName}];\n"
-    else if ty.isNonterminal || ty.isPartiallyDecorated && ntType.isNonterminal
+    else if ty.isNonterminal || ty.isUniqueDecorated && ntType.isNonterminal
     then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_inh_attrs];\n"
     else "";
 

--- a/grammars/silver/compiler/translation/java/core/OccursDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/OccursDcl.sv
@@ -1,7 +1,7 @@
 grammar silver:compiler:translation:java:core;
 
 aspect production defaultAttributionDcl
-top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   local ntfn :: String = nt.lookupType.fullName;
   local occursType :: String = if at.lookupAttribute.dcl.isSynthesized then "syn" else "inh";
@@ -30,7 +30,7 @@ top::AGDcl ::= at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QNam
 }
 
 aspect production errorAttributionDcl
-top::AGDcl ::= msg::[Message] at::PartiallyDecorated QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+top::AGDcl ::= msg::[Message] at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   top.setupInh := error("Internal compiler error: translation not defined in the presence of errors");
   top.valueWeaving := error("Internal compiler error: translation not defined in the presence of errors");

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -109,7 +109,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
     then
       s"\t\t//${top.unparse}\n" ++
       s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = " ++ 
-      if te.typerep.isNonterminal || te.typerep.isPartiallyDecorated
+      if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
       then s"new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n"
       else s"new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n"
     else "";
@@ -132,7 +132,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
     then
       s"\t\t//${top.unparse}\n" ++
       s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = " ++ 
-      if te.typerep.isNonterminal || te.typerep.isPartiallyDecorated
+      if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
       then s"new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n"
       else s"new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n"
     else "";
@@ -143,43 +143,43 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
 }
 
 aspect production childDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   top.translation = s"${top.frame.className}.childInheritedAttributes[${top.frame.className}.i_${q.lookupValue.fullName}]";
 }
 
 aspect production lhsDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   top.translation = s"${top.frame.className}.synthesizedAttributes";
 }
 
 aspect production localDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   top.translation = s"${top.frame.className}.localInheritedAttributes[${q.lookupValue.dcl.attrOccursIndex}]";
 }
 
 aspect production forwardDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   top.translation = s"${top.frame.className}.forwardInheritedAttributes";
 }
 
 aspect production errorDefLHS
-top::DefLHS ::= q::PartiallyDecorated QName
+top::DefLHS ::= q::Decorated! QName
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
 }
 
 aspect production errorAttributeDef
-top::ProductionStmt ::= msg::[Message] dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= msg::[Message] dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
 }
 
 aspect production synthesizedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   top.translation = 
     s"\t\t// ${dl.unparse}.${attr.unparse} = ${e.unparse}\n" ++
@@ -187,7 +187,7 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 }
 
 aspect production inheritedAttributeDef
-top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated QNameAttrOccur  e::Expr
+top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   top.translation = 
     s"\t\t// ${dl.unparse}.${attr.unparse} = ${e.unparse}\n" ++
@@ -196,13 +196,13 @@ top::ProductionStmt ::= dl::PartiallyDecorated DefLHS  attr::PartiallyDecorated 
 
 
 aspect production errorValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   top.translation = error("Internal compiler error: translation not defined in the presence of errors");
 }
 
 aspect production localValueDef
-top::ProductionStmt ::= val::PartiallyDecorated QName  e::Expr
+top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   top.translation =
 	s"\t\t// ${val.unparse} = ${e.unparse}\n" ++

--- a/grammars/silver/compiler/translation/java/type/Type.sv
+++ b/grammars/silver/compiler/translation/java/type/Type.sv
@@ -178,7 +178,7 @@ top::Type ::= te::Type i::Type
   top.transTypeName = "Decorated_" ++ te.transTypeName;
 }
 
-aspect production partiallyDecoratedType
+aspect production uniqueDecoratedType
 top::Type ::= te::Type i::Type
 {
   -- TODO: this should probably be a generic.  e.g. "DecoratedNode<something>"

--- a/grammars/silver/core/Undecorate.sv
+++ b/grammars/silver/core/Undecorate.sv
@@ -14,13 +14,13 @@ foreign {
 }
 
 @{-
-  - Undecorate a partially-decorated reference.
+  - Undecorate a unique reference.
   -
   - @param x  The reference to undecorate.
   - @return A new, undecorated term coresponding to x.
   -}
-function newPartial
-a ::= x::PartiallyDecorated a with i
+function newUnique
+a ::= x::Decorated! a with i
 { return error("foreign function"); }
 foreign {
   "java": return "common.OriginsUtil.duplicatePoly(%x%.undecorate(), originCtx)";

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -39,7 +39,7 @@ public class DecoratedNode implements Decorable, Typed {
 	protected final Node self;
 	/**
 	 * The node that forwards to this one. (May be null)
-	 * Not final, because we may set this when forwarding to a partially-decorated reference.
+	 * Not final, because we may set this when forwarding to a (unique) reference.
 	 * 
 	 * @see #inheritedForwarded(String)
 	 */
@@ -177,7 +177,7 @@ public class DecoratedNode implements Decorable, Typed {
 	}
 
 	/**
-	 * Decorate this (partially decorated) node with additional inherited attributes.
+	 * Decorate this (unique decorated) node with additional inherited attributes.
 	 * 
 	 * @param parent The DecoratedNode extra-decorating this one. (Whether this is a child or a local (or other) of that node.)
 	 * @param inhs A map from attribute names to Lazys that define them.  These Lazys will be supplied with 'parent' as their context for evaluation.

--- a/runtime/lsp4j/src/main/java/edu/umn/cs/melt/lsp4jutil/CopperParserNodeFactory.java
+++ b/runtime/lsp4j/src/main/java/edu/umn/cs/melt/lsp4jutil/CopperParserNodeFactory.java
@@ -16,7 +16,6 @@ import silver.core.NParseResult;
 * A wrapper to treat a Silver-generated Copper parser as a Silver function.
 * 
 * @author krame505
-* @see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens
 */
 public class CopperParserNodeFactory extends NodeFactory<NParseResult> {
     private Supplier<? extends SilverCopperParser<?>> parserFactory;

--- a/test/flow/PartialDec.sv
+++ b/test/flow/PartialDec.sv
@@ -13,9 +13,9 @@ top::PDExpr ::= e::PDExpr
 }
 
 production dispatchThing
-top::PDExpr ::= e::PartiallyDecorated PDExpr with {env1}
+top::PDExpr ::= e::Decorated! PDExpr with {env1}
 {
-  -- Accesses on partially decorated children should not give flow errors
+  -- Accesses on unique decorated children should not give flow errors
   top.errors1 = e.errors1;
   top.errors2 = !null(e.env1);
 }
@@ -24,22 +24,22 @@ function getEnv2FromPartialRef
 [String] ::= e::Expr
 {
   e.env2 = [];
-  -- Accesses on partially decorated local should not give flow errors
-  local e2::PartiallyDecorated Expr with {env2} = e;
+  -- Accesses on unique decorated local should not give flow errors
+  local e2::Decorated! Expr with {env2} = e;
   return e2.env2;
 }
 {-
-warnCode "Multiple partially decorated references taken to e in production flow:overloadThing2 (reference has type PartiallyDecorated flow:PDExpr with {flow:env1})." {
+warnCode "Multiple unique references taken to e in production flow:overloadThing2 (reference has type Decorated! flow:PDExpr with {flow:env1})." {
 production overloadThing2
 top::PDExpr ::= e::PDExpr
 {
-  local otherRef::PartiallyDecorated PDExpr with {env1} = e;
+  local otherRef::Decorated! PDExpr with {env1} = e;
   e.env1 = top.env1;
   forwards to dispatchThing(e);
 }
 }
 -}
-warnCode "Attribute env2 with an equation on e is not in the partially decorated reference taken" {
+warnCode "Attribute env2 with an equation on e is not in the unique reference taken" {
 aspect production overloadThing
 top::PDExpr ::= e::PDExpr
 {
@@ -47,36 +47,36 @@ top::PDExpr ::= e::PDExpr
 }
 }
 {-
-warnCode "Multiple partially decorated references taken to e2 in production flow:overloadThing (reference has type PartiallyDecorated flow:PDExpr with {flow:env1})." {
+warnCode "Multiple unique references taken to e2 in production flow:overloadThing (reference has type Decorated! flow:PDExpr with {flow:env1})." {
 aspect production overloadThing
 top::PDExpr ::= e::PDExpr
 {
   local e2::PDExpr = e;
   e2.env1 = [];
   e2.env2 = [];
-  local ref1::PartiallyDecorated PDExpr with {env1} = e2;
-  local ref2::PartiallyDecorated PDExpr with {env1, env2} = e2;
+  local ref1::Decorated! PDExpr with {env1} = e2;
+  local ref2::Decorated! PDExpr with {env1, env2} = e2;
 }
 }
 -}
-warnCode "Partially decorated reference of type PartiallyDecorated flow:PDExpr with {} does not contain all attributes in the reference set of e's type PartiallyDecorated flow:PDExpr with {flow:env1}" {
+warnCode "Unique reference of type Decorated! flow:PDExpr with {} does not contain all attributes in the reference set of e's type Decorated! flow:PDExpr with {flow:env1}" {
 aspect production dispatchThing
-top::PDExpr ::= e::PartiallyDecorated PDExpr with {env1}
+top::PDExpr ::= e::Decorated! PDExpr with {env1}
 {
-  local otherRef::PartiallyDecorated PDExpr with {} = e;
+  local otherRef::Decorated! PDExpr with {} = e;
 }
 }
 
 function thingWithBoundedRefArg
 {env1, env2} subset i, i subset {env1} =>  -- Uninhabited, but shouldn't give an error
-PartiallyDecorated PDExpr with {env1} ::= e::PartiallyDecorated PDExpr with i
+Decorated! PDExpr with {env1} ::= e::Decorated! PDExpr with i
 {
   return e;
 }
 
-warnCode "Cannot take a partially decorated reference to e of type PartiallyDecorated flow:PDExpr with i, as the reference set is not bounded" {
+warnCode "Cannot take a unique reference to e of type Decorated! flow:PDExpr with i, as the reference set is not bounded" {
 function thingWithUnboundedRefArg
-{env1, env2} subset i => PartiallyDecorated PDExpr with {env1} ::= e::PartiallyDecorated PDExpr with i
+{env1, env2} subset i => Decorated! PDExpr with {env1} ::= e::Decorated! PDExpr with i
 {
   return e;
 }
@@ -84,16 +84,16 @@ function thingWithUnboundedRefArg
 
 warnCode "Duplicate equation for env2 on e in production flow:alreadyDec" {
 function alreadyDec
-() ::= e::PartiallyDecorated PDExpr with {env2}
+() ::= e::Decorated! PDExpr with {env2}
 {
   e.env2 = [];
   return ();
 }
 }
 
-warnCode "Attribute env1 with an equation on e is not in the partially decorated reference taken" {
+warnCode "Attribute env1 with an equation on e is not in the unique reference taken" {
 function eqnNotInRef
-PartiallyDecorated PDExpr with {env2} ::= e::PDExpr
+Decorated! PDExpr with {env2} ::= e::PDExpr
 {
   e.env1 = [];
   e.env2 = [];
@@ -101,10 +101,10 @@ PartiallyDecorated PDExpr with {env2} ::= e::PDExpr
 }
 }
 
-warnCode "Partially decorated reference of type PartiallyDecorated flow:PDExpr with {} does not contain all attributes in the reference set of e's type PartiallyDecorated flow:PDExpr with {flow:env1}" {
+warnCode "Unique reference of type Decorated! flow:PDExpr with {} does not contain all attributes in the reference set of e's type Decorated! flow:PDExpr with {flow:env1}" {
 aspect production dispatchThing
-top::PDExpr ::= e::PartiallyDecorated PDExpr with {env1}
+top::PDExpr ::= e::Decorated! PDExpr with {env1}
 {
-  local otherRef::PartiallyDecorated PDExpr with {} = e;
+  local otherRef::Decorated! PDExpr with {} = e;
 }
 }

--- a/test/silver_features/PartialDec.sv
+++ b/test/silver_features/PartialDec.sv
@@ -20,7 +20,7 @@ top::PDExpr ::= e::PDExpr
 }
 
 production pdOp1Impl
-top::PDExpr ::= e::PartiallyDecorated PDExpr with {env1}
+top::PDExpr ::= e::Decorated! PDExpr with {env1}
 {
   undecorates to pdOp1(e);
   e.env2 = top.env2;
@@ -36,10 +36,10 @@ top::PDExpr ::= e::PDExpr
 }
 
 production pdOp2Impl
-top::PDExpr ::= e::PartiallyDecorated PDExpr with {env1}
+top::PDExpr ::= e::Decorated! PDExpr with {env1}
 {
   undecorates to pdOp2(e);
-  local e2::PartiallyDecorated PDExpr with {env1} = e;
+  local e2::Decorated! PDExpr with {env1} = e;
   e2.env2 = top.env2;
   top.errors1 = e2.errors1;
   top.errors2 = e2.errors2;
@@ -54,7 +54,7 @@ top::PDExpr ::= e::PDExpr
 }
 
 production pdOp3Impl
-top::PDExpr ::= e::PartiallyDecorated PDExpr with {env1}
+top::PDExpr ::= e::Decorated! PDExpr with {env1}
 {
   undecorates to pdOp3(e);
   local e2::Decorated PDExpr = decorate withEnv1(e) with {env2 = top.env2;};
@@ -62,22 +62,22 @@ top::PDExpr ::= e::PartiallyDecorated PDExpr with {env1}
   top.errors2 = e2.errors2;
 }
 
-global withEnv1::(PartiallyDecorated PDExpr with {env1} ::= PartiallyDecorated PDExpr with {env1}) = id;
+global withEnv1::(Decorated! PDExpr with {env1} ::= Decorated! PDExpr with {env1}) = id;
 
 production pdOp4
 top::PDExpr ::= e::PDExpr
 {
   e.env1 = top.env1;
-  local e2::PartiallyDecorated PDExpr with {env1} = e;
+  local e2::Decorated! PDExpr with {env1} = e;
   e2.env2 = top.env2;
   forwards to pdOp4Impl(e2);
 }
 
 production pdOp4Impl
-top::PDExpr ::= e::PartiallyDecorated PDExpr
+top::PDExpr ::= e::Decorated! PDExpr
 {
   undecorates to pdOp4(e);
-  local e2::PartiallyDecorated PDExpr = e;
+  local e2::Decorated! PDExpr = e;
   top.errors1 = e2.errors1;
   top.errors2 = e2.errors2;
 }

--- a/test/silver_features/UndecoratesTo.sv
+++ b/test/silver_features/UndecoratesTo.sv
@@ -5,7 +5,7 @@ flowtype UndecNT = decorate {};
 propagate compareTo, isEqual on UndecNT;
 
 production fork1UNT
-top::UndecNT ::= a::PartiallyDecorated UndecNT b::UndecNT
+top::UndecNT ::= a::Decorated! UndecNT b::UndecNT
 {
   undecorates to fork2UNT(a, b);
 }
@@ -20,7 +20,7 @@ top::UndecNT ::=
 {}
 
 production wrapUNT
-top::UndecNT ::= a::PartiallyDecorated UndecNT
+top::UndecNT ::= a::Decorated! UndecNT
 {
   undecorates to a;
 }


### PR DESCRIPTION
# Changes
* "Partially decorated references" are now referred to as "unique references"
* The type expression syntax `PartiallyDecorated` is changed to `Decorated!` (suggested by @RandomActsOfGrammar)

# Documentation
This will be reflected in the updated docs once feature/uniqueness-analysis is ready to merge.
