### PR TITLE
Refactor doc extension error handling to avoid flow error

### DIFF
--- a/grammars/silver/compiler/definition/core/GrammarParts.sv
+++ b/grammars/silver/compiler/definition/core/GrammarParts.sv
@@ -7,7 +7,7 @@ nonterminal Grammar with
   grammarName, env, globalImports, grammarDependencies,
   -- Synthesized attributes
   declaredName, moduleNames, exportedGrammars, optionalGrammars, condBuild,
-  defs, occursDefs, importedDefs, importedOccursDefs, grammarErrors, allFileErrors, jarName;
+  defs, occursDefs, importedDefs, importedOccursDefs, allFileErrors, jarName;
 
 flowtype Grammar = decorate {config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, grammarName, env, flowEnv, globalImports, grammarDependencies};
 
@@ -51,7 +51,6 @@ top::Grammar ::=
   -- A value here is actually used. Grammars without any .sv files
   -- turn into this, and this "aren't found". TODO verify this is true?
   top.declaredName = ":null";
-  top.grammarErrors = [];
   top.allFileErrors = [];
 }
 
@@ -59,10 +58,10 @@ abstract production consGrammar
 top::Grammar ::= h::Root  t::Grammar
 {
   top.declaredName = if h.declaredName == t.declaredName then h.declaredName else top.grammarName;
-  top.grammarErrors =
-    if null(h.errors ++ jarNameErrors) then t.grammarErrors
-     else pair(h.location.filename, h.errors ++ jarNameErrors) :: t.grammarErrors;
-  top.allFileErrors = (h.location.filename, h.errors ++ jarNameErrors) :: t.allFileErrors;
 
-  local jarNameErrors :: [Message] = warnIfMultJarName(h.jarName, t.jarName, h.location);
+  production attribute rootErrors::[Message] with ++;
+  rootErrors := h.errors;
+  top.allFileErrors = (h.location.filename, rootErrors) :: t.allFileErrors;
+
+  rootErrors <- warnIfMultJarName(h.jarName, t.jarName, h.location);
 }

--- a/grammars/silver/compiler/driver/util/RootSpec.sv
+++ b/grammars/silver/compiler/driver/util/RootSpec.sv
@@ -129,9 +129,15 @@ top::RootSpec ::= g::Grammar  oldInterface::Maybe<InterfaceItems>  grammarName::
   top.declaredName = g.declaredName;
   top.moduleNames := nub(g.moduleNames ++ ["silver:core"]); -- Ensure the prelude is in the deps, always
   top.allGrammarDependencies := actualDependencies;
-  top.grammarErrors = g.grammarErrors;
+
+  top.grammarErrors = filter(\ fe::(String, [Message]) -> !null(fe.2), top.allFileErrors);
   top.parsingErrors = [];
-  top.allFileErrors = g.allFileErrors;
+
+  production attribute extraFileErrors::[(String, [Message])] with ++;
+  extraFileErrors := [];
+  top.allFileErrors = map(
+    \ fe::(String, [Message]) -> (fe.1, fe.2 ++ concat(lookupAll(fe.1, extraFileErrors))),
+    g.allFileErrors);
 
   top.jarName := g.jarName;
 }

--- a/grammars/silver/compiler/driver/util/RootSpec.sv
+++ b/grammars/silver/compiler/driver/util/RootSpec.sv
@@ -136,7 +136,9 @@ top::RootSpec ::= g::Grammar  oldInterface::Maybe<InterfaceItems>  grammarName::
   production attribute extraFileErrors::[(String, [Message])] with ++;
   extraFileErrors := [];
   top.allFileErrors = map(
-    \ fe::(String, [Message]) -> (fe.1, fe.2 ++ concat(lookupAll(fe.1, extraFileErrors))),
+    \ fe::(String, [Message]) -> case fe of (fileName, fileErrors) ->
+      (fileName, fileErrors ++ concat(lookupAll(fileName, extraFileErrors)))
+    end,
     g.allFileErrors);
 
   top.jarName := g.jarName;

--- a/grammars/silver/compiler/extension/doc/core/Root.sv
+++ b/grammars/silver/compiler/extension/doc/core/Root.sv
@@ -49,6 +49,9 @@ monoid attribute docErrors :: [Message];
 attribute docErrors occurs on Root, AGDcls, AGDcl, ClassBodyItem, InstanceBodyItem, ClassBody, InstanceBody;
 propagate docErrors on Root, AGDcls, AGDcl, ClassBodyItem, InstanceBodyItem, ClassBody, InstanceBody;
 
+@{-
+ - All file names in a grammar, paired with their documentation-related error messages.
+ -}
 synthesized attribute allFileDocErrors::[(String, [Message])] occurs on Grammar;
 
 aspect production root

--- a/grammars/silver/compiler/extension/doc/core/Root.sv
+++ b/grammars/silver/compiler/extension/doc/core/Root.sv
@@ -49,6 +49,8 @@ monoid attribute docErrors :: [Message];
 attribute docErrors occurs on Root, AGDcls, AGDcl, ClassBodyItem, InstanceBodyItem, ClassBody, InstanceBody;
 propagate docErrors on Root, AGDcls, AGDcl, ClassBodyItem, InstanceBodyItem, ClassBody, InstanceBody;
 
+synthesized attribute allFileDocErrors::[(String, [Message])] occurs on Grammar;
+
 aspect production root
 top::Root ::= gdcl::GrammarDcl ms::ModuleStmts ims::ImportStmts ags::AGDcls
 {
@@ -61,7 +63,6 @@ top::Root ::= gdcl::GrammarDcl ms::ModuleStmts ims::ImportStmts ags::AGDcls
 
   ags.downDocConfig = filter((\x::DocConfigSetting -> x.fileScope), ags.upDocConfig) ++ top.downDocConfig;
   ags.docEnv = tm:add(flatMap((.docDcls), searchEnvTree(top.grammarName, top.compiledGrammars)), tm:empty());
-  top.errors <- ags.docErrors;
 }
 
 aspect production nilAGDcls
@@ -109,6 +110,7 @@ top::Grammar ::=
   top.docDcls := [];
   top.undocumentedNamed = [];
   top.documentedNamed = [];
+  top.allFileDocErrors = [];
 }
 
 aspect production consGrammar
@@ -121,6 +123,7 @@ top::Grammar ::= c1::Root  c2::Grammar
   top.docDcls := c1.docDcls ++ c2.docDcls;
   top.undocumentedNamed = c1.undocumentedNamed ++ c2.undocumentedNamed;
   top.documentedNamed = c1.documentedNamed ++ c2.documentedNamed;
+  top.allFileDocErrors = (c1.location.filename, c1.docErrors) :: c2.allFileDocErrors;
 }
 
 -- consGrammar(FILE1, consGrammar(FILE2, nilGrammar()))

--- a/grammars/silver/compiler/extension/doc/core/RootSpec.sv
+++ b/grammars/silver/compiler/extension/doc/core/RootSpec.sv
@@ -24,6 +24,7 @@ top::RootSpec ::= g::Grammar  _ _ _ _ _
 {
   top.genFiles := toSplitFiles(g, g.upDocConfig, [], []);
   top.docDcls := g.docDcls;
+  extraFileErrors <- g.allFileDocErrors;
 
   g.downDocConfig = g.upDocConfig;
 }


### PR DESCRIPTION
# Changes
feature/dec-site-projections includes some bug fixes to flow analysis for collection contribution equations.  This fixes a flow error that was found as a result of that, where the contribution equation for `errors` on `root` adds transitive deps on `top.downDocConfig`.  

Instead, we need to collect doc errors further up the tree, and add a way to inject them at the `RootSpec` level.

# Documentation
This fixes a flow bug in the documentation extension.
