### PR TITLE
Implement forward production attributes

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/ProductionBody.sv
@@ -3,7 +3,7 @@ grammar silver:compiler:analysis:typechecking:core;
 
 attribute upSubst, downSubst, finalSubst occurs on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr;
 propagate upSubst, downSubst on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr
-  excluding productionStmtAppend, attachNoteStmt, forwardsTo, forwardInh, undecoratesTo, returnDef, synthesizedAttributeDef, inheritedAttributeDef, forwardProductionAttributeDcl, localValueDef;
+  excluding productionStmtAppend, attachNoteStmt, forwardsTo, forwardInh, undecoratesTo, returnDef, synthesizedAttributeDef, inheritedAttributeDef, localValueDef;
 propagate finalSubst on ProductionStmt, ForwardInhs, ForwardInh, ForwardLHSExpr excluding productionStmtAppend;
 
 {--
@@ -174,22 +174,6 @@ aspect production productionAttributeDcl
 top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
 {
   top.errors <- te.errorsKindStar;
-}
-
-aspect production forwardProductionAttributeDcl
-top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name '::' te::TypeExpr ';'
-{
-  top.errors <- te.errorsKindStar;
-
-  local attribute errCheck1 :: TypeCheck; errCheck1.finalSubst = top.finalSubst;
-
-  thread downSubst, upSubst on top, errCheck1, top;
-
-  errCheck1 = check(top.frame.signature.outputElement.typerep, te.typerep);
-  top.errors <-
-    if errCheck1.typeerror
-    then [err(top.location, "Forward production attribute " ++ a.name ++ " has type " ++ errCheck1.rightpp ++ " that does not match the production left side " ++ errCheck1.leftpp)]
-    else [];
 }
 
 aspect production localValueDef

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -135,6 +135,7 @@ function checkEqDeps
       if isInherited(attrName, realEnv)
       then if !null(lookupLocalInh(prodName, fName, attrName, flowEnv))
            || fName == "forward"
+           || isForwardProdAttr(fName, realEnv)
            || localAttrViaReference(fName, attrName, realEnv)
            || !null(lookupLocalRefDecSite(fName, flowEnv))
            then []

--- a/grammars/silver/compiler/analysis/warnings/flow/MWDA.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/MWDA.sv
@@ -48,6 +48,15 @@ Boolean ::= v::FlowVertex
   end;
 }
 
+function isForwardProdAttr
+Boolean ::= a::String  e::Decorated Env
+{
+  return case getValueDclAll(a, e) of
+  | d :: _ -> d.hasForward
+  | _ -> false
+  end;
+}
+
 
 
 -- TODO: better way of generating warnings. We ad-hoc check for errors before

--- a/grammars/silver/compiler/definition/core/BlockContext.sv
+++ b/grammars/silver/compiler/definition/core/BlockContext.sv
@@ -7,7 +7,7 @@ import silver:compiler:definition:flow:driver only ProductionGraph;
  - statements, etc.  i.e. "can forward/return/pluck?"
  -}
 nonterminal BlockContext with permitReturn, permitForward, permitProductionAttributes,
-  permitLocalAttributes, lazyApplication, hasFullSignature, hasPartialSignature,
+  permitForwardProductionAttributes, permitLocalAttributes, lazyApplication, hasFullSignature, hasPartialSignature,
   fullName, lhsNtName, signature, sourceGrammar, flowGraph;
 
 
@@ -20,6 +20,8 @@ synthesized attribute permitLocalAttributes :: Boolean;
 {-- Are 'production attribute' equations allowed in this context?
     DISTINCT from locals, due to action blocks. -}
 synthesized attribute permitProductionAttributes :: Boolean;
+{-- Are 'forward production attribute' equations allowed in this context? -}
+synthesized attribute permitForwardProductionAttributes :: Boolean;
 
 {--
  - Whether the signature includes the name of a LHS.
@@ -79,6 +81,7 @@ top::BlockContext ::=
   top.permitReturn = false;
   top.permitForward = false;
   top.permitProductionAttributes = false;
+  top.permitForwardProductionAttributes = false;
   top.permitLocalAttributes = false;
   top.lazyApplication = true;
   top.hasPartialSignature = false;
@@ -113,6 +116,7 @@ top::BlockContext ::= sig::NamedSignature  g::ProductionGraph
   top.hasPartialSignature = true;
   top.hasFullSignature = true;
   top.permitProductionAttributes = true;
+  top.permitForwardProductionAttributes = true;
   top.permitLocalAttributes = true;
 }
 

--- a/grammars/silver/compiler/definition/core/DclInfo.sv
+++ b/grammars/silver/compiler/definition/core/DclInfo.sv
@@ -52,7 +52,7 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.defLHSDispatcher = lhsDefLHS(_, location=_);
 }
 aspect production localDcl
-top::ValueDclInfo ::= fn::String ty::Type
+top::ValueDclInfo ::= fn::String ty::Type _
 {
   top.refDispatcher = localReference(_, location=_);
   top.defDispatcher = localValueDef(_, _, location=_);

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -188,22 +188,22 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
 }
 
 concrete production forwardProductionAttributeDcl
-top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name '::' te::TypeExpr ';'
+top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name ';'
 {
-  top.unparse = "\tforward production attribute " ++ a.unparse ++ "::" ++ te.unparse ++ ";";
+  top.unparse = "\tforward production attribute " ++ a.unparse ++ ";";
 
   production attribute fName :: String;
   fName = top.frame.fullName ++ ":local:" ++ top.grammarName ++ ":" ++ a.name;
 
-  top.productionAttributes := [localDef(top.grammarName, a.location, fName, te.typerep, true)];
+  top.productionAttributes := [localDef(top.grammarName, a.location, fName, top.frame.signature.outputElement.typerep, true)];
 
   top.errors <-
         if length(getValueDclAll(fName, top.env)) > 1 
         then [err(a.location, "Value '" ++ fName ++ "' is already bound.")]
         else [];
 
-  top.errors <- if !top.frame.permitProductionAttributes
-                then [err(top.location, "Production attributes are not valid in this context.")]
+  top.errors <- if !top.frame.permitForwardProductionAttributes
+                then [err(top.location, "Forward production attributes are not valid in this context.")]
                 else [];
 }
 

--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -78,13 +78,14 @@ top::ValueDclInfo ::= fn::String ty::Type
 
 -- ValueDclInfos that CAN appear in interface files, but only via "production attributes:"
 abstract production localDcl
-top::ValueDclInfo ::= fn::String ty::Type
+top::ValueDclInfo ::= fn::String ty::Type isForward::Boolean
 {
   top.fullName = fn;
   
   top.typeScheme = monoType(ty);
   
-  top.substitutedDclInfo = localDcl( fn, performRenaming(ty, top.givenSubstitution), sourceGrammar=top.sourceGrammar, sourceLocation=top.sourceLocation);
+  top.hasForward = isForward;
+  top.substitutedDclInfo = localDcl( fn, performRenaming(ty, top.givenSubstitution), isForward, sourceGrammar=top.sourceGrammar, sourceLocation=top.sourceLocation);
 }
 abstract production forwardDcl
 top::ValueDclInfo ::= ty::Type

--- a/grammars/silver/compiler/definition/env/Defs.sv
+++ b/grammars/silver/compiler/definition/env/Defs.sv
@@ -131,9 +131,9 @@ Def ::= sg::String  sl::Location  fn::String  ty::Type
   return valueDef(defaultEnvItem(lhsDcl(fn,ty,sourceGrammar=sg,sourceLocation=sl)));
 }
 function localDef
-Def ::= sg::String  sl::Location  fn::String  ty::Type
+Def ::= sg::String  sl::Location  fn::String  ty::Type  isForward::Boolean
 {
-  return valueDef(defaultEnvItem(localDcl(fn,ty,sourceGrammar=sg,sourceLocation=sl)));
+  return valueDef(defaultEnvItem(localDcl(fn,ty,isForward,sourceGrammar=sg,sourceLocation=sl)));
 }
 function prodDef
 Def ::= sg::String  sl::Location  ns::NamedSignature  hasForward::Boolean

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -247,11 +247,12 @@ top::FlowDef ::= prod::String  attr::String  deps::[FlowVertex]
  - @param fName  the name of the local/production attribute
  - @param typeName  the full name of the type, or empty string if not a decorable type!
  - @param isNT  true if the type is a nonterminal
+ - @param isFwrd  true if this is a forward production attribute
  - @param deps  the dependencies of this equation on other flow graph elements
  - CONTRIBUTIONS ARE POSSIBLE
  -}
 abstract production localEq
-top::FlowDef ::= prod::String  fName::String  typeName::String  isNT::Boolean  deps::[FlowVertex]
+top::FlowDef ::= prod::String  fName::String  typeName::String  isNT::Boolean  isFwrd::Boolean deps::[FlowVertex]
 {
   top.localTreeContribs := [pair(crossnames(prod, fName), top)];
   top.prodGraphContribs := [pair(prod, top)];

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -133,8 +133,12 @@ top::Expr ::= q::Decorated! QName
     then just(localVertexType(q.lookupValue.fullName))
     else nothing();
 
+  -- If this is a forward production attribute, then all inh attributes have an equation here.
+  local isForwardProdAttr::Boolean = q.lookupValue.found && q.lookupValue.dcl.hasForward;
+
   -- Inherited attributes on q's NT that aren't in the reference set and don't have an equation:
   local notSuppliedInhs::[String] =
+    if isForwardProdAttr then [] else
     filter(
       isEquationMissing(lookupLocalInh(top.frame.fullName, q.lookupValue.fullName, _, top.flowEnv), _),
       removeAll(
@@ -143,7 +147,7 @@ top::Expr ::= q::Decorated! QName
   -- Add remote equations for reference site decoration with attributes that aren't supplied here
   top.flowDefs <-
     case top.decSiteVertexInfo of
-    | just(decSite) when finalTy.isUniqueDecorated ->
+    | just(decSite) when finalTy.isUniqueDecorated && !isForwardProdAttr ->
       [localRefDecSiteEq(top.frame.fullName, q.lookupValue.fullName, top.alwaysDecorated, decSite, notSuppliedInhs)]
     | _ -> []
     end;

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -140,7 +140,9 @@ top::ProductionStmt ::= val::Decorated! QName  e::Expr
   -- technically, it's possible to break this if you declare it in one grammar, but define it in another, but
   -- I think we should forbid that syntactically, later on...
   top.flowDefs <-
-    [localEq(top.frame.fullName, val.lookupValue.fullName, val.lookupValue.typeScheme.typeName, val.lookupValue.typeScheme.typerep.isNonterminal, e.flowDeps)];
+    [localEq(
+      top.frame.fullName, val.lookupValue.fullName, val.lookupValue.typeScheme.typeName,
+      val.lookupValue.typeScheme.typerep.isNonterminal, val.lookupValue.found && val.lookupValue.dcl.hasForward, e.flowDeps)];
 
   -- If we have a type var with occurs-on contexts, add the specified syn -> inh deps for the new vertex
   top.flowDefs <- occursContextDeps(top.frame.signature, top.env, val.lookupValue.typeScheme.typerep, localVertexType(val.lookupValue.fullName));

--- a/grammars/silver/compiler/extension/convenience/ShortLocalProdAttrDeclDef.sv
+++ b/grammars/silver/compiler/extension/convenience/ShortLocalProdAttrDeclDef.sv
@@ -45,23 +45,23 @@ top::ProductionStmt ::= pk::'production' ak::'attribute'
 }
 
 concrete production shortForwardProductionDecl
-top::ProductionStmt ::= fk::'forward' a::Name ht::'::' te::TypeExpr 
+top::ProductionStmt ::= fk::'forward' a::Name
                         eq::'=' v::Expr sm::';'
 {
   forwards to
     productionStmtAppend(
-      forwardProductionAttributeDcl(fk, 'production', 'attribute', a, ht, te, sm, location=top.location),
+      forwardProductionAttributeDcl(fk, 'production', 'attribute', a, sm, location=top.location),
       valueEq(qNameId(a, location=a.location), eq, v, sm, location=v.location),
       location=top.location);
 }
 
 concrete production shortForwardProductionDeclwKwds
 top::ProductionStmt ::= fk::'forward' pk::'production' ak::'attribute' 
-                        a::Name ht::'::' te::TypeExpr eq::'=' v::Expr sm::';'
+                        a::Name eq::'=' v::Expr sm::';'
 {
   forwards to
     productionStmtAppend(
-      forwardProductionAttributeDcl(fk, pk, ak, a, ht, te, sm, location=top.location),
+      forwardProductionAttributeDcl(fk, pk, ak, a, sm, location=top.location),
       valueEq(qNameId(a, location=a.location), eq, v, sm, location=v.location),
       location=top.location);
 }

--- a/grammars/silver/compiler/extension/convenience/ShortLocalProdAttrDeclDef.sv
+++ b/grammars/silver/compiler/extension/convenience/ShortLocalProdAttrDeclDef.sv
@@ -44,3 +44,25 @@ top::ProductionStmt ::= pk::'production' ak::'attribute'
       location=top.location);
 }
 
+concrete production shortForwardProductionDecl
+top::ProductionStmt ::= fk::'forward' a::Name ht::'::' te::TypeExpr 
+                        eq::'=' v::Expr sm::';'
+{
+  forwards to
+    productionStmtAppend(
+      forwardProductionAttributeDcl(fk, 'production', 'attribute', a, ht, te, sm, location=top.location),
+      valueEq(qNameId(a, location=a.location), eq, v, sm, location=v.location),
+      location=top.location);
+}
+
+concrete production shortForwardProductionDeclwKwds
+top::ProductionStmt ::= fk::'forward' pk::'production' ak::'attribute' 
+                        a::Name ht::'::' te::TypeExpr eq::'=' v::Expr sm::';'
+{
+  forwards to
+    productionStmtAppend(
+      forwardProductionAttributeDcl(fk, pk, ak, a, ht, te, sm, location=top.location),
+      valueEq(qNameId(a, location=a.location), eq, v, sm, location=v.location),
+      location=top.location);
+}
+

--- a/grammars/silver/compiler/langserver/ReferenceLocations.sv
+++ b/grammars/silver/compiler/langserver/ReferenceLocations.sv
@@ -103,6 +103,7 @@ end;
 aspect valueRefLocs on top::ProductionStmt using <- of
 | localAttributeDcl(_, _, id, _, _, _) -> map(\dcl :: ValueDclInfo -> (id.location, dcl), getValueDcl(id.name, top.env))
 | productionAttributeDcl(_, _, id, _, _, _) -> map(\dcl :: ValueDclInfo -> (id.location, dcl), getValueDcl(id.name, top.env))
+| forwardProductionAttributeDcl(_, _, _, id, _, _, _) -> map(\dcl :: ValueDclInfo -> (id.location, dcl), getValueDcl(id.name, top.env))
 end;
 
 aspect valueRefLocs on ProductionStmt using := of

--- a/grammars/silver/compiler/langserver/ReferenceLocations.sv
+++ b/grammars/silver/compiler/langserver/ReferenceLocations.sv
@@ -103,7 +103,7 @@ end;
 aspect valueRefLocs on top::ProductionStmt using <- of
 | localAttributeDcl(_, _, id, _, _, _) -> map(\dcl :: ValueDclInfo -> (id.location, dcl), getValueDcl(id.name, top.env))
 | productionAttributeDcl(_, _, id, _, _, _) -> map(\dcl :: ValueDclInfo -> (id.location, dcl), getValueDcl(id.name, top.env))
-| forwardProductionAttributeDcl(_, _, _, id, _, _, _) -> map(\dcl :: ValueDclInfo -> (id.location, dcl), getValueDcl(id.name, top.env))
+| forwardProductionAttributeDcl(_, _, _, id, _) -> map(\dcl :: ValueDclInfo -> (id.location, dcl), getValueDcl(id.name, top.env))
 end;
 
 aspect valueRefLocs on ProductionStmt using := of

--- a/grammars/silver/compiler/modification/collection/DclInfo.sv
+++ b/grammars/silver/compiler/modification/collection/DclInfo.sv
@@ -99,7 +99,7 @@ top::ValueDclInfo ::= fn::String ty::Type o::Operation
   
   -- TODO: attrOccursIndex
   -- We shouldn't be forwarding here
-  forwards to localDcl(fn,ty,sourceGrammar=top.sourceGrammar,sourceLocation=top.sourceLocation);
+  forwards to localDcl(fn,ty,false,sourceGrammar=top.sourceGrammar,sourceLocation=top.sourceLocation);
 }
 
 global nonCollectionAttrBaseDefError::(ProductionStmt ::= Decorated! DefLHS  Decorated! QNameAttrOccur  Expr  Location) =

--- a/grammars/silver/compiler/modification/copper/ActionCode.sv
+++ b/grammars/silver/compiler/modification/copper/ActionCode.sv
@@ -114,7 +114,7 @@ function hackTransformLocals
 {
   return
     case d of
-    | valueDef(item) when item.dcl matches localDcl(fn,ty,sourceGrammar=sg,sourceLocation=sl) -> [parserLocalDef(sg,sl,fn,ty)]
+    | valueDef(item) when item.dcl matches localDcl(fn,ty,false,sourceGrammar=sg,sourceLocation=sl) -> [parserLocalDef(sg,sl,fn,ty)]
     | _ -> [] -- TODO: possibly error??
     end;
 }

--- a/grammars/silver/compiler/translation/java/core/DclInfo.sv
+++ b/grammars/silver/compiler/translation/java/core/DclInfo.sv
@@ -102,7 +102,7 @@ top::ValueDclInfo ::=
 }
 
 aspect production localDcl
-top::ValueDclInfo ::= fn::String ty::Type
+top::ValueDclInfo ::= fn::String ty::Type _
 {
   local attribute li :: Integer;
   li = lastIndexOf(":local:", fn);

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -179,6 +179,11 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		}
 
 		@Override
+		public boolean getLocalIsForward(final int index) {
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+		}
+
+		@Override
 		public common.Lazy[] getLocalInheritedAttributes(final int index) {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
 		}

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -157,7 +157,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
 }
 
 aspect production forwardProductionAttributeDcl
-top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name '::' te::TypeExpr ';'
+top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name ';'
 {
   local attribute ugh_dcl_hack :: ValueDclInfo;
   ugh_dcl_hack = head(getValueDclAll(fName, top.env)); -- TODO really, we should have a DclInfo for ourselves no problem. but out current approach of constructing it via localDef makes this annoyingly difficult. this suggests a probably environment refactoring...
@@ -168,9 +168,7 @@ top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name '::' te::Type
     s"\t\t//${top.unparse}\n" ++
     s"\t\t${top.frame.className}.localIsForward[${ugh_dcl_hack.attrOccursInitIndex}] = true;\n" ++ 
     s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = " ++ 
-    if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
-    then s"new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n"
-    else s"new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n";
+    s"new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_inh_attrs];\n";
 
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
 

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -156,6 +156,28 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
     end;
 }
 
+aspect production forwardProductionAttributeDcl
+top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name '::' te::TypeExpr ';'
+{
+  local attribute ugh_dcl_hack :: ValueDclInfo;
+  ugh_dcl_hack = head(getValueDclAll(fName, top.env)); -- TODO really, we should have a DclInfo for ourselves no problem. but out current approach of constructing it via localDef makes this annoyingly difficult. this suggests a probably environment refactoring...
+  
+  top.valueWeaving := s"public static final int ${ugh_dcl_hack.attrOccursIndexName} = ${top.frame.prodLocalCountName}++;\n";
+
+  top.setupInh :=
+    s"\t\t//${top.unparse}\n" ++
+    s"\t\t${top.frame.className}.localIsForward[${ugh_dcl_hack.attrOccursInitIndex}] = true;\n" ++ 
+    s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = " ++ 
+    if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
+    then s"new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n"
+    else s"new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n";
+
+  top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
+
+  -- Decoration through a remote reference has no effect, since all inhs are supplied here via a forward parent
+  top.translation = "";
+}
+
 aspect production childDefLHS
 top::DefLHS ::= q::Decorated! QName
 {

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -85,6 +85,7 @@ ${makeIndexDcls(0, namedSig.inputElements)}
 
     public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
     public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
+    public static final boolean[] localIsForward = new boolean[num_local_attrs];
     public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
 
 ${namedSig.inhOccursIndexDecls}
@@ -215,6 +216,11 @@ ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInh
     @Override
     public common.Lazy getLocalDecSite(final int key) {
         return localDecSites[key];
+    }
+
+    @Override
+    public boolean getLocalIsForward(final int key) {
+        return localIsForward[key];
     }
 
     @Override

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -401,7 +401,14 @@ public class DecoratedNode implements Decorable, Typed {
 		if(localCreated[attribute]) {
 			throw new SilverInternalError("Decorated local " + self.getNameOfLocalAttr(attribute) + " created more than once!");
 		}
-		DecoratedNode result = ((Decorable)evalLocalAsIs(attribute)).decorate(this, self.getLocalInheritedAttributes(attribute));
+		Decorable localAsIs = (Decorable)evalLocalAsIs(attribute);
+		Lazy[] inhs = self.getLocalInheritedAttributes(attribute);
+		DecoratedNode result;
+		if(self.getLocalIsForward(attribute)) {
+			result = localAsIs.decorate(this, inhs, this);
+		} else {
+			result = localAsIs.decorate(this, inhs);
+		}
 		localCreated[attribute] = true;
 		return result;
 	}

--- a/runtime/java/src/common/FunctionNode.java
+++ b/runtime/java/src/common/FunctionNode.java
@@ -34,6 +34,11 @@ public abstract class FunctionNode extends Node {
 	}
 
 	@Override
+	public final boolean getLocalIsForward(final int index) {
+		return false;
+	}
+
+	@Override
 	public final boolean hasForward() {
 		// Functions should never even have this consulted. Ever.
 		throw new SilverInternalError("Functions do not forward!");

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -214,11 +214,17 @@ public abstract class Node implements Decorable, Typed {
 	/**
 	 * Access the decorated form of this local through its reference decoration site, if it has one.
 	 * 
-	 * @param child The index of a local or production attribute on this Node
+	 * @param index The index of a local or production attribute on this Node
 	 * @return A Lazy to evaluate on a decorated form of this Node, to get the decorated child,
 	 * 	or null if it has no reference decoration site
 	 */
 	public abstract Lazy getLocalDecSite(final int index);
+
+	/**
+	 * @param index The index of a local or production attribute on this Node
+	 * @return true if this is a forward production attribute.
+	 */
+	public abstract boolean getLocalIsForward(final int index);
 
 	/**
 	 * @param key The index for a local, to retrieve inherited attributes for.

--- a/test/flow/RefSiteProj.sv
+++ b/test/flow/RefSiteProj.sv
@@ -350,7 +350,7 @@ top::RSExpr ::= e::RSExpr
 {
   top.errors1 = null(e.env1);
 
-  forward production attribute fwrd::RSExpr = copy12(@e);
+  forward fwrd::RSExpr = copy12(@e);
 
   forwards to if e.errors1 then base() else @fwrd;
 }

--- a/test/flow/RefSiteProj.sv
+++ b/test/flow/RefSiteProj.sv
@@ -350,7 +350,7 @@ top::RSExpr ::= e::RSExpr
 {
   top.errors1 = null(e.env1);
 
-  forward fwrd::RSExpr = copy12(@e);
+  forward fwrd = copy12(@e);
 
   forwards to if e.errors1 then base() else @fwrd;
 }

--- a/test/flow/RefSiteProj.sv
+++ b/test/flow/RefSiteProj.sv
@@ -344,3 +344,13 @@ top::RSExpr ::= e::RSExpr
   forwards to projChain(@e);
 }
 }
+
+production fwrdProdAttrThing
+top::RSExpr ::= e::RSExpr
+{
+  top.errors1 = null(e.env1);
+
+  forward production attribute fwrd::RSExpr = copy12(@e);
+
+  forwards to if e.errors1 then base() else @fwrd;
+}

--- a/test/silver_features/ForwardKeyword.sv
+++ b/test/silver_features/ForwardKeyword.sv
@@ -32,7 +32,7 @@ equalityTest ( bar().fkSyn2, "foobar", String, silver_tests ) ;
 abstract production bar3
 t::ForwardKeyword ::=
 {
-  forward production attribute fwrd::ForwardKeyword = bar2();
+  forward production attribute fwrd = bar2();
 
   t.fkSyn1 = fwrd.fkSyn1;
   t.fkSyn2 = fwrd.fkSyn2;
@@ -40,12 +40,13 @@ t::ForwardKeyword ::=
 
 equalityTest ( decorate bar3() with {fkInh1 = "foobar";}.fkSyn1, "foobar", String, silver_tests ) ;
 
-nonterminal OtherForwardNT with fkInh1, fkInh2;
-wrongCode "Forward production attribute fwrd has type silver_features:ForwardKeyword that does not match the production left side silver_features:OtherForwardNT" {
-production wrongLHSType
-top::OtherForwardNT ::=
+wrongCode "Forward production attributes are not valid in this context." {
+function forwardProdAttrFn
+ForwardKeyword ::=
 {
-  forward production attribute fwrd::ForwardKeyword;
+  forward production attribute fwrd;
   fwrd = bar2();
+
+  return fwrd;
 }
 }

--- a/test/silver_features/ForwardKeyword.sv
+++ b/test/silver_features/ForwardKeyword.sv
@@ -29,3 +29,23 @@ t::ForwardKeyword ::=
 equalityTest ( bar().fkSyn1, "foobar", String, silver_tests ) ;
 equalityTest ( bar().fkSyn2, "foobar", String, silver_tests ) ;
 
+abstract production bar3
+t::ForwardKeyword ::=
+{
+  forward production attribute fwrd::ForwardKeyword = bar2();
+
+  t.fkSyn1 = fwrd.fkSyn1;
+  t.fkSyn2 = fwrd.fkSyn2;
+}
+
+equalityTest ( decorate bar3() with {fkInh1 = "foobar";}.fkSyn1, "foobar", String, silver_tests ) ;
+
+nonterminal OtherForwardNT with fkInh1, fkInh2;
+wrongCode "Forward production attribute fwrd has type silver_features:ForwardKeyword that does not match the production left side silver_features:OtherForwardNT" {
+production wrongLHSType
+top::OtherForwardNT ::=
+{
+  forward production attribute fwrd::ForwardKeyword;
+  fwrd = bar2();
+}
+}


### PR DESCRIPTION
# Changes
This adds support for forward production attributes, as proposed previously.  For example
```
production listComp
top::Expr ::= n::String l::Expr res::Expr cond::Expr
{
  local localErrors::[Message] =
     l.errors ++ res.errors ++ cond.errors ++
     case l.typerep of
     | listType(_) -> []
     | _ -> [err(l, "Input expected a list")]
     end ++
     case cond.typerep of
     | boolType() -> []
     | _ -> [err(cond, "Condition expected a bool")]
     end;
  
  forward fwrd =
    stmtExpr(
      seqStmt(
        varDecl("result", emptyList(res.typerep)),
        forEach(n, @l, ifStmt(@cond, appendList("result", @res)))),
      var("result"));

  forwards to if null(localErrors) then @fwrd else errorExpr(localErrors);
}
```
Here we want to decorate the children through forwarding, but conditionally forward to an error production if there are local errors.  Instead we can decorate the forward tree under a local production attribute.  Forward production attributes avoid the need to write copy equations for all the inherited attributes on `fwrd` by decorating the prod attr with the current node as its forward parent.

(I thought there was a github issue for this opened, but maybe not?)

# Documentation
The above example and some explanation are included in [this writeup](https://github.umn.edu/krame505/thesis-proposal/blob/main/decoration-and-forwarding.tex), and we may want to mention forward prod attrs in the forthcoming paper on forwarding.  This should eventually all get written up for the website docs, too.