### PR TITLE
Allow specifying a relative path for the Silver compiler jar in language server settings

### DIFF
--- a/support/vs-code/silverlsp/package.json
+++ b/support/vs-code/silverlsp/package.json
@@ -61,7 +61,7 @@
           },
           "silver.compilerJar": {
             "type": "string",
-            "description": "Path to the jar containing an alternate version of the Silver compiler"
+            "description": "Path to the jar containing an alternate version of the Silver compiler. This can be a relative path from the first workspace folder."
           },
           "silver.parserName": {
             "type": "string",


### PR DESCRIPTION
# Changes
Resolve relative paths specified for compiler jar in language server settings.

# Documentation
Updated the help message for the compiler jar settings field in the SilverLSP extension.
