### PR TITLE
Load the Silver compiler grammars and parser from the specified jar at initialization rather than at runtime

### DIFF
--- a/language-server/langserver/src/main/java/edu/umn/cs/melt/silver/langserver/SilverLanguageServer.java
+++ b/language-server/langserver/src/main/java/edu/umn/cs/melt/silver/langserver/SilverLanguageServer.java
@@ -54,10 +54,16 @@ public class SilverLanguageServer implements LanguageServer, LanguageClientAware
         String compilerJar = "", parserName = "";
         try {
             JsonObject initOptions = (JsonObject)initializeParams.getInitializationOptions();
-            compilerJar = initOptions.get("compilerJar").getAsString();
-            parserName = initOptions.get("parserName").getAsString();
+            if (initOptions != null) {
+                if (initOptions.has("compilerJar")) {
+                    compilerJar = initOptions.get("compilerJar").getAsString();
+                }
+                if (initOptions.has("parserName")) {
+                    parserName = initOptions.get("parserName").getAsString();
+                }
+            }
         } catch(ClassCastException e) {
-            System.err.println("Failed to get compiler jar/parser name");
+            System.err.println("Got unexpected init options: " + initializeParams.getInitializationOptions());
         }
         if (parserName.isEmpty()) {
             parserName = "silver:compiler:composed:Default:svParse";

--- a/runtime/lsp4j/src/main/java/edu/umn/cs/melt/lsp4jutil/Util.java
+++ b/runtime/lsp4j/src/main/java/edu/umn/cs/melt/lsp4jutil/Util.java
@@ -127,10 +127,58 @@ public class Util {
     }
 
     /**
+     * Convert a grammar name to a Java package name
+     * @param grammar The grammar name
+     * @return The package name
+     */
+    public static String grammarToPackage(final String grammar) {
+        return grammar.replace(':', '.');
+    }
+
+    /**
+     * Reflectively initialize a Silver grammar, using the default ClassLoader.
+     * This transitively initialize all dependencies.
+     * 
+     * @param grammar The name of the grammar to initialize
+     */
+    public static void initGrammar(final String grammar)
+        throws SecurityException, ReflectiveOperationException {
+        initGrammar(grammar, ClassLoader.getSystemClassLoader());
+    }
+    /**
+     * Reflectively initialize a Silver grammar, using the specified ClassLoader.
+     * This transitively initialize all dependencies.
+     * 
+     * @param grammar The name of the grammar to initialize
+     * @param loader The ClassLoader from which to load the grammar's classes
+     */
+    public static void initGrammar(final String grammar, final ClassLoader loader)
+        throws SecurityException, ReflectiveOperationException {
+        Class<?> initClass = Class.forName(grammarToPackage(grammar) + ".Init", true, loader);
+        initClass.getMethod("initAllStatics").invoke(null);
+        initClass.getMethod("init").invoke(null);
+        initClass.getMethod("postInit").invoke(null);
+    }
+
+    /**
+     * Initialize a ClassLoader from a jar path.
+     * 
+     * @param jarPath The path to the jar
+     * @return A ClassLoader for the jar
+     */
+    public static URLClassLoader getJarClassLoader(final Path jarPath) {
+        try {
+            return new URLClassLoader(new URL[] {jarPath.toUri().toURL()}, Util.class.getClassLoader());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
      * Dynamically load a Copper parser from a compiled Silver grammar.
      * 
      * @param <ROOT> The start nonterminal type of the parser
-     * @param jarPath The path to the jar file to be loaded
+     * @param loader The ClassLoader to use to load the parser
      * @param name The name of the declared parser, prefixed by its grammar
      * @param rootClass The class of the start nonterminal for the parser
      * @return A factory object for instantiating the parser
@@ -139,18 +187,11 @@ public class Util {
      */
     @SuppressWarnings("unchecked")
     public static <ROOT> Supplier<SilverCopperParser<ROOT>> loadCopperParserFactory(
-        final Path jarPath, final String name, final Class<ROOT> rootClass)
+        final ClassLoader loader, final String name, final Class<ROOT> rootClass)
         throws SecurityException, ReflectiveOperationException {
-        // Initialize a class loader for the jar
-        URLClassLoader loader;
-        try {
-            loader = new URLClassLoader(new URL[] {jarPath.toUri().toURL()}, Util.class.getClassLoader());
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-
         // Load the parser class
-        String pkg = String.join(".", name.substring(0, Math.max(name.lastIndexOf(":"), 0)).split(":"));
+        String grammar = name.substring(0, Math.max(name.lastIndexOf(":"), 0));
+        String pkg = grammarToPackage(grammar);
         String parserClassName = pkg + ".Parser_" + String.join("_", name.split(":"));
         Class<?> parserClass = Class.forName(parserClassName, true, loader);
 
@@ -174,11 +215,7 @@ public class Util {
         }
 
         // Initialize the grammar containing the parser.
-        // This transitively initializes any dependent grammars, e.g. extensions included in the parser.
-        Class<?> initClass = Class.forName(pkg + ".Init", true, loader);
-        initClass.getMethod("initAllStatics").invoke(null);
-        initClass.getMethod("init").invoke(null);
-        initClass.getMethod("postInit").invoke(null);
+        initGrammar(grammar, loader);
 
         // Set up the parser factory
         Constructor<?> constructor = parserClass.getConstructor();

--- a/support/vs-code/silverlsp/CHANGELOG.md
+++ b/support/vs-code/silverlsp/CHANGELOG.md
@@ -6,9 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.3]
+- Load alternate compiler jar/parser on startup, fixing some bugs when using an extended compiler jar built against alternate version of Silver 
+
 ## [0.0.2]
 - Add support for specifying a jar containing an alternate Silver parser
-- Fix issue with semantic tokens for lines contianing tabs
+- Fix issue with semantic tokens for lines containing tabs
 - Internal refactoring to move reusable lsp4j utilities
 - Fixes in the flow analysis and build process corresponding to changes in the forthcoming 0.4.5 release of Silver
 

--- a/support/vs-code/silverlsp/package.json
+++ b/support/vs-code/silverlsp/package.json
@@ -66,7 +66,7 @@
           "silver.parserName": {
             "type": "string",
             "default": "silver:compiler:composed:Default:svParse",
-            "description": "Full name of the Silver parser to use, must be set if compiler jar is specified"
+            "description": "Full name of the Silver parser to use"
           }
         }
       }

--- a/support/vs-code/silverlsp/package.json
+++ b/support/vs-code/silverlsp/package.json
@@ -2,7 +2,7 @@
   "name": "silverlsp",
   "displayName": "Silver LSP",
   "description": "Plugin for Silver Language Server Protocol support",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "engines": {
     "vscode": "^1.67.0"
   },

--- a/support/vs-code/silverlsp/src/extension.ts
+++ b/support/vs-code/silverlsp/src/extension.ts
@@ -46,6 +46,10 @@ export function activate(context: vscode.ExtensionContext) {
 			synchronize: {
 				configurationSection: 'Silver'
 			},
+			initializationOptions: {
+				'compilerJar': config.get('compilerJar'),
+				'parserName': config.get('parserName')
+			}
 		};
 
 		// Create the language client and start the client.


### PR DESCRIPTION
# Changes
This fixes #731.   Now the compiler grammars and parser are reflectively loaded from the specified jar (falling back to the Silver compiler implementation that the language server was built against) at startup, instead of checking this setting every time a build is triggered.

This now requires reloading the editor when changing to a different Silver jar/parser, but that is infrequent enough to not be a significant annoyance.

# Documentation
This is essentially an internal change in the language server implementation. Added javadoc comments for the new utilities.
