### PR TITLE
Finish long-standing cleanup splitting flow vertices into syn/inh

### DIFF
--- a/deep-rebuild
+++ b/deep-rebuild
@@ -3,7 +3,7 @@
 set -eu
 
 export SILVER_HOME=$(pwd)
-JVM_ARGS="-Xss25M -Xmx6G -jar ../jars/silver.compiler.composed.Default.jar"
+JVM_ARGS="-Xss16M -Xmx6G -jar ../jars/silver.compiler.composed.Default.jar"
 export ANT_OPTS=-Xss10M
 
 # just run this script, no parameters or options.

--- a/deep-rebuild
+++ b/deep-rebuild
@@ -3,7 +3,7 @@
 set -eu
 
 export SILVER_HOME=$(pwd)
-JVM_ARGS="-Xss16M -Xmx6G -jar ../jars/silver.compiler.composed.Default.jar"
+JVM_ARGS="-Xss25M -Xmx6G -jar ../jars/silver.compiler.composed.Default.jar"
 export ANT_OPTS=-Xss10M
 
 # just run this script, no parameters or options.

--- a/grammars/silver/compiler/analysis/typechecking/core/Context.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Context.sv
@@ -1,5 +1,6 @@
 grammar silver:compiler:analysis:typechecking:core;
 
+import silver:compiler:definition:flow:env only getFlowTypeSpecFor, flowEnv;
 import silver:compiler:analysis:warnings:flow only inhDepsForSynOnType;
 import silver:util:treeset as set;
 

--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -1,5 +1,7 @@
 grammar silver:compiler:analysis:typechecking:core;
 
+import silver:compiler:definition:flow:env;
+
 attribute upSubst, downSubst, finalSubst occurs on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoExpr, AnnoAppExprs;
 
 propagate upSubst, downSubst

--- a/grammars/silver/compiler/analysis/uniqueness/Project.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Project.sv
@@ -5,8 +5,10 @@ imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:flow:ast;
+imports silver:compiler:definition:flow:env;
 imports silver:compiler:definition:flow:syntax;
 imports silver:compiler:definition:concrete_syntax;
+imports silver:compiler:analysis:typechecking:core;
 imports silver:compiler:translation:java:core only finalType;
 imports silver:compiler:driver:util;
 

--- a/grammars/silver/compiler/analysis/warnings/exporting/Graph.sv
+++ b/grammars/silver/compiler/analysis/warnings/exporting/Graph.sv
@@ -9,16 +9,24 @@ import silver:compiler:definition:env;
 -- This isn't exactly a warning, but it can live here for now...
 
 synthesized attribute dumpDepGraph :: Boolean occurs on CmdArgs;
+synthesized attribute dumpExportGraph :: Boolean occurs on CmdArgs;
 
 aspect production endCmdArgs
 top::CmdArgs ::= _
 {
   top.dumpDepGraph = false;
+  top.dumpExportGraph = false;
 }
 abstract production dumpDepGraphFlag
 top::CmdArgs ::= rest::CmdArgs
 {
   top.dumpDepGraph = true;
+  forwards to rest;
+}
+abstract production dumpExportGraphFlag
+top::CmdArgs ::= rest::CmdArgs
+{
+  top.dumpExportGraph = true;
   forwards to rest;
 }
 aspect function parseArgs
@@ -28,12 +36,17 @@ Either<String  Decorated CmdArgs> ::= args::[String]
     flagSpec(name="--dump-import-graph", paramString=nothing(),
       help="dump a graph of dependencies between grammars as a Graphviz file",
       flagParser=flag(dumpDepGraphFlag))];
+  flags <- [
+    flagSpec(name="--dump-export-graph", paramString=nothing(),
+      help="dump a graph of exports between grammars as a Graphviz file",
+      flagParser=flag(dumpExportGraphFlag))];
   -- not omitting from descriptions deliberately!
 }
 aspect production compilation
 top::Compilation ::= g::Grammars  _  _  benv::BuildEnv
 {
   top.postOps <- if top.config.dumpDepGraph then [dumpDepGraphAction(g.grammarList)] else [];
+  top.postOps <- if top.config.dumpExportGraph then [dumpExportGraphAction(g.grammarList)] else [];
 }
 
 abstract production dumpDepGraphAction
@@ -42,6 +55,18 @@ top::DriverAction ::= specs::[Decorated RootSpec]
   top.run = do {
     eprintln("Generating import graph");
     writeFile("deps.dot", "digraph deps {\n" ++ generateDotGraph(specs) ++ "}");
+    return 0;
+  };
+
+  top.order = 0;
+}
+
+abstract production dumpExportGraphAction
+top::DriverAction ::= specs::[Decorated RootSpec]
+{
+  top.run = do {
+    eprintln("Generating export graph");
+    writeFile("exports.dot", "digraph exports {\n" ++ generateDotExportGraph(specs) ++ "}");
     return 0;
   };
 
@@ -57,6 +82,18 @@ String ::= specs::[Decorated RootSpec]
       "\"" ++ h.declaredName ++ "\"[label=\"" ++ h.declaredName ++ "\"];\n" ++
       implode("", map(makeDotArrow(h.declaredName, _), h.moduleNames)) ++
       generateDotGraph(t)
+  end;
+}
+
+function generateDotExportGraph
+String ::= specs::[Decorated RootSpec]
+{
+  return case specs of
+  | [] -> ""
+  | h::t ->
+      "\"" ++ h.declaredName ++ "\"[label=\"" ++ h.declaredName ++ "\"];\n" ++
+      implode("", map(makeDotArrow(h.declaredName, _), computeOptionalDeps([h.declaredName], h.compiledGrammars))) ++
+      generateDotExportGraph(t)
   end;
 }
 

--- a/grammars/silver/compiler/analysis/warnings/flow/FlowTypeCopyEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/FlowTypeCopyEquation.sv
@@ -40,7 +40,7 @@ function raiseImplicitFwdEqFlowTypes
 [Message] ::= config::Decorated CmdArgs  l::Location  lhsNt::String  prod::String  attr::String  e::FlowEnv  myGraph::ProductionGraph  myFlow::EnvTree<FlowType> 
 {
   -- The actual dependencies for `forward.attr`
-  local fwdFlowDeps :: set:Set<String> = onlyLhsInh(expandGraph([forwardVertex(attr)], myGraph));
+  local fwdFlowDeps :: set:Set<String> = onlyLhsInh(expandGraph([forwardSynVertex(attr)], myGraph));
   -- The flow type for `attr` on `lhsNt`
   local depsForThisAttr :: set:Set<String> = inhDepsForSyn(attr, lhsNt, myFlow);
   -- Actual forwards equation deps not in the flow type for `attr`

--- a/grammars/silver/compiler/analysis/warnings/flow/MWDA.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/MWDA.sv
@@ -28,17 +28,6 @@ imports silver:compiler:modification:defaultattr;
 imports silver:compiler:modification:primitivepattern;
 imports silver:compiler:modification:copper only parserAttributeDefLHS;
 
--- TODO: why is this a thing I have to write here. Sheesh. FIX THIS.
--- The real fix is for our vertexes to remember whether they are syn/inh.
-function isInherited
-Boolean ::= a::String  e::Decorated Env
-{
-  return case getAttrDclAll(a, e) of
-  | at :: _ -> at.isInherited
-  | _ -> false
-  end;
-}
-
 function isLhsInh
 Boolean ::= v::FlowVertex
 {

--- a/grammars/silver/compiler/analysis/warnings/flow/MWDA.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/MWDA.sv
@@ -15,8 +15,12 @@ imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:env;
 
+-- type checking
+imports silver:compiler:analysis:typechecking:core;
+
 -- flow analysis
 imports silver:compiler:definition:flow:ast;
+imports silver:compiler:definition:flow:env;
 imports silver:compiler:definition:flow:driver only ProductionGraph, FlowType, prod, inhDepsForSyn, findProductionGraph, expandGraph, onlyLhsInh;
 
 -- uniqueness analysis

--- a/grammars/silver/compiler/definition/concrete_syntax/Project.sv
+++ b/grammars/silver/compiler/definition/concrete_syntax/Project.sv
@@ -7,6 +7,7 @@ imports silver:compiler:definition:type:syntax;
 
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
+imports silver:compiler:definition:flow:env;
 
 imports silver:compiler:definition:concrete_syntax:ast;
 

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -1076,6 +1076,10 @@ nonterminal AnnoExpr with
   isPartial, appExprApplied, exprs,
   remainingFuncAnnotations, funcAnnotations,
   missingAnnotations, partialAnnoTypereps, annoIndexConverted, annoIndexSupplied, originRules;
+flowtype decorate {
+    grammarName, env, flowEnv, downSubst, finalSubst, frame, originRules, compiledGrammars, config,
+    appExprApplied, remainingFuncAnnotations, funcAnnotations
+  } on AnnoAppExprs, AnnoExpr;
 
 propagate config, grammarName, env, errors, freeVars, frame, compiledGrammars, exprs, funcAnnotations, appExprApplied, originRules
   on AnnoAppExprs, AnnoExpr;

--- a/grammars/silver/compiler/definition/core/Project.sv
+++ b/grammars/silver/compiler/definition/core/Project.sv
@@ -10,8 +10,14 @@ imports silver:compiler:definition:type:syntax;
 -- Type Representation
 imports silver:compiler:definition:type;
 
+-- Type Checking
+imports silver:compiler:analysis:typechecking:core;
+
 -- Environment Representation
 imports silver:compiler:definition:env;
+
+-- Flow Information
+imports silver:compiler:definition:flow:env;
 
 -- Utilities
 
@@ -33,6 +39,7 @@ option silver:compiler:modification:copper_mda;
 option silver:compiler:extension:testing; -- TODO this is about that buggy experiment of Eric's...
 
 -- These are somewhat less than desirable exports, due to the modularity analysis.
-exports silver:compiler:analysis:typechecking:core;
-exports silver:compiler:definition:flow:env;
+option silver:compiler:definition:type:syntax;
+option silver:compiler:analysis:typechecking:core;
+option silver:compiler:definition:flow:env;
 

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -188,7 +188,7 @@ top::FlowDef ::= prod::String  sigName::String  attr::String  deps::[FlowVertex]
 {
   top.inhTreeContribs := [pair(crossnames(prod, crossnames(sigName, attr)), top)];
   top.prodGraphContribs := [pair(prod, top)];
-  top.flowEdges = map(pair(rhsVertex(sigName, attr), _), deps);
+  top.flowEdges = map(pair(rhsInhVertex(sigName, attr), _), deps);
 }
 
 {--
@@ -236,7 +236,7 @@ top::FlowDef ::= prod::String  attr::String  deps::[FlowVertex]
 {
   top.fwdInhTreeContribs := [pair(crossnames(prod, attr), top)];
   top.prodGraphContribs := [pair(prod, top)];
-  top.flowEdges = map(pair(forwardVertex(attr), _), deps);
+  top.flowEdges = map(pair(forwardInhVertex(attr), _), deps);
 }
 
 {--
@@ -273,7 +273,7 @@ top::FlowDef ::= prod::String  fName::String  attr::String  deps::[FlowVertex]
 {
   top.localInhTreeContribs := [pair(crossnames(prod, crossnames(fName, attr)), top)];
   top.prodGraphContribs := [pair(prod, top)];
-  top.flowEdges = map(pair(localVertex(fName, attr), _), deps);
+  top.flowEdges = map(pair(localInhVertex(fName, attr), _), deps);
 }
 
 {--
@@ -325,7 +325,7 @@ top::FlowDef ::= prod::String  fName::String  attr::String  deps::[FlowVertex]
 {
   top.localInhTreeContribs := [pair(crossnames(prod, crossnames(fName, attr)), top)];
   top.prodGraphContribs := [pair(prod, top)];
-  top.flowEdges = map(pair(anonVertex(fName, attr), _), deps);
+  top.flowEdges = map(pair(anonInhVertex(fName, attr), _), deps);
 }
 
 {--
@@ -389,7 +389,7 @@ abstract production childRefDecSiteEq
 top::FlowDef ::= prod::String  sigName::String  alwaysDec::Boolean  decSite::VertexType  attrs::[String]
 {
   top.prodGraphContribs := [pair(prod, top)];
-  top.flowEdges = map(\ attr::String -> (rhsVertex(sigName, attr), decSite.inhVertex(attr)), attrs);
+  top.flowEdges = map(\ attr::String -> (rhsInhVertex(sigName, attr), decSite.inhVertex(attr)), attrs);
   top.refPossibleDecSiteContribs := [(s"${prod}:${sigName}", decSite)];
   top.refDecSiteContribs := if alwaysDec then top.refPossibleDecSiteContribs else [];
 }
@@ -407,7 +407,7 @@ abstract production localRefDecSiteEq
 top::FlowDef ::= prod::String  fName::String  alwaysDec::Boolean  decSite::VertexType  attrs::[String]
 {
   top.prodGraphContribs := [pair(prod, top)];
-  top.flowEdges = map(\ attr::String -> (localVertex(fName, attr), decSite.inhVertex(attr)), attrs);
+  top.flowEdges = map(\ attr::String -> (localInhVertex(fName, attr), decSite.inhVertex(attr)), attrs);
   top.refPossibleDecSiteContribs := [(fName, decSite)];
   top.refDecSiteContribs := if alwaysDec then top.refPossibleDecSiteContribs else [];
 }

--- a/grammars/silver/compiler/definition/flow/ast/Vertex.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Vertex.sv
@@ -29,15 +29,23 @@ abstract production lhsInhVertex
 top::FlowVertex ::= attrName::String
 {}
 
--- TODO: we should do the above syn/inh separation for everything below too.
-
 {--
- - A vertex representing an attribute on an element of the signature RHS.
+ - A vertex representing a synthesized attribute on an element of the signature RHS.
  -
  - @param sigName  the name given to a signature nonterminal.
  - @param attrName  the full name of an attribute on that signature element.
  -}
-abstract production rhsVertex
+abstract production rhsSynVertex
+top::FlowVertex ::= sigName::String  attrName::String
+{}
+
+{--
+ - A vertex representing an inherited attribute on an element of the signature RHS.
+ -
+ - @param sigName  the name given to a signature nonterminal.
+ - @param attrName  the full name of an attribute on that signature element.
+ -}
+abstract production rhsInhVertex
 top::FlowVertex ::= sigName::String  attrName::String
 {}
 
@@ -54,14 +62,26 @@ top::FlowVertex ::= fName::String
 {}
 
 {--
- - A vertex representing an attribute on a local equation. i.e. forward, local
+ - A vertex representing a synthesized attribute on a local equation. i.e. forward, local
  - attribute, production attribute, etc.  Note this this implies the equation
  - above IS a decorable type!
  -
  - @param fName  the full name of the NTA/FWD
  - @param attrName  the full name of the attribute on that element
  -}
-abstract production localVertex
+abstract production localSynVertex
+top::FlowVertex ::= fName::String  attrName::String
+{}
+
+{--
+ - A vertex representing an inherited attribute on a local equation. i.e. forward, local
+ - attribute, production attribute, etc.  Note this this implies the equation
+ - above IS a decorable type!
+ -
+ - @param fName  the full name of the NTA/FWD
+ - @param attrName  the full name of the attribute on that element
+ -}
+abstract production localInhVertex
 top::FlowVertex ::= fName::String  attrName::String
 {}
 
@@ -75,10 +95,15 @@ FlowVertex ::=
 }
 
 -- An attribute on the forward node for this production
-function forwardVertex
+function forwardSynVertex
 FlowVertex ::= attrName::String
 {
-  return localVertex("forward", attrName);
+  return localSynVertex("forward", attrName);
+}
+function forwardInhVertex
+FlowVertex ::= attrName::String
+{
+  return localInhVertex("forward", attrName);
 }
 
 {--
@@ -92,18 +117,29 @@ top::FlowVertex ::= fName::String
 {}
 
 {--
- - A vertex representing an attribute on an anonymous equation.
+ - A vertex representing a synthesized attribute on an anonymous equation.
+ - e.g. 'decorate e with { a = d } . b' this represents 'b'.
+ -
+ - @param fName  the anonymous name
+ - @param attrName  the full name of the attribute on that element
+ -}
+abstract production anonSynVertex
+top::FlowVertex ::= fName::String  attrName::String
+{}
+
+{--
+ - A vertex representing an inherited attribute on an anonymous equation.
  - e.g. 'decorate e with { a = d }' this represents 'e_nt.a's deps 'd'.
  -
  - @param fName  the anonymous name
  - @param attrName  the full name of the attribute on that element
  -}
-abstract production anonVertex
+abstract production anonInhVertex
 top::FlowVertex ::= fName::String  attrName::String
 {}
 
 {--
- - A vertex corresponding to a sub-terms of an expression with a known decoration site.
+ - A vertex corresponding to a synthesized attribute on a sub-term of an expression with a known decoration site.
  - e.g. 'local foo::Foo = bar(baz(@x));', we need a vertex for the attributes on baz(@x)
  - for decoration site projections.
  -
@@ -112,6 +148,20 @@ top::FlowVertex ::= fName::String  attrName::String
  - @param sigName  the name given to the corresponding child
  - @param attrName  the full name of an attribute on this subterm, when decorated
  -}
-abstract production subtermVertex
+abstract production subtermSynVertex
+top::FlowVertex ::= parent::VertexType prodName::String sigName::String  attrName::String
+{}
+
+{--
+ - A vertex corresponding to an inherited synthesized attribute on a sub-term of an expression with a known decoration site.
+ - e.g. 'local foo::Foo = bar(baz(@x));', we need a vertex for the attributes on baz(@x)
+ - for decoration site projections.
+ -
+ - @param parent  the decoration site of the enclosing term
+ - @param prodName  the full name of the applied production
+ - @param sigName  the name given to the corresponding child
+ - @param attrName  the full name of an attribute on this subterm, when decorated
+ -}
+abstract production subtermInhVertex
 top::FlowVertex ::= parent::VertexType prodName::String sigName::String  attrName::String
 {}

--- a/grammars/silver/compiler/definition/flow/ast/VertexType.sv
+++ b/grammars/silver/compiler/definition/flow/ast/VertexType.sv
@@ -48,9 +48,9 @@ top::VertexType ::=
 abstract production rhsVertexType
 top::VertexType ::= sigName::String
 {
-  top.synVertex = rhsVertex(sigName, _);
-  top.inhVertex = rhsVertex(sigName, _);
-  top.fwdVertex = rhsVertex(sigName, "forward");
+  top.synVertex = rhsSynVertex(sigName, _);
+  top.inhVertex = rhsInhVertex(sigName, _);
+  top.fwdVertex = rhsSynVertex(sigName, "forward");
   top.eqVertex = [];
 }
 
@@ -60,9 +60,9 @@ top::VertexType ::= sigName::String
 abstract production localVertexType
 top::VertexType ::= fName::String
 {
-  top.synVertex = localVertex(fName, _);
-  top.inhVertex = localVertex(fName, _);
-  top.fwdVertex = localVertex(fName, "forward");
+  top.synVertex = localSynVertex(fName, _);
+  top.inhVertex = localInhVertex(fName, _);
+  top.fwdVertex = localSynVertex(fName, "forward");
   top.eqVertex = [localEqVertex(fName)];
 }
 
@@ -72,9 +72,9 @@ top::VertexType ::= fName::String
 abstract production forwardVertexType_real
 top::VertexType ::=
 {
-  top.synVertex = localVertex("forward", _);
-  top.inhVertex = localVertex("forward", _);
-  top.fwdVertex = localVertex("forward", "forward");
+  top.synVertex = forwardSynVertex;
+  top.inhVertex = forwardInhVertex;
+  top.fwdVertex = forwardSynVertex("forward");
   top.eqVertex = [forwardEqVertex_singleton];
 }
 
@@ -84,9 +84,9 @@ top::VertexType ::=
 abstract production anonVertexType
 top::VertexType ::= x::String
 {
-  top.synVertex = anonVertex(x, _);
-  top.inhVertex = anonVertex(x, _);
-  top.fwdVertex = anonVertex(x, "forward");
+  top.synVertex = anonSynVertex(x, _);
+  top.inhVertex = anonInhVertex(x, _);
+  top.fwdVertex = anonSynVertex(x, "forward");
   top.eqVertex = [anonEqVertex(x)];
 }
 
@@ -96,8 +96,8 @@ top::VertexType ::= x::String
 abstract production subtermVertexType
 top::VertexType ::= parent::VertexType prodName::String sigName::String
 {
-  top.synVertex = subtermVertex(parent, prodName, sigName, _);
-  top.inhVertex = subtermVertex(parent, prodName, sigName, _);
-  top.fwdVertex = subtermVertex(parent, prodName, sigName, "forward");
+  top.synVertex = subtermSynVertex(parent, prodName, sigName, _);
+  top.inhVertex = subtermInhVertex(parent, prodName, sigName, _);
+  top.fwdVertex = subtermSynVertex(parent, prodName, sigName, "forward");
   top.eqVertex = [];
 }

--- a/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
@@ -143,7 +143,12 @@ top::FlowVertex ::= attrName::String
 {
   top.dotName = attrName;
 }
-aspect production rhsVertex
+aspect production rhsSynVertex
+top::FlowVertex ::= sigName::String  attrName::String
+{
+  top.dotName = sigName ++ "/" ++ attrName;
+}
+aspect production rhsInhVertex
 top::FlowVertex ::= sigName::String  attrName::String
 {
   top.dotName = sigName ++ "/" ++ attrName;
@@ -153,7 +158,12 @@ top::FlowVertex ::= fName::String
 {
   top.dotName = fName;
 }
-aspect production localVertex
+aspect production localSynVertex
+top::FlowVertex ::= fName::String  attrName::String
+{
+  top.dotName = fName ++ "/" ++ attrName;
+}
+aspect production localInhVertex
 top::FlowVertex ::= fName::String  attrName::String
 {
   top.dotName = fName ++ "/" ++ attrName;
@@ -163,15 +173,25 @@ top::FlowVertex ::= fName::String
 {
   top.dotName = fName;
 }
-aspect production anonVertex
+aspect production anonSynVertex
 top::FlowVertex ::= fName::String  attrName::String
 {
   top.dotName = fName ++ "/" ++ attrName;
 }
-aspect production subtermVertex
+aspect production anonInhVertex
+top::FlowVertex ::= fName::String  attrName::String
+{
+  top.dotName = fName ++ "/" ++ attrName;
+}
+aspect production subtermSynVertex
 top::FlowVertex ::= parent::VertexType prodName::String sigName::String  attrName::String
 {
   top.dotName = parent.synVertex(prodName ++ "@" ++ sigName ++ "/" ++ attrName).dotName;  -- Hack!
+}
+aspect production subtermInhVertex
+top::FlowVertex ::= parent::VertexType prodName::String sigName::String  attrName::String
+{
+  top.dotName = parent.inhVertex(prodName ++ "@" ++ sigName ++ "/" ++ attrName).dotName;  -- Hack!
 }
 
 

--- a/grammars/silver/compiler/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/compiler/definition/flow/driver/FlowTypes.sv
@@ -178,17 +178,27 @@ top::FlowVertex ::= attrName::String
 {
   top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for inherited attributes?");
 }
-aspect production rhsVertex
+aspect production rhsSynVertex
 top::FlowVertex ::= sigName::String  attrName::String
 {
-  top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for child attributes?");
+  top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for child synthesized attributes?");
+}
+aspect production rhsInhVertex
+top::FlowVertex ::= sigName::String  attrName::String
+{
+  top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for child inherited attributes?");
 }
 aspect production localEqVertex
 top::FlowVertex ::= fName::String
 {
   top.flowTypeName = fName; -- secretly only ever "forward" when we actually demand flowTypeName
 }
-aspect production localVertex
+aspect production localSynVertex
+top::FlowVertex ::= fName::String  attrName::String
+{
+  top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for local synthesized attributes?");
+}
+aspect production localInhVertex
 top::FlowVertex ::= fName::String  attrName::String
 {
   top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for local inherited attributes?");
@@ -198,12 +208,22 @@ top::FlowVertex ::= fName::String
 {
   top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for anon equations?");
 }
-aspect production anonVertex
+aspect production anonSynVertex
+top::FlowVertex ::= fName::String  attrName::String
+{
+  top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for anon synthesized attributes?");
+}
+aspect production anonInhVertex
 top::FlowVertex ::= fName::String  attrName::String
 {
   top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for anon inherited attributes?");
 }
-aspect production subtermVertex
+aspect production subtermSynVertex
+top::FlowVertex ::= parent::VertexType prodName::String sigName::String  attrName::String
+{
+  top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for subterm synthesized attributes?");
+}
+aspect production subtermInhVertex
 top::FlowVertex ::= parent::VertexType prodName::String sigName::String  attrName::String
 {
   top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for subterm inherited attributes?");

--- a/grammars/silver/compiler/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/compiler/definition/flow/driver/FlowTypes.sv
@@ -2,7 +2,7 @@ grammar silver:compiler:definition:flow:driver;
 
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
---import silver:compiler:definition:flow:env;
+imports silver:compiler:definition:flow:env;
 imports silver:compiler:definition:flow:ast;
 imports silver:compiler:analysis:warnings:flow only isOccursSynthesized;
 imports silver:compiler:analysis:uniqueness;

--- a/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
@@ -380,7 +380,7 @@ function addFwdSynEqs
 {
   return if null(syns) then []
   else (if null(lookupSyn(prod, head(syns), flowEnv))
-    then [pair(lhsSynVertex(head(syns)), forwardVertex(head(syns))),
+    then [pair(lhsSynVertex(head(syns)), forwardSynVertex(head(syns))),
           pair(lhsSynVertex(head(syns)), forwardEqVertex())] else []) ++
     addFwdSynEqs(prod, tail(syns), flowEnv);
 }
@@ -392,7 +392,7 @@ function addFwdInhEqs
 [Pair<FlowVertex FlowVertex>] ::= prod::ProdName inhs::[String] flowEnv::FlowEnv
 {
   return if null(inhs) then []
-  else (if null(lookupFwdInh(prod, head(inhs), flowEnv)) then [pair(forwardVertex(head(inhs)), lhsInhVertex(head(inhs)))] else []) ++
+  else (if null(lookupFwdInh(prod, head(inhs), flowEnv)) then [pair(forwardInhVertex(head(inhs)), lhsInhVertex(head(inhs)))] else []) ++
     addFwdInhEqs(prod, tail(inhs), flowEnv);
 }
 {--
@@ -403,7 +403,7 @@ function addFwdProdAttrInhEqs
 [Pair<FlowVertex FlowVertex>] ::= prod::ProdName fName::String inhs::[String] flowEnv::FlowEnv
 {
   return if null(inhs) then []
-  else (if null(lookupLocalInh(prod, fName, head(inhs), flowEnv)) then [pair(localVertex(fName, head(inhs)), lhsInhVertex(head(inhs)))] else []) ++
+  else (if null(lookupLocalInh(prod, fName, head(inhs), flowEnv)) then [pair(localInhVertex(fName, head(inhs)), lhsInhVertex(head(inhs)))] else []) ++
     addFwdProdAttrInhEqs(prod, fName, tail(inhs), flowEnv);
 }
 function allFwdProdAttrs

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -2,6 +2,7 @@ grammar silver:compiler:definition:flow:env;
 
 import silver:compiler:definition:type:syntax;
 import silver:compiler:definition:type;
+import silver:compiler:analysis:typechecking:core;
 import silver:compiler:modification:copper;
 import silver:compiler:modification:primitivepattern;
 import silver:compiler:extension:patternmatching only Arrow_kwd, Vbar_kwd; -- TODO remove

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -175,9 +175,9 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
 {
   local vertex :: FlowVertex =
     case dl of
-    | childDefLHS(q) -> rhsVertex(q.lookupValue.fullName, attr.attrDcl.fullName)
-    | localDefLHS(q) -> localVertex(q.lookupValue.fullName, attr.attrDcl.fullName)
-    | forwardDefLHS(q) -> forwardVertex(attr.attrDcl.fullName)
+    | childDefLHS(q) -> rhsInhVertex(q.lookupValue.fullName, attr.attrDcl.fullName)
+    | localDefLHS(q) -> localInhVertex(q.lookupValue.fullName, attr.attrDcl.fullName)
+    | forwardDefLHS(q) -> forwardInhVertex(attr.attrDcl.fullName)
     | _ -> localEqVertex("bogus:value:from:inhcontrib:flow")
     end;
   top.flowDefs <-

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -229,7 +229,6 @@ aspect production appendCollectionValueDef
 top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   local locDefGram :: String = hackGramFromQName(val.lookupValue);
-  -- TODO: possible bug? this would include ":local" in the gram wouldn't it?
 
   local mayAffectFlowType :: Boolean =
     isExportedBy(top.grammarName, [locDefGram], top.compiledGrammars);

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -240,7 +240,8 @@ top::ProductionStmt ::= val::Decorated! QName  e::Expr
   -- If we do, we'll have to come back here to add 'location' info anyway,
   -- so if we do that, uhhh... fix this! Because you're here! Reading this!
 
-  top.flowDefs <-
+  -- TODO: This shouldn't be a forwarding prod!
+  top.flowDefs := e.flowDefs ++
     if mayAffectFlowType
     then [extraEq(top.frame.fullName, localEqVertex(val.lookupValue.fullName), e.flowDeps, true)]
     else [];

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -2,6 +2,7 @@ grammar silver:compiler:definition:flow:syntax;
 
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:flow:ast;
+imports silver:compiler:definition:flow:env;
 imports silver:compiler:definition:flow:driver only FlowType, inhDepsForSyn;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -4,6 +4,7 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:flow:syntax;
+imports silver:compiler:definition:flow:env;
 
 nonterminal TypeExpr  with config, location, grammarName, errors, env, flowEnv, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds, errorsTyVars, errorsKindStar, freeVariables, mentionedAliases, onNt, errorsInhSet, typerepInhSet;
 nonterminal Signature with config, location, grammarName, errors, env, flowEnv, unparse, typerep, lexicalTypeVariables, lexicalTyVarKinds, mentionedAliases;

--- a/grammars/silver/compiler/driver/util/Compilation.sv
+++ b/grammars/silver/compiler/driver/util/Compilation.sv
@@ -78,9 +78,9 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::Bu
   top.postOps := [];
 }
 
-nonterminal Grammars with config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dependentGrammars, allFlowDefs, grammarList, dirtyGrammars, recompiledGrammars, jarName;
+nonterminal Grammars with config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dependentGrammars, grammarList, dirtyGrammars, recompiledGrammars, jarName;
 
-propagate config, productionFlowGraphs, grammarFlowTypes, dirtyGrammars, recompiledGrammars, jarName, dependentGrammars, allFlowDefs on Grammars;
+propagate config, productionFlowGraphs, grammarFlowTypes, dirtyGrammars, recompiledGrammars, jarName, dependentGrammars on Grammars;
 
 abstract production consGrammars
 top::Grammars ::= h::RootSpec  t::Grammars

--- a/grammars/silver/compiler/driver/util/Compilation.sv
+++ b/grammars/silver/compiler/driver/util/Compilation.sv
@@ -78,9 +78,9 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::Bu
   top.postOps := [];
 }
 
-nonterminal Grammars with config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dependentGrammars, grammarList, dirtyGrammars, recompiledGrammars, jarName;
+nonterminal Grammars with config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dependentGrammars, allFlowDefs, grammarList, dirtyGrammars, recompiledGrammars, jarName;
 
-propagate config, productionFlowGraphs, grammarFlowTypes, dirtyGrammars, recompiledGrammars, jarName, dependentGrammars on Grammars;
+propagate config, productionFlowGraphs, grammarFlowTypes, dirtyGrammars, recompiledGrammars, jarName, dependentGrammars, allFlowDefs on Grammars;
 
 abstract production consGrammars
 top::Grammars ::= h::RootSpec  t::Grammars

--- a/grammars/silver/compiler/driver/util/FlowTypes.sv
+++ b/grammars/silver/compiler/driver/util/FlowTypes.sv
@@ -51,11 +51,9 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::Bu
   
   g.productionFlowGraphs = finalGraphEnv;
   g.grammarFlowTypes = flowTypes;
-  g.allFlowDefs = allFlowDefs;
   
   r.productionFlowGraphs = finalGraphEnv;
   r.grammarFlowTypes = flowTypes;
-  r.allFlowDefs = allFlowDefs;
 }
 
 function getProdNt

--- a/grammars/silver/compiler/driver/util/FlowTypes.sv
+++ b/grammars/silver/compiler/driver/util/FlowTypes.sv
@@ -51,9 +51,11 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  benv::Bu
   
   g.productionFlowGraphs = finalGraphEnv;
   g.grammarFlowTypes = flowTypes;
+  g.allFlowDefs = allFlowDefs;
   
   r.productionFlowGraphs = finalGraphEnv;
   r.grammarFlowTypes = flowTypes;
+  r.allFlowDefs = allFlowDefs;
 }
 
 function getProdNt

--- a/grammars/silver/compiler/driver/util/RootSpec.sv
+++ b/grammars/silver/compiler/driver/util/RootSpec.sv
@@ -135,6 +135,10 @@ top::RootSpec ::= g::Grammar  oldInterface::Maybe<InterfaceItems>  grammarName::
 
   production attribute extraFileErrors::[(String, [Message])] with ++;
   extraFileErrors := [];
+
+  -- Seed flow deps with {compiledGrammars, config}
+  extraFileErrors <- if false then error(hackUnparse((top.compiledGrammars, top.config))) else [];
+
   top.allFileErrors = map(
     \ fe::(String, [Message]) -> case fe of (fileName, fileErrors) ->
       (fileName, fileErrors ++ concat(lookupAll(fileName, extraFileErrors)))

--- a/grammars/silver/compiler/driver/util/RootSpec.sv
+++ b/grammars/silver/compiler/driver/util/RootSpec.sv
@@ -7,7 +7,7 @@ import silver:langutil:pp only show;
 
 import silver:compiler:definition:core only Grammar, grammarErrors, allFileErrors, grammarName, importedDefs, importedOccursDefs, grammarDependencies, globalImports;
 import silver:compiler:definition:flow:env only flowEnv, flowDefs, specDefs, refDefs, fromFlowDefs;
-import silver:compiler:definition:flow:ast only FlowDefs;
+import silver:compiler:definition:flow:ast only nilFlow, consFlow, FlowDef;
 
 import silver:compiler:definition:core only jarName;
 
@@ -21,13 +21,13 @@ nonterminal RootSpec with
   -- compiler-wide inherited attributes
   config, compiledGrammars, productionFlowGraphs, grammarFlowTypes,
   -- driver-specific inherited attributes
-  dependentGrammars, allFlowDefs,
+  dependentGrammars,
   -- synthesized attributes
   declaredName, moduleNames, exportedGrammars, optionalGrammars, condBuild, allGrammarDependencies,
   defs, occursDefs, grammarErrors, grammarSource, grammarTime, dirtyGrammars, recompiledGrammars,
   parsingErrors, allFileErrors, jarName, generateLocation, serInterface;
 
-flowtype RootSpec = decorate {config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dependentGrammars, allFlowDefs};
+flowtype RootSpec = decorate {config, compiledGrammars, productionFlowGraphs, grammarFlowTypes, dependentGrammars};
 
 propagate productionFlowGraphs, grammarFlowTypes, exportedGrammars, optionalGrammars, condBuild, defs, occursDefs on RootSpec;
 
@@ -35,11 +35,6 @@ propagate productionFlowGraphs, grammarFlowTypes, exportedGrammars, optionalGram
  - Grammars (a, b) where b depends on a
  -}
 inherited attribute dependentGrammars :: [(String, String)];
-
-{--
- - All flow defs for the compilation
- -}
-inherited attribute allFlowDefs :: FlowDefs;
 
 {--
  - Grammars that must be recompiled
@@ -95,12 +90,7 @@ top::RootSpec ::= g::Grammar  oldInterface::Maybe<InterfaceItems>  grammarName::
       flatMap((.specDefs), rootSpecs),
       flatMap((.refDefs), rootSpecs),
       flatMap((.uniqueRefs), rootSpecs),
-      -- The production flow graphs computed during flow type inference are built from the global
-      -- flow defs, which may include transitive deps on attributes that aren't in grammars depended
-      -- upon by this grammar.  So we need to use the same global flow defs in error checking.
-      -- Note that we don't compare flow defs in comparing interface file equality, so this doesn't
-      -- cause any circularity issues.
-      top.allFlowDefs);
+      foldr(consFlow, nilFlow(), flatMap((.flowDefs), rootSpecs)));
   
   production newInterface::InterfaceItems = packInterfaceItems(top);
   top.serInterface =

--- a/grammars/silver/compiler/extension/attrsection/AttrSection.sv.md
+++ b/grammars/silver/compiler/extension/attrsection/AttrSection.sv.md
@@ -5,6 +5,8 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
+imports silver:compiler:definition:flow:env;
+imports silver:compiler:analysis:typechecking:core;
 imports silver:compiler:modification:lambda_fn;
 
 import silver:util:treeset as ts;

--- a/grammars/silver/compiler/extension/auto_ast/AutoAst.sv
+++ b/grammars/silver/compiler/extension/auto_ast/AutoAst.sv
@@ -3,7 +3,7 @@ grammar silver:compiler:extension:auto_ast;
 import silver:compiler:definition:core;
 import silver:compiler:definition:env;
 import silver:compiler:definition:type;
---import silver:compiler:analysis:typechecking:core;
+import silver:compiler:analysis:typechecking:core;
 
 
 concrete production autoAstDcl

--- a/grammars/silver/compiler/extension/autoattr/Project.sv
+++ b/grammars/silver/compiler/extension/autoattr/Project.sv
@@ -4,6 +4,8 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
+imports silver:compiler:definition:flow:env;
+imports silver:compiler:analysis:typechecking:core;
 imports silver:compiler:modification:collection;
 imports silver:compiler:modification:let_fix;
 imports silver:compiler:extension:patternmatching;

--- a/grammars/silver/compiler/extension/implicit_monads/Project.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Project.sv
@@ -4,10 +4,12 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:flow:driver;
 imports silver:compiler:definition:flow:ast;
+imports silver:compiler:definition:flow:env;
 imports silver:compiler:driver:util;
 
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
+imports silver:compiler:analysis:typechecking:core;
 
 imports silver:util:cmdargs;
 

--- a/grammars/silver/compiler/extension/patternmatching/Case.sv
+++ b/grammars/silver/compiler/extension/patternmatching/Case.sv
@@ -10,8 +10,7 @@ imports silver:compiler:modification:list;
 
 --Get mwdaWrn production for completeness analysis
 import silver:compiler:analysis:warnings:flow;
---Get getNonforwardingProds to check all are covered
-import silver:compiler:definition:flow:env only getNonforwardingProds;
+import silver:compiler:definition:flow:env;
 
 import silver:compiler:definition:type:syntax only typerepTypeExpr;
 import silver:compiler:modification:let_fix;

--- a/grammars/silver/compiler/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/compiler/extension/rewriting/Rewriting.sv
@@ -11,6 +11,8 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:env;
+imports silver:compiler:definition:flow:env;
+imports silver:compiler:analysis:typechecking:core;
 imports silver:compiler:translation:java:core only finalType;
 imports silver:compiler:extension:patternmatching;
 imports silver:compiler:modification:list;

--- a/grammars/silver/compiler/extension/strategyattr/Project.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Project.sv
@@ -6,6 +6,8 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax hiding Arrow_t;
+imports silver:compiler:definition:flow:env;
+imports silver:compiler:analysis:typechecking:core;
 imports silver:compiler:extension:autoattr;
 imports silver:compiler:extension:patternmatching;
 imports silver:compiler:modification:list;

--- a/grammars/silver/compiler/extension/testing/EqualityTest.sv
+++ b/grammars/silver/compiler/extension/testing/EqualityTest.sv
@@ -5,6 +5,8 @@ import silver:compiler:definition:env;
 import silver:compiler:definition:concrete_syntax;
 import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
+import silver:compiler:definition:flow:env;
+import silver:compiler:analysis:typechecking:core;
 import silver:compiler:modification:collection;
 import silver:compiler:modification:list;
 

--- a/grammars/silver/compiler/extension/testing/WrongCode.sv
+++ b/grammars/silver/compiler/extension/testing/WrongCode.sv
@@ -2,6 +2,7 @@ grammar silver:compiler:extension:testing;
 
 import silver:compiler:definition:core;
 import silver:compiler:definition:env;
+import silver:compiler:definition:flow:env;
 import silver:compiler:analysis:uniqueness;
 
 terminal WrongCode_kwd 'wrongCode' lexer classes {KEYWORD};

--- a/grammars/silver/compiler/extension/treegen/Arbitrary.sv
+++ b/grammars/silver/compiler/extension/treegen/Arbitrary.sv
@@ -6,6 +6,7 @@ imports silver:compiler:definition:concrete_syntax;
 imports silver:compiler:definition:concrete_syntax:ast;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
+imports silver:compiler:definition:flow:env;
 imports silver:compiler:extension:convenience;
 imports silver:compiler:modification:list;
 imports silver:compiler:extension:tuple;

--- a/grammars/silver/compiler/extension/tuple/Tuple.sv
+++ b/grammars/silver/compiler/extension/tuple/Tuple.sv
@@ -7,6 +7,8 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type:syntax;
 imports silver:compiler:definition:type;
+imports silver:compiler:definition:flow:env;
+imports silver:compiler:analysis:typechecking:core;
 
 imports silver:compiler:extension:patternmatching;
 

--- a/grammars/silver/compiler/host/Project.sv
+++ b/grammars/silver/compiler/host/Project.sv
@@ -22,13 +22,13 @@ exports silver:compiler:modification:primitivepattern;
 exports silver:compiler:modification:ffi;
 exports silver:compiler:modification:copper;
 exports silver:compiler:modification:defaultattr;
+exports silver:compiler:modification:list;
 -- slight hacks, for the moment
 exports silver:compiler:modification:copper_mda;
 
 -- Pure extensions to Silver
 exports silver:compiler:extension:doc;
 exports silver:compiler:extension:convenience;
-exports silver:compiler:modification:list; -- Not really a pure extension, yuck.
 exports silver:compiler:extension:easyterminal;
 exports silver:compiler:extension:deprecation;
 exports silver:compiler:extension:testing;
@@ -36,7 +36,6 @@ exports silver:compiler:extension:auto_ast;
 exports silver:compiler:extension:templating;
 exports silver:compiler:extension:patternmatching;
 exports silver:compiler:extension:treegen;
-exports silver:compiler:extension:doc;
 exports silver:compiler:extension:autoattr;
 exports silver:compiler:extension:strategyattr;
 exports silver:compiler:extension:do_notation;

--- a/grammars/silver/compiler/host/core/Project.sv
+++ b/grammars/silver/compiler/host/core/Project.sv
@@ -16,6 +16,7 @@ exports silver:regex:concrete_syntax;
 
 -- symbols
 exports silver:compiler:analysis:typechecking:core;
+exports silver:compiler:definition:flow:env;
 
 --We wish regex to remain a generic grammar, so we resolve the conflict here!
 -- Regexes end with /. Escape it if you want it.

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -3,7 +3,7 @@ grammar silver:compiler:modification:collection;
 import silver:compiler:definition:type:syntax;
 import silver:compiler:modification:list;
 
---import silver:compiler:analysis:typechecking:core;
+import silver:compiler:analysis:typechecking:core;
 import silver:compiler:driver:util;
 import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, constructAnonymousGraph;
 import silver:compiler:translation:java:core;

--- a/grammars/silver/compiler/modification/collection/Project.sv
+++ b/grammars/silver/compiler/modification/collection/Project.sv
@@ -3,6 +3,7 @@ grammar silver:compiler:modification:collection;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:type;
+imports silver:compiler:definition:flow:env;
 
 exports silver:compiler:modification:collection:java with silver:compiler:translation:java:core;
 

--- a/grammars/silver/compiler/modification/copper/Project.sv
+++ b/grammars/silver/compiler/modification/copper/Project.sv
@@ -8,10 +8,11 @@ imports silver:compiler:definition:concrete_syntax;
 imports silver:compiler:definition:concrete_syntax:ast;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
+imports silver:compiler:definition:flow:env;
 
 imports silver:compiler:modification:list;
 
---imports silver:compiler:analysis:typechecking:core;
+imports silver:compiler:analysis:typechecking:core;
 imports silver:compiler:analysis:uniqueness;
 
 imports silver:compiler:translation:java:core;

--- a/grammars/silver/compiler/modification/copper_mda/Analysis.sv
+++ b/grammars/silver/compiler/modification/copper_mda/Analysis.sv
@@ -4,6 +4,7 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:concrete_syntax;
 imports silver:compiler:definition:concrete_syntax:ast;
+imports silver:compiler:definition:flow:env;
 imports silver:compiler:modification:copper;
 
 import silver:compiler:driver:util only computeDependencies, RootSpec;

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -5,9 +5,10 @@ import silver:compiler:definition:origins;
 import silver:compiler:definition:env;
 import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
---import silver:compiler:analysis:typechecking:core;
+import silver:compiler:analysis:typechecking:core;
 import silver:compiler:translation:java;
 
+import silver:compiler:definition:flow:env;
 import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, constructDefaultProductionGraph; -- for the "oh no again!" hack below
 import silver:compiler:driver:util only RootSpec; -- ditto
 

--- a/grammars/silver/compiler/modification/ffi/TypeDcl.sv
+++ b/grammars/silver/compiler/modification/ffi/TypeDcl.sv
@@ -4,6 +4,7 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
+imports silver:compiler:definition:flow:env;
 
 -- Yikes, this was a weird choice of syntax.
 concrete production ffiTypeDclLegacy

--- a/grammars/silver/compiler/modification/ffi/java/FunctionDcl.sv
+++ b/grammars/silver/compiler/modification/ffi/java/FunctionDcl.sv
@@ -7,6 +7,7 @@ import silver:compiler:translation:java:type;
 import silver:compiler:definition:core;
 import silver:compiler:definition:env;
 import silver:compiler:definition:type;
+import silver:compiler:definition:flow:env;
 
 synthesized attribute ffiTranslationString :: [String] occurs on FFIDef, FFIDefs;
 

--- a/grammars/silver/compiler/modification/lambda_fn/Project.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Project.sv
@@ -4,7 +4,7 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
---imports silver:compiler:analysis:typechecking:core;
+imports silver:compiler:analysis:typechecking:core;
 imports silver:compiler:analysis:uniqueness;
 imports silver:compiler:translation:java:core only finalType;
 

--- a/grammars/silver/compiler/modification/let_fix/Project.sv
+++ b/grammars/silver/compiler/modification/let_fix/Project.sv
@@ -4,7 +4,8 @@ imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
---imports silver:compiler:analysis:typechecking:core;
+imports silver:compiler:definition:flow:env;
+imports silver:compiler:analysis:typechecking:core;
 imports silver:compiler:analysis:uniqueness;
 
 exports silver:compiler:modification:let_fix:java with silver:compiler:translation:java:core;

--- a/grammars/silver/compiler/modification/let_fix/java/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/java/Let.sv
@@ -6,6 +6,7 @@ import silver:compiler:definition:core;
 import silver:compiler:definition:env;
 import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax;
+import silver:compiler:analysis:typechecking:core;
 
 import silver:compiler:translation:java:core;
 import silver:compiler:translation:java:type;

--- a/grammars/silver/compiler/modification/list/Project.sv
+++ b/grammars/silver/compiler/modification/list/Project.sv
@@ -3,6 +3,7 @@ grammar silver:compiler:modification:list;
 imports silver:compiler:definition:type;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:core;
+imports silver:compiler:definition:flow:env;
 
 exports silver:compiler:modification:list:java with silver:compiler:translation:java:core;  -- special case for []
 exports silver:compiler:modification:list:java:type with silver:compiler:translation:java:type;  -- listCtrType translation

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -5,7 +5,9 @@ imports silver:util:treeset as ts;
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
+imports silver:compiler:definition:flow:env;
 
+imports silver:compiler:analysis:typechecking:core;
 imports silver:compiler:analysis:uniqueness;
 
 import silver:compiler:definition:type:syntax only typerepType, TypeExpr, errorsKindStar;

--- a/grammars/silver/compiler/translation/java/core/Project.sv
+++ b/grammars/silver/compiler/translation/java/core/Project.sv
@@ -7,6 +7,7 @@ imports silver:compiler:definition:type:syntax;
 
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;
+imports silver:compiler:definition:flow:env;
 
 imports silver:compiler:analysis:uniqueness;
 

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -96,6 +96,9 @@ top::Compilation ::= g::Grammars  _  buildGrammars::[String]  benv::BuildEnv
   production attribute keepFiles :: [String] with ++;
   keepFiles := [];
 
+  -- Seed flow deps with {config}
+  keepFiles <- if false then error(hackUnparse(top.config)) else [];
+
   top.postOps <-
     [genBuild(buildXmlLocation, buildXml)] ++
     (if top.config.noJavaGeneration then []

--- a/self-compile
+++ b/self-compile
@@ -4,7 +4,7 @@
 set -eu
 
 # Defaults overridable by setting an environment variable:
-SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx6G -Xss16M"}
+SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx6G -Xss25M"}
   # These can be fun sometimes:
   # -XX:+PrintCompilation -verbose:gc -XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:-PrintGC -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining
 SV_BUILD_TARGET=${SV_BUILD_TARGET:-"silver:compiler:composed:Default"}

--- a/self-compile
+++ b/self-compile
@@ -4,7 +4,7 @@
 set -eu
 
 # Defaults overridable by setting an environment variable:
-SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx6G -Xss25M"}
+SVJVM_FLAGS=${SVJVM_FLAGS:-"-Xmx6G -Xss16M"}
   # These can be fun sometimes:
   # -XX:+PrintCompilation -verbose:gc -XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:-PrintGC -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining
 SV_BUILD_TARGET=${SV_BUILD_TARGET:-"silver:compiler:composed:Default"}


### PR DESCRIPTION
# Changes
FInish some cleanup to flow vertices that Ted started a while back, before making some big changes for translation attributes.

Also add an option to dump out the graph of grammar exports, needed for debugging an MWDA issue.  

# Documentation
Updated doc comments.
