### PR TITLE
Fix bug with check for missing remote equations

### DIFF
--- a/grammars/silver/core/List.sv
+++ b/grammars/silver/core/List.sv
@@ -423,6 +423,13 @@ function zipWith
          else f(head(l1), head(l2)) :: zipWith(f, tail(l1), tail(l2));
 }
 
+function unzipWith
+[c] ::= f::(c ::= a b)  l::[(a, b)]
+{
+  return if null(l) then []
+         else f(head(l).1, head(l).2) :: unzipWith(f, tail(l));
+}
+
 function reverse
 [a] ::= lst::[a]
 {

--- a/test/flow/RefSiteProj.sv
+++ b/test/flow/RefSiteProj.sv
@@ -322,3 +322,25 @@ top::RSExpr ::= e::RSExpr
 }
 }
 
+production projChain
+top::RSExpr ::= e::RSExpr
+{
+  local foo::RSExpr = @e;
+  forwards to copy1(@foo);
+}
+
+production projChain1Present
+top::RSExpr ::= e::RSExpr
+{
+  top.errors1 = !null(e.env1);
+  forwards to projChain(@e);
+}
+
+warnCode "missing remote equation" {
+production projChain2Missing
+top::RSExpr ::= e::RSExpr
+{
+  top.errors2 = !null(e.env2);
+  forwards to projChain(@e);
+}
+}


### PR DESCRIPTION
# Changes
This fixes an issue with chaining multiple levels of decoration through references across multiple productions:
```
production foo
top::Expr ::= e::Expr
{
  top.errors = ... e.env ...;
  forwards to bar(@e);
}

production bar
top::Expr ::= e::Expr
{
  forwards to baz(@e);
}

production baz
top::Expr ::= e::Expr
{
  e.env = top.env;
}
```
`foo` depends on `e.env`, but this equation is in `baz`, not `bar`.  We need to find all decoration sites for `e`, and ensure that there is an `env` equation at any of them.  

# Documentation
Added source comments and a test case.
