### PR TITLE
Fix bug with error handling when equation lhs is not a child

### DIFF
--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -359,7 +359,7 @@ top::DefLHS ::= q::Decorated! QName
   top.errors <- q.lookupValue.errors;
   top.errors <-
     if top.typerep.isError then [] else [err(q.location, "Cannot define attributes on " ++ q.name)];
-  top.typerep = q.lookupValue.typeScheme.monoType;
+  top.typerep = q.lookupValue.typeScheme.typerep;
 }
 
 concrete production concreteDefLHSfwd


### PR DESCRIPTION
# Changes
Bug fix, this should not be asserting that the attribute LHS typescheme is a monotype when we are in an error case.

# Documentation
None, this is a minor bug fix
