### PR TITLE
Fix spurious appearances of silver:core:stringAppend in reference locations of string template expressions

### DIFF
--- a/grammars/silver/compiler/langserver/ReferenceLocations.sv
+++ b/grammars/silver/compiler/langserver/ReferenceLocations.sv
@@ -132,6 +132,7 @@ aspect valueRefLocs on Expr using := of
 | attributeSection(_, _, _, _) -> []
 | consListOp(h, _, t) -> h.valueRefLocs ++ t.valueRefLocs
 | emptyList(_, _) -> []
+| stringAppendCall(a, b) -> a.valueRefLocs ++ b.valueRefLocs
 end;
 
 aspect attributeRefLocs on Expr using := of


### PR DESCRIPTION
# Changes
Fix another instance where we need to override an extension's reference locations to avoid including names from an extension's forward.

# Documentation
Minor fix, not needed.
