### PR TITLE
Fix broken translation of child/local refs with remote decoration sites

### DIFF
--- a/grammars/silver/compiler/modification/copper/ParserDcl.sv
+++ b/grammars/silver/compiler/modification/copper/ParserDcl.sv
@@ -131,7 +131,7 @@ top::AGDcl ::= 'parser' n::Name '::' t::TypeExpr '{' m::ParserComponents '}'
   -- do generate files for the lifted dcl. Needed to generate terminal class files.
   top.genFiles := m.genFiles ++
     [pair(className ++ ".java",
-          generateFunctionClassString(top.grammarName, n.name, namedSig, parseResult))];
+          generateFunctionClassString(top.env, top.flowEnv, top.grammarName, n.name, namedSig, parseResult))];
   
   local parseResult :: String =
     s"""return common.Util.callCopperParser(new ${packageName}.${parserName}(), c_stringToParse, c_filenameToReport);""";

--- a/grammars/silver/compiler/modification/ffi/FunctionDcl.sv
+++ b/grammars/silver/compiler/modification/ffi/FunctionDcl.sv
@@ -9,26 +9,16 @@ concrete production functionDclFFI
 top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody 'foreign' '{' ffidefs::FFIDefs '}'
 {
   top.unparse = "function " ++ id.unparse ++ "\n" ++ ns.unparse ++ "\n" ++ body.unparse ++ " foreign {\n" ++ ffidefs.unparse ++ "}";
-  propagate grammarName, flowEnv;
+  propagate grammarName;
 
   production fName :: String = top.grammarName ++ ":" ++ id.name;
   production namedSig :: NamedSignature = ns.namedSignature;
 
   top.errors <- ffidefs.errors;
 
-  -- Quick copy & paste to make signatures look right. Otherwise they contain errorTypes for
-  -- type parameters
-  production attribute sigDefs :: [Def] with ++;
-  sigDefs := ns.defs;
-  ns.signatureName = fName;
-  ns.env = newScopeEnv(sigDefs, top.env);
-  production attribute allLexicalTyVars :: [String];
-  allLexicalTyVars = nub(ns.lexicalTypeVariables);
-  sigDefs <- addNewLexicalTyVars(top.grammarName, top.location, ns.lexicalTyVarKinds, allLexicalTyVars);
-
-  -- TODO this is a BS use of forwarding and should be eliminated. body.env and .frame are all wrong locally...
+  -- TODO this is a BS use of forwarding and should be eliminated.
   
-  forwards to functionDcl($1, id, ns, body, location=top.location);
+  forwards to functionDcl($1, @id, @ns, @body, location=top.location);
 } action {
   insert semantic token IdFnProdDcl_t at id.location;
   sigNames = [];

--- a/grammars/silver/compiler/modification/ffi/java/FunctionDcl.sv
+++ b/grammars/silver/compiler/modification/ffi/java/FunctionDcl.sv
@@ -64,7 +64,7 @@ top::AGDcl ::= 'function' id::Name ns::FunctionSignature body::ProductionBody 'f
                     then forward.genFiles
                     else 
                     [pair("P" ++ id.name ++ ".java",
-                      generateFunctionClassString(top.grammarName, id.name, namedSig, "return (" ++ namedSig.outputElement.typerep.transClassType ++ ")" ++ computeSigTranslation(head(ffidefs.ffiTranslationString), namedSig) ++ ";\n")
+                      generateFunctionClassString(body.env, top.flowEnv, top.grammarName, id.name, namedSig, "return (" ++ namedSig.outputElement.typerep.transClassType ++ ")" ++ computeSigTranslation(head(ffidefs.ffiTranslationString), namedSig) ++ ";\n")
                     )];
 
   top.errors <- if length(ffidefs.ffiTranslationString) > 1

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -111,7 +111,7 @@ top::Expr ::= q::Decorated! QName
     then s"((${finalType(top).transType})context.localDecorated(${q.lookupValue.dcl.attrOccursIndex}).undecorate())"
     else
       case lookupLocalRefDecSite(q.lookupValue.fullName, top.flowEnv) of
-      | [v] when !finalType(top).isUniqueDecorated -> s"context.evalLocalDecorated(${q.lookupValue.dcl.attrOccursIndex})"
+      | [v] when finalType(top).isUniqueDecorated -> s"context.evalLocalDecorated(${q.lookupValue.dcl.attrOccursIndex})"
       | _ -> s"context.localDecorated(${q.lookupValue.dcl.attrOccursIndex})"
       end;
   -- reminder: look at comments for childReference
@@ -124,7 +124,7 @@ top::Expr ::= q::Decorated! QName
     then s"common.Thunk.transformUndecorate(context.localDecoratedLazy(${q.lookupValue.dcl.attrOccursIndex}))"
     else
       case lookupLocalRefDecSite(q.lookupValue.fullName, top.flowEnv) of
-      | [v] when !finalType(top).isUniqueDecorated -> wrapThunk(top.translation, true)
+      | [v] when finalType(top).isUniqueDecorated -> wrapThunk(top.translation, true)
       | _ -> s"context.localDecoratedLazy(${q.lookupValue.dcl.attrOccursIndex})"
       end;
 }

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -146,8 +146,13 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 			return ref.getNode().getProdleton();
 		}
 
-		// Accessors only by DecoratedNode.
+		// Accessors used only by DecoratedNode.
 		// This should never happen.
+		@Override
+		public common.Lazy getChildDecSite(final int child) {
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+		}
+
 		@Override
 		public common.Lazy[] getChildInheritedAttributes(final int index) {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
@@ -165,6 +170,11 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 
 		@Override
 		public common.Lazy getLocal(final int index) {
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+		}
+
+		@Override
+		public common.Lazy getLocalDecSite(final int index) {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
 		}
 

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -117,9 +117,10 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
 
   top.translation = 
-    case lookupRefDecSite(top.frame.fullName, fName, top.flowEnv) of
+    case lookupLocalRefDecSite(fName, top.flowEnv) of
     | [v] ->
-        s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] =" ++
+        s"\t\t//${top.unparse}\n" ++
+        s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = " ++
         s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, v)};\n"
     | _ -> ""
     end;
@@ -146,9 +147,10 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
 
   top.translation = 
-    case lookupRefDecSite(top.frame.fullName, fName, top.flowEnv) of
+    case lookupLocalRefDecSite(fName, top.flowEnv) of
     | [v] ->
-        s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] =" ++
+        s"\t\t//${top.unparse}\n" ++
+        s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = " ++
         s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, v)};\n"
     | _ -> ""
     end;

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -116,7 +116,13 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
 
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
 
-  top.translation = "";
+  top.translation = 
+    case lookupRefDecSite(top.frame.fullName, fName, top.flowEnv) of
+    | [v] ->
+        s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] =" ++
+        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, v)};\n"
+    | _ -> ""
+    end;
 }
 
 aspect production productionAttributeDcl
@@ -139,7 +145,13 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
 
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
 
-  top.translation = "";
+  top.translation = 
+    case lookupRefDecSite(top.frame.fullName, fName, top.flowEnv) of
+    | [v] ->
+        s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] =" ++
+        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, v)};\n"
+    | _ -> ""
+    end;
 }
 
 aspect production childDefLHS

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -84,6 +84,7 @@ ${makeIndexDcls(0, namedSig.inputElements)}
     public static final common.Lazy[][] childInheritedAttributes = new common.Lazy[${toString(length(namedSig.inputElements))}][];
 
     public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
+    public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
     public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
 
 ${namedSig.inhOccursIndexDecls}
@@ -134,6 +135,14 @@ ${implode("", map(makeChildAccessCase, namedSig.inputElements))}
     public Object getChildLazy(final int index) {
         switch(index) {
 ${implode("", map(makeChildAccessCaseLazy, namedSig.inputElements))}
+            default: return null;
+        }
+    }
+
+	@Override
+	public common.Lazy getChildDecSite(final int index) {
+		switch(index) {
+${implode("", map(makeChildDecSiteAccessCase(body.env, top.flowEnv, fName, _), namedSig.inputElements))}
             default: return null;
         }
     }
@@ -201,6 +210,11 @@ ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInh
     @Override
     public common.Lazy getLocal(final int key) {
         return localAttributes[key];
+    }
+
+    @Override
+    public common.Lazy getLocalDecSite(final int key) {
+        return localDecSites[key];
     }
 
     @Override

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -2,6 +2,7 @@ package common;
 
 import common.exceptions.MissingDefinitionException;
 import common.exceptions.SilverException;
+import common.exceptions.SilverInternalError;
 import common.exceptions.TraceException;
 
 /**
@@ -39,7 +40,7 @@ public class DecoratedNode implements Decorable, Typed {
 	protected final Node self;
 	/**
 	 * The node that forwards to this one. (May be null)
-	 * Not final, because we may set this when forwarding to a (unique) reference.
+	 * Not final, because we may set this when forwarding to a decorated tree via a unique reference.
 	 * 
 	 * @see #inheritedForwarded(String)
 	 */
@@ -95,6 +96,17 @@ public class DecoratedNode implements Decorable, Typed {
 	 */
 	protected final Object[] localValues;
 
+	/**
+	 * Track whether a decorated child has already been created, for sanity checking.
+	 * This may be true when childrenValues[i] == null, because of how unique references are translated.
+	 */
+	protected final boolean[] childCreated;
+	/**
+	 * Track whether a decorated local has already been created, for sanity checking.
+	 * This may be true when localValues[i] == null, because of how unique references are translated.
+	 */
+	protected final boolean[] localCreated;
+
 	
 	/**
 	 * Construct a decorated form of a Node. Called only via Node.
@@ -128,6 +140,8 @@ public class DecoratedNode implements Decorable, Typed {
 		this.inheritedValues =   (ic > 0) ? new Object[ic] : null;
 		this.synthesizedValues = (sc > 0) ? new Object[sc] : null;
 		this.localValues =       (lc > 0) ? new Object[lc] : null;
+		this.childCreated =      (cc > 0) ? new boolean[cc] : null;
+		this.localCreated =      (lc > 0) ? new boolean[lc] : null;
 		
 		// STATS: Uncomment to enable statistics
 		//Statistics.dnSpawn(self!=null?self.getClass():TopNode.class);
@@ -154,6 +168,8 @@ public class DecoratedNode implements Decorable, Typed {
 		this.inheritedValues = null;
 		this.synthesizedValues = null;
 		this.localValues = (lc > 0) ? new Object[lc] : null;
+		this.childCreated = new boolean[cc];
+		this.localCreated = (lc > 0) ? new boolean[lc] : null;
 	}
 	
 	// STATS: Uncomment to enable statistics
@@ -252,7 +268,7 @@ public class DecoratedNode implements Decorable, Typed {
 	public DecoratedNode childDecorated(final int child) {
 		Object o = this.childrenValues[child]; 
 		if(o == null) {
-			o = createDecoratedChild(child);
+			o = obtainDecoratedChild(child);
 			
 			assert(o != null);
 
@@ -263,11 +279,32 @@ public class DecoratedNode implements Decorable, Typed {
 	}
 
 	/**
-	 * Create the DecoratedNode for a child.
+	 * Create or retrieve the DecoratedNode for a child.
 	 * Separate function to keep {@link #childDecorated} small and inlineable.
 	 * This is, after all, the "slow path."
 	 */
-	private final DecoratedNode createDecoratedChild(final int child) {
+	private final DecoratedNode obtainDecoratedChild(final int child) { 
+		Lazy decSite = self.getChildDecSite(child);
+		if(decSite == null) {
+			return createDecoratedChild(child);
+		} else {
+			return (DecoratedNode)decSite.eval(this);
+		}
+	}
+
+	/**
+	 * Create the DecoratedNode for a child.
+	 * This can also be called directly in the translation of taking a unique reference.
+	 * Invariant: should never be called more than once for a child!
+	 * 
+	 * @param child The number of the child to create.
+	 * @return The decorated value of the child.
+	 */
+	public final DecoratedNode createDecoratedChild(final int child) {
+		if(childCreated[child]) {
+			throw new SilverInternalError("Decorated child created more than once!");
+		}
+		childCreated[child] = true;
 		return ((Decorable)self.getChild(child)).decorate(this, self.getChildInheritedAttributes(child));
 	}
 
@@ -322,7 +359,7 @@ public class DecoratedNode implements Decorable, Typed {
 	 * 
 	 * <p>Warning: do not mix {@link #localAsIs} and {@link #localDecorated} on the same local attribute!
 	 * 
-	 * @param attribute The full name of the local to obtain.
+	 * @param attribute The index of the local to obtain.
 	 * @return The value of the local.
 	 */
 	public DecoratedNode localDecorated(final int attribute) {
@@ -338,11 +375,32 @@ public class DecoratedNode implements Decorable, Typed {
 		}
 		return (DecoratedNode)o;
 	}
-	
+
 	/**
 	 * Another case of keeping the slow paths out of here, so it can be inlined.
 	 */
-	private final DecoratedNode evalLocalDecorated(final int attribute) {
+	private final DecoratedNode obtainDecoratedLocal(final int attribute) { 
+		Lazy decSite = self.getLocalDecSite(attribute);
+		if(decSite == null) {
+			return evalLocalDecorated(attribute);
+		} else {
+			return (DecoratedNode)decSite.eval(this);
+		}
+	}
+
+	/**
+	 * Evaluate a local and decorate it.
+	 * This can also be called directly in the translation of taking a unique reference.
+	 * Invariant: should never be called more than once for a local!
+	 * 
+	 * @param attribute The index of the local to obtain.
+	 * @return The decorated value of the local.
+	 */
+	public final DecoratedNode evalLocalDecorated(final int attribute) {
+		if(localCreated[attribute]) {
+			throw new SilverInternalError("Decorated local created more than once!");
+		}
+		localCreated[attribute] = true;
 		return ((Decorable)evalLocalAsIs(attribute)).decorate(this, self.getLocalInheritedAttributes(attribute));
 	}
 

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -304,8 +304,9 @@ public class DecoratedNode implements Decorable, Typed {
 		if(childCreated[child]) {
 			throw new SilverInternalError("Decorated child created more than once!");
 		}
+		DecoratedNode result = ((Decorable)self.getChild(child)).decorate(this, self.getChildInheritedAttributes(child));
 		childCreated[child] = true;
-		return ((Decorable)self.getChild(child)).decorate(this, self.getChildInheritedAttributes(child));
+		return result;
 	}
 
 	/**
@@ -365,7 +366,7 @@ public class DecoratedNode implements Decorable, Typed {
 	public DecoratedNode localDecorated(final int attribute) {
 		Object o = this.localValues[attribute];
 		if(o == null) {
-			o = evalLocalDecorated(attribute);
+			o = obtainDecoratedLocal(attribute);
 			
 			assert(o != null);
 
@@ -398,10 +399,11 @@ public class DecoratedNode implements Decorable, Typed {
 	 */
 	public final DecoratedNode evalLocalDecorated(final int attribute) {
 		if(localCreated[attribute]) {
-			throw new SilverInternalError("Decorated local created more than once!");
+			throw new SilverInternalError("Decorated local " + self.getNameOfLocalAttr(attribute) + " created more than once!");
 		}
+		DecoratedNode result = ((Decorable)evalLocalAsIs(attribute)).decorate(this, self.getLocalInheritedAttributes(attribute));
 		localCreated[attribute] = true;
-		return ((Decorable)evalLocalAsIs(attribute)).decorate(this, self.getLocalInheritedAttributes(attribute));
+		return result;
 	}
 
 	/**

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -174,6 +174,15 @@ public abstract class Node implements Decorable, Typed {
 	 * @return The child object, WITHOUT forcing the Thunk, if any.
 	 */
 	public abstract Object getChildLazy(final int child);
+
+	/**
+	 * Access the decorated form of this child through its reference decoration site, if it has one.
+	 * 
+	 * @param child A number in the range <code>0 - getNumberofChildren()</code>
+	 * @return A Lazy to evaluate on a decorated form of this Node, to get the decorated child,
+	 * 	or null if it has no reference decoration site
+	 */
+	public abstract Lazy getChildDecSite(final int child);
 	
 	/**
 	 * @param key The child index to look up the inherited attributes.
@@ -201,6 +210,15 @@ public abstract class Node implements Decorable, Typed {
 	 * @return A Lazy to evaluate on a decorated form of this Node, to get the value of the attribute
 	 */
 	public abstract Lazy getLocal(final int index);
+
+	/**
+	 * Access the decorated form of this local through its reference decoration site, if it has one.
+	 * 
+	 * @param child The index of a local or production attribute on this Node
+	 * @return A Lazy to evaluate on a decorated form of this Node, to get the decorated child,
+	 * 	or null if it has no reference decoration site
+	 */
+	public abstract Lazy getLocalDecSite(final int index);
 
 	/**
 	 * @param key The index for a local, to retrieve inherited attributes for.


### PR DESCRIPTION
# Changes
See #759 - a related problem exists in the translation.  This change moves the logic for extracting the decorated tree from its remote decoration site into `DecoratedNode`, so the translation of an ordinary reference to a child/local can just call `childDecorated`/`localDecorated`.  This also means that getting the tree from its remote decoration site is now cached.  

# Documentation
Added source comments.