### PR TITLE
Avoid introducing superfluous append when collection antiquote is the last in a list

### DIFF
--- a/grammars/silver/core/Alternative.sv
+++ b/grammars/silver/core/Alternative.sv
@@ -46,3 +46,12 @@ Annihilation
   ap(empty, x) = empty
 -}
 class Applicative f, Plus f => Alternative f {}
+
+@{-
+Conditional failure of Alternative computations.
+-}
+function guard
+Alternative f => f<()> ::= b::Boolean
+{
+  return if b then pure(()) else empty;
+}


### PR DESCRIPTION
# Changes
When an a collection antiquote is the last item in the list, avoid generating an append operation.  For example:
```
ableC_Decl {
  int foo(int a, float b, $Parameters{params}, int c, $Parameters{moreParams}) {
    ...
    int res = foo(1, 2, $Exprs{args}, 3, ${moreArgs});
    ...
  }
}
```
With `params` and `args` above, we need to use `appendParams` and `appendExprs` to append extra items to the antiquoted expressions, but with `moreParams` and `moreArgs` we can just place them end of the cons chain instead of `nilParameters()`/`nilExpr()`.

This change is needed in my experiments with using decoration-site expressions in ableC extensions, since functions like `appendParameters` transform/re-decorate the operands and aren't currently compatible with decorated tree sharing.

# Documentation
Corresponding changes in silver-ableC, and docs updated there: https://github.com/melt-umn/silver-ableC/compare/feature/collection-antiquote-tail.
