### PR TITLE
Make fetch-jars default to the latest commit on the current branch that has jars

### DIFF
--- a/fetch-jars
+++ b/fetch-jars
@@ -20,18 +20,15 @@ if [[ $* != *--copper* && $# -gt 0 || $# -gt 1 ]]; then
   rev=$(git rev-parse $1)
 fi
 
+# Get the hash of the latest commit on develop.
+# This always gives the latest commit regardless of if the repo is up to date,
+# and works in a Jenkins checkout.
+DEVELOP=$(git ls-remote https://github.com/melt-umn/silver develop | cut -f1)
+
 # Look for jars in the current commit and its parents.
 # First, check that we are inside a git repo.
-if git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/null && [[ -z $rev ]]; then
-  # List all cantidate commits
-  if git rev-parse develop 1> /dev/null 2> /dev/null; then
-    # We see develop, only list commits not on develop
-    commits=$(git rev-list HEAD ^develop)
-  else
-    # We don't see develop (checked out by Jenkins?), list all commits
-    commits=$(git rev-list HEAD)
-  fi
-  for commit in $commits; do
+if [[ -z $rev ]] && git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/null; then
+  for commit in $(git rev-list HEAD ^$DEVELOP); do
     if has_jars $commit; then
       echo "Found jars from past commit"
       rev=$commit
@@ -40,7 +37,7 @@ if git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/null && [[ -z $rev ]
   done
 fi
 
-if [[ -z $rev || $rev == $(git rev-parse develop) ]]; then
+if [[ -z $rev || $rev == $DEVELOP ]]; then
   echo "Fetching latest stable jars..."
   LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
   REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"

--- a/fetch-jars
+++ b/fetch-jars
@@ -36,7 +36,7 @@ if [ -z $rev ]; then
   done
 fi
 
-if [ -z $rev ]; then
+if [[ -z $rev || $rev == $(git rev-parse develop) ]]; then
   echo "Fetching latest stable jars..."
   LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
   REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"

--- a/fetch-jars
+++ b/fetch-jars
@@ -13,10 +13,6 @@ function has_jars {
   wget --spider -q "$COMMIT_ARTIFACTS/$1"
 }
 
-function in_git_repo {
-  git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/null
-}
-
 rev=""
 
 # Look for jars in the specified revision
@@ -24,9 +20,18 @@ if [[ $* != *--copper* && $# -gt 0 || $# -gt 1 ]]; then
   rev=$(git rev-parse $1)
 fi
 
-# Look for jars in the current commit and its parents
-if in_git_repo && [[ -z $rev ]]; then
-  for commit in $(git rev-list HEAD ^develop); do
+# Look for jars in the current commit and its parents.
+# First, check that we are inside a git repo.
+if git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/null && [[ -z $rev ]]; then
+  # List all cantidate commits
+  if git rev-parse develop 1> /dev/null 2> /dev/null; then
+    # We see develop, only list commits not on develop
+    commits=$(git rev-list HEAD ^develop)
+  else
+    # We don't see develop (checked out by Jenkins?), list all commits
+    commits=$(git rev-list HEAD)
+  fi
+  for commit in $commits; do
     if has_jars $commit; then
       echo "Found jars from past commit"
       rev=$commit
@@ -35,7 +40,7 @@ if in_git_repo && [[ -z $rev ]]; then
   done
 fi
 
-if ! in_git_repo || [[ -z $rev || $rev == $(git rev-parse develop) ]]; then
+if [[ -z $rev || $rev == $(git rev-parse develop) ]]; then
   echo "Fetching latest stable jars..."
   LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
   REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"

--- a/fetch-jars
+++ b/fetch-jars
@@ -3,26 +3,56 @@
 set -eu
 
 # Usage: ./fetch-jars [rev-name] [--copper]
+# If a revision is not specified, the script fetches the latest jars from the current branch,
+# falling back to develop.
+# If --copper is specified, only fetch the Copper jars.
 
+COMMIT_ARTIFACTS="https://foundry.remexre.xyz/commit-artifacts/"
 
+function has_jars {
+  test_rev=$(git rev-parse $1)
+  wget --spider -q "$COMMIT_ARTIFACTS/$test_rev"
+}
+
+rev=""
+
+# Look for jars in the specified revision
 if [[ $* != *--copper* && $# -gt 0 || $# -gt 1 ]]; then
-    rev=$(git rev-parse $1)
-    echo "Warning: Fetching unstable jars!  (commit $rev)"
+  rev=$(git rev-parse $1)
+  if ! has_jars $rev; then
+    echo "Cound not find jars for $1 (commit $rev)"
+    exit 1
+  fi
+fi
 
-    LOCAL_STORE=
-    REMOTE_STORE="https://foundry.remexre.xyz/commit-artifacts/$rev"
-    JARS_BAK="JARS-BAK/$rev"
+# Look for jars in the current commit and its parents
+if [ -z $rev ]; then
+  for test_rev in $(git rev-list HEAD ^develop); do
+    if has_jars $test_rev; then
+      echo "Found jars in commit $test_rev"
+      rev=$test_rev
+      break
+    fi
+  done
+fi
+
+if [ -z $rev ]; then
+  echo "Fetching latest stable jars..."
+  LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
+  REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"
+  JARS_BAK=JARS-BAK
 else
-    LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
-    REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"
-    JARS_BAK=JARS-BAK
+  echo "Warning: Fetching unstable jars!  (commit $rev)"
+  LOCAL_STORE=
+  REMOTE_STORE="$COMMIT_ARTIFACTS/$rev"
+  JARS_BAK="JARS-BAK/$rev"
 fi
 
 if [[ $* == *--copper* ]]; then
-    # Only fetch the Copper jars, if requested
-    FILES="CopperCompiler.jar"
+  # Only fetch the Copper jars, if requested
+  FILES="CopperCompiler.jar"
 else
-    FILES="CopperCompiler.jar commonmark-0.17.1.jar silver.compiler.composed.Default.jar SilverRuntime.jar"
+  FILES="CopperCompiler.jar commonmark-0.17.1.jar silver.compiler.composed.Default.jar SilverRuntime.jar"
 fi
 
 mkdir -p jars

--- a/fetch-jars
+++ b/fetch-jars
@@ -13,6 +13,10 @@ function has_jars {
   wget --spider -q "$COMMIT_ARTIFACTS/$1"
 }
 
+function in_git_repo {
+  git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/null
+}
+
 rev=""
 
 # Look for jars in the specified revision
@@ -21,7 +25,7 @@ if [[ $* != *--copper* && $# -gt 0 || $# -gt 1 ]]; then
 fi
 
 # Look for jars in the current commit and its parents
-if [ -z $rev ]; then
+if in_git_repo && [[ -z $rev ]]; then
   for commit in $(git rev-list HEAD ^develop); do
     if has_jars $commit; then
       echo "Found jars from past commit"
@@ -31,18 +35,17 @@ if [ -z $rev ]; then
   done
 fi
 
-git --no-pager show --quiet $rev
-if ! has_jars $rev; then
-  echo "Cound not find jars for commit"
-  exit 1
-fi
-
-if [[ -z $rev || $rev == $(git rev-parse develop) ]]; then
+if ! in_git_repo || [[ -z $rev || $rev == $(git rev-parse develop) ]]; then
   echo "Fetching latest stable jars..."
   LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
   REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"
   JARS_BAK=JARS-BAK
 else
+  git --no-pager show --quiet $rev
+  if ! has_jars $rev; then
+    echo "Cound not find jars for commit"
+    exit 1
+  fi
   echo "Warning: Fetching unstable jars!"
   LOCAL_STORE=
   REMOTE_STORE="$COMMIT_ARTIFACTS/$rev"

--- a/fetch-jars
+++ b/fetch-jars
@@ -10,8 +10,7 @@ set -eu
 COMMIT_ARTIFACTS="https://foundry.remexre.xyz/commit-artifacts/"
 
 function has_jars {
-  test_rev=$(git rev-parse $1)
-  wget --spider -q "$COMMIT_ARTIFACTS/$test_rev"
+  wget --spider -q "$COMMIT_ARTIFACTS/$1"
 }
 
 rev=""
@@ -19,21 +18,23 @@ rev=""
 # Look for jars in the specified revision
 if [[ $* != *--copper* && $# -gt 0 || $# -gt 1 ]]; then
   rev=$(git rev-parse $1)
-  if ! has_jars $rev; then
-    echo "Cound not find jars for $1 (commit $rev)"
-    exit 1
-  fi
 fi
 
 # Look for jars in the current commit and its parents
 if [ -z $rev ]; then
-  for test_rev in $(git rev-list HEAD ^develop); do
-    if has_jars $test_rev; then
-      echo "Found jars in commit $test_rev"
-      rev=$test_rev
+  for commit in $(git rev-list HEAD ^develop); do
+    if has_jars $commit; then
+      echo "Found jars from past commit"
+      rev=$commit
       break
     fi
   done
+fi
+
+git --no-pager show --quiet $rev
+if ! has_jars $rev; then
+  echo "Cound not find jars for commit"
+  exit 1
 fi
 
 if [[ -z $rev || $rev == $(git rev-parse develop) ]]; then
@@ -42,7 +43,7 @@ if [[ -z $rev || $rev == $(git rev-parse develop) ]]; then
   REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"
   JARS_BAK=JARS-BAK
 else
-  echo "Warning: Fetching unstable jars!  (commit $rev)"
+  echo "Warning: Fetching unstable jars!"
   LOCAL_STORE=
   REMOTE_STORE="$COMMIT_ARTIFACTS/$rev"
   JARS_BAK="JARS-BAK/$rev"

--- a/fetch-jars
+++ b/fetch-jars
@@ -7,6 +7,16 @@ set -eu
 # falling back to develop.
 # If --copper is specified, only fetch the Copper jars.
 
+# Parse command line argumants.
+# Hacky, but getopts seems like overkill for this...
+if [[ $# -gt 1 && $1 == --copper ]]; then
+  REV_NAME=$2
+elif [[ $# -gt 0 && $1 != --copper ]]; then
+  REV_NAME=$1
+else
+  REV_NAME=""
+fi
+
 COMMIT_ARTIFACTS="https://foundry.remexre.xyz/commit-artifacts/"
 
 function has_jars {
@@ -16,8 +26,8 @@ function has_jars {
 rev=""
 
 # Look for jars in the specified revision
-if [[ $* != *--copper* && $# -gt 0 || $# -gt 1 ]]; then
-  rev=$(git rev-parse $1)
+if [[ -n $REV_NAME ]]; then
+  rev=$(git rev-parse "$REV_NAME")
 fi
 
 # Get the hash of the latest commit on develop.
@@ -28,8 +38,8 @@ DEVELOP=$(git ls-remote https://github.com/melt-umn/silver develop | cut -f1)
 # Look for jars in the current commit and its parents.
 # First, check that we are inside a git repo.
 if [[ -z $rev ]] && git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/null; then
-  for commit in $(git rev-list HEAD ^$DEVELOP); do
-    if has_jars $commit; then
+  for commit in $(git rev-list HEAD "^$DEVELOP"); do
+    if has_jars "$commit"; then
       echo "Found jars from past commit"
       rev=$commit
       break
@@ -37,14 +47,14 @@ if [[ -z $rev ]] && git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/nul
   done
 fi
 
-if [[ -z $rev || $rev == $DEVELOP ]]; then
+if [[ -z $rev || $rev == "$DEVELOP" ]]; then
   echo "Fetching latest stable jars..."
   LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
   REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"
   JARS_BAK=JARS-BAK
 else
-  git --no-pager show --quiet $rev
-  if ! has_jars $rev; then
+  git --no-pager show --quiet "$rev"
+  if ! has_jars "$rev"; then
     echo "Cound not find jars for commit"
     exit 1
   fi
@@ -65,7 +75,7 @@ mkdir -p jars
 
 if [[ -n "$LOCAL_STORE" && -d $LOCAL_STORE ]]; then
   for file in $FILES; do
-      cp $LOCAL_STORE/$file jars/
+      cp "$LOCAL_STORE/$file" jars/
   done
 else
   # There's probably a better way to do this!
@@ -78,16 +88,16 @@ else
   done
   
   # We're going to download them to here
-  mkdir -p $JARS_BAK
+  mkdir -p "$JARS_BAK"
   
   # -N Pay attention to timestamps, to avoid needless redownloads.
   # -P jars/  Put the files in jars/
   # -nv Don't be so verbose!
-  wget -N -P $JARS_BAK/ -nv $URLS
+  wget -N -P "$JARS_BAK/" -nv $URLS
   
   # Always overwrite all the files in jars.
   for file in $FILES; do
-      cp $JARS_BAK/$file jars/
+      cp "$JARS_BAK/$file" jars/
   done
 fi
 


### PR DESCRIPTION
# Changes
The most common workflow when switching to a new-jars branch is to run `./fetch-jars HEAD`.  However this fails if the latest commit on the branch doesn't build, or the build hasn't finished yet, etc. in which case one needs to walk back to find the most recent commit.  

This changes the default behavior when `./fetch-jars` is run without arguments to find the most recent commit on the branch that has jars.    If the chosen commit matches develop, the stable jars are downloaded as before.  An explicit revision (e.g. `./fetch-jars develop`) can also still be specified.

This change is also needed for new-jars branches to work with Github's new merge queue feature, since that works by creating new temporary branches, and we must determine the appropriate jars to use from when the commit was previously built.  Technically, this also obsoletes some of the logic in Silver's Jenkinsfile for getting jars from a previous build's artifacts, but I'm leaving that for now as it still helpfully annotates which jars were used for the build. Although we could probably pull the logic for choosing a commit out into a separate script, and just have Jenkins use that instead for annotating the build.  

# Documentation
I updated the comments in the script.
