### PR TITLE
Fix bug with polymorphic Decorated types in aspect production signatures

### DIFF
--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -314,6 +314,7 @@ top::TypeExpr ::= 'Decorated' t::TypeExpr 'with' i::TypeExpr
     case t.typerep.baseType of
     | nonterminalType(_,_,_) -> []
     | skolemType(_) -> []
+    | varType(_) -> []
     | _ -> [err(t.location, t.unparse ++ " is not a nonterminal, and cannot be Decorated.")]
     end;
   top.errors <-
@@ -342,6 +343,7 @@ top::TypeExpr ::= 'Decorated' t::TypeExpr
     case t.typerep.baseType of
     | nonterminalType(_,_,_) -> []
     | skolemType(_) -> [err(t.location, "polymorphic Decorated types must specify an explicit reference set")]
+    | varType(_) -> [err(t.location, "polymorphic Decorated types must specify an explicit reference set")]
     | _ -> [err(t.location, t.unparse ++ " is not a nonterminal, and cannot be Decorated.")]
     end;
 }
@@ -360,6 +362,7 @@ top::TypeExpr ::= 'Decorated!' t::TypeExpr 'with' i::TypeExpr
     case t.typerep.baseType of
     | nonterminalType(_,_,_) -> []
     | skolemType(_) -> []
+    | varType(_) -> []
     | _ -> [err(t.location, t.unparse ++ " is not a nonterminal, and cannot be Decorated!.")]
     end;
   top.errors <-
@@ -388,6 +391,7 @@ top::TypeExpr ::= 'Decorated!' t::TypeExpr
     case t.typerep.baseType of
     | nonterminalType(_,_,_) -> []
     | skolemType(_) -> [err(t.location, "polymorphic Decorated! types must specify an explicit reference set")]
+    | varType(_) -> [err(t.location, "polymorphic Decorated! types must specify an explicit reference set")]
     | _ -> [err(t.location, t.unparse ++ " is not a nonterminal, and cannot be Decorated!.")]
     end;
 }

--- a/test/silver_features/OccursContext.sv
+++ b/test/silver_features/OccursContext.sv
@@ -198,3 +198,15 @@ equalityTest(
   case decorate ocPolyWrap(ocThing()) with {prodName = "blah";} of
   | ocPolyWrap(thing) -> thing.prodName
   end, "blah", String, silver_tests);
+
+
+nonterminal OCWrapDec<a> with prodName;
+
+production ocWrapDec
+attribute prodName i occurs on a =>
+top::OCWrapDec<a> ::= x::Decorated a with i
+{}
+
+aspect production ocWrapDec
+top::OCWrapDec<a> ::= x::Decorated a with i
+{ top.prodName = x.prodName; }


### PR DESCRIPTION
# Changes
Due to the way that type variables in aspect signatures are treated, we can sometimes have a fresh type variable appearing in a `Decorated` type.

# Documentation
Added a test case.
