### PR TITLE
Implement translation attributes

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
@@ -12,8 +12,8 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
   top.errors <- te.errorsKindStar;
 }
 
-aspect production attributeDclSynTrans
-top::AGDcl ::= 'synthesized' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+aspect production attributeDclTrans
+top::AGDcl ::= 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
   top.errors <- te.errorsKindStar;
 

--- a/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
@@ -12,3 +12,33 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
   top.errors <- te.errorsKindStar;
 }
 
+aspect production attributeDclInhTrans
+top::AGDcl ::= 'inherited' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+{
+  top.errors <- te.errorsKindStar;
+
+  local checkNT::TypeCheck = checkNonterminal(top.env, false, te.typerep);
+  checkNT.downSubst = emptySubst();
+  checkNT.finalSubst = emptySubst();
+  
+  top.errors <-
+    if checkNT.typeerror
+    then [err(top.location, "Translation attribute type must be a nonterminal.  Instead it is of type " ++ checkNT.leftpp)]
+    else [];
+}
+
+aspect production attributeDclSynTrans
+top::AGDcl ::= 'synthesized' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+{
+  top.errors <- te.errorsKindStar;
+
+  local checkNT::TypeCheck = checkNonterminal(top.env, false, te.typerep);
+  checkNT.downSubst = emptySubst();
+  checkNT.finalSubst = emptySubst();
+  
+  top.errors <-
+    if checkNT.typeerror
+    then [err(top.location, "Translation attribute type must be a nonterminal.  Instead it is of type " ++ checkNT.leftpp)]
+    else [];
+}
+

--- a/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
@@ -16,14 +16,5 @@ aspect production attributeDclTrans
 top::AGDcl ::= 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
   top.errors <- te.errorsKindStar;
-
-  local checkNT::TypeCheck = checkNonterminal(top.env, false, te.typerep);
-  checkNT.downSubst = emptySubst();
-  checkNT.finalSubst = emptySubst();
-  
-  top.errors <-
-    if checkNT.typeerror
-    then [err(top.location, "Translation attribute type must be a nonterminal.  Instead it is of type " ++ checkNT.leftpp)]
-    else [];
 }
 

--- a/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/AttributeDcl.sv
@@ -12,21 +12,6 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
   top.errors <- te.errorsKindStar;
 }
 
-aspect production attributeDclInhTrans
-top::AGDcl ::= 'inherited' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
-{
-  top.errors <- te.errorsKindStar;
-
-  local checkNT::TypeCheck = checkNonterminal(top.env, false, te.typerep);
-  checkNT.downSubst = emptySubst();
-  checkNT.finalSubst = emptySubst();
-  
-  top.errors <-
-    if checkNT.typeerror
-    then [err(top.location, "Translation attribute type must be a nonterminal.  Instead it is of type " ++ checkNT.leftpp)]
-    else [];
-}
-
 aspect production attributeDclSynTrans
 top::AGDcl ::= 'synthesized' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {

--- a/grammars/silver/compiler/analysis/typechecking/core/OccursDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/OccursDcl.sv
@@ -1,0 +1,14 @@
+grammar silver:compiler:analysis:typechecking:core;
+
+aspect production defaultAttributionDcl
+top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
+{
+  local checkNT::TypeCheck = checkNonterminal(top.env, false, protoatty);
+  checkNT.downSubst = emptySubst();
+  checkNT.finalSubst = emptySubst();
+  
+  top.errors <-
+    if at.lookupAttribute.found && at.lookupAttribute.dcl.isTranslation && checkNT.typeerror
+    then [err(top.location, s"Occurrence of translation attribute ${at.lookupAttribute.fullName} must have a nonterminal type.  Instead it is of type " ++ checkNT.leftpp)]
+    else [];
+}

--- a/grammars/silver/compiler/analysis/uniqueness/Expr.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Expr.sv
@@ -5,7 +5,7 @@ propagate uniqueRefs on Expr, Exprs, AppExprs, AppExpr, PrimPatterns, PrimPatter
   excluding
     errorAccessHandler, annoAccessHandler, terminalAccessHandler,
     synDecoratedAccessHandler, inhDecoratedAccessHandler,
-    synTransDecoratedAccessHandler, inhTransDecoratedAccessHandler,
+    synTransDecoratedAccessHandler,
     errorDecoratedAccessHandler,
     ifThenElse, lambdap, letp, matchPrimitiveReal, consPattern;
 
@@ -273,42 +273,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         else []) ++
         if !null(lookupLocalUniqueRefs(fName, top.flowEnv))
         then [err(top.location, s"Cannot take a unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}) since there is also a unique reference taken to ${e.unparse}.")]
-        else []
-      | _ -> [err(top.location, s"Cannot take a unique reference (of type ${prettyType(finalTy)}) to ${top.unparse}")]
-      end
-    | _ -> []
-    end;
-}
-aspect production inhTransDecoratedAccessHandler
-top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
-{
-  local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
-
-  top.uniqueRefs :=
-    case finalTy, refSet of
-    | uniqueDecoratedType(_, _), just(inhs)
-      when isExportedBy(top.grammarName, [q.attrDcl.sourceGrammar], top.compiledGrammars) ->
-        [(s"${top.frame.fullName}.${q.attrDcl.fullName}",
-          uniqueRefSite(
-            sourceGrammar=top.grammarName,
-            sourceLocation=q.location,
-            refSet=inhs,
-            refFlowDeps=top.flowDeps
-          ))]
-    | _, _ -> []
-    end;
-
-  top.errors <-
-    case finalTy of
-    | uniqueDecoratedType(_, _) when q.found ->
-      case e.flowVertexInfo of
-      | just(lhsVertexType_real()) ->
-        -- Check that we are exported by the decoration site.
-        if !isExportedBy(top.grammarName, [top.frame.sourceGrammar], top.compiledGrammars)
-        then [err(top.location, s"Orphaned unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
-        -- Check that there is at most one unique reference taken to this decoration site.
-        else if length(lookupInhTransUniqueRefs(top.frame.fullName, q.attrDcl.fullName, top.flowEnv)) > 1
-        then [err(top.location, s"Multiple unique references taken to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         else []
       | _ -> [err(top.location, s"Cannot take a unique reference (of type ${prettyType(finalTy)}) to ${top.unparse}")]
       end

--- a/grammars/silver/compiler/analysis/uniqueness/Expr.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Expr.sv
@@ -5,7 +5,7 @@ propagate uniqueRefs on Expr, Exprs, AppExprs, AppExpr, PrimPatterns, PrimPatter
   excluding
     errorAccessHandler, annoAccessHandler, terminalAccessHandler,
     synDecoratedAccessHandler, inhDecoratedAccessHandler,
-    synTransDecoratedAccessHandler,
+    transDecoratedAccessHandler,
     errorDecoratedAccessHandler,
     ifThenElse, lambdap, letp, matchPrimitiveReal, consPattern;
 
@@ -224,7 +224,7 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   top.uniqueRefs := e.accessUniqueRefs;
 }
-aspect production synTransDecoratedAccessHandler
+aspect production transDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
@@ -255,7 +255,7 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         if !isExportedBy(top.grammarName, [top.frame.sourceGrammar], top.compiledGrammars)
         then [err(top.location, s"Orphaned unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there is at most one unique reference taken to this decoration site.
-        else (if length(lookupSynTransUniqueRefs(top.frame.fullName, sigName, q.attrDcl.fullName, top.flowEnv)) > 1
+        else (if length(lookupTransUniqueRefs(top.frame.fullName, sigName, q.attrDcl.fullName, top.flowEnv)) > 1
         then [err(top.location, s"Multiple unique references taken to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there isn't also a unique reference taken to e
         else []) ++
@@ -267,7 +267,7 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         if !isExportedBy(top.grammarName, [top.frame.sourceGrammar], top.compiledGrammars)
         then [err(top.location, s"Orphaned unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there is at most one unique reference taken to this decoration site.
-        else (if length(lookupLocalSynTransUniqueRefs(fName, q.attrDcl.fullName, top.flowEnv)) > 1
+        else (if length(lookupLocalTransUniqueRefs(fName, q.attrDcl.fullName, top.flowEnv)) > 1
         then [err(top.location, s"Multiple unique references taken to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there isn't also a unique reference taken to e
         else []) ++

--- a/grammars/silver/compiler/analysis/uniqueness/Expr.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Expr.sv
@@ -254,27 +254,29 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         if !isExportedBy(top.grammarName, [q.dcl.sourceGrammar, top.frame.sourceGrammar], top.compiledGrammars)
         then [err(top.location, s"Orphaned unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there is at most one unique reference taken to this decoration site.
-        else (if length(lookupTransUniqueRefs(top.frame.fullName, sigName, q.attrDcl.fullName, top.flowEnv)) > 1
-        then [err(top.location, s"Multiple unique references taken to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
-        -- Check that there isn't also a unique reference taken to e
-        else []) ++
-        if !null(lookupUniqueRefs(top.frame.fullName, sigName, top.flowEnv))
-        then [err(top.location, s"Cannot take a unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}) since there is also a unique reference taken to ${e.unparse}.")]
-        else []
+        else
+         (if length(lookupTransUniqueRefs(top.frame.fullName, sigName, q.attrDcl.fullName, top.flowEnv)) > 1
+          then [err(top.location, s"Multiple unique references taken to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
+          -- Check that there isn't also a unique reference taken to e
+          else []) ++
+          if !null(lookupUniqueRefs(top.frame.fullName, sigName, top.flowEnv))
+          then [err(top.location, s"Cannot take a unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}) since there is also a unique reference taken to ${e.unparse}.")]
+          else []
       | just(localVertexType(fName)) ->
         -- Check that we are exported by the occurs-on or the local.
         if !isExportedBy(top.grammarName, [q.dcl.sourceGrammar, head(getValueDcl(fName, top.env)).sourceGrammar], top.compiledGrammars)
         then [err(top.location, s"Orphaned unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there is at most one unique reference taken to this decoration site.
-        else (if length(lookupLocalTransUniqueRefs(fName, q.attrDcl.fullName, top.flowEnv)) > 1
-        then [err(top.location, s"Multiple unique references taken to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
-        -- Check that there isn't also a unique reference taken to e
-        else []) ++
-        case lookupLocalUniqueRefs(fName, top.flowEnv) of
-        | u :: _ ->
-          [err(top.location, s"Cannot take a unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}) since there is also a unique reference taken to ${e.unparse} at ${u.sourceGrammar}:${u.sourceLocation.unparse}.")]
-        | [] -> []
-        end
+        else
+         (if length(lookupLocalTransUniqueRefs(fName, q.attrDcl.fullName, top.flowEnv)) > 1
+          then [err(top.location, s"Multiple unique references taken to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
+          -- Check that there isn't also a unique reference taken to e
+          else []) ++
+          case lookupLocalUniqueRefs(fName, top.flowEnv) of
+          | u :: _ ->
+            [err(top.location, s"Cannot take a unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}) since there is also a unique reference taken to ${e.unparse} at ${u.sourceGrammar}:${u.sourceLocation.unparse}.")]
+          | [] -> []
+          end
       | _ -> [err(top.location, s"Cannot take a unique reference (of type ${prettyType(finalTy)}) to ${top.unparse}")]
       end
     | _ -> []

--- a/grammars/silver/compiler/analysis/uniqueness/Expr.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Expr.sv
@@ -271,9 +271,11 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         then [err(top.location, s"Multiple unique references taken to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there isn't also a unique reference taken to e
         else []) ++
-        if !null(lookupLocalUniqueRefs(fName, top.flowEnv))
-        then [err(top.location, s"Cannot take a unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}) since there is also a unique reference taken to ${e.unparse}.")]
-        else []
+        case lookupLocalUniqueRefs(fName, top.flowEnv) of
+        | u :: _ ->
+          [err(top.location, s"Cannot take a unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}) since there is also a unique reference taken to ${e.unparse} at ${u.sourceGrammar}:${u.sourceLocation.unparse}.")]
+        | [] -> []
+        end
       | _ -> [err(top.location, s"Cannot take a unique reference (of type ${prettyType(finalTy)}) to ${top.unparse}")]
       end
     | _ -> []

--- a/grammars/silver/compiler/analysis/uniqueness/Expr.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Expr.sv
@@ -230,8 +230,7 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   top.uniqueRefs :=
     case finalTy, refSet of
-    | uniqueDecoratedType(_, _), just(inhs)
-      when isExportedBy(top.grammarName, [q.attrDcl.sourceGrammar], top.compiledGrammars) ->
+    | uniqueDecoratedType(_, _), just(inhs) ->
         [(case e.flowVertexInfo of
           | just(rhsVertexType(sigName)) -> s"${top.frame.fullName}:${sigName}.${q.attrDcl.fullName}"
           | just(localVertexType(fName)) -> s"${fName}.${q.attrDcl.fullName}"
@@ -263,8 +262,8 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         then [err(top.location, s"Cannot take a unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}) since there is also a unique reference taken to ${e.unparse}.")]
         else []
       | just(localVertexType(fName)) ->
-        -- Check that we are exported by the occurs-on or the production.
-        if !isExportedBy(top.grammarName, [q.dcl.sourceGrammar, top.frame.sourceGrammar], top.compiledGrammars)
+        -- Check that we are exported by the occurs-on or the local.
+        if !isExportedBy(top.grammarName, [q.dcl.sourceGrammar, head(getValueDcl(fName, top.env)).sourceGrammar], top.compiledGrammars)
         then [err(top.location, s"Orphaned unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there is at most one unique reference taken to this decoration site.
         else (if length(lookupLocalTransUniqueRefs(fName, q.attrDcl.fullName, top.flowEnv)) > 1

--- a/grammars/silver/compiler/analysis/uniqueness/Expr.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Expr.sv
@@ -251,8 +251,8 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
     | uniqueDecoratedType(_, _) when q.found ->
       case e.flowVertexInfo of
       | just(rhsVertexType(sigName)) ->
-        -- Check that we are exported by the decoration site.
-        if !isExportedBy(top.grammarName, [top.frame.sourceGrammar], top.compiledGrammars)
+        -- Check that we are exported by the occurs-on or the production.
+        if !isExportedBy(top.grammarName, [q.dcl.sourceGrammar, top.frame.sourceGrammar], top.compiledGrammars)
         then [err(top.location, s"Orphaned unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there is at most one unique reference taken to this decoration site.
         else (if length(lookupTransUniqueRefs(top.frame.fullName, sigName, q.attrDcl.fullName, top.flowEnv)) > 1
@@ -263,8 +263,8 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         then [err(top.location, s"Cannot take a unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}) since there is also a unique reference taken to ${e.unparse}.")]
         else []
       | just(localVertexType(fName)) ->
-        -- Check that we are exported by the decoration site.
-        if !isExportedBy(top.grammarName, [top.frame.sourceGrammar], top.compiledGrammars)
+        -- Check that we are exported by the occurs-on or the production.
+        if !isExportedBy(top.grammarName, [q.dcl.sourceGrammar, top.frame.sourceGrammar], top.compiledGrammars)
         then [err(top.location, s"Orphaned unique reference to ${top.unparse} in production ${top.frame.fullName} (reference has type ${prettyType(finalTy)}).")]
         -- Check that there is at most one unique reference taken to this decoration site.
         else (if length(lookupLocalTransUniqueRefs(fName, q.attrDcl.fullName, top.flowEnv)) > 1

--- a/grammars/silver/compiler/analysis/uniqueness/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/ProductionBody.sv
@@ -40,7 +40,9 @@ top::ProductionStmt ::= 'undecorates' 'to' e::Expr ';'
 aspect production synthesizedAttributeDef
 top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
-  top.errors <- uniqueContextErrors(e.uniqueRefs);
+  top.errors <-
+    if !attr.found || attr.attrDcl.isTranslation then []
+    else uniqueContextErrors(e.uniqueRefs);
 }
 aspect production inheritedAttributeDef
 top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr

--- a/grammars/silver/compiler/analysis/uniqueness/ProductionBody.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/ProductionBody.sv
@@ -109,15 +109,3 @@ top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   top.errors <- uniqueContextErrors(e.uniqueRefs);
 }
-
-synthesized attribute refSiteName::String occurs on DefLHS;
-aspect refSiteName on top::DefLHS of
-| childDefLHS(q) -> top.frame.fullName ++ ":" ++ q.lookupValue.fullName
-| localDefLHS(q) -> q.lookupValue.fullName
--- These aren't used by the analysis, but doesn't hurt to include them:
-| lhsDefLHS(q) -> top.frame.fullName ++ ":" ++ q.lookupValue.fullName
-| forwardDefLHS(q) -> top.frame.fullName ++ ":forward"
-| defaultLhsDefLHS(q) -> top.frame.fullName ++ ":" ++ q.lookupValue.fullName
-| parserAttributeDefLHS(q) -> top.frame.fullName ++ ":" ++ q.lookupValue.fullName
-| errorDefLHS(q) -> top.frame.fullName ++ ":" ++ q.name
-end;

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -133,7 +133,7 @@ function checkEqDeps
   | localInhVertex(fName, attrName) -> 
       if !null(lookupLocalInh(prodName, fName, attrName, flowEnv))
       || fName == "forward"
-      || isForwardProdAttr(fName, realEnv)
+      || isForwardProdAttr(fName, realEnv) && indexOf(".", attrName) == -1  -- Forward prod attribute, not inh on trans
       || localAttrViaReference(fName, attrName, realEnv)
       || !null(lookupLocalRefDecSite(fName, flowEnv))
       then []

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -858,9 +858,6 @@ function lookupAllDecSites
     | synTransAttrVertexType(localVertexType(fName), transAttr) ->
       flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupLocalSynTransRefDecSite(fName, transAttr, flowEnv))
     | synTransAttrVertexType(_, _) -> []
-    | inhTransAttrVertexType(lhsVertexType_real(), transAttr) ->
-      flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupInhTransRefDecSite(prodName, transAttr, flowEnv))
-    | inhTransAttrVertexType(_, _) -> []
     | anonVertexType(fName) -> []
     | forwardVertexType_real() -> []
     | subtermVertexType(_, remoteProdName, sigName) ->
@@ -880,7 +877,6 @@ Boolean ::= prodName::String  vt::VertexType  attrName::String  flowEnv::FlowEnv
     | synTransAttrVertexType(localVertexType(fName), transAttr) ->
       !null(lookupLocalInh(prodName, fName, s"${transAttr}.${attrName}", flowEnv))
     | synTransAttrVertexType(_, _) -> false
-    | inhTransAttrVertexType(_, _) -> false  -- Inh equations on these are considered as syns.
     | anonVertexType(fName) -> !null(lookupLocalInh(prodName, fName, attrName, flowEnv))
     | subtermVertexType(_, remoteProdName, sigName) ->
       vertexHasInhEq(remoteProdName, rhsVertexType(sigName), attrName, flowEnv)

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -748,8 +748,8 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
           then
             let inhs :: [String] =
                 filter(\ attr::String ->
-                  -- If the dep is for an inh on a trans attribute, check for a decoration site projection for the trans attribute
                   case splitTransAttrInh(attr) of
+                  -- If the dep is for an inh on a trans attribute, check for a decoration site projection for the trans attribute
                   | just((transAttr, _)) -> null(lookupTransRefDecSite(top.frame.fullName, lq.lookupValue.fullName, transAttr, top.flowEnv))
                   | _ -> true
                   end,
@@ -769,10 +769,11 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
           then
             let inhs :: [String] = 
                 filter(\ attr::String ->
-                  -- If the dep is for an inh on a trans attribute, check for a decoration site projection for the trans attribute
                   case splitTransAttrInh(attr) of
+                  -- If the dep is for an inh on a trans attribute, check for a decoration site projection for the trans attribute
                   | just((transAttr, _)) -> null(lookupLocalTransRefDecSite(lq.lookupValue.fullName, transAttr, top.flowEnv))
-                  | _ -> true
+                  -- If the dep is for a normal inh attribute, ignore if the local is a forward production attribute
+                  | nothing() -> !lq.lookupValue.dcl.hasForward
                   end,
                   filter(
                     isEquationMissing(
@@ -888,8 +889,8 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
           then
             let inhs :: [String] =
                 filter(\ attr::String ->
-                  -- If the dep is for an inh on a trans attribute, check for a decoration site projection for the trans attribute
                   case splitTransAttrInh(attr) of
+                  -- If the dep is for an inh on a trans attribute, check for a decoration site projection for the trans attribute
                   | just((transAttr, _)) -> null(lookupTransRefDecSite(top.frame.fullName, lq.lookupValue.fullName, transAttr, top.flowEnv))
                   | _ -> true
                   end,
@@ -909,10 +910,11 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
           then
             let inhs :: [String] = 
                 filter(\ attr::String ->
-                  -- If the dep is for an inh on a trans attribute, check for a decoration site projection for the trans attribute
                   case splitTransAttrInh(attr) of
+                  -- If the dep is for an inh on a trans attribute, check for a decoration site projection for the trans attribute
                   | just((transAttr, _)) -> null(lookupLocalTransRefDecSite(lq.lookupValue.fullName, transAttr, top.flowEnv))
-                  | _ -> true
+                  -- If the dep is for a normal inh attribute, ignore if the local is a forward production attribute
+                  | nothing() -> !lq.lookupValue.dcl.hasForward
                   end,
                   filter(
                     isEquationMissing(

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -853,6 +853,14 @@ function lookupAllDecSites
       flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupRefDecSite(prodName, sigName, flowEnv))
     | localVertexType(fName) ->
       flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupLocalRefDecSite(fName, flowEnv))
+    | synTransAttrVertexType(rhsVertexType(sigName), transAttr) ->
+      flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupSynTransRefDecSite(prodName, sigName, transAttr, flowEnv))
+    | synTransAttrVertexType(localVertexType(fName), transAttr) ->
+      flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupLocalSynTransRefDecSite(fName, transAttr, flowEnv))
+    | synTransAttrVertexType(_, _) -> []
+    | inhTransAttrVertexType(lhsVertexType_real(), transAttr) ->
+      flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupInhTransRefDecSite(prodName, transAttr, flowEnv))
+    | inhTransAttrVertexType(_, _) -> []
     | anonVertexType(fName) -> []
     | forwardVertexType_real() -> []
     | subtermVertexType(_, remoteProdName, sigName) ->
@@ -867,6 +875,12 @@ Boolean ::= prodName::String  vt::VertexType  attrName::String  flowEnv::FlowEnv
     case vt of
     | rhsVertexType(sigName) -> !null(lookupInh(prodName, sigName, attrName, flowEnv))
     | localVertexType(fName) -> !null(lookupLocalInh(prodName, fName, attrName, flowEnv))
+    | synTransAttrVertexType(rhsVertexType(sigName), transAttr) ->
+      !null(lookupInh(prodName, sigName, s"${transAttr}.${attrName}", flowEnv))
+    | synTransAttrVertexType(localVertexType(fName), transAttr) ->
+      !null(lookupLocalInh(prodName, fName, s"${transAttr}.${attrName}", flowEnv))
+    | synTransAttrVertexType(_, _) -> false
+    | inhTransAttrVertexType(_, _) -> false  -- Inh equations on these are considered as syns.
     | anonVertexType(fName) -> !null(lookupLocalInh(prodName, fName, attrName, flowEnv))
     | subtermVertexType(_, remoteProdName, sigName) ->
       vertexHasInhEq(remoteProdName, rhsVertexType(sigName), attrName, flowEnv)

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -350,7 +350,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
   local childUniqueRefs::[UniqueRefSite] =
     lookupUniqueRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv);
   local childTransAttrUniqueRefs::[UniqueRefSite] =
-    lookupSynTransUniqueRefs(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.flowEnv);
+    lookupTransUniqueRefs(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.flowEnv);
   top.lhsUniqueRefs = if !null(childUniqueRefs) then childUniqueRefs else childTransAttrUniqueRefs;
   top.refDecSiteInhDeps =
     case childUniqueRefs, childTransAttrUniqueRefs of
@@ -363,7 +363,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
         u.refFlowDeps ++
         map(
           \ v::VertexType -> v.inhVertex(top.defLHSattr.attrDcl.fullName),
-          lookupSynTransRefPossibleDecSites(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.flowEnv)))
+          lookupTransRefPossibleDecSites(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.flowEnv)))
     | _, _ -> nothing()
     end;
 }
@@ -373,7 +373,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
   local localUniqueRefs::[UniqueRefSite] =
     lookupUniqueRefs(top.frame.fullName, q.lookupValue.fullName, top.flowEnv);
   local localTransAttrUniqueRefs::[UniqueRefSite] =
-    lookupSynTransUniqueRefs(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.flowEnv);
+    lookupTransUniqueRefs(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.flowEnv);
   top.lhsUniqueRefs = if !null(localUniqueRefs) then localUniqueRefs else localTransAttrUniqueRefs;
   top.refDecSiteInhDeps =
     case localUniqueRefs, localTransAttrUniqueRefs of
@@ -386,7 +386,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
         u.refFlowDeps ++
         map(
           \ v::VertexType -> v.inhVertex(top.defLHSattr.attrDcl.fullName),
-          lookupLocalSynTransRefPossibleDecSites(q.lookupValue.fullName, attr.attrDcl.fullName, top.flowEnv)))
+          lookupLocalTransRefPossibleDecSites(q.lookupValue.fullName, attr.attrDcl.fullName, top.flowEnv)))
     | _, _ -> nothing()
     end;
 }
@@ -790,7 +790,7 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
     else [];
 }
 
-aspect production synTransDecoratedAccessHandler
+aspect production transDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   -- oh no again
@@ -1006,11 +1006,11 @@ function lookupAllDecSites
       flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupRefDecSite(prodName, sigName, flowEnv))
     | localVertexType(fName) ->
       flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupLocalRefDecSite(fName, flowEnv))
-    | synTransAttrVertexType(rhsVertexType(sigName), transAttr) ->
-      flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupSynTransRefDecSite(prodName, sigName, transAttr, flowEnv))
-    | synTransAttrVertexType(localVertexType(fName), transAttr) ->
-      flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupLocalSynTransRefDecSite(fName, transAttr, flowEnv))
-    | synTransAttrVertexType(_, _) -> []
+    | transAttrVertexType(rhsVertexType(sigName), transAttr) ->
+      flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupTransRefDecSite(prodName, sigName, transAttr, flowEnv))
+    | transAttrVertexType(localVertexType(fName), transAttr) ->
+      flatMap(lookupAllDecSites(prodName, _, flowEnv), lookupLocalTransRefDecSite(fName, transAttr, flowEnv))
+    | transAttrVertexType(_, _) -> []
     | anonVertexType(fName) -> []
     | forwardVertexType_real() -> []
     | subtermVertexType(_, remoteProdName, sigName) ->
@@ -1025,11 +1025,11 @@ Boolean ::= prodName::String  vt::VertexType  attrName::String  flowEnv::FlowEnv
     case vt of
     | rhsVertexType(sigName) -> !null(lookupInh(prodName, sigName, attrName, flowEnv))
     | localVertexType(fName) -> !null(lookupLocalInh(prodName, fName, attrName, flowEnv))
-    | synTransAttrVertexType(rhsVertexType(sigName), transAttr) ->
+    | transAttrVertexType(rhsVertexType(sigName), transAttr) ->
       !null(lookupInh(prodName, sigName, s"${transAttr}.${attrName}", flowEnv))
-    | synTransAttrVertexType(localVertexType(fName), transAttr) ->
+    | transAttrVertexType(localVertexType(fName), transAttr) ->
       !null(lookupLocalInh(prodName, fName, s"${transAttr}.${attrName}", flowEnv))
-    | synTransAttrVertexType(_, _) -> false
+    | transAttrVertexType(_, _) -> false
     | anonVertexType(fName) -> !null(lookupLocalInh(prodName, fName, attrName, flowEnv))
     | subtermVertexType(_, remoteProdName, sigName) ->
       vertexHasInhEq(remoteProdName, rhsVertexType(sigName), attrName, flowEnv)

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -137,12 +137,11 @@ function checkEqDeps
   | localInhVertex(fName, attrName) -> 
       if !null(lookupLocalInh(prodName, fName, attrName, flowEnv))
       || fName == "forward"
-      || isForwardProdAttr(fName, realEnv) && indexOf(".", attrName) == -1  -- Forward prod attribute, not inh on trans
       || localAttrViaReference(fName, attrName, realEnv)
       || !null(lookupLocalRefDecSite(fName, flowEnv))
       || case splitTransAttrInh(attrName) of
          | just((transAttr, _)) -> !null(lookupLocalTransRefDecSite(fName, transAttr, flowEnv))
-         | nothing() -> false
+         | nothing() -> isForwardProdAttr(fName, realEnv)  -- Inh on trans are not copied with forwarding
          end
       then []
       else [mwdaWrn(config, l, "Equation has transitive dependency on local " ++ fName ++ "'s inherited attribute for " ++ attrName ++ " but this equation appears to be missing.")]

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -315,7 +315,7 @@ synthesized attribute lhsUniqueRefs::[UniqueRefSite] occurs on DefLHS;
 -- Minimum flow deps of this inherited attribute on any unique references to this decoration site
 synthesized attribute refDecSiteInhDeps::Maybe<[FlowVertex]> occurs on DefLHS;
 
-flowtype DefLHS = lhsUniqueRefs {frame, env, flowEnv}, refDecSiteInhDeps {frame, env, flowEnv, defLHSattr};
+flowtype DefLHS = lhsUniqueRefs {grammarName, config, frame, env, flowEnv}, refDecSiteInhDeps {grammarName, config, frame, env, flowEnv, defLHSattr};
 
 aspect default production
 top::DefLHS ::=

--- a/grammars/silver/compiler/analysis/warnings/flow/MWDA.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/MWDA.sv
@@ -32,15 +32,6 @@ imports silver:compiler:modification:defaultattr;
 imports silver:compiler:modification:primitivepattern;
 imports silver:compiler:modification:copper only parserAttributeDefLHS;
 
-function isLhsInh
-Boolean ::= v::FlowVertex
-{
-  return case v of
-  | lhsInhVertex(_) -> true
-  | _ -> false
-  end;
-}
-
 function isForwardProdAttr
 Boolean ::= a::String  e::Decorated Env
 {

--- a/grammars/silver/compiler/analysis/warnings/flow/MissingSynEq.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/MissingSynEq.sv
@@ -86,16 +86,16 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
 {
   -- All locally known synthesized attributes. This does not need to be exhaustive,
   -- because this error message is a courtesy, not the basis of the analysis.
-  local attrs :: [OccursDclInfo] = 
+  local attrs :: [String] = 
     getSynAttrsOn(namedSig.outputElement.typerep.typeName, top.env);
 
   top.errors <-
     if null(body.errors ++ ns.errors)
     && top.config.warnMissingSyn
-    -- Forwarding productions do no have missing synthesized equations:
+    -- Forwarding productions do not have missing synthesized equations:
     && null(body.forwardExpr)
     -- Otherwise, examine them all:
-    then flatMap(raiseMissingAttrs(top.config, top.location, fName, _, top.flowEnv), attrs)
+    then flatMap(raiseMissingAttrs(top.config, top.location, fName, namedSig.outputElement.typerep.typeName, _, top.flowEnv), attrs)
     else [];
 }
 
@@ -104,28 +104,28 @@ top::AGDcl ::= 'abstract' 'production' id::Name ns::ProductionSignature body::Pr
  - for the synthesized attribute `attr`.
  -
  - @param l      Location to raise the error message (of the production)
- - @param attr   DclInfo of a synthesized attribute occurrence
  - @param prod   Full name of the non-forwarding production in question
+ - @param nt     Full name of prod's lhs nonterminal
+ - @param attr   Full name of a synthesized attribute
  - @param e      The local flow environment
  - @returns      An error message from the production's perspective, if any
  -}
 function raiseMissingAttrs
-[Message] ::= config::Decorated CmdArgs  l::Location  prod::String  attr::OccursDclInfo  e::FlowEnv
+[Message] ::= config::Decorated CmdArgs  l::Location  prod::String  nt::String  attr::String  e::FlowEnv
 {
   -- Because the location is of the production, deliberately use the production's shortname
   local shortName :: String = substring(lastIndexOf(":", prod) + 1, length(prod), prod);
 
-  local lacks_default_equation :: Boolean = 
-    null(lookupDef(attr.fullName, attr.attrOccurring, e));
+  local lacks_default_equation :: Boolean = null(lookupDef(nt, attr, e));
 
   local missing_explicit_equation :: Boolean =
-    case lookupSyn(prod, attr.attrOccurring, e) of
+    case lookupSyn(prod, attr, e) of
     | eq :: _ -> false
     | [] -> true
     end;
  
   return if lacks_default_equation && missing_explicit_equation
-  then [mwdaWrn(config, l, "production " ++ shortName ++ " lacks synthesized equation for " ++ attr.attrOccurring)]
+  then [mwdaWrn(config, l, "production " ++ shortName ++ " lacks synthesized equation for " ++ attr)]
   else [];
 }
 

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
@@ -159,13 +159,13 @@ aspect lookupEqDefLHS on top::DefLHS of
   -- prod, child, attr
 | childDefLHS(q) -> lookupInh(top.frame.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
   -- prod, child, trans attr, attr
-| childTransAttrDefLHS(q, attr) -> lookupTransInh(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
+| childTransAttrDefLHS(q, attr) -> lookupInh(top.frame.fullName, q.lookupValue.fullName, s"${attr.attrDcl.fullName}.${top.defLHSattr.attrDcl.fullName}", top.flowEnv)
   -- prod, attr
 | lhsDefLHS(q) -> lookupSyn(top.frame.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
   -- prod, local, attr
 | localDefLHS(q) -> lookupLocalInh(top.frame.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
   -- prod, local, trans attr, attr
-| localTransAttrDefLHS(q, attr) -> lookupLocalTransInh(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
+| localTransAttrDefLHS(q, attr) -> lookupLocalInh(top.frame.fullName, q.lookupValue.fullName, s"${attr.attrDcl.fullName}.${top.defLHSattr.attrDcl.fullName}", top.flowEnv)
   -- prod, attr
 | forwardDefLHS(q) -> lookupFwdInh(top.frame.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
   -- nt, attr

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
@@ -56,7 +56,14 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
     -- Exported by the declaration of the thing we're giving inh to, or to the occurs
     | localDefLHS(q) -> [q.lookupValue.dcl.sourceGrammar, attr.dcl.sourceGrammar]
     -- For rhs or forwards, that's the production.
-    | _ -> [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
+    | childDefLHS(_) -> [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
+    | forwardDefLHS(_) -> [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
+    -- Eqs on translation attributes can be with the thing we're giving inh to, or either attr occurs
+    | localTransAttrDefLHS(q, transAttr) ->
+      [q.lookupValue.dcl.sourceGrammar, transAttr.dcl.sourceGrammar, attr.dcl.sourceGrammar]
+    | childTransAttrDefLHS(_, transAttr) ->
+      [top.frame.sourceGrammar, transAttr.dcl.sourceGrammar, attr.dcl.sourceGrammar]
+    | _ -> []
     end;
 
   top.errors <-
@@ -68,7 +75,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
     else [];
     
   top.errors <-
-    if length(dl.lookupEqDefLHS) > 1 || contains(dl.defLHSattr.attrDcl.fullName, getMinRefSet(dl.typerep, top.env))
+    if length(dl.lookupEqDefLHS) > 1 || contains(dl.inhAttrName, getMinRefSet(dl.typerep, top.env))
     then [mwdaWrn(top.config, top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName)]
     else [];
 }
@@ -106,7 +113,14 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
     -- Exported by the declaration of the thing we're giving inh to, or to the occurs
     | localDefLHS(q) -> [q.lookupValue.dcl.sourceGrammar, attr.dcl.sourceGrammar]
     -- For rhs or forwards, that's the production.
-    | _ -> [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
+    | childDefLHS(_) -> [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
+    | forwardDefLHS(_) -> [top.frame.sourceGrammar, attr.dcl.sourceGrammar]
+    -- Eqs on translation attributes can be with the thing we're giving inh to, or either attr occurs
+    | localTransAttrDefLHS(q, transAttr) ->
+      [q.lookupValue.dcl.sourceGrammar, transAttr.dcl.sourceGrammar, attr.dcl.sourceGrammar]
+    | childTransAttrDefLHS(_, transAttr) ->
+      [top.frame.sourceGrammar, transAttr.dcl.sourceGrammar, attr.dcl.sourceGrammar]
+    | _ -> []
     end;
 
   top.errors <-
@@ -118,7 +132,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
     else [];
     
   top.errors <-
-    if length(dl.lookupEqDefLHS) > 1 || contains(dl.defLHSattr.attrDcl.fullName, getMinRefSet(dl.typerep, top.env))
+    if length(dl.lookupEqDefLHS) > 1 || contains(dl.inhAttrName, getMinRefSet(dl.typerep, top.env))
     then [mwdaWrn(top.config, top.location, "Duplicate equation for " ++ attr.name ++ " on " ++ dl.name ++ " in production " ++ top.frame.fullName)]
     else [];
 }

--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedEquation.sv
@@ -158,15 +158,20 @@ flowtype lookupEqDefLHS {decorate} on DefLHS;
 aspect lookupEqDefLHS on top::DefLHS of
   -- prod, child, attr
 | childDefLHS(q) -> lookupInh(top.frame.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
+  -- prod, child, trans attr, attr
+| childTransAttrDefLHS(q, attr) -> lookupTransInh(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
   -- prod, attr
 | lhsDefLHS(q) -> lookupSyn(top.frame.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
   -- prod, local, attr
 | localDefLHS(q) -> lookupLocalInh(top.frame.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
+  -- prod, local, trans attr, attr
+| localTransAttrDefLHS(q, attr) -> lookupLocalTransInh(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
   -- prod, attr
 | forwardDefLHS(q) -> lookupFwdInh(top.frame.fullName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
   -- nt, attr
 | defaultLhsDefLHS(q) -> lookupDef(top.frame.lhsNtName, top.defLHSattr.attrDcl.fullName, top.flowEnv)
 
 | errorDefLHS(q) -> []
+| errorTransAttrDefLHS(_, _) -> []
 | parserAttributeDefLHS(q) -> [] -- TODO: maybe error?
 end;

--- a/grammars/silver/compiler/definition/core/AttributeDcl.sv
+++ b/grammars/silver/compiler/definition/core/AttributeDcl.sv
@@ -44,15 +44,15 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
   top.errors <- tl.errorsTyVars;
 }
 
-concrete production attributeDclSynTrans
-top::AGDcl ::= 'synthesized' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+concrete production attributeDclTrans
+top::AGDcl ::= 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {
-  top.unparse = "synthesized translation attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
+  top.unparse = "translation attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
 
   production attribute fName :: String;
   fName = top.grammarName ++ ":" ++ a.name;
 
-  top.defs := [synTransDef(top.grammarName, a.location, fName, tl.freeVariables, te.typerep)];
+  top.defs := [transDef(top.grammarName, a.location, fName, tl.freeVariables, te.typerep)];
 
   tl.initialEnv = top.env;
   tl.env = tl.envBindingTyVars;

--- a/grammars/silver/compiler/definition/core/AttributeDcl.sv
+++ b/grammars/silver/compiler/definition/core/AttributeDcl.sv
@@ -44,28 +44,6 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
   top.errors <- tl.errorsTyVars;
 }
 
-concrete production attributeDclInhTrans
-top::AGDcl ::= 'inherited' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
-{
-  top.unparse = "inherited translation attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
-
-  production attribute fName :: String;
-  fName = top.grammarName ++ ":" ++ a.name;
-
-  top.defs := [inhTransDef(top.grammarName, a.location, fName, tl.freeVariables, te.typerep)];
-
-  tl.initialEnv = top.env;
-  tl.env = tl.envBindingTyVars;
-  te.env = tl.envBindingTyVars;
-
-  top.errors <-
-    if length(getAttrDclAll(fName, top.env)) > 1
-    then [err(a.location, "Attribute '" ++ fName ++ "' is already bound.")]
-    else [];
-
-  top.errors <- tl.errorsTyVars;
-}
-
 concrete production attributeDclSynTrans
 top::AGDcl ::= 'synthesized' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
 {

--- a/grammars/silver/compiler/definition/core/AttributeDcl.sv
+++ b/grammars/silver/compiler/definition/core/AttributeDcl.sv
@@ -43,3 +43,48 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
 
   top.errors <- tl.errorsTyVars;
 }
+
+concrete production attributeDclInhTrans
+top::AGDcl ::= 'inherited' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+{
+  top.unparse = "inherited translation attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
+
+  production attribute fName :: String;
+  fName = top.grammarName ++ ":" ++ a.name;
+
+  top.defs := [inhTransDef(top.grammarName, a.location, fName, tl.freeVariables, te.typerep)];
+
+  tl.initialEnv = top.env;
+  tl.env = tl.envBindingTyVars;
+  te.env = tl.envBindingTyVars;
+
+  top.errors <-
+    if length(getAttrDclAll(fName, top.env)) > 1
+    then [err(a.location, "Attribute '" ++ fName ++ "' is already bound.")]
+    else [];
+
+  top.errors <- tl.errorsTyVars;
+}
+
+concrete production attributeDclSynTrans
+top::AGDcl ::= 'synthesized' 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+{
+  top.unparse = "synthesized translation attribute " ++ a.unparse ++ tl.unparse ++ " :: " ++ te.unparse ++ ";";
+
+  production attribute fName :: String;
+  fName = top.grammarName ++ ":" ++ a.name;
+
+  top.defs := [synTransDef(top.grammarName, a.location, fName, tl.freeVariables, te.typerep)];
+
+  tl.initialEnv = top.env;
+  tl.env = tl.envBindingTyVars;
+  te.env = tl.envBindingTyVars;
+  
+  top.errors <-
+    if length(getAttrDclAll(fName, top.env)) > 1
+    then [err(a.location, "Attribute '" ++ fName ++ "' is already bound.")]
+    else [];
+
+  top.errors <- tl.errorsTyVars;
+}
+

--- a/grammars/silver/compiler/definition/core/DclInfo.sv
+++ b/grammars/silver/compiler/definition/core/DclInfo.sv
@@ -55,7 +55,7 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.refDispatcher = lhsReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- TODO: be smarter about the error message
   top.defLHSDispatcher = lhsDefLHS(_, location=_);
-  top.transDefLHSDispatcher = lhsTransAttrDefLHS(_, _, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 aspect production localDcl
 top::ValueDclInfo ::= fn::String ty::Type _
@@ -144,14 +144,6 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
   top.decoratedAccessHandler = synTransDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = transUndecoratedAccessErrorHandler(_, _, location=_);
   top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_);
-  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
-}
-aspect production inhTransDcl
-top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
-{
-  top.decoratedAccessHandler = inhTransDecoratedAccessHandler(_, _, location=_);
-  top.undecoratedAccessHandler = transUndecoratedAccessErrorHandler(_, _, location=_);
-  top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
 }
 aspect production annoDcl

--- a/grammars/silver/compiler/definition/core/DclInfo.sv
+++ b/grammars/silver/compiler/definition/core/DclInfo.sv
@@ -138,10 +138,10 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
   top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
 }
-aspect production synTransDcl
+aspect production transDcl
 top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
 {
-  top.decoratedAccessHandler = synTransDecoratedAccessHandler(_, _, location=_);
+  top.decoratedAccessHandler = transDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = transUndecoratedAccessErrorHandler(_, _, location=_);
   top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);

--- a/grammars/silver/compiler/definition/core/DclInfo.sv
+++ b/grammars/silver/compiler/definition/core/DclInfo.sv
@@ -14,6 +14,10 @@ synthesized attribute defDispatcher :: (ProductionStmt ::= Decorated! QName  Exp
  - The production an "equation" left hand side should forward to for this type of value (i.e. the 'x' in 'x.a = e')
  -}
 synthesized attribute defLHSDispatcher :: (DefLHS ::= Decorated! QName  Location) occurs on ValueDclInfo;
+{--
+ - The production a translation attribute left hand side should forward to, for this type of value (i.e. the 'x.a' in 'x.a.b = e')
+ -}
+synthesized attribute transDefLHSDispatcher :: (DefLHS ::= Decorated! QName  Decorated!  QNameAttrOccur  Location) occurs on ValueDclInfo;
 
 {--
  - The handler for 'x.a' for 'a', given that 'x' is DECORATED.
@@ -43,6 +47,7 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.refDispatcher = childReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- TODO: we should be smarted about error messages, and mention its a child
   top.defLHSDispatcher = childDefLHS(_, location=_);
+  top.transDefLHSDispatcher = childTransAttrDefLHS(_, _, location=_);
 }
 aspect production lhsDcl
 top::ValueDclInfo ::= fn::String ty::Type
@@ -50,6 +55,7 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.refDispatcher = lhsReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- TODO: be smarter about the error message
   top.defLHSDispatcher = lhsDefLHS(_, location=_);
+  top.transDefLHSDispatcher = lhsTransAttrDefLHS(_, _, location=_);
 }
 aspect production localDcl
 top::ValueDclInfo ::= fn::String ty::Type _
@@ -57,6 +63,7 @@ top::ValueDclInfo ::= fn::String ty::Type _
   top.refDispatcher = localReference(_, location=_);
   top.defDispatcher = localValueDef(_, _, location=_);
   top.defLHSDispatcher = localDefLHS(_, location=_);
+  top.transDefLHSDispatcher = localTransAttrDefLHS(_, _, location=_);
 }
 
 
@@ -68,6 +75,7 @@ top::ValueDclInfo ::= ns::NamedSignature hasForward::Boolean
    -- Note that we still need production references, even though bug #16 removes the production type.
   top.defDispatcher = errorValueDef(_, _, location=_);
   top.defLHSDispatcher = errorDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 aspect production funDcl
 top::ValueDclInfo ::= ns::NamedSignature
@@ -75,6 +83,7 @@ top::ValueDclInfo ::= ns::NamedSignature
   top.refDispatcher = functionReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
   top.defLHSDispatcher = errorDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 aspect production globalValueDcl
 top::ValueDclInfo ::= fn::String bound::[TyVar] contexts::[Context] ty::Type
@@ -82,6 +91,7 @@ top::ValueDclInfo ::= fn::String bound::[TyVar] contexts::[Context] ty::Type
   top.refDispatcher = globalValueReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
   top.defLHSDispatcher = errorDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 aspect production classMemberDcl
 top::ValueDclInfo ::= fn::String bound::[TyVar] head::Context contexts::[Context] ty::Type
@@ -89,6 +99,7 @@ top::ValueDclInfo ::= fn::String bound::[TyVar] head::Context contexts::[Context
   top.refDispatcher = classMemberReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
   top.defLHSDispatcher = errorDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 
 -- -- interface Production attr (values)
@@ -98,6 +109,7 @@ top::ValueDclInfo ::= ty::Type
   top.refDispatcher = forwardReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- TODO: better error message
   top.defLHSDispatcher = forwardDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 
 aspect production termIdDcl
@@ -106,6 +118,7 @@ top::ValueDclInfo ::= fn::String
   top.refDispatcher = terminalIdReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
   top.defLHSDispatcher = errorDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 
 -- -- interface Attributes
@@ -122,6 +135,22 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
 {
   top.decoratedAccessHandler = inhDecoratedAccessHandler(_, _, location=_);
   top.undecoratedAccessHandler = accessBounceDecorate(inhDecoratedAccessHandler(_, _, location=_), _, _, _); -- TODO: above should probably be an error handler! access inh from undecorated?
+  top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_);
+  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
+}
+aspect production synTransDcl
+top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
+{
+  top.decoratedAccessHandler = synTransDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = transUndecoratedAccessErrorHandler(_, _, location=_);
+  top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_);
+  top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
+}
+aspect production inhTransDcl
+top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
+{
+  top.decoratedAccessHandler = inhTransDecoratedAccessHandler(_, _, location=_);
+  top.undecoratedAccessHandler = transUndecoratedAccessErrorHandler(_, _, location=_);
   top.attrDefDispatcher = inheritedAttributeDef(_, _, _, location=_);
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
 }

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -476,6 +476,7 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
                else q.attrDcl.undecoratedAccessHandler)(e, q, top.location);
   -- annoAccessHandler
   -- accessBouncer
+  -- transUndecoratedAccessErrorHandler
 }
 
 {--

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -546,6 +546,35 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   top.typerep = q.typerep;
 }
 
+abstract production synTransDecoratedAccessHandler
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
+{
+  undecorates to access(e, '.', q, location=top.location);
+  top.unparse = e.unparse ++ "." ++ q.unparse;
+  
+  top.typerep = q.typerep.asNtOrDecType;
+}
+
+abstract production inhTransDecoratedAccessHandler
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
+{
+  undecorates to access(e, '.', q, location=top.location);
+  top.unparse = e.unparse ++ "." ++ q.unparse;
+  
+  top.typerep = q.typerep.asNtOrDecType;
+}
+
+abstract production transUndecoratedAccessErrorHandler
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
+{
+  undecorates to access(e, '.', q, location=top.location);
+  top.unparse = e.unparse ++ "." ++ q.unparse;
+  
+  top.typerep = q.typerep.asNtOrDecType;
+
+  top.errors <- [err(top.location, s"Cannot access translation attribute ${q.attrDcl.fullName} from an undecorated type")];
+}
+
 -- TODO: change name. really "unknownDclAccessHandler"
 abstract production errorDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -555,15 +555,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   top.typerep = q.typerep.asNtOrDecType;
 }
 
-abstract production inhTransDecoratedAccessHandler
-top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
-{
-  undecorates to access(e, '.', q, location=top.location);
-  top.unparse = e.unparse ++ "." ++ q.unparse;
-  
-  top.typerep = q.typerep.asNtOrDecType;
-}
-
 abstract production transUndecoratedAccessErrorHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -546,7 +546,7 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   top.typerep = q.typerep;
 }
 
-abstract production synTransDecoratedAccessHandler
+abstract production transDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   undecorates to access(e, '.', q, location=top.location);

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -17,7 +17,9 @@ nonterminal ExprLHSExpr with
 
 flowtype unparse {} on Expr, Exprs, ExprInhs, ExprInh, ExprLHSExpr;
 flowtype freeVars {frame} on Expr, Exprs, ExprInhs, ExprInh, ExprLHSExpr;
-flowtype Expr = decorate {grammarName, env, flowEnv, downSubst, finalSubst, frame, isRoot, originRules, compiledGrammars, config}, forward {decorate};
+flowtype Expr =
+  forward {grammarName, env, flowEnv, downSubst, finalSubst, frame, isRoot, originRules, compiledGrammars, config},
+  decorate {forward, alwaysDecorated};
 
 flowtype decorate {grammarName, env, flowEnv, downSubst, finalSubst, frame, originRules, compiledGrammars, config} on Exprs;
 flowtype decorate {grammarName, env, flowEnv, downSubst, finalSubst, frame, originRules, compiledGrammars, config, decoratingnt, allSuppliedInhs} on ExprInhs, ExprInh;

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -647,6 +647,7 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e::Expr ';'
   e.isRoot = false;
 }
 
+-- TODO: permit supplying inhs on translation attributes
 concrete production exprLhsExpr
 top::ExprLHSExpr ::= q::QNameAttrOccur
 {

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -341,6 +341,13 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
   top.unparse = "\t" ++ dl.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";
 
   e.isRoot = true;
+
+  top.errors <-
+    case getValueDcl(top.frame.fullName, top.env) of
+    | dcl :: _ when dcl.hasForward && attr.found && attr.attrDcl.isTranslation ->
+      [err(top.location, s"Overriding translation attribute ${attr.attrDcl.fullName} in a forwarding production is not currently supported.")]
+    | _ -> []
+    end;
 }
 
 abstract production inheritedAttributeDef

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -19,7 +19,7 @@ flowtype decorate {frame, grammarName, compiledGrammars, config, env, flowEnv, d
 flowtype forward {decorate} on ProductionBody, ProductionStmts, ProductionStmt;
 
 nonterminal DefLHS with 
-  config, grammarName, env, location, unparse, errors, frame, compiledGrammars, name, typerep, defLHSattr, found, originRules;
+  config, grammarName, env, location, unparse, errors, frame, compiledGrammars, name, typerep, isTranslation, defLHSattr, found, originRules;
 
 flowtype decorate {frame, grammarName, compiledGrammars, config, env, flowEnv, defLHSattr, originRules}
   on DefLHS;
@@ -375,6 +375,7 @@ top::DefLHS ::= q::Decorated! QName
   top.name = q.name;
   top.unparse = q.unparse;
   top.found = false;
+  top.isTranslation = false;
   
   top.errors <- q.lookupValue.errors;
   top.errors <-
@@ -395,6 +396,7 @@ top::DefLHS ::= q::Decorated! QName
   top.name = q.name;
   top.unparse = q.unparse;
   top.found = !existingProblems && top.defLHSattr.attrDcl.isInherited;
+  top.isTranslation = false;
   
   local existingProblems :: Boolean = !top.defLHSattr.found || top.typerep.isError;
   
@@ -412,6 +414,7 @@ top::DefLHS ::= q::Decorated! QName
   top.name = q.name;
   top.unparse = q.unparse;
   top.found = !existingProblems && top.defLHSattr.attrDcl.isSynthesized;
+  top.isTranslation = false;
   
   local existingProblems :: Boolean = !top.defLHSattr.found || top.typerep.isError;
   
@@ -429,6 +432,7 @@ top::DefLHS ::= q::Decorated! QName
   top.name = q.name;
   top.unparse = q.unparse;
   top.found = !existingProblems && top.defLHSattr.attrDcl.isInherited;
+  top.isTranslation = false;
   
   local existingProblems :: Boolean = !top.defLHSattr.found || top.typerep.isError;
   
@@ -446,6 +450,7 @@ top::DefLHS ::= q::Decorated! QName
   top.name = q.name;
   top.unparse = q.unparse;
   top.found = !existingProblems && top.defLHSattr.attrDcl.isInherited;
+  top.isTranslation = false;
   
   local existingProblems :: Boolean = !top.defLHSattr.found || top.typerep.isError;
   
@@ -480,6 +485,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
   top.name = q.name;
   top.unparse = s"${q.unparse}.${attr.unparse}";
   top.found = false;
+  top.isTranslation = true;
   
   top.errors <- q.lookupValue.errors;
   top.errors <-
@@ -494,6 +500,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
   top.name = q.name;
   top.unparse = s"${q.unparse}.${attr.unparse}";
   top.found = !existingProblems && attr.attrDcl.isSynthesized && top.defLHSattr.attrDcl.isInherited;
+  top.isTranslation = true;
   
   local existingProblems :: Boolean = !top.defLHSattr.found || !attr.found || top.typerep.isError;
 
@@ -515,6 +522,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
   top.name = q.name;
   top.unparse = s"${q.unparse}.${attr.unparse}";
   top.found = !existingProblems && attr.attrDcl.isInherited && top.defLHSattr.attrDcl.isInherited;
+  top.isTranslation = true;
   
   local existingProblems :: Boolean = !top.defLHSattr.found || !attr.found || top.typerep.isError;
 
@@ -524,6 +532,8 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
     then [err(attr.location, s"Translation attribute '${attr.name}' is not inherited, and cannot have attributes defined on it for the lhs '${q.name}'")]
     else if !top.defLHSattr.attrDcl.isInherited
     then [err(attr.location, s"Attribute '${attr.name}' is not inherited and cannot be defined on '${top.unparse}'")]
+    else if top.frame.hasPartialSignature
+    then [err(top.location, s"Inherited equations on inherited translation attributes in default productions are not supported")]
     else [];
 
   top.typerep = q.lookupValue.typeScheme.monoType;
@@ -536,6 +546,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
   top.name = q.name;
   top.unparse = s"${q.unparse}.${attr.unparse}";
   top.found = !existingProblems && attr.attrDcl.isSynthesized && top.defLHSattr.attrDcl.isInherited;
+  top.isTranslation = true;
   
   local existingProblems :: Boolean = !top.defLHSattr.found || !attr.found || top.typerep.isError;
 

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -509,7 +509,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
   top.errors <- q.lookupValue.errors;
   top.errors <-
     if top.typerep.isError then [] else [err(q.location, "Cannot define attributes on " ++ top.unparse)];
-  top.typerep = q.lookupValue.typeScheme.typerep;
+  top.typerep = attr.typerep;
 }
 
 abstract production childTransAttrDefLHS
@@ -536,7 +536,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
     then [err(q.location, s"Inherited equations on translation attributes on child ${q.name} of type ${prettyType(ty)} are not supported")]
     else [];
 
-  top.typerep = q.lookupValue.typeScheme.monoType;
+  top.typerep = attr.typerep;
 }
 
 abstract production localTransAttrDefLHS
@@ -563,7 +563,7 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
     then [err(q.location, s"Inherited equations on translation attributes on local ${q.name} of type ${prettyType(ty)} are not supported")]
     else [];
 
-  top.typerep = q.lookupValue.typeScheme.monoType;
+  top.typerep = attr.typerep;
 }
 
 ----- done with DefLHS

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -493,7 +493,7 @@ top::DefLHS ::= q::QName attr::QNameAttrOccur
   attr.config = top.config;
   attr.attrFor = q.lookupValue.typeScheme.monoType;
   
-  forwards to (if null(q.lookupValue.dcls) || !attr.attrDcl.isTranslation 
+  forwards to (if null(q.lookupValue.dcls) || !attr.found || !attr.attrDcl.isTranslation 
                then errorTransAttrDefLHS(_, _, location=_)
                else q.lookupValue.dcl.transDefLHSDispatcher)(q, attr, top.location);
 }

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -360,7 +360,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
 }
 
 -- The grammar needs to be structured in this way to avoid a shift/reduce conflict...
-concrete production transAttributeDef
+concrete production transInhAttributeDef
 top::ProductionStmt ::= dl::DefLHS '.' transAttr::QNameAttrOccur '.' attr::QNameAttrOccur '=' e::Expr ';'
 {
   top.unparse = "\t" ++ dl.unparse ++ "." ++ transAttr.unparse ++ "." ++ attr.unparse ++ " = " ++ e.unparse ++ ";";

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -528,30 +528,6 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
   top.typerep = q.lookupValue.typeScheme.monoType;
 }
 
-abstract production lhsTransAttrDefLHS
-top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
-{
-  undecorates to transAttrDefLHS(q, attr, location=top.location);
-  top.name = q.name;
-  top.unparse = s"${q.unparse}.${attr.unparse}";
-  top.found = !existingProblems && attr.attrDcl.isInherited && top.defLHSattr.attrDcl.isInherited;
-  top.isTranslation = true;
-  
-  local existingProblems :: Boolean = !top.defLHSattr.found || !attr.found || top.typerep.isError;
-
-  top.errors <-
-    if existingProblems then []
-    else if !attr.attrDcl.isInherited
-    then [err(attr.location, s"Translation attribute '${attr.name}' is not inherited, and cannot have attributes defined on it for the lhs '${q.name}'")]
-    else if !top.defLHSattr.attrDcl.isInherited
-    then [err(attr.location, s"Attribute '${attr.name}' is not inherited and cannot be defined on '${top.unparse}'")]
-    else if top.frame.hasPartialSignature
-    then [err(top.location, s"Inherited equations on inherited translation attributes in default productions are not supported")]
-    else [];
-
-  top.typerep = q.lookupValue.typeScheme.monoType;
-}
-
 abstract production localTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -524,8 +524,6 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 
   top.errors <-
     if existingProblems then []
-    else if !attr.attrDcl.isSynthesized
-    then [err(attr.location, s"Translation attribute '${attr.name}' is not synthesized, and cannot have attributes defined on it for child '${q.name}'")]
     else if !top.defLHSattr.attrDcl.isInherited
     then [err(attr.location, s"Attribute '${attr.name}' is not inherited and cannot be defined on '${top.unparse}'")]
     else [];
@@ -551,8 +549,6 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 
   top.errors <-
     if existingProblems then []
-    else if !attr.attrDcl.isSynthesized
-    then [err(attr.location, s"Translation attribute '${attr.name}' is not synthesized, and cannot have attributes defined on it for local '${q.name}'")]
     else if !top.defLHSattr.attrDcl.isInherited
     then [err(attr.location, s"Attribute '${attr.name}' is not inherited and cannot be defined on '${top.unparse}'")]
     else [];

--- a/grammars/silver/compiler/definition/core/Terminals.sv
+++ b/grammars/silver/compiler/definition/core/Terminals.sv
@@ -34,7 +34,6 @@ terminal Aspect_kwd      'aspect'       lexer classes {KEYWORD,RESERVED};
 terminal Attribute_kwd   'attribute'    lexer classes {KEYWORD,RESERVED};
 terminal Class_kwd       'class'        lexer classes {KEYWORD};
 terminal Closed_kwd      'closed'       lexer classes {KEYWORD};
-terminal Tracked_kwd     'tracked'      lexer classes {KEYWORD};
 terminal Concrete_kwd    'concrete'     lexer classes {KEYWORD,RESERVED};
 terminal Decorate_kwd    'decorate'     lexer classes {KEYWORD,RESERVED};
 terminal Else_kwd        'else'         lexer classes {KEYWORD,RESERVED}, precedence = 4, association = left; -- Association needed for dangling else in action code.
@@ -57,6 +56,8 @@ terminal Synthesized_kwd 'synthesized'  lexer classes {KEYWORD,RESERVED};
 terminal Terminal_kwd    'terminal'     lexer classes {KEYWORD,RESERVED};
 terminal Then_kwd        'then'         lexer classes {KEYWORD,RESERVED};
 terminal To_kwd          'to'           lexer classes {KEYWORD,RESERVED};
+terminal Tracked_kwd     'tracked'      lexer classes {KEYWORD};
+terminal Translation_kwd 'translation'  lexer classes {KEYWORD};
 terminal Type_t          'type'         lexer classes {KEYWORD};
 terminal Undecorates_t   'undecorates'  lexer classes {KEYWORD,RESERVED};
 terminal With_kwd        'with'         lexer classes {KEYWORD,RESERVED}, precedence = 3; -- Precedence to fix Decorated Decorated Expr with {}, which is a semantic error either way

--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -267,7 +267,7 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
   top.typeScheme = polyType(bound, ty);
   top.isInherited = true;
 }
-abstract production synTransDcl
+abstract production transDcl
 top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
 {
   top.fullName = fn;

--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -38,6 +38,7 @@ synthesized attribute isAnnotation :: Boolean; -- also "attrs"
 -- attrs
 synthesized attribute isSynthesized :: Boolean;
 synthesized attribute isInherited :: Boolean;
+synthesized attribute isTranslation :: Boolean;
 
 -- production attribute
 synthesized attribute prodDefs :: [Def];
@@ -233,7 +234,7 @@ top::TypeDclInfo ::= fn::String supers::[Context] tv::TyVar k::Kind members::[Pa
 
 closed nonterminal AttributeDclInfo with
   sourceGrammar, sourceLocation, fullName, compareTo, compareKey, isEqual,
-  typeScheme, isInherited, isSynthesized, isAnnotation;
+  typeScheme, isInherited, isSynthesized, isAnnotation, isTranslation;
 propagate compareKey on AttributeDclInfo;
 
 aspect default production
@@ -247,6 +248,7 @@ top::AttributeDclInfo ::=
   top.isSynthesized = false;
   top.isInherited = false;
   top.isAnnotation = false;
+  top.isTranslation = false;
 }
 
 abstract production synDcl
@@ -264,6 +266,24 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
 
   top.typeScheme = polyType(bound, ty);
   top.isInherited = true;
+}
+abstract production synTransDcl
+top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
+{
+  top.fullName = fn;
+
+  top.typeScheme = polyType(bound, ty);
+  top.isSynthesized = true;
+  top.isTranslation = true;
+}
+abstract production inhTransDcl
+top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
+{
+  top.fullName = fn;
+
+  top.typeScheme = polyType(bound, ty);
+  top.isInherited = true;
+  top.isTranslation = true;
 }
 abstract production annoDcl
 top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type

--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -276,15 +276,6 @@ top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
   top.isSynthesized = true;
   top.isTranslation = true;
 }
-abstract production inhTransDcl
-top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
-{
-  top.fullName = fn;
-
-  top.typeScheme = polyType(bound, ty);
-  top.isInherited = true;
-  top.isTranslation = true;
-}
 abstract production annoDcl
 top::AttributeDclInfo ::= fn::String bound::[TyVar] ty::Type
 {

--- a/grammars/silver/compiler/definition/env/Defs.sv
+++ b/grammars/silver/compiler/definition/env/Defs.sv
@@ -193,6 +193,16 @@ Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
 {
   return attrDef(defaultEnvItem(inhDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
 }
+function synTransDef
+Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
+{
+  return attrDef(defaultEnvItem(synTransDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
+}
+function inhTransDef
+Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
+{
+  return attrDef(defaultEnvItem(inhTransDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
+}
 function prodOccursDef
 Def ::= sg::String  sl::Location  ns::NamedSignature  dcls::[Def]
 { 

--- a/grammars/silver/compiler/definition/env/Defs.sv
+++ b/grammars/silver/compiler/definition/env/Defs.sv
@@ -198,11 +198,6 @@ Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
 {
   return attrDef(defaultEnvItem(synTransDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
 }
-function inhTransDef
-Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
-{
-  return attrDef(defaultEnvItem(inhTransDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
-}
 function prodOccursDef
 Def ::= sg::String  sl::Location  ns::NamedSignature  dcls::[Def]
 { 

--- a/grammars/silver/compiler/definition/env/Defs.sv
+++ b/grammars/silver/compiler/definition/env/Defs.sv
@@ -193,10 +193,10 @@ Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
 {
   return attrDef(defaultEnvItem(inhDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
 }
-function synTransDef
+function transDef
 Def ::= sg::String  sl::Location  fn::String  bound::[TyVar]  ty::Type
 {
-  return attrDef(defaultEnvItem(synTransDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
+  return attrDef(defaultEnvItem(transDcl(fn,bound,ty,sourceGrammar=sg,sourceLocation=sl)));
 }
 function prodOccursDef
 Def ::= sg::String  sl::Location  ns::NamedSignature  dcls::[Def]

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -272,7 +272,7 @@ function getAttrOccursOn
 
 {--
  - Returns the names of all synthesized attributes known locally to occur on a nonterminal.
- - Also includes all inherited attributes occuring on inherited translation attributes on the
+ - Also includes all synthesized attributes occuring on synthesized translation attributes on the
  - nonterminal, since those are treated like synthesized attributes.
  -}
 function getSynAttrsOn
@@ -286,15 +286,17 @@ function getSynAttrsOn
   return flatMap(
     \ o::OccursDclInfo ->
       case getAttrDcl(o.attrOccurring, e) of
-      | at :: _ when at.isSynthesized -> [o.attrOccurring]
-      | at :: _ when at.isInherited && at.isTranslation ->
-        flatMap(
+      | at :: _ when at.isSynthesized -> 
+        o.attrOccurring ::
+        if at.isTranslation
+        then flatMap(
           \ o2::OccursDclInfo ->
             case getAttrDcl(o2.attrOccurring, e) of
-            | at :: _ when at.isInherited -> [s"${o.attrOccurring}.${o2.attrOccurring}"]
+            | at :: _ when at.isSynthesized -> [s"${o.attrOccurring}.${o2.attrOccurring}"]
             | _ -> []
             end,
           getAttrOccursOn(determineAttributeType(o, ntty).typeName, e))
+        else []
       | _ -> []
       end,
     getAttrOccursOn(fnnt, e));

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -287,7 +287,7 @@ function getSynAttrsOn
 
 {--
  - Returns the names of all synthesized attributes known locally to occur on a nonterminal.
- - Also includes all synthesized attributes occuring on synthesized translation attributes on the
+ - Also includes all synthesized attributes occuring on translation attributes on the
  - nonterminal, when we want to treat these like synthesized attributes.
  -}
 function getSynAndSynOnTransAttrsOn
@@ -325,7 +325,7 @@ function getInhAttrsOn
 
 {--
  - Returns the names of all inherited attributes known locally to occur on a nonterminal.
- - Also includes all inherited attributes occuring on synthesized translation attributes on the
+ - Also includes all inherited attributes occuring on translation attributes on the
  - nonterminal, when we want to treat these like inherited attributes.
  -}
 function getInhAndInhOnTransAttrsOn

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -286,29 +286,6 @@ function getSynAttrsOn
 }
 
 {--
- - Returns the names of all synthesized attributes known locally to occur on a nonterminal.
- - Also includes all synthesized attributes occuring on translation attributes on the
- - nonterminal, when we want to treat these like synthesized attributes.
- -}
-function getSynAndSynOnTransAttrsOn
-[String] ::= fnnt::String e::Decorated Env
-{
-  return flatMap(
-    \ o::OccursDclInfo ->
-      case getAttrDcl(o.attrOccurring, e) of
-      | at :: _ when at.isSynthesized -> 
-        o.attrOccurring ::
-        if at.isTranslation
-        then map(
-          \ syn::String -> s"${o.attrOccurring}.${syn}",
-          getSynAttrsOn(at.typeScheme.typeName, e))
-        else []
-      | _ -> []
-      end,
-    getAttrOccursOn(fnnt, e));
-}
-
-{--
  - Returns the names of all inherited attributes known locally to occur on a nonterminal.
  -}
 function getInhAttrsOn

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -291,7 +291,7 @@ top::FlowDef ::= prod::String  transAttr::String  attr::String  deps::[FlowVerte
 {
   top.synTreeContribs := [pair(crossnames(prod, crossnames(transAttr, attr)), top)];
   top.prodGraphContribs := [pair(prod, top)];
-  local edges :: [Pair<FlowVertex FlowVertex>] = map(pair(transAttrInhVertex(lhsInhVertex(transAttr), attr), _), deps);
+  local edges :: [Pair<FlowVertex FlowVertex>] = map(pair(lhsInhVertex(s"${transAttr}.${attr}"), _), deps);
   top.flowEdges = if mayAffectFlowType then edges else [];
   top.suspectFlowEdges = if mayAffectFlowType then [] else edges;
 }
@@ -311,7 +311,7 @@ top::FlowDef ::= prod::String  sigName::String  transAttr::String  attr::String 
 {
   top.inhTreeContribs := [(crossnames(prod, crossnames(sigName, crossnames(transAttr, attr))), top)];
   top.prodGraphContribs := [(prod, top)];
-  top.flowEdges = map(pair(transAttrInhVertex(rhsSynVertex(sigName, transAttr), attr), _), deps);
+  top.flowEdges = map(pair(rhsInhVertex(sigName, s"${transAttr}.${attr}"), _), deps);
 }
 
 {--
@@ -329,7 +329,7 @@ top::FlowDef ::= prod::String  fName::String  transAttr::String  attr::String  d
 {
   top.inhTreeContribs := [(crossnames(prod, crossnames(fName, crossnames(transAttr, attr))), top)];
   top.prodGraphContribs := [(prod, top)];
-  top.flowEdges = map(pair(transAttrInhVertex(localSynVertex(fName, transAttr), attr), _), deps);
+  top.flowEdges = map(pair(localSynVertex(fName, s"${transAttr}.${attr}"), _), deps);
 }
 
 {--

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -277,26 +277,6 @@ top::FlowDef ::= prod::String  fName::String  attr::String  deps::[FlowVertex]
 }
 
 {--
- - The definition of an inherited attribute for an inherited translation attribute
- - on the production lhs.
- - Note that this is effectively a synthesized equation, since it is the input to an input.
- -
- - @param prod  the full name of the production
- - @param transAttr  the full name of the translation attribute
- - @param attr  the full name of the attribute
- - @param deps  the dependencies of this equation on other flow graph elements
- -}
-abstract production inhTransInhEq
-top::FlowDef ::= prod::String  transAttr::String  attr::String  deps::[FlowVertex]  mayAffectFlowType::Boolean
-{
-  top.synTreeContribs := [pair(crossnames(prod, s"${transAttr}.${attr}"), top)];
-  top.prodGraphContribs := [pair(prod, top)];
-  local edges :: [Pair<FlowVertex FlowVertex>] = map(pair(lhsInhVertex(s"${transAttr}.${attr}"), _), deps);
-  top.flowEdges = if mayAffectFlowType then edges else [];
-  top.suspectFlowEdges = if mayAffectFlowType then [] else edges;
-}
-
-{--
  - The definition of an inherited attribute for a synthesized translation attribute
  - on an rhs signature element in a production.
  -

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -277,6 +277,62 @@ top::FlowDef ::= prod::String  fName::String  attr::String  deps::[FlowVertex]
 }
 
 {--
+ - The definition of an inherited attribute for an inherited translation attribute
+ - on the production lhs.
+ - Note that this is effectively a synthesized equation, since it is the input to an input.
+ -
+ - @param prod  the full name of the production
+ - @param transAttr  the full name of the translation attribute
+ - @param attr  the full name of the attribute
+ - @param deps  the dependencies of this equation on other flow graph elements
+ -}
+abstract production inhTransInhEq
+top::FlowDef ::= prod::String  transAttr::String  attr::String  deps::[FlowVertex]  mayAffectFlowType::Boolean
+{
+  top.synTreeContribs := [pair(crossnames(prod, crossnames(transAttr, attr)), top)];
+  top.prodGraphContribs := [pair(prod, top)];
+  local edges :: [Pair<FlowVertex FlowVertex>] = map(pair(transAttrInhVertex(lhsInhVertex(transAttr), attr), _), deps);
+  top.flowEdges = if mayAffectFlowType then edges else [];
+  top.suspectFlowEdges = if mayAffectFlowType then [] else edges;
+}
+
+{--
+ - The definition of an inherited attribute for a synthesized translation attribute
+ - on an rhs signature element in a production.
+ -
+ - @param prod  the full name of the production
+ - @param sigName  the name of the RHS element
+ - @param transAttr  the full name of the translation attribute
+ - @param attr  the full name of the attribute
+ - @param deps  the dependencies of this equation on other flow graph elements
+ -}
+abstract production synTransInhEq
+top::FlowDef ::= prod::String  sigName::String  transAttr::String  attr::String  deps::[FlowVertex]
+{
+  top.inhTreeContribs := [(crossnames(prod, crossnames(sigName, crossnames(transAttr, attr))), top)];
+  top.prodGraphContribs := [(prod, top)];
+  top.flowEdges = map(pair(transAttrInhVertex(rhsSynVertex(sigName, transAttr), attr), _), deps);
+}
+
+{--
+ - The definition of an inherited attribute for a synthesized translation attribute
+ - on an local attribute.
+ -
+ - @param prod  the full name of the production
+ - @param fName  the name of the local/production attribute
+ - @param transAttr  the full name of the translation attribute
+ - @param attr  the full name of the attribute
+ - @param deps  the dependencies of this equation on other flow graph elements
+ -}
+abstract production localSynTransInhEq
+top::FlowDef ::= prod::String  fName::String  transAttr::String  attr::String  deps::[FlowVertex]
+{
+  top.inhTreeContribs := [(crossnames(prod, crossnames(fName, crossnames(transAttr, attr))), top)];
+  top.prodGraphContribs := [(prod, top)];
+  top.flowEdges = map(pair(transAttrInhVertex(localSynVertex(fName, transAttr), attr), _), deps);
+}
+
+{--
  - Used for contributions to collections. Allows tacking on dependencies
  - to vertices.
  -

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -289,7 +289,7 @@ top::FlowDef ::= prod::String  fName::String  attr::String  deps::[FlowVertex]
 abstract production inhTransInhEq
 top::FlowDef ::= prod::String  transAttr::String  attr::String  deps::[FlowVertex]  mayAffectFlowType::Boolean
 {
-  top.synTreeContribs := [pair(crossnames(prod, crossnames(transAttr, attr)), top)];
+  top.synTreeContribs := [pair(crossnames(prod, s"${transAttr}.${attr}"), top)];
   top.prodGraphContribs := [pair(prod, top)];
   local edges :: [Pair<FlowVertex FlowVertex>] = map(pair(lhsInhVertex(s"${transAttr}.${attr}"), _), deps);
   top.flowEdges = if mayAffectFlowType then edges else [];
@@ -309,7 +309,7 @@ top::FlowDef ::= prod::String  transAttr::String  attr::String  deps::[FlowVerte
 abstract production synTransInhEq
 top::FlowDef ::= prod::String  sigName::String  transAttr::String  attr::String  deps::[FlowVertex]
 {
-  top.inhTreeContribs := [(crossnames(prod, crossnames(sigName, crossnames(transAttr, attr))), top)];
+  top.inhTreeContribs := [(crossnames(prod, crossnames(sigName, s"${transAttr}.${attr}")), top)];
   top.prodGraphContribs := [(prod, top)];
   top.flowEdges = map(pair(rhsInhVertex(sigName, s"${transAttr}.${attr}"), _), deps);
 }
@@ -327,7 +327,7 @@ top::FlowDef ::= prod::String  sigName::String  transAttr::String  attr::String 
 abstract production localSynTransInhEq
 top::FlowDef ::= prod::String  fName::String  transAttr::String  attr::String  deps::[FlowVertex]
 {
-  top.inhTreeContribs := [(crossnames(prod, crossnames(fName, crossnames(transAttr, attr))), top)];
+  top.inhTreeContribs := [(crossnames(prod, crossnames(fName, s"${transAttr}.${attr}")), top)];
   top.prodGraphContribs := [(prod, top)];
   top.flowEdges = map(pair(localSynVertex(fName, s"${transAttr}.${attr}"), _), deps);
 }

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -277,7 +277,7 @@ top::FlowDef ::= prod::String  fName::String  attr::String  deps::[FlowVertex]
 }
 
 {--
- - The definition of an inherited attribute for a synthesized translation attribute
+ - The definition of an inherited attribute for a translation attribute
  - on an rhs signature element in a production.
  -
  - @param prod  the full name of the production
@@ -286,7 +286,7 @@ top::FlowDef ::= prod::String  fName::String  attr::String  deps::[FlowVertex]
  - @param attr  the full name of the attribute
  - @param deps  the dependencies of this equation on other flow graph elements
  -}
-abstract production synTransInhEq
+abstract production transInhEq
 top::FlowDef ::= prod::String  sigName::String  transAttr::String  attr::String  deps::[FlowVertex]
 {
   top.inhTreeContribs := [(crossnames(prod, crossnames(sigName, s"${transAttr}.${attr}")), top)];
@@ -295,7 +295,7 @@ top::FlowDef ::= prod::String  sigName::String  transAttr::String  attr::String 
 }
 
 {--
- - The definition of an inherited attribute for a synthesized translation attribute
+ - The definition of an inherited attribute for a translation attribute
  - on an local attribute.
  -
  - @param prod  the full name of the production
@@ -304,7 +304,7 @@ top::FlowDef ::= prod::String  sigName::String  transAttr::String  attr::String 
  - @param attr  the full name of the attribute
  - @param deps  the dependencies of this equation on other flow graph elements
  -}
-abstract production localSynTransInhEq
+abstract production localTransInhEq
 top::FlowDef ::= prod::String  fName::String  transAttr::String  attr::String  deps::[FlowVertex]
 {
   top.inhTreeContribs := [(crossnames(prod, crossnames(fName, s"${transAttr}.${attr}")), top)];

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -413,7 +413,7 @@ top::FlowDef ::= prod::String  parent::VertexType  termProd::String  sigName::St
 }
 
 {--
- - A unique reference to a child that is decorated with additional inherited attributes.
+ - A unique reference to a child that is elsewhere decorated with additional inherited attributes.
  -
  - @param prod      the full name of the production
  - @param sigName   the name of the child
@@ -431,7 +431,7 @@ top::FlowDef ::= prod::String  sigName::String  alwaysDec::Boolean  decSite::Ver
 }
 
 {--
- - A unique reference to a local/production attribute that is decorated with additional inherited attributes.
+ - A unique reference to a local/production attribute that is elsewhere decorated with additional inherited attributes.
  -
  - @param prod      the full name of the production
  - @param fName     the full name of the local/production attribute
@@ -445,6 +445,44 @@ top::FlowDef ::= prod::String  fName::String  alwaysDec::Boolean  decSite::Verte
   top.prodGraphContribs := [pair(prod, top)];
   top.flowEdges = map(\ attr::String -> (localInhVertex(fName, attr), decSite.inhVertex(attr)), attrs);
   top.refPossibleDecSiteContribs := [(fName, decSite)];
+  top.refDecSiteContribs := if alwaysDec then top.refPossibleDecSiteContribs else [];
+}
+
+{--
+ - A unique reference to a translation attribute on a child that is elsewhere decorated with additional inherited attributes.
+ -
+ - @param prod      the full name of the production
+ - @param sigName   the name of the child
+ - @param transAttr the name of the translation attribute
+ - @param alwaysDec is this decoration uncondtional (as opposed to e.g. a unique reference appearing in an if/else branch)
+ - @param decSite   the vertex type that is supplying the attributes
+ - @param attrs     the inherited attributes that are being supplied
+ -}
+abstract production childTransRefDecSiteEq
+top::FlowDef ::= prod::String  sigName::String  transAttr::String  alwaysDec::Boolean  decSite::VertexType  attrs::[String]
+{
+  top.prodGraphContribs := [pair(prod, top)];
+  top.flowEdges = map(\ attr::String -> (rhsInhVertex(sigName, s"${transAttr}.${attr}"), decSite.inhVertex(attr)), attrs);
+  top.refPossibleDecSiteContribs := [(s"${prod}:${sigName}.${transAttr}", decSite)];
+  top.refDecSiteContribs := if alwaysDec then top.refPossibleDecSiteContribs else [];
+}
+
+{--
+ - A unique reference to a translation attribute on a local/production attribute that is elsewhere decorated with additional inherited attributes.
+ -
+ - @param prod      the full name of the production
+ - @param fName     the full name of the local/production attribute
+ - @param transAttr the name of the translation attribute
+ - @param alwaysDec is this decoration uncondtional (as opposed to e.g. a unique reference appearing in an if/else branch)
+ - @param decSite   the vertex type that is supplying the attributes
+ - @param attrs     the inherited attributes that are being supplied
+ -}
+abstract production localTransRefDecSiteEq
+top::FlowDef ::= prod::String  fName::String  transAttr::String  alwaysDec::Boolean  decSite::VertexType  attrs::[String]
+{
+  top.prodGraphContribs := [pair(prod, top)];
+  top.flowEdges = map(\ attr::String -> (localInhVertex(fName, s"${transAttr}.${attr}"), decSite.inhVertex(attr)), attrs);
+  top.refPossibleDecSiteContribs := [(s"${fName}.${transAttr}", decSite)];
   top.refDecSiteContribs := if alwaysDec then top.refPossibleDecSiteContribs else [];
 }
 

--- a/grammars/silver/compiler/definition/flow/ast/Vertex.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Vertex.sv
@@ -85,30 +85,6 @@ abstract production localInhVertex
 top::FlowVertex ::= fName::String  attrName::String
 {}
 
-{--
- - A vertex representing a synthesized attribute on a (syn or inh) translation attribute
- - on an lhs/rhs/local.
- -
- - @param v  the flow vertex of the translation attribute instance.
- - @param attrName  the full name of the attribute on that element
- -}
-abstract production transAttrSynVertex
-top::FlowVertex ::= v::FlowVertex  attrName::String
-{}
-
-{--
- - A vertex representing an inherited attribute on a (syn or inh) translation attribute
- - on an lhs/rhs/local.
- -
- - @param v  the flow vertex of the translation attribute instance.
- - @param attrName  the full name of the attribute on that element
- -}
-abstract production transAttrInhVertex
-top::FlowVertex ::= v::FlowVertex  attrName::String
-{}
-
-
--- TODO: we should distinguish these!
 
 -- The forward equation for this production. We do not care to distinguish it.
 function forwardEqVertex

--- a/grammars/silver/compiler/definition/flow/ast/Vertex.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Vertex.sv
@@ -85,6 +85,29 @@ abstract production localInhVertex
 top::FlowVertex ::= fName::String  attrName::String
 {}
 
+{--
+ - A vertex representing a synthesized attribute on a (syn or inh) translation attribute
+ - on an lhs/rhs/local.
+ -
+ - @param v  the flow vertex of the translation attribute instance.
+ - @param attrName  the full name of the attribute on that element
+ -}
+abstract production transAttrSynVertex
+top::FlowVertex ::= v::FlowVertex  attrName::String
+{}
+
+{--
+ - A vertex representing an inherited attribute on a (syn or inh) translation attribute
+ - on an lhs/rhs/local.
+ -
+ - @param v  the flow vertex of the translation attribute instance.
+ - @param attrName  the full name of the attribute on that element
+ -}
+abstract production transAttrInhVertex
+top::FlowVertex ::= v::FlowVertex  attrName::String
+{}
+
+
 -- TODO: we should distinguish these!
 
 -- The forward equation for this production. We do not care to distinguish it.

--- a/grammars/silver/compiler/definition/flow/ast/VertexType.sv
+++ b/grammars/silver/compiler/definition/flow/ast/VertexType.sv
@@ -79,18 +79,6 @@ top::VertexType ::= v::VertexType  transAttr::String
 }
 
 {--
- - Represents the vertexes for each inherited translation attribute on a production lhs/rhs/local.
- -}
-abstract production inhTransAttrVertexType
-top::VertexType ::= v::VertexType  transAttr::String
-{
-  top.synVertex = \ attr::String -> v.inhVertex(s"${transAttr}.${attr}");
-  top.inhVertex = \ attr::String -> v.synVertex(s"${transAttr}.${attr}");
-  top.fwdVertex = v.inhVertex(s"${transAttr}.forward");
-  top.eqVertex = [v.inhVertex(transAttr)];
-}
-
-{--
  - Represents the vertexes for the forward of a production. You can use forwardVertexType instead of this production directly.
  -}
 abstract production forwardVertexType_real

--- a/grammars/silver/compiler/definition/flow/ast/VertexType.sv
+++ b/grammars/silver/compiler/definition/flow/ast/VertexType.sv
@@ -70,24 +70,24 @@ top::VertexType ::= fName::String
  - Represents the vertexes for each synthesized translation attribute on a production lhs/rhs/local.
  -}
 abstract production synTransAttrVertexType
-top::VertexType ::= v::VertexType  attr::String
+top::VertexType ::= v::VertexType  transAttr::String
 {
-  top.synVertex = transAttrSynVertex(v.synVertex(attr), _);
-  top.inhVertex = transAttrInhVertex(v.synVertex(attr), _);
-  top.fwdVertex = transAttrSynVertex(v.synVertex(attr), "forward");
-  top.eqVertex = [v.synVertex(attr)];
+  top.synVertex = \ attr::String -> v.synVertex(s"${transAttr}.${attr}");
+  top.inhVertex = \ attr::String -> v.inhVertex(s"${transAttr}.${attr}");
+  top.fwdVertex = v.synVertex(s"${transAttr}.forward");
+  top.eqVertex = [v.synVertex(transAttr)];
 }
 
 {--
  - Represents the vertexes for each inherited translation attribute on a production lhs/rhs/local.
  -}
 abstract production inhTransAttrVertexType
-top::VertexType ::= v::VertexType  attr::String
+top::VertexType ::= v::VertexType  transAttr::String
 {
-  top.synVertex = transAttrSynVertex(v.inhVertex(attr), _);
-  top.inhVertex = transAttrInhVertex(v.inhVertex(attr), _);
-  top.fwdVertex = transAttrSynVertex(v.inhVertex(attr), "forward");
-  top.eqVertex = [v.inhVertex(attr)];
+  top.synVertex = \ attr::String -> v.inhVertex(s"${transAttr}.${attr}");
+  top.inhVertex = \ attr::String -> v.synVertex(s"${transAttr}.${attr}");
+  top.fwdVertex = v.inhVertex(s"${transAttr}.forward");
+  top.eqVertex = [v.inhVertex(transAttr)];
 }
 
 {--

--- a/grammars/silver/compiler/definition/flow/ast/VertexType.sv
+++ b/grammars/silver/compiler/definition/flow/ast/VertexType.sv
@@ -67,6 +67,30 @@ top::VertexType ::= fName::String
 }
 
 {--
+ - Represents the vertexes for each synthesized translation attribute on a production lhs/rhs/local.
+ -}
+abstract production synTransAttrVertexType
+top::VertexType ::= v::VertexType  attr::String
+{
+  top.synVertex = transAttrSynVertex(v.synVertex(attr), _);
+  top.inhVertex = transAttrInhVertex(v.synVertex(attr), _);
+  top.fwdVertex = transAttrSynVertex(v.synVertex(attr), "forward");
+  top.eqVertex = [v.synVertex(attr)];
+}
+
+{--
+ - Represents the vertexes for each inherited translation attribute on a production lhs/rhs/local.
+ -}
+abstract production inhTransAttrVertexType
+top::VertexType ::= v::VertexType  attr::String
+{
+  top.synVertex = transAttrSynVertex(v.inhVertex(attr), _);
+  top.inhVertex = transAttrInhVertex(v.inhVertex(attr), _);
+  top.fwdVertex = transAttrSynVertex(v.inhVertex(attr), "forward");
+  top.eqVertex = [v.inhVertex(attr)];
+}
+
+{--
  - Represents the vertexes for the forward of a production. You can use forwardVertexType instead of this production directly.
  -}
 abstract production forwardVertexType_real

--- a/grammars/silver/compiler/definition/flow/ast/VertexType.sv
+++ b/grammars/silver/compiler/definition/flow/ast/VertexType.sv
@@ -67,9 +67,9 @@ top::VertexType ::= fName::String
 }
 
 {--
- - Represents the vertexes for each synthesized translation attribute on a production lhs/rhs/local.
+ - Represents the vertexes for each translation attribute on a production lhs/rhs/local.
  -}
-abstract production synTransAttrVertexType
+abstract production transAttrVertexType
 top::VertexType ::= v::VertexType  transAttr::String
 {
   top.synVertex = \ attr::String -> v.synVertex(s"${transAttr}.${attr}");

--- a/grammars/silver/compiler/definition/flow/ast/VertexType.sv
+++ b/grammars/silver/compiler/definition/flow/ast/VertexType.sv
@@ -9,8 +9,11 @@ grammar silver:compiler:definition:flow:ast;
  -}
 nonterminal VertexType with
   compareTo, isEqual, compareKey, compare,
+  vertexName,
   synVertex, inhVertex, fwdVertex, eqVertex;
 propagate compareTo, isEqual, compareKey, compare on VertexType;
+
+synthesized attribute vertexName::String;
 
 {-- FlowVertex for a synthesized attribute for this FlowVertex -}
 synthesized attribute synVertex :: (FlowVertex ::= String);
@@ -36,6 +39,7 @@ global forwardEqVertex_singleton :: FlowVertex = localEqVertex("forward");
 abstract production lhsVertexType_real
 top::VertexType ::=
 {
+  top.vertexName = "top";
   top.synVertex = lhsSynVertex;
   top.inhVertex = lhsInhVertex;
   top.fwdVertex = forwardEqVertex_singleton;
@@ -48,6 +52,7 @@ top::VertexType ::=
 abstract production rhsVertexType
 top::VertexType ::= sigName::String
 {
+  top.vertexName = sigName;
   top.synVertex = rhsSynVertex(sigName, _);
   top.inhVertex = rhsInhVertex(sigName, _);
   top.fwdVertex = rhsSynVertex(sigName, "forward");
@@ -60,6 +65,7 @@ top::VertexType ::= sigName::String
 abstract production localVertexType
 top::VertexType ::= fName::String
 {
+  top.vertexName = fName;
   top.synVertex = localSynVertex(fName, _);
   top.inhVertex = localInhVertex(fName, _);
   top.fwdVertex = localSynVertex(fName, "forward");
@@ -72,6 +78,7 @@ top::VertexType ::= fName::String
 abstract production transAttrVertexType
 top::VertexType ::= v::VertexType  transAttr::String
 {
+  top.vertexName = s"${v.vertexName}.${transAttr}";
   top.synVertex = \ attr::String -> v.synVertex(s"${transAttr}.${attr}");
   top.inhVertex = \ attr::String -> v.inhVertex(s"${transAttr}.${attr}");
   top.fwdVertex = v.synVertex(s"${transAttr}.forward");
@@ -84,6 +91,7 @@ top::VertexType ::= v::VertexType  transAttr::String
 abstract production forwardVertexType_real
 top::VertexType ::=
 {
+  top.vertexName = "forward";
   top.synVertex = forwardSynVertex;
   top.inhVertex = forwardInhVertex;
   top.fwdVertex = forwardSynVertex("forward");
@@ -96,6 +104,7 @@ top::VertexType ::=
 abstract production anonVertexType
 top::VertexType ::= x::String
 {
+  top.vertexName = x;
   top.synVertex = anonSynVertex(x, _);
   top.inhVertex = anonInhVertex(x, _);
   top.fwdVertex = anonSynVertex(x, "forward");
@@ -108,6 +117,7 @@ top::VertexType ::= x::String
 abstract production subtermVertexType
 top::VertexType ::= parent::VertexType prodName::String sigName::String
 {
+  top.vertexName = s"${parent.vertexName}[${prodName}:${sigName}]";
   top.synVertex = subtermSynVertex(parent, prodName, sigName, _);
   top.inhVertex = subtermInhVertex(parent, prodName, sigName, _);
   top.fwdVertex = subtermSynVertex(parent, prodName, sigName, "forward");

--- a/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
@@ -168,16 +168,6 @@ top::FlowVertex ::= fName::String  attrName::String
 {
   top.dotName = fName ++ "/" ++ attrName;
 }
-aspect production transAttrSynVertex
-top::FlowVertex ::= v::FlowVertex  attrName::String
-{
-  top.dotName = v.dotName ++ "." ++ attrName;
-}
-aspect production transAttrInhVertex
-top::FlowVertex ::= v::FlowVertex  attrName::String
-{
-  top.dotName = v.dotName ++ "." ++ attrName;
-}
 aspect production anonEqVertex
 top::FlowVertex ::= fName::String
 {

--- a/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/DumpGraph.sv
@@ -168,6 +168,16 @@ top::FlowVertex ::= fName::String  attrName::String
 {
   top.dotName = fName ++ "/" ++ attrName;
 }
+aspect production transAttrSynVertex
+top::FlowVertex ::= v::FlowVertex  attrName::String
+{
+  top.dotName = v.dotName ++ "." ++ attrName;
+}
+aspect production transAttrInhVertex
+top::FlowVertex ::= v::FlowVertex  attrName::String
+{
+  top.dotName = v.dotName ++ "." ++ attrName;
+}
 aspect production anonEqVertex
 top::FlowVertex ::= fName::String
 {

--- a/grammars/silver/compiler/definition/flow/driver/FlowGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/FlowGraph.sv
@@ -52,7 +52,7 @@ set:Set<FlowVertex> ::= todolist::[FlowVertex]  current::set:Set<FlowVertex>  p:
 
 {--
  - Look up flow types.
- - @param syn  A synthesized attribute's full name (or "forward")
+ - @param syn  A synthesized attribute's full name (or "forward", or inhTrans.inh)
  - @param nt  The nonterminal to look up this attribute on
  - @param flow  The flow type environment (NOTE: TODO: this is currently 'myFlow' or something, NOT top.flowEnv)
  - @return A set of inherited attributes on this nonterminal, needed to compute this synthesized attribute.
@@ -70,6 +70,7 @@ Boolean ::= v::FlowVertex  inhSet::set:Set<String>
 {
   return case v of
   | lhsInhVertex(a) -> set:contains(a, inhSet)
+  | transAttrInhVertex(lhsSynVertex(ta), a) -> set:contains(s"${ta}.${a}", inhSet)
   | _ -> false
   end;
 }

--- a/grammars/silver/compiler/definition/flow/driver/FlowGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/FlowGraph.sv
@@ -70,7 +70,6 @@ Boolean ::= v::FlowVertex  inhSet::set:Set<String>
 {
   return case v of
   | lhsInhVertex(a) -> set:contains(a, inhSet)
-  | transAttrInhVertex(lhsSynVertex(ta), a) -> set:contains(s"${ta}.${a}", inhSet)
   | _ -> false
   end;
 }

--- a/grammars/silver/compiler/definition/flow/driver/FlowGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/FlowGraph.sv
@@ -52,7 +52,7 @@ set:Set<FlowVertex> ::= todolist::[FlowVertex]  current::set:Set<FlowVertex>  p:
 
 {--
  - Look up flow types.
- - @param syn  A synthesized attribute's full name (or "forward", or inhTrans.inh)
+ - @param syn  A synthesized attribute's full name (or "forward", or trans.syn)
  - @param nt  The nonterminal to look up this attribute on
  - @param flow  The flow type environment (NOTE: TODO: this is currently 'myFlow' or something, NOT top.flowEnv)
  - @return A set of inherited attributes on this nonterminal, needed to compute this synthesized attribute.

--- a/grammars/silver/compiler/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/compiler/definition/flow/driver/FlowTypes.sv
@@ -156,7 +156,6 @@ function collectInhs
 {
   return case f of
   | lhsInhVertex(a) -> a::l
-  | transAttrInhVertex(lhsSynVertex(ta), a) -> s"${ta}.${a}"::l
   | _ -> l
   end;
 }
@@ -201,20 +200,6 @@ aspect production localInhVertex
 top::FlowVertex ::= fName::String  attrName::String
 {
   top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for local inherited attributes?");
-}
-aspect production transAttrSynVertex
-top::FlowVertex ::= v::FlowVertex  attrName::String
-{
-  top.flowTypeName = error("Internal compiler error: shouldn't be solving flow types for translation attribute synthesized attributes?");
-}
-aspect production transAttrInhVertex
-top::FlowVertex ::= v::FlowVertex  attrName::String
-{
-  top.flowTypeName =
-    case v of
-    | lhsInhVertex(transAttrName) -> s"${transAttrName}.${attrName}"
-    | _ -> error("Internal compiler error: should only be solving flow types for inherited attributes on inherited translation attributes?")
-    end;
 }
 aspect production anonEqVertex
 top::FlowVertex ::= fName::String

--- a/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
@@ -440,16 +440,18 @@ function addDefEqs
 function nonterminalStitchPoints
 [StitchPoint] ::= realEnv::Decorated Env  nt::NtName  vertexType::VertexType
 {
-  return flatMap(
-    \ o::OccursDclInfo ->
-      case getAttrDcl(o.attrOccurring, realEnv) of
-      | at :: _ when at.isSynthesized && at.isTranslation ->
-        [nonterminalStitchPoint(
-           at.typeScheme.typeName,
-           transAttrVertexType(vertexType, o.attrOccurring))]
-      | _ -> []
-      end,
-    getAttrOccursOn(nt, realEnv));
+  return
+    nonterminalStitchPoint(nt, vertexType) ::
+    flatMap(
+      \ o::OccursDclInfo ->
+        case getAttrDcl(o.attrOccurring, realEnv) of
+        | at :: _ when at.isSynthesized && at.isTranslation ->
+          [nonterminalStitchPoint(
+            at.typeScheme.typeName,
+            transAttrVertexType(vertexType, o.attrOccurring))]
+        | _ -> []
+        end,
+      getAttrOccursOn(nt, realEnv));
 }
 function localStitchPoints
 [StitchPoint] ::= realEnv::Decorated Env  nt::NtName  ds::[FlowDef]

--- a/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
@@ -160,7 +160,7 @@ ProductionGraph ::= dcl::ValueDclInfo  defs::[FlowDef]  flowEnv::FlowEnv  realEn
   local prod :: String = dcl.fullName;
   -- The LHS nonterminal full name
   local nt :: NtName = dcl.namedSignature.outputElement.typerep.typeName;
-  -- Just synthesized and inherited on inherited translation attributes.
+  -- Just synthesized attributes.
   local syns :: [String] = getSynAttrsOn(nt, realEnv);
   -- Just inherited and inherited on synthesized translation attributes.
   local inhs :: [String] = getInhAttrsOn(nt, realEnv);
@@ -342,7 +342,7 @@ ProductionGraph ::= ns::NamedSignature  defs::[FlowDef]  realEnv::Decorated Env 
 function constructPhantomProductionGraph
 ProductionGraph ::= nt::String  flowEnv::FlowEnv  realEnv::Decorated Env
 {
-  -- Just synthesized and inherited on inherited translation attributes.
+  -- Just synthesized attributes.
   local syns :: [String] = getSynAttrsOn(nt, realEnv);
   -- Those syns that are not part of the host, and so should have edges to fwdeq
   local extSyns :: [String] = removeAll(getHostSynsFor(nt, flowEnv), syns);

--- a/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
@@ -162,7 +162,7 @@ ProductionGraph ::= dcl::ValueDclInfo  defs::[FlowDef]  flowEnv::FlowEnv  realEn
   local nt :: NtName = dcl.namedSignature.outputElement.typerep.typeName;
   -- Just synthesized attributes.
   local syns :: [String] = getSynAttrsOn(nt, realEnv);
-  -- Just inherited and inherited on synthesized translation attributes.
+  -- Just inherited and inherited on translation attributes.
   local inhs :: [String] = getInhAndInhOnTransAttrsOn(nt, realEnv);
   -- Does this production forward?
   local nonForwarding :: Boolean = null(lookupFwd(prod, flowEnv));
@@ -446,7 +446,7 @@ function nonterminalStitchPoints
       | at :: _ when at.isSynthesized && at.isTranslation ->
         [nonterminalStitchPoint(
            at.typeScheme.typeName,
-           synTransAttrVertexType(vertexType, o.attrOccurring))]
+           transAttrVertexType(vertexType, o.attrOccurring))]
       | _ -> []
       end,
     getAttrOccursOn(nt, realEnv));

--- a/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
@@ -160,10 +160,10 @@ ProductionGraph ::= dcl::ValueDclInfo  defs::[FlowDef]  flowEnv::FlowEnv  realEn
   local prod :: String = dcl.fullName;
   -- The LHS nonterminal full name
   local nt :: NtName = dcl.namedSignature.outputElement.typerep.typeName;
-  -- Just synthesized attributes.
-  local syns :: [String] = map((.attrOccurring), getSynAttrsOn(nt, realEnv));
-  -- Just inherited.
-  local inhs :: [String] = map((.attrOccurring), getInhAttrsOn(nt, realEnv));
+  -- Just synthesized and inherited on inherited translation attributes.
+  local syns :: [String] = getSynAttrsOn(nt, realEnv);
+  -- Just inherited and inherited on synthesized translation attributes.
+  local inhs :: [String] = getInhAttrsOn(nt, realEnv);
   -- Does this production forward?
   local nonForwarding :: Boolean = null(lookupFwd(prod, flowEnv));
     
@@ -342,8 +342,8 @@ ProductionGraph ::= ns::NamedSignature  defs::[FlowDef]  realEnv::Decorated Env 
 function constructPhantomProductionGraph
 ProductionGraph ::= nt::String  flowEnv::FlowEnv  realEnv::Decorated Env
 {
-  -- Just synthesized attributes.
-  local syns :: [String] = map((.attrOccurring), getSynAttrsOn(nt, realEnv));
+  -- Just synthesized and inherited on inherited translation attributes.
+  local syns :: [String] = getSynAttrsOn(nt, realEnv);
   -- Those syns that are not part of the host, and so should have edges to fwdeq
   local extSyns :: [String] = removeAll(getHostSynsFor(nt, flowEnv), syns);
 
@@ -477,7 +477,7 @@ function patVarStitchPoints
       [nonterminalStitchPoint(typeName, anonVertexType(patternVar)),
        projectionStitchPoint(
          matchProd, anonVertexType(patternVar), scrutinee, rhsVertexType(child),
-         map((.attrOccurring), getInhAttrsOn(typeName, realEnv)))]
+         getInhAttrsOn(typeName, realEnv))]
   end;
 }
 function subtermDecSiteStitchPoints
@@ -489,7 +489,7 @@ function subtermDecSiteStitchPoints
       map(\ prodDcl::ValueDclInfo ->
         projectionStitchPoint(
           termProdName, subtermVertexType(parent, termProdName, sigName), parent, rhsVertexType(sigName),
-          map((.attrOccurring), getInhAttrsOn(prodDcl.namedSignature.outputElement.typerep.typeName, realEnv))),
+          getInhAttrsOn(prodDcl.namedSignature.outputElement.typerep.typeName, realEnv)),
         getValueDcl(termProdName, realEnv))
     | _ -> []
     end,

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -344,18 +344,18 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   top.flowDefs <-
     case top.decSiteVertexInfo of
     | just(decSite) when finalTy.isUniqueDecorated ->
-      case e.flowVertexInfo of
-      | just(rhsVertexType(sigName)) ->
+      case e of
+      | childReference(cqn) ->
         [childTransRefDecSiteEq(
-          top.frame.fullName, sigName, q.attrDcl.fullName, top.alwaysDecorated, decSite,
+          top.frame.fullName, cqn.lookupValue.fullName, q.attrDcl.fullName, top.alwaysDecorated, decSite,
           filter(
-            isEquationMissing(lookupInh(top.frame.fullName, sigName, _, top.flowEnv), _),
+            isEquationMissing(lookupInh(top.frame.fullName, cqn.lookupValue.fullName, _, top.flowEnv), _),
             allInhs))]
-      | just(localVertexType(fName)) ->
+      | localReference(lqn) ->
         [localTransRefDecSiteEq(
-          top.frame.fullName, fName, q.attrDcl.fullName, top.alwaysDecorated, decSite,
+          top.frame.fullName, lqn.lookupValue.fullName, q.attrDcl.fullName, top.alwaysDecorated, decSite,
           filter(
-            isEquationMissing(lookupLocalInh(top.frame.fullName, fName, _, top.flowEnv), _),
+            isEquationMissing(lookupLocalInh(top.frame.fullName, lqn.lookupValue.fullName, _, top.flowEnv), _),
             allInhs))]
       | _ -> []
       end

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -95,7 +95,7 @@ top::Expr ::= q::Decorated! QName
       isEquationMissing(lookupInh(top.frame.fullName, q.lookupValue.fullName, _, top.flowEnv), _),
       removeAll(
         origRefSet,
-        getInhAttrsOn(finalTy.decoratedType.typeName, top.env)));
+        getInhAndInhOnTransAttrsOn(finalTy.decoratedType.typeName, top.env)));
   -- Add remote equations for reference site decoration with attributes that aren't supplied here
   top.flowDefs <-
     case top.decSiteVertexInfo of
@@ -145,7 +145,7 @@ top::Expr ::= q::Decorated! QName
       isEquationMissing(lookupLocalInh(top.frame.fullName, q.lookupValue.fullName, _, top.flowEnv), _),
       removeAll(
         origRefSet,
-        getInhAttrsOn(finalTy.decoratedType.typeName, top.env)));
+        getInhAndInhOnTransAttrsOn(finalTy.decoratedType.typeName, top.env)));
   -- Add remote equations for reference site decoration with attributes that aren't supplied here
   top.flowDefs <-
     case top.decSiteVertexInfo of

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -179,6 +179,7 @@ aspect production application
 top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 {
   propagate flowEnv;
+  e.alwaysDecorated = false;
 }
 
 aspect production errorApplication
@@ -186,7 +187,6 @@ top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAp
 {
   e.decSiteVertexInfo = nothing();
   es.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
   es.alwaysDecorated = false;
   es.appProd = nothing();
 }
@@ -202,7 +202,6 @@ top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAp
     end;
   e.decSiteVertexInfo = nothing();
   es.decSiteVertexInfo = top.decSiteVertexInfo;
-  e.alwaysDecorated = false;
   es.alwaysDecorated = top.alwaysDecorated;
 }
 
@@ -216,7 +215,6 @@ top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAp
     end;
   e.decSiteVertexInfo = nothing();
   es.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
   es.alwaysDecorated = false;
 }
 
@@ -224,8 +222,8 @@ aspect production annoExpr
 top::AnnoExpr ::= qn::QName '=' e::AppExpr
 {
   e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
   e.appProd = nothing();
+  e.alwaysDecorated = false;
 }
 
 aspect production presentAppExpr
@@ -264,12 +262,14 @@ aspect production access
 top::Expr ::= e::Expr '.' q::QNameAttrOccur
 {
   propagate flowEnv;
+  e.alwaysDecorated = false;
 }
 
 aspect production accessBouncer
 top::Expr ::= target::(Expr ::= Decorated! Expr  Decorated! QNameAttrOccur  Location) e::Expr  q::Decorated! QNameAttrOccur
 {
   propagate flowEnv;
+  e.alwaysDecorated = false;
 }
 
 aspect production forwardAccess
@@ -289,19 +289,16 @@ aspect production errorAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
 }
 aspect production annoAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
 }
 aspect production terminalAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
 }
 -- Note that below we IGNORE the flow deps of the lhs if we know what it is
 -- this is because by default the lhs will have 'taking ref' flow deps (see above)
@@ -314,7 +311,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
     | nothing() -> e.flowDeps
     end;
   e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
 }
 aspect production inhDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
@@ -325,7 +321,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
     | nothing() -> e.flowDeps
     end;
   e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
 }
 aspect production transDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
@@ -362,19 +357,16 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
     | _ -> []
     end;
   e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
 }
 aspect production errorDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
 }
 aspect production transUndecoratedAccessErrorHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
 }
 
 aspect production decorateExprWith

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -56,7 +56,7 @@ attribute flowVertexInfo occurs on Expr;
 propagate flowDeps on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr
   excluding
     childReference, lhsReference, localReference, forwardReference, forwardAccess,
-    synDecoratedAccessHandler, inhDecoratedAccessHandler, synTransDecoratedAccessHandler, inhTransDecoratedAccessHandler,
+    synDecoratedAccessHandler, inhDecoratedAccessHandler, synTransDecoratedAccessHandler,
     decorateExprWith, letp, lexicalLocalReference, matchPrimitiveReal;
 propagate flowDefs, flowEnv on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr;
 
@@ -336,20 +336,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   top.flowDeps := 
     case e.flowVertexInfo of
     | just(vertex) -> vertex.synVertex(q.attrDcl.fullName) :: vertex.eqVertex
-    | nothing() -> e.flowDeps
-    end;
-  e.decSiteVertexInfo = nothing();
-  e.alwaysDecorated = false;
-}
-aspect production inhTransDecoratedAccessHandler
-top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
-{
-  local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
-  production refSet::Maybe<[String]> = getMaxRefSet(finalTy, top.env);
-  top.flowVertexInfo = map(inhTransAttrVertexType(_, q.attrDcl.fullName), e.flowVertexInfo);
-  top.flowDeps :=
-    case e.flowVertexInfo of
-    | just(vertex) -> vertex.inhVertex(q.attrDcl.fullName) :: vertex.eqVertex
     | nothing() -> e.flowDeps
     end;
   e.decSiteVertexInfo = nothing();

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -339,6 +339,28 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
       if finalTy.isDecorated then map(vertex.inhVertex, fromMaybe([], refSet)) else []
     | nothing() -> e.flowDeps
     end;
+
+  local allInhs::[String] = getInhAndInhOnTransAttrsOn(finalTy.decoratedType.typeName, top.env);
+  top.flowDefs <-
+    case top.decSiteVertexInfo of
+    | just(decSite) when finalTy.isUniqueDecorated ->
+      case e.flowVertexInfo of
+      | just(rhsVertexType(sigName)) ->
+        [childTransRefDecSiteEq(
+          top.frame.fullName, sigName, q.attrDcl.fullName, top.alwaysDecorated, decSite,
+          filter(
+            isEquationMissing(lookupInh(top.frame.fullName, sigName, _, top.flowEnv), _),
+            allInhs))]
+      | just(localVertexType(fName)) ->
+        [localTransRefDecSiteEq(
+          top.frame.fullName, fName, q.attrDcl.fullName, top.alwaysDecorated, decSite,
+          filter(
+            isEquationMissing(lookupLocalInh(top.frame.fullName, fName, _, top.flowEnv), _),
+            allInhs))]
+      | _ -> []
+      end
+    | _ -> []
+    end;
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
 }

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -335,7 +335,8 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   top.flowVertexInfo = map(synTransAttrVertexType(_, q.attrDcl.fullName), e.flowVertexInfo);
   top.flowDeps := 
     case e.flowVertexInfo of
-    | just(vertex) -> vertex.synVertex(q.attrDcl.fullName) :: vertex.eqVertex
+    | just(vertex) -> vertex.synVertex(q.attrDcl.fullName) :: vertex.eqVertex ++
+      if finalTy.isDecorated then map(vertex.inhVertex, fromMaybe([], refSet)) else []
     | nothing() -> e.flowDeps
     end;
   e.decSiteVertexInfo = nothing();

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -56,7 +56,7 @@ attribute flowVertexInfo occurs on Expr;
 propagate flowDeps on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr
   excluding
     childReference, lhsReference, localReference, forwardReference, forwardAccess,
-    synDecoratedAccessHandler, inhDecoratedAccessHandler, synTransDecoratedAccessHandler,
+    synDecoratedAccessHandler, inhDecoratedAccessHandler, transDecoratedAccessHandler,
     decorateExprWith, letp, lexicalLocalReference, matchPrimitiveReal;
 propagate flowDefs, flowEnv on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr;
 
@@ -327,12 +327,12 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
 }
-aspect production synTransDecoratedAccessHandler
+aspect production transDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
   production refSet::Maybe<[String]> = getMaxRefSet(finalTy, top.env);
-  top.flowVertexInfo = map(synTransAttrVertexType(_, q.attrDcl.fullName), e.flowVertexInfo);
+  top.flowVertexInfo = map(transAttrVertexType(_, q.attrDcl.fullName), e.flowVertexInfo);
   top.flowDeps := 
     case e.flowVertexInfo of
     | just(vertex) -> vertex.synVertex(q.attrDcl.fullName) :: vertex.eqVertex ++

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -330,6 +330,8 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 aspect production synTransDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
+  local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
+  production refSet::Maybe<[String]> = getMaxRefSet(finalTy, top.env);
   top.flowVertexInfo = map(synTransAttrVertexType(_, q.attrDcl.fullName), e.flowVertexInfo);
   top.flowDeps := 
     case e.flowVertexInfo of
@@ -342,6 +344,8 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 aspect production inhTransDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
+  local finalTy::Type = performSubstitution(top.typerep, top.finalSubst);
+  production refSet::Maybe<[String]> = getMaxRefSet(finalTy, top.env);
   top.flowVertexInfo = map(inhTransAttrVertexType(_, q.attrDcl.fullName), e.flowVertexInfo);
   top.flowDeps :=
     case e.flowVertexInfo of

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -348,6 +348,12 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
 }
+aspect production transUndecoratedAccessErrorHandler
+top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
+{
+  e.decSiteVertexInfo = nothing();
+  e.alwaysDecorated = false;
+}
 
 aspect production decorateExprWith
 top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -79,13 +79,6 @@ function lookupInh
   return searchEnvTree(crossnames(prod, crossnames(sigName, attr)), e.inhTree);
 }
 
--- inherited equation for a translation attribute on a child in a production
-function lookupTransInh
-[FlowDef] ::= prod::String  sigName::String  transAttr::String  attr::String  e::FlowEnv
-{
-  return searchEnvTree(crossnames(prod, crossnames(sigName, s"${transAttr}.${attr}")), e.inhTree);
-}
-
 -- default equation for a nonterminal
 function lookupDef
 [FlowDef] ::= nt::String  attr::String  e::FlowEnv
@@ -112,13 +105,6 @@ function lookupLocalInh
 [FlowDef] ::= prod::String  fName::String  attr::String  e::FlowEnv
 {
   return searchEnvTree(crossnames(prod, crossnames(fName, attr)), e.localInhTree);
-}
-
--- inherited equation for a translation attribute on a local in a production
-function lookupLocalTransInh
-[FlowDef] ::= prod::String  fName::String  transAttr::String  attr::String  e::FlowEnv
-{
-  return searchEnvTree(crossnames(prod, crossnames(fName, s"${transAttr}.${attr}")), e.inhTree);
 }
 
 function lookupLocalEq
@@ -310,4 +296,12 @@ function occursContextDeps
   return map(
     \ synDeps::(String, [String]) -> synOccursContextEq(ns.fullName, vt, synDeps.fst, synDeps.snd),
     lookupAll(t.typeName, contexts.occursContextInhDeps));
+}
+
+function splitTransAttrInh
+Maybe<(String, String)> ::= attr::String
+{
+  local i::Integer = indexOf(".", attr);
+  return if i == -1 then nothing() else
+    just((substring(0, i, attr), substring(i + 1, length(attr), attr)));
 }

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -155,6 +155,20 @@ function lookupLocalRefPossibleDecSites
   return searchEnvTree(fName, e.refPossibleDecSiteTree);
 }
 
+-- possible decoration sites for unique references taken for a synthesized translation attribute on a child
+function lookupSynTransRefPossibleDecSites
+[VertexType] ::= prod::String  sigName::String  attrName::String  e::FlowEnv
+{
+  return searchEnvTree(s"${prod}:${sigName}.${attrName}", e.refPossibleDecSiteTree);
+}
+
+-- possible decoration sites for unique references taken for a synthesized translation attribute on a local/production attribute
+function lookupLocalSynTransRefPossibleDecSites
+[VertexType] ::= fName::String  attrName::String  e::FlowEnv
+{
+  return searchEnvTree(s"${fName}.${attrName}", e.refPossibleDecSiteTree);
+}
+
 -- unconditional decoration sites for unique references taken for a child
 function lookupRefDecSite
 [VertexType] ::= prod::String  sigName::String  e::FlowEnv

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -127,6 +127,27 @@ function lookupLocalUniqueRefs
   return searchEnvTree(fName, e.uniqueRefTree);
 }
 
+-- unique references taken for a synthesized translation attribute on a child
+function lookupSynTransUniqueRefs
+[UniqueRefSite] ::= prod::String sigName::String attrName::String e::FlowEnv
+{
+  return searchEnvTree(prod ++ ":" ++ sigName ++ "." ++ attrName, e.uniqueRefTree);
+}
+
+-- unique references taken for a synthesized translation attribute on a local
+function lookupLocalSynTransUniqueRefs
+[UniqueRefSite] ::= fName::String attrName::String e::FlowEnv
+{
+  return searchEnvTree(fName ++ "." ++ attrName, e.uniqueRefTree);
+}
+
+-- unique references taken for a synthesized translation attribute on a child
+function lookupInhTransUniqueRefs
+[UniqueRefSite] ::= prod::String attrName::String e::FlowEnv
+{
+  return searchEnvTree(prod ++ "." ++ attrName, e.uniqueRefTree);
+}
+
 -- possible decoration sites for unique references taken for a child
 function lookupRefPossibleDecSites
 [VertexType] ::= prod::String  sigName::String  e::FlowEnv

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -79,6 +79,13 @@ function lookupInh
   return searchEnvTree(crossnames(prod, crossnames(sigName, attr)), e.inhTree);
 }
 
+-- inherited equation for a translation attribute on a child in a production
+function lookupTransInh
+[FlowDef] ::= prod::String  sigName::String  transAttr::String  attr::String  e::FlowEnv
+{
+  return searchEnvTree(crossnames(prod, crossnames(sigName, s"${transAttr}.${attr}")), e.inhTree);
+}
+
 -- default equation for a nonterminal
 function lookupDef
 [FlowDef] ::= nt::String  attr::String  e::FlowEnv
@@ -105,6 +112,13 @@ function lookupLocalInh
 [FlowDef] ::= prod::String  fName::String  attr::String  e::FlowEnv
 {
   return searchEnvTree(crossnames(prod, crossnames(fName, attr)), e.localInhTree);
+}
+
+-- inherited equation for a translation attribute on a local in a production
+function lookupLocalTransInh
+[FlowDef] ::= prod::String  fName::String  transAttr::String  attr::String  e::FlowEnv
+{
+  return searchEnvTree(crossnames(prod, crossnames(fName, s"${transAttr}.${attr}")), e.inhTree);
 }
 
 function lookupLocalEq

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -141,13 +141,6 @@ function lookupLocalSynTransUniqueRefs
   return searchEnvTree(fName ++ "." ++ attrName, e.uniqueRefTree);
 }
 
--- unique references taken for a synthesized translation attribute on a child
-function lookupInhTransUniqueRefs
-[UniqueRefSite] ::= prod::String attrName::String e::FlowEnv
-{
-  return searchEnvTree(prod ++ "." ++ attrName, e.uniqueRefTree);
-}
-
 -- possible decoration sites for unique references taken for a child
 function lookupRefPossibleDecSites
 [VertexType] ::= prod::String  sigName::String  e::FlowEnv
@@ -188,13 +181,6 @@ function lookupLocalSynTransRefDecSite
 [VertexType] ::= fName::String  attrName::String  e::FlowEnv
 {
   return searchEnvTree(s"${fName}.${attrName}", e.refDecSiteTree);
-}
-
--- unconditional decoration sites for unique references taken for an inherited translation attribute on the lhs
-function lookupInhTransRefDecSite
-[VertexType] ::= prod::String  attrName::String  e::FlowEnv
-{
-  return searchEnvTree(s"${prod}.${attrName}", e.refDecSiteTree);
 }
 
 {--

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -176,6 +176,27 @@ function lookupLocalRefDecSite
   return searchEnvTree(fName, e.refDecSiteTree);
 }
 
+-- unconditional decoration sites for unique references taken for a synthesized translation attribute on a child
+function lookupSynTransRefDecSite
+[VertexType] ::= prod::String  sigName::String  attrName::String  e::FlowEnv
+{
+  return searchEnvTree(s"${prod}:${sigName}.${attrName}", e.refDecSiteTree);
+}
+
+-- unconditional decoration sites for unique references taken for a synthesized translation attribute on a local/production attribute
+function lookupLocalSynTransRefDecSite
+[VertexType] ::= fName::String  attrName::String  e::FlowEnv
+{
+  return searchEnvTree(s"${fName}.${attrName}", e.refDecSiteTree);
+}
+
+-- unconditional decoration sites for unique references taken for an inherited translation attribute on the lhs
+function lookupInhTransRefDecSite
+[VertexType] ::= prod::String  attrName::String  e::FlowEnv
+{
+  return searchEnvTree(s"${prod}.${attrName}", e.refDecSiteTree);
+}
+
 {--
  - This is a glorified lambda function, to help look for equations.
  - Literally, we're just checking for null here.

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -127,15 +127,15 @@ function lookupLocalUniqueRefs
   return searchEnvTree(fName, e.uniqueRefTree);
 }
 
--- unique references taken for a synthesized translation attribute on a child
-function lookupSynTransUniqueRefs
+-- unique references taken for a translation attribute on a child
+function lookupTransUniqueRefs
 [UniqueRefSite] ::= prod::String sigName::String attrName::String e::FlowEnv
 {
   return searchEnvTree(prod ++ ":" ++ sigName ++ "." ++ attrName, e.uniqueRefTree);
 }
 
--- unique references taken for a synthesized translation attribute on a local
-function lookupLocalSynTransUniqueRefs
+-- unique references taken for a translation attribute on a local
+function lookupLocalTransUniqueRefs
 [UniqueRefSite] ::= fName::String attrName::String e::FlowEnv
 {
   return searchEnvTree(fName ++ "." ++ attrName, e.uniqueRefTree);
@@ -155,15 +155,15 @@ function lookupLocalRefPossibleDecSites
   return searchEnvTree(fName, e.refPossibleDecSiteTree);
 }
 
--- possible decoration sites for unique references taken for a synthesized translation attribute on a child
-function lookupSynTransRefPossibleDecSites
+-- possible decoration sites for unique references taken for a translation attribute on a child
+function lookupTransRefPossibleDecSites
 [VertexType] ::= prod::String  sigName::String  attrName::String  e::FlowEnv
 {
   return searchEnvTree(s"${prod}:${sigName}.${attrName}", e.refPossibleDecSiteTree);
 }
 
--- possible decoration sites for unique references taken for a synthesized translation attribute on a local/production attribute
-function lookupLocalSynTransRefPossibleDecSites
+-- possible decoration sites for unique references taken for a translation attribute on a local/production attribute
+function lookupLocalTransRefPossibleDecSites
 [VertexType] ::= fName::String  attrName::String  e::FlowEnv
 {
   return searchEnvTree(s"${fName}.${attrName}", e.refPossibleDecSiteTree);
@@ -183,15 +183,15 @@ function lookupLocalRefDecSite
   return searchEnvTree(fName, e.refDecSiteTree);
 }
 
--- unconditional decoration sites for unique references taken for a synthesized translation attribute on a child
-function lookupSynTransRefDecSite
+-- unconditional decoration sites for unique references taken for a translation attribute on a child
+function lookupTransRefDecSite
 [VertexType] ::= prod::String  sigName::String  attrName::String  e::FlowEnv
 {
   return searchEnvTree(s"${prod}:${sigName}.${attrName}", e.refDecSiteTree);
 }
 
--- unconditional decoration sites for unique references taken for a synthesized translation attribute on a local/production attribute
-function lookupLocalSynTransRefDecSite
+-- unconditional decoration sites for unique references taken for a translation attribute on a local/production attribute
+function lookupLocalTransRefDecSite
 [VertexType] ::= fName::String  attrName::String  e::FlowEnv
 {
   return searchEnvTree(s"${fName}.${attrName}", e.refDecSiteTree);

--- a/grammars/silver/compiler/definition/flow/env/NonterminalDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/NonterminalDcl.sv
@@ -23,7 +23,9 @@ top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTy
 }
 
 -- If it is inherited and exported by this grammar (according to authority)
--- Also includes inherited on translation attributes
+-- Also includes inherited on translation attributes.
+-- Note that we only include trans.inh when both trans and inh are exported by nt's grammar.
+-- We might want to consider including all trans.inh where inh is in the ref set of trans's nonterminal.
 function getInhAttrsOnForReferences
 [String] ::= nt::String  e::Decorated Env  authority::(Boolean ::= String)
 {
@@ -37,7 +39,7 @@ function getInhAttrsOnForReferences
     | at :: _ when authority(occ.sourceGrammar) ->
         if at.isInherited
         then [occ.attrOccurring]
-        else if at.isSynthesized
+        else if at.isSynthesized && at.isTranslation
         then flatMap(\ occ2::OccursDclInfo ->
           case getAttrDcl(occ2.attrOccurring, e) of
           | at2 :: _ when authority(occ2.sourceGrammar) && at2.isInherited ->

--- a/grammars/silver/compiler/definition/flow/env/NonterminalDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/NonterminalDcl.sv
@@ -1,5 +1,6 @@
 grammar silver:compiler:definition:flow:env;
 
+import silver:compiler:definition:type;
 import silver:compiler:definition:type:syntax only BracketedOptTypeExprs;
 import silver:compiler:driver:util only isStrictlyExportedBy;
 
@@ -10,9 +11,7 @@ top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTy
   -- Here, to avoid creating a hard dependency on options, we ignore options when
   -- deciding the include things in the *inferred* ref set. (Thus, isStrictlyExportedBy.)
   local inferredInhs :: [String] =
-    flatMap(
-      filterOccursForReferences(_, top.env, isStrictlyExportedBy(_, [top.grammarName], top.compiledGrammars)),
-      getAttrsOn(fName, top.env));
+    getInhAttrsOnForReferences(fName, top.env, isStrictlyExportedBy(_, [top.grammarName], top.compiledGrammars));
   
   local specInhs :: Maybe<[String]> =
     map(fst, lookup("decorate", getFlowTypeSpecFor(fName, top.flowEnv)));
@@ -24,14 +23,29 @@ top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTy
 }
 
 -- If it is inherited and exported by this grammar (according to authority)
-function filterOccursForReferences
-[String] ::= occ::OccursDclInfo  e::Decorated Env  authority::(Boolean ::= String)
+function getInhAttrsOnForReferences
+[String] ::= nt::String  e::Decorated Env  authority::(Boolean ::= String)
 {
-  return case getAttrDcl(occ.attrOccurring, e) of
-         | at :: _ ->
-             if at.isInherited && authority(occ.sourceGrammar)
-             then [occ.attrOccurring]
-             else []
-         | _ -> []
-         end; 
+  local ntty::Type =
+    case getTypeDcl(nt, e) of
+    | ty :: _ -> ty.typeScheme.monoType
+    | [] -> errorType()
+    end;
+  return flatMap(\ occ::OccursDclInfo ->
+    case getAttrDcl(occ.attrOccurring, e) of
+    | at :: _ when authority(occ.sourceGrammar) ->
+        if at.isInherited
+        then [occ.attrOccurring]
+        else if at.isSynthesized
+        then flatMap(\ occ2::OccursDclInfo ->
+          case getAttrDcl(occ2.attrOccurring, e) of
+          | at2 :: _ when authority(occ2.sourceGrammar) && at2.isInherited ->
+            [s"${occ.attrOccurring}.${occ2.attrOccurring}"]
+          | _ -> []
+          end,
+          getAttrOccursOn(determineAttributeType(occ, ntty).typeName, e))
+        else []
+    | _ -> []
+    end,
+    getAttrOccursOn(nt, e)); 
 }

--- a/grammars/silver/compiler/definition/flow/env/NonterminalDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/NonterminalDcl.sv
@@ -23,6 +23,7 @@ top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTy
 }
 
 -- If it is inherited and exported by this grammar (according to authority)
+-- Also includes inherited on translation attributes
 function getInhAttrsOnForReferences
 [String] ::= nt::String  e::Decorated Env  authority::(Boolean ::= String)
 {

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -124,55 +124,70 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
   e.alwaysDecorated = false;
 }
 
+-- The flow vertex type corresponding to attributes on this DefLHS
 synthesized attribute defLHSVertex::VertexType occurs on DefLHS;
+
+-- The constructor for inherited equations on this DefLHS
 synthesized attribute defLHSInhEq::[(FlowDef ::= [FlowVertex])] occurs on DefLHS;
+
+-- The name of the inherited attribute described by this DefLHS.  May be syn.inh for translation attributes.
+synthesized attribute inhAttrName::String occurs on DefLHS;
+
 aspect production errorDefLHS
 top::DefLHS ::= q::Decorated! QName
 {
   top.defLHSVertex = localVertexType("bogus:lhs:vertex");
   top.defLHSInhEq = [];
+  top.inhAttrName = "";
 }
 aspect production childDefLHS
 top::DefLHS ::= q::Decorated! QName
 {
   top.defLHSVertex = rhsVertexType(q.lookupValue.fullName);
   top.defLHSInhEq = [inhEq(top.frame.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, _)];
+  top.inhAttrName = top.defLHSattr.attrDcl.fullName;
 }
 aspect production lhsDefLHS
 top::DefLHS ::= q::Decorated! QName
 {
   top.defLHSVertex = lhsVertexType;
   top.defLHSInhEq = [];
+  top.inhAttrName = top.defLHSattr.attrDcl.fullName;
 }
 aspect production localDefLHS
 top::DefLHS ::= q::Decorated! QName
 {
   top.defLHSVertex = localVertexType(q.lookupValue.fullName);
   top.defLHSInhEq = [localInhEq(top.frame.fullName, q.lookupValue.fullName, top.defLHSattr.attrDcl.fullName, _)];
+  top.inhAttrName = top.defLHSattr.attrDcl.fullName;
 }
 aspect production forwardDefLHS
 top::DefLHS ::= q::Decorated! QName
 {
   top.defLHSVertex = forwardVertexType;
   top.defLHSInhEq = [fwdInhEq(top.frame.fullName, top.defLHSattr.attrDcl.fullName, _)];
+  top.inhAttrName = top.defLHSattr.attrDcl.fullName;
 }
 aspect production errorTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
   top.defLHSVertex = localVertexType("bogus:lhs:vertex");
   top.defLHSInhEq = [];
+  top.inhAttrName = "";
 }
 aspect production childTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
   top.defLHSVertex = synTransAttrVertexType(rhsVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
   top.defLHSInhEq = [synTransInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, _)];
+  top.inhAttrName = s"${attr.attrDcl.fullName}.${top.defLHSattr.attrDcl.fullName}";
 }
 aspect production localTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
   top.defLHSVertex = synTransAttrVertexType(localVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
   top.defLHSInhEq = [localSynTransInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, _)];
+  top.inhAttrName = s"${attr.attrDcl.fullName}.${top.defLHSattr.attrDcl.fullName}";
 }
 
 aspect production errorValueDef

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -112,7 +112,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
       [defaultSynEq(top.frame.lhsNtName, attr.attrDcl.fullName, e.flowDeps)];
   e.decSiteVertexInfo =
     if attr.found && attr.attrDcl.isTranslation
-    then just(synTransAttrVertexType(dl.defLHSVertex, attr.attrDcl.fullName))
+    then just(transAttrVertexType(dl.defLHSVertex, attr.attrDcl.fullName))
     else nothing();
   e.alwaysDecorated = false;
 }
@@ -178,15 +178,15 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 aspect production childTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  top.defLHSVertex = synTransAttrVertexType(rhsVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
-  top.defLHSInhEq = [synTransInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, _)];
+  top.defLHSVertex = transAttrVertexType(rhsVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
+  top.defLHSInhEq = [transInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, _)];
   top.inhAttrName = s"${attr.attrDcl.fullName}.${top.defLHSattr.attrDcl.fullName}";
 }
 aspect production localTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  top.defLHSVertex = synTransAttrVertexType(localVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
-  top.defLHSInhEq = [localSynTransInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, _)];
+  top.defLHSVertex = transAttrVertexType(localVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
+  top.defLHSInhEq = [localTransInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, _)];
   top.inhAttrName = s"${attr.attrDcl.fullName}.${top.defLHSattr.attrDcl.fullName}";
 }
 

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -114,7 +114,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
     if attr.found && attr.attrDcl.isTranslation
     then just(transAttrVertexType(dl.defLHSVertex, attr.attrDcl.fullName))
     else nothing();
-  e.alwaysDecorated = false;
+  e.alwaysDecorated = attr.found && attr.attrDcl.isTranslation;
 }
 aspect production inheritedAttributeDef
 top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -120,10 +120,7 @@ aspect production inheritedAttributeDef
 top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  e::Expr
 {
   top.flowDefs <- flap(dl.defLHSInhEq, e.flowDeps);
-  e.decSiteVertexInfo =
-    if attr.found && attr.attrDcl.isTranslation
-    then just(inhTransAttrVertexType(dl.defLHSVertex, attr.attrDcl.fullName))
-    else nothing();
+  e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
 }
 
@@ -168,27 +165,13 @@ top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 aspect production childTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  top.defLHSVertex = inhTransAttrVertexType(rhsVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
+  top.defLHSVertex = synTransAttrVertexType(rhsVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
   top.defLHSInhEq = [synTransInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, _)];
-}
-aspect production lhsTransAttrDefLHS
-top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
-{
-  top.defLHSVertex = inhTransAttrVertexType(lhsVertexType, attr.attrDcl.fullName);
-  
-  local ntDefGram :: String = hackGramFromFName(top.frame.lhsNtName);
-
-  local srcGrams :: [String] = [ntDefGram, hackGramFromDcl(top.defLHSattr)];
-
-  local mayAffectFlowType :: Boolean =
-    isExportedBy(top.grammarName, srcGrams, top.compiledGrammars);
-
-  top.defLHSInhEq = [inhTransInhEq(top.frame.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, _, mayAffectFlowType)];
 }
 aspect production localTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  top.defLHSVertex = inhTransAttrVertexType(localVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
+  top.defLHSVertex = synTransAttrVertexType(localVertexType(q.lookupValue.fullName), attr.attrDcl.fullName);
   top.defLHSInhEq = [localSynTransInhEq(top.frame.fullName, q.lookupValue.fullName, attr.attrDcl.fullName, top.defLHSattr.attrDcl.fullName, _)];
 }
 

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -133,8 +133,8 @@ synthesized attribute defLHSInhEq::[(FlowDef ::= [FlowVertex])] occurs on DefLHS
 -- The name of the inherited attribute described by this DefLHS.  May be syn.inh for translation attributes.
 synthesized attribute inhAttrName::String occurs on DefLHS;
 
-aspect production errorDefLHS
-top::DefLHS ::= q::Decorated! QName
+aspect default production
+top::DefLHS ::=
 {
   top.defLHSVertex = localVertexType("bogus:lhs:vertex");
   top.defLHSInhEq = [];
@@ -152,7 +152,7 @@ top::DefLHS ::= q::Decorated! QName
 {
   top.defLHSVertex = lhsVertexType;
   top.defLHSInhEq = [];
-  top.inhAttrName = top.defLHSattr.attrDcl.fullName;
+  top.inhAttrName = "";
 }
 aspect production localDefLHS
 top::DefLHS ::= q::Decorated! QName
@@ -167,13 +167,6 @@ top::DefLHS ::= q::Decorated! QName
   top.defLHSVertex = forwardVertexType;
   top.defLHSInhEq = [fwdInhEq(top.frame.fullName, top.defLHSattr.attrDcl.fullName, _)];
   top.inhAttrName = top.defLHSattr.attrDcl.fullName;
-}
-aspect production errorTransAttrDefLHS
-top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
-{
-  top.defLHSVertex = localVertexType("bogus:lhs:vertex");
-  top.defLHSInhEq = [];
-  top.inhAttrName = "";
 }
 aspect production childTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -132,6 +132,26 @@ top::FlowSpecId ::= syn::QNameAttrOccur
     else [err(syn.location, syn.name ++ " is not a synthesized attribute, and so cannot have a flow type")];
 }
 
+concrete production transSpecId
+top::FlowSpecId ::= transInh::QNameAttrOccur '.' inh::QNameAttrOccur
+{
+  top.name = s"${transInh.name}.${inh.name}";
+  top.unparse = s"${transInh.unparse}.${inh.unparse}";
+  top.synName = s"${transInh.attrDcl.fullName}.${inh.attrDcl.fullName}";
+  top.authorityGrammar = inh.dcl.sourceGrammar;
+  top.found = transInh.found && transInh.attrDcl.isInherited && inh.found && inh.attrDcl.isInherited;
+  
+  transInh.attrFor = top.onNt;
+  inh.attrFor = transInh.typerep;
+  
+  top.errors <-
+    if !transInh.found || transInh.attrDcl.isInherited && transInh.attrDcl.isTranslation then []
+    else [err(transInh.location, transInh.name ++ " is not an inherited translation attribute, and so cannot appear in a flow type identifer")];
+  top.errors <-
+    if !inh.found || inh.attrDcl.isInherited then []
+    else [err(inh.location, inh.name ++ " is not an inherited attribute, and so cannot appear in a flow type identifer")];
+}
+
 concrete production forwardSpecId
 top::FlowSpecId ::= 'forward'
 {
@@ -191,6 +211,27 @@ top::FlowSpecInh ::= inh::QNameAttrOccur
   
   inh.attrFor = top.onNt;
 
+  top.errors <-
+    if !inh.found || inh.attrDcl.isInherited then []
+    else [err(inh.location, inh.name ++ " is not an inherited attribute and so cannot be within a flow type")];
+}
+
+concrete production flowSpecTrans
+top::FlowSpecInh ::= transSyn::QNameAttrOccur '.' inh::QNameAttrOccur
+{
+  top.unparse = s"${transSyn.unparse}.${inh.unparse}";
+  top.inhList :=
+    if transSyn.attrFound && inh.attrFound
+    then [s"${transSyn.attrDcl.fullName}.${inh.attrDcl.fullName}"]
+    else [];
+  top.refList := [];
+
+  transSyn.attrFor = top.onNt;
+  inh.attrFor = transSyn.typerep;
+
+  top.errors <-
+    if !transSyn.found || transSyn.attrDcl.isSynthesized && transSyn.attrDcl.isTranslation then []
+    else [err(transSyn.location, transSyn.name ++ " is not a synthesized translation attribute and so cannot be within a flow type")];
   top.errors <-
     if !inh.found || inh.attrDcl.isInherited then []
     else [err(inh.location, inh.name ++ " is not an inherited attribute and so cannot be within a flow type")];

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -211,7 +211,7 @@ top::FlowSpecInh ::= transSyn::QNameAttrOccur '.' inh::QNameAttrOccur
 
   top.errors <-
     if !transSyn.found || transSyn.attrDcl.isSynthesized && transSyn.attrDcl.isTranslation then []
-    else [err(transSyn.location, transSyn.name ++ " is not a synthesized translation attribute and so cannot be within a flow type")];
+    else [err(transSyn.location, transSyn.name ++ " is not a translation attribute and so cannot be within a flow type")];
   top.errors <-
     if !inh.found || inh.attrDcl.isInherited then []
     else [err(inh.location, inh.name ++ " is not an inherited attribute and so cannot be within a flow type")];

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -132,26 +132,6 @@ top::FlowSpecId ::= syn::QNameAttrOccur
     else [err(syn.location, syn.name ++ " is not a synthesized attribute, and so cannot have a flow type")];
 }
 
-concrete production transSpecId
-top::FlowSpecId ::= transInh::QNameAttrOccur '.' inh::QNameAttrOccur
-{
-  top.name = s"${transInh.name}.${inh.name}";
-  top.unparse = s"${transInh.unparse}.${inh.unparse}";
-  top.synName = s"${transInh.attrDcl.fullName}.${inh.attrDcl.fullName}";
-  top.authorityGrammar = inh.dcl.sourceGrammar;
-  top.found = transInh.found && transInh.attrDcl.isInherited && inh.found && inh.attrDcl.isInherited;
-  
-  transInh.attrFor = top.onNt;
-  inh.attrFor = transInh.typerep;
-  
-  top.errors <-
-    if !transInh.found || transInh.attrDcl.isInherited && transInh.attrDcl.isTranslation then []
-    else [err(transInh.location, transInh.name ++ " is not an inherited translation attribute, and so cannot appear in a flow type identifer")];
-  top.errors <-
-    if !inh.found || inh.attrDcl.isInherited then []
-    else [err(inh.location, inh.name ++ " is not an inherited attribute, and so cannot appear in a flow type identifer")];
-}
-
 concrete production forwardSpecId
 top::FlowSpecId ::= 'forward'
 {

--- a/grammars/silver/compiler/extension/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/convenience/Convenience.sv
@@ -81,6 +81,16 @@ top::AGDcl ::= 'synthesized' 'attribute' a::Name tl::BracketedOptTypeExprs '::' 
     location=top.location);
 }
 
+concrete production attributeDclTransMultiple
+top::AGDcl ::= 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr 'occurs' 'on' qs::QNames ';'
+{
+  top.unparse = "translation attribute " ++ a.name ++ tl.unparse ++ " :: " ++ te.unparse ++ " occurs on " ++ qs.unparse ++ ";" ;
+  forwards to appendAGDcl(
+    attributeDclTrans($1, $2, a, tl, $5, te, $10, location=top.location),
+    makeOccursDclsHelp(top.location, qNameWithTL(qNameId(a, location=a.location), tl), qs.qnames),
+    location=top.location);
+}
+
 concrete production collectionAttributeDclInhMultiple
 top::AGDcl ::= 'inherited' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr 'with' q::NameOrBOperator 'occurs' 'on' qs::QNames ';'
 {

--- a/grammars/silver/compiler/extension/doc/core/AGDcl.sv
+++ b/grammars/silver/compiler/extension/doc/core/AGDcl.sv
@@ -68,6 +68,15 @@ top::AGDcl ::= 'inherited' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te
   top.docs := [mkUndocumentedItem(top.docForName, top)];
 }
 
+aspect production attributeDclTrans
+top::AGDcl ::= 'translation' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::TypeExpr ';'
+{
+  top.docForName = a.name;
+  top.docUnparse = s"`translation attribute ${a.name}${tl.unparse} :: ${te.unparse}`";
+  top.docDcls := [pair(a.name, docDclInfo(a.name, sourceLocation=top.location, sourceGrammar=top.grammarName))];
+  top.docs := [mkUndocumentedItem(top.docForName, top)];
+}
+
 aspect production nonterminalDcl
 top::AGDcl ::= quals::NTDeclQualifiers 'nonterminal' id::Name tl::BracketedOptTypeExprs nm::NonterminalModifiers ';'
 {

--- a/grammars/silver/compiler/extension/implicit_monads/Case.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Case.sv
@@ -104,6 +104,7 @@ top::Expr ::= 'case' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
   monadLocal.downSubst = ml.mUpSubst;
   monadLocal.finalSubst = top.finalSubst;
   monadLocal.expectedMonad = top.expectedMonad;
+  monadLocal.alwaysDecorated = false;
   monadLocal.originRules = top.originRules;
   monadLocal.isRoot = false;
   top.monadRewritten = monadLocal.monadRewritten;
@@ -118,7 +119,7 @@ top::Expr ::= 'case' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
                 decorate x.fst with {env=top.env; mDownSubst=top.mDownSubst;
                                      frame=top.frame; grammarName=top.grammarName; downSubst=top.mDownSubst;
                                      finalSubst=top.mDownSubst; compiledGrammars=top.compiledGrammars;
-                                     config=top.config; flowEnv=top.flowEnv;expectedMonad=top.expectedMonad;
+                                     config=top.config; alwaysDecorated = false; flowEnv=top.flowEnv;expectedMonad=top.expectedMonad;
                                      isRoot=top.isRoot; originRules=top.originRules;}
              in if isMonad(a.mtyperep, top.env) && monadsMatch(a.mtyperep, top.expectedMonad, top.mDownSubst).fst &&
                    !isMonad(performSubstitution(x.snd, top.mDownSubst), top.env)
@@ -126,7 +127,7 @@ top::Expr ::= 'case' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
                                      frame=top.frame; grammarName=top.grammarName; downSubst=top.mDownSubst;
                                      finalSubst=top.mDownSubst; compiledGrammars=top.compiledGrammars;
                                      config=top.config; flowEnv=top.flowEnv; monadicallyUsed=true;
-                                     expectedMonad=top.expectedMonad; isRoot=top.isRoot; originRules=top.originRules;}.monadicNames
+                                     expectedMonad=top.expectedMonad; alwaysDecorated = false; isRoot=top.isRoot; originRules=top.originRules;}.monadicNames
                 else []
              end ++ l,
            monadLocal.monadicNames, zipWith(\x::Expr y::Type -> pair(x,y), es.rawExprs, ml.patternTypeList));
@@ -143,7 +144,7 @@ Boolean ::= elst::[Expr] env::Decorated Env sub::Substitution f::BlockContext gn
               | e::etl ->
                 let etyp::Type = decorate e with {env=env; mDownSubst=sub; frame=f; grammarName=gn;
                                                   downSubst=sub; finalSubst=sub;
-                                                  compiledGrammars=cg; config=c; flowEnv=fe;
+                                                  compiledGrammars=cg; config=c; alwaysDecorated = false; flowEnv=fe;
                                                   expectedMonad=em; isRoot=iR; originRules=oR;}.mtyperep
                 in
                   fst(monadsMatch(etyp, em, sub)) ||  monadicallyUsedExpr(etl, env, sub, f, gn, cg, c, fe, em, iR, oR)
@@ -190,19 +191,7 @@ function monadicMatchTypesNames
   fails.-}
 aspect production caseExpr
 top::Expr ::= es::[Expr] ml::[AbstractMatchRule] complete::Boolean failExpr::Expr retType::Type {
-  local monadLocal::Expr = monadCompileCaseExpr(es, ml, failExpr, retType, top.location, top.env);
-  monadLocal.mDownSubst = top.mDownSubst;
-  monadLocal.frame = top.frame;
-  monadLocal.grammarName = top.grammarName;
-  monadLocal.compiledGrammars = top.compiledGrammars;
-  monadLocal.config = top.config;
-  monadLocal.env = top.env;
-  monadLocal.flowEnv = top.flowEnv;
-  monadLocal.downSubst = top.mDownSubst;
-  monadLocal.finalSubst = top.finalSubst;
-  monadLocal.expectedMonad = top.expectedMonad;
-  monadLocal.originRules = top.originRules;
-  monadLocal.isRoot = top.isRoot;
+  forward monadLocal = monadCompileCaseExpr(es, ml, failExpr, retType, top.location, top.env);
 
   top.monadRewritten = monadLocal.monadRewritten;
 
@@ -422,6 +411,7 @@ top::Expr ::= 'case_any' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
                   downSubst = top.mDownSubst;
                   finalSubst = top.mDownSubst;
                   expectedMonad = top.expectedMonad;
+                  alwaysDecorated = false;
                   isRoot = top.isRoot;
                   originRules = top.originRules;
                  }.monadRewritten,
@@ -491,7 +481,7 @@ Expr ::= exprs::[Expr] names::[String] loc::Location base::Expr
                               downSubst=sub; finalSubst=sub;
                               compiledGrammars=cg; config=c; flowEnv=fe;
                               expectedMonad=em; originRules = oR;
-                              isRoot = iR;}.mtyperep
+                              isRoot = iR; alwaysDecorated = false; }.mtyperep
            in
              if isMonad(ety, env) && fst(monadsMatch(ety, em, sub))
              then buildApplication(
@@ -596,6 +586,7 @@ top::MatchRule ::= pt::PatternList arr::Arrow_kwd e::Expr
   ne.frame = top.frame;
   ne.finalSubst = top.mDownSubst;
   ne.downSubst = top.mDownSubst;
+  ne.alwaysDecorated = false;
   ne.originRules = [];
   ne.isRoot = false;
 
@@ -616,6 +607,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr arr::Arrow_kwd e::Expr
   ncond.frame = top.frame;
   ncond.finalSubst = top.mDownSubst;
   ncond.downSubst = top.mDownSubst;
+  ncond.alwaysDecorated = false;
   ncond.originRules = [];
   ncond.isRoot = false;
   local ne::Expr = e;
@@ -627,6 +619,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr arr::Arrow_kwd e::Expr
   ne.frame = top.frame;
   ne.finalSubst = top.mDownSubst;
   ne.downSubst = top.mDownSubst;
+  ne.alwaysDecorated = false;
   ne.originRules = [];
   ne.isRoot = false;
 
@@ -647,6 +640,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr 'matches' p::Pattern arr::A
   ncond.frame = top.frame;
   ncond.finalSubst = top.mDownSubst;
   ncond.downSubst = top.mDownSubst;
+  ncond.alwaysDecorated = false;
   ncond.originRules = [];
   ncond.isRoot = false;
   local ne::Expr = e;
@@ -658,6 +652,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr 'matches' p::Pattern arr::A
   ne.frame = top.frame;
   ne.finalSubst = top.mDownSubst;
   ne.downSubst = top.mDownSubst;
+  ne.alwaysDecorated = false;
   ne.originRules = [];
   ne.isRoot = false;
 
@@ -708,6 +703,7 @@ top::AbstractMatchRule ::= pl::[Decorated Pattern] cond::Maybe<(Expr, Maybe<Patt
   ne.frame = top.temp_frame;
   ne.finalSubst = top.temp_finalSubst;
   ne.downSubst = top.temp_downSubst;
+  ne.alwaysDecorated = false;
   ne.originRules = [];
   ne.isRoot = false;
 

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -789,8 +789,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 aspect production transDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
-  e.mDownSubst = top.mDownSubst;
-  e.expectedMonad = top.expectedMonad;
   e.monadicallyUsed = false; --this needs to change when we decorate monadic trees
   top.monadicNames = if top.monadicallyUsed
                      then [access(e, '.', q, location=top.location)] ++ e.monadicNames
@@ -919,8 +917,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 aspect production transUndecoratedAccessErrorHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
-  e.mDownSubst = top.mDownSubst;
-  e.expectedMonad = top.expectedMonad;
   e.monadicallyUsed = false; --this needs to change when we decorate monadic trees
   top.monadicNames = if top.monadicallyUsed
                      then [access(e, '.', q, location=top.location)] ++ e.monadicNames

--- a/grammars/silver/compiler/extension/implicit_monads/Let.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Let.sv
@@ -19,6 +19,7 @@ top::Expr ::= la::AssignExpr  e::Expr
   ne.finalSubst = top.mUpSubst;
   ne.env = newScopeEnv(la.mdefs, top.env);
   ne.expectedMonad = top.expectedMonad;
+  ne.alwaysDecorated = top.alwaysDecorated;
   ne.originRules = top.originRules;
   ne.isRoot = top.isRoot;
 

--- a/grammars/silver/compiler/extension/implicit_monads/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/PrimitiveMatch.sv
@@ -264,6 +264,7 @@ top::PrimPattern ::= qn::QName '(' ns::VarBinders ')' arr::Arrow_kwd e::Expr
   ne.grammarName = top.grammarName;
   ne.config = top.config;
   ne.flowEnv = top.flowEnv;
+  ne.alwaysDecorated = false;
   ne.originRules = top.originRules;
   ne.isRoot = false;
 

--- a/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
@@ -200,6 +200,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS attr::Decorated! QNameAttrOccur e:
   propagate grammarName, compiledGrammars, config, frame, env, flowEnv, finalSubst, originRules;
 
   e.downSubst = top.downSubst;
+  e.alwaysDecorated = false;
   e.isRoot = true;
 
   top.containsPluck = false;
@@ -226,6 +227,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS attr::Decorated! QNameAttrOccur e:
   propagate grammarName, compiledGrammars, config, frame, env, flowEnv, finalSubst, originRules;
 
   e.downSubst = top.downSubst;
+  e.alwaysDecorated = false;
   e.isRoot = true;
 
   top.containsPluck = false;
@@ -257,6 +259,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS attr::Decorated! QNameAttrOccur e:
   e.downSubst = top.downSubst;
   e.mDownSubst = top.downSubst;
   e.finalSubst = e.mUpSubst;
+  e.alwaysDecorated = false;
   e.isRoot = true;
 
   e.expectedMonad = attr.typerep;
@@ -288,6 +291,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS attr::Decorated! QNameAttrOccur e:
   e.downSubst = top.downSubst;
   e.mDownSubst = top.downSubst;
   e.finalSubst = e.mUpSubst;
+  e.alwaysDecorated = false;
   e.isRoot = true;
 
   e.expectedMonad = attr.typerep;

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -8,7 +8,7 @@ propagate boundVars on Expr, Exprs, ExprInhs, ExprInh, AppExprs, AppExpr, AnnoAp
 
 attribute transform<ASTExpr> occurs on Expr;
 
-synthesized attribute decRuleExprs::[(String, Decorated Expr with {decorate, boundVars})] occurs on Expr, AssignExpr, PrimPatterns, PrimPattern;
+synthesized attribute decRuleExprs::[(String, Decorated Expr with {decorate, decSiteVertexInfo, boundVars})] occurs on Expr, AssignExpr, PrimPatterns, PrimPattern;
 
 aspect default production
 top::Expr ::=

--- a/grammars/silver/compiler/extension/rewriting/Pattern.sv
+++ b/grammars/silver/compiler/extension/rewriting/Pattern.sv
@@ -37,7 +37,7 @@ inherited attribute namedTypesHaveUniversalVars :: [(String, Boolean)] occurs on
 
 synthesized attribute wrappedMatchRuleList :: [AbstractMatchRule] occurs on MRuleList, MatchRule;
 
-inherited attribute decRuleExprsIn::[(String, Decorated Expr with {decorate, boundVars})] occurs on MRuleList, MatchRule;
+inherited attribute decRuleExprsIn::[(String, Decorated Expr with {decorate, decSiteVertexInfo, boundVars})] occurs on MRuleList, MatchRule;
 inherited attribute ruleIndex::Integer occurs on MRuleList, MatchRule;
 
 propagate decRuleExprsIn on MRuleList;

--- a/grammars/silver/compiler/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/compiler/extension/rewriting/Rewriting.sv
@@ -220,6 +220,8 @@ top::Expr ::= 'rule' 'on' ty::TypeExpr 'of' Opt_Vbar_t ml::MRuleList 'end'
   checkExpr.config = top.config;
   checkExpr.compiledGrammars = top.compiledGrammars;
   checkExpr.boundVars = [];
+  checkExpr.alwaysDecorated = false;
+  checkExpr.decSiteVertexInfo = nothing();
   checkExpr.isRoot = false;
   checkExpr.originRules = top.originRules;
   

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -237,15 +237,12 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
       exprInhsCons(_, _, location=top.location),
       exprInhsEmpty(location=top.location),
       map(
-        \ a::AttributeDclInfo ->
+        \ attr::String ->
+          -- TODO: translation attributes!
           Silver_ExprInh {
-            $name{a.fullName} = $name{top.frame.signature.outputElement.elementName}.$name{a.fullName};
+            $name{attr} = $name{top.frame.signature.outputElement.elementName}.$name{attr};
           },
-        filter(
-          (.isInherited),
-          flatMap(
-            getAttrDcl(_, top.env),
-            map((.attrOccurring), getAttrsOn(top.frame.lhsNtName, top.env))))));
+        getInhAttrsOn(top.frame.lhsNtName, top.env)));
   top.partialTranslation =
     -- Optimizations when one or both of these is total, in this case a
     -- monadic bind may not be required.

--- a/grammars/silver/compiler/modification/copper/DclInfo.sv
+++ b/grammars/silver/compiler/modification/copper/DclInfo.sv
@@ -22,6 +22,8 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.refDispatcher = parserAttributeReference(_, location=_);
   top.defDispatcher = parserAttributeValueDef(_, _, location=_);
   top.defLHSDispatcher = parserAttributeDefLHS(_, location=_);
+  top.transDefLHSDispatcher = \ q::Decorated! QName  Decorated! QNameAttrOccur  l::Location ->
+    parserAttributeDefLHS(q, location=l);
 }
 
 {--
@@ -40,6 +42,7 @@ top::ValueDclInfo ::= fn::String
   top.refDispatcher = pluckTerminalReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
   top.defLHSDispatcher = errorDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 
 {--
@@ -59,6 +62,7 @@ top::ValueDclInfo ::= fn::String  superClasses::[String]
   top.refDispatcher = lexerClassReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
   top.defLHSDispatcher = errorDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 
 {--
@@ -75,6 +79,7 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.refDispatcher = termAttrValueReference(_, location=_);
   top.defDispatcher = termAttrValueValueDef(_, _, location=_);
   top.defLHSDispatcher = errorDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 
 {--
@@ -91,6 +96,8 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.refDispatcher = actionChildReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_);
   top.defLHSDispatcher = parserAttributeDefLHS(_, location=_); -- TODO: specialize this
+  top.transDefLHSDispatcher = \ q::Decorated! QName  Decorated! QNameAttrOccur  l::Location ->
+    parserAttributeDefLHS(q, location=l);
 }
 
 {--
@@ -108,4 +115,6 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.refDispatcher = parserAttributeReference(_, location=_);
   top.defDispatcher = parserAttributeValueDef(_, _, location=_);
   top.defLHSDispatcher = parserAttributeDefLHS(_, location=_);
+  top.transDefLHSDispatcher = \ q::Decorated! QName  Decorated! QNameAttrOccur  l::Location ->
+    parserAttributeDefLHS(q, location=l);
 }

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -9,6 +9,7 @@ import silver:compiler:analysis:typechecking:core;
 import silver:compiler:translation:java;
 
 import silver:compiler:definition:flow:env;
+import silver:compiler:definition:flow:ast only lhsVertexType;
 import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, constructDefaultProductionGraph; -- for the "oh no again!" hack below
 import silver:compiler:driver:util only RootSpec; -- ditto
 
@@ -98,6 +99,7 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.refDispatcher = lhsReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- TODO: be smarter about the error message
   top.defLHSDispatcher = defaultLhsDefLHS(_, location=_);
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 
 abstract production defaultLhsDefLHS
@@ -115,6 +117,10 @@ top::DefLHS ::= q::Decorated! QName
     else [err(q.location, "Cannot define inherited attribute '" ++ top.defLHSattr.name ++ "' on the lhs '" ++ q.name ++ "'")];
   
   top.typerep = q.lookupValue.typeScheme.monoType;
+
+  top.defLHSVertex = lhsVertexType;
+  top.defLHSInhEq = [];
+  top.inhAttrName = "";
 
   top.translation = makeNTName(top.frame.lhsNtName) ++ ".defaultSynthesizedAttributes";
 }

--- a/grammars/silver/compiler/modification/lambda_fn/DclInfo.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/DclInfo.sv
@@ -23,6 +23,7 @@ top::ValueDclInfo ::= fn::String ty::Type id::Integer paramIndex::Integer
   top.refDispatcher = lambdaParamReference(_, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- should be impossible (never in scope at production level?)
   top.defLHSDispatcher = errorDefLHS(_, location=_); -- ditto
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 
 function lambdaParamDef

--- a/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/java/Lambda.sv
@@ -48,6 +48,8 @@ ${makeTyVarDecls(5, finTy.freeVariables)}
   -- (e.g. global id :: (a ::= a) = \ x::a -> x;)
   -- so freshen all skolem type vars in the run-time type representation.
   top.generalizedTranslation = lambdaTrans(transFreshTypeRep(finTy));
+
+  propagate initTransDecSites;
 }
 
 aspect production lambdaParamReference
@@ -55,4 +57,5 @@ top::Expr ::= q::Decorated! QName
 {
   top.translation = s"common.Util.<${finalType(top).transType}>demandIndex(lambda_${toString(q.lookupValue.dcl.lambdaId)}_args, ${toString(q.lookupValue.dcl.lambdaParamIndex)})";
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
+  top.initTransDecSites := "";
 }

--- a/grammars/silver/compiler/modification/let_fix/DclInfo.sv
+++ b/grammars/silver/compiler/modification/let_fix/DclInfo.sv
@@ -18,6 +18,7 @@ top::ValueDclInfo ::= fn::String ty::Type fi::Maybe<VertexType> fd::[FlowVertex]
   top.refDispatcher = lexicalLocalReference(_, fi, fd, rs, location=_);
   top.defDispatcher = errorValueDef(_, _, location=_); -- should be impossible (never in scope at production level?)
   top.defLHSDispatcher = errorDefLHS(_, location=_); -- ditto
+  top.transDefLHSDispatcher = errorTransAttrDefLHS(_, _, location=_);
 }
 
 function lexicalLocalDef

--- a/grammars/silver/compiler/modification/let_fix/java/Let.sv
+++ b/grammars/silver/compiler/modification/let_fix/java/Let.sv
@@ -28,9 +28,13 @@ top::Expr ::= la::AssignExpr  e::Expr
     if top.frame.lazyApplication
     then closureExpr
     else top.translation;
+  
+  propagate initTransDecSites;
 }
 
 synthesized attribute let_translation :: String occurs on AssignExpr;
+attribute initTransDecSites occurs on AssignExpr;
+propagate initTransDecSites on AssignExpr;
 
 function makeLocalValueName
 String ::= s::String
@@ -82,5 +86,7 @@ top::Expr ::= q::Decorated! QName  _ _ _
     else if needsUndecorating
     then "common.Thunk.transformUndecorate(" ++ makeLocalValueName(q.lookupValue.fullName) ++ ")"
     else makeLocalValueName(q.lookupValue.fullName);
+  
+  top.initTransDecSites := "";
 }
 

--- a/grammars/silver/compiler/modification/list/List.sv
+++ b/grammars/silver/compiler/modification/list/List.sv
@@ -59,6 +59,12 @@ top::Expr ::= h::Expr '::' t::Expr
 {
   top.unparse = "(" ++ h.unparse ++ " :: " ++ t.unparse ++ ")" ;
 
+  -- Needed to satisfy flow analysis, since we demand translation of h and t.
+  h.decSiteVertexInfo = nothing();
+  t.decSiteVertexInfo = nothing();
+  h.alwaysDecorated = false;
+  t.alwaysDecorated = false;
+
   forwards to application(
     baseExpr(
       qName(top.location, "silver:core:cons"),

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -27,17 +27,17 @@ nonterminal PrimPatterns with
   config, grammarName, env, compiledGrammars, frame,
   location, unparse, errors, freeVars,
   downSubst, upSubst, finalSubst,
-  scrutineeType, returnType, translation, originRules;
+  scrutineeType, returnType, translation, initTransDecSites, originRules;
 nonterminal PrimPattern with 
   config, grammarName, env, compiledGrammars, frame,
   location, unparse, errors, freeVars,
   downSubst, upSubst, finalSubst,
-  scrutineeType, returnType, translation, originRules;
+  scrutineeType, returnType, translation, initTransDecSites, originRules;
 
 inherited attribute scrutineeType :: Type;
 inherited attribute returnType :: Type;
 
-propagate config, grammarName, compiledGrammars, frame, errors, scrutineeType, returnType, originRules
+propagate config, grammarName, compiledGrammars, frame, errors, scrutineeType, returnType, initTransDecSites, originRules
   on PrimPatterns, PrimPattern;
 propagate env, finalSubst, freeVars on PrimPatterns, PrimPattern excluding prodPatternNormal, prodPatternGadt, conslstPattern;
 
@@ -138,6 +138,8 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
 
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication); 
   -- TODO there seems to be an opportunity here to avoid an anon class somehow...
+
+  propagate initTransDecSites;
 }
 
 concrete production onePattern

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -376,7 +376,7 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         end then
       -- Unique reference to a translation attribute on a child or local that is a remote decoration site:
       -- Note that this is not cached; uniqueness guarantees that it should only be demanded once.
-      s"${e.translation}.evalTrans(${q.attrOccursIndex}, ${q.attrOccursIndex}_dec_site)"
+      s"${e.translation}.evalTrans(${q.attrOccursIndex})"
     else
       -- Normal decorated reference:
       -- This may create the child, or demand it via the remote decoration site if the child has one.

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -418,7 +418,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
 {
   top.translation = s"((common.Decorable)${e.translation})" ++ 
     case inh of
-    | exprInhsEmpty() -> ".decorate(context, (common.Lazy[])null)"
+    | exprInhsEmpty() -> ".decorate(context, (common.Lazy[])null, (common.Lazy[][])null, (common.Lazy[])null)"
       -- Note: we don't NEED to pass context here, but it's good for error messages!
       -- When the user forgets to provide inherited attributes
       -- (especially important because we're implicitly inserted when accessing attributes
@@ -431,7 +431,8 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
       | t -> s"${makeNTName(t.typeName)}.num_inh_attrs"
       end ++ ", " ++
       s"new int[]{${implode(", ", inh.nameTrans)}}, " ++ 
-      s"new common.Lazy[]{${implode(", ", inh.valueTrans)}}))"
+      s"new common.Lazy[]{${implode(", ", inh.valueTrans)}}), " ++
+      "(common.Lazy[][])null, (common.Lazy[])null)"  -- TODO: permit supplying inhs on translation attributes
     end;
 
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -392,11 +392,11 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
       | childReference(cqn) ->
 	      s"\t\t// Decoration site for ${q.unparse}: ${decSite.vertexName}\n" ++
         s"\t\t${top.frame.className}.childInheritedAttributes[${top.frame.className}.i_${cqn.lookupValue.fullName}][${q.attrOccursInitIndex}_dec_site] = " ++
-        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, top.grammarName, top.frame.lhsNtName, decSite)};\n"
+        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, top.frame.lhsNtName, decSite)};\n"
       | localReference(lqn) ->
 	      s"\t\t// Decoration site for ${q.unparse}: ${decSite.vertexName}\n" ++
         s"\t\t${top.frame.className}.localInheritedAttributes[${lqn.lookupValue.dcl.attrOccursIndex}][${q.attrOccursInitIndex}_dec_site] = " ++
-        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, top.grammarName, top.frame.lhsNtName, decSite)};\n"
+        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, top.frame.lhsNtName, decSite)};\n"
       | _ -> ""
       end
     | _ -> ""

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -367,7 +367,7 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
   local finalTy::Type = finalType(top);
   top.translation =
     if !finalTy.isDecorated then
-      s"((${finalTy.transType})${e.translation}.translation(${q.attrOccursIndex}, ${q.attrOccursIndex}_dec_site).undecorate())"
+      s"((${finalTy.transType})${e.translation}.translation(${q.attrOccursIndex}, ${q.attrOccursIndex}_inhs, ${q.attrOccursIndex}_dec_site).undecorate())"
     else if finalTy.isUniqueDecorated && top.alwaysDecorated &&
         case e of
         | childReference(cqn) -> true
@@ -376,11 +376,11 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         end then
       -- Unique reference to a translation attribute on a child or local that is a remote decoration site:
       -- Note that this is not cached; uniqueness guarantees that it should only be demanded once.
-      s"${e.translation}.evalTrans(${q.attrOccursIndex})"
+      s"${e.translation}.evalTrans(${q.attrOccursIndex}, ${q.attrOccursIndex}_inhs)"
     else
       -- Normal decorated reference:
       -- This may create the child, or demand it via the remote decoration site if the child has one.
-      s"${e.translation}.translation(${q.attrOccursIndex}, ${q.attrOccursIndex}_dec_site)";
+      s"${e.translation}.translation(${q.attrOccursIndex}, ${q.attrOccursIndex}_inhs, ${q.attrOccursIndex}_dec_site)";
 
   -- TODO: Specialized thunks for accesses on child/local, for efficency
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);
@@ -437,7 +437,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
 {
   top.translation = s"((common.Decorable)${e.translation})" ++ 
     case inh of
-    | exprInhsEmpty() -> ".decorate(context, (common.Lazy[])null, (common.Lazy[][])null)"
+    | exprInhsEmpty() -> ".decorate(context, (common.Lazy[])null)"
       -- Note: we don't NEED to pass context here, but it's good for error messages!
       -- When the user forgets to provide inherited attributes
       -- (especially important because we're implicitly inserted when accessing attributes
@@ -450,8 +450,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
       | t -> s"${makeNTName(t.typeName)}.num_inh_attrs"
       end ++ ", " ++
       s"new int[]{${implode(", ", inh.nameTrans)}}, " ++ 
-      s"new common.Lazy[]{${implode(", ", inh.valueTrans)}}), " ++
-      "(common.Lazy[][])null)"  -- TODO: permit supplying inhs on translation attributes
+      s"new common.Lazy[]{${implode(", ", inh.valueTrans)}}))"
     end;
 
   top.lazyTranslation = wrapThunk(top.translation, top.frame.lazyApplication);

--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -35,7 +35,7 @@ propagate initTransDecSites on
 
 synthesized attribute invokeTranslation :: String occurs on Expr;
 inherited attribute invokeIsUnique :: Boolean occurs on Expr;
-inherited attribute invokeArgs :: Decorated AppExprs occurs on Expr;
+inherited attribute invokeArgs :: Decorated AppExprs with {decorate, decSiteVertexInfo, alwaysDecorated, appProd} occurs on Expr;
 inherited attribute invokeNamedArgs :: Decorated AnnoAppExprs occurs on Expr;
 inherited attribute sameProdAsProductionDefinedOn :: Boolean occurs on Expr;
 
@@ -252,7 +252,7 @@ top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs annos::Decorated! AnnoA
 }
 
 function argsTranslation
-String ::= e::Decorated AppExprs
+String ::= e::Decorated AppExprs with {decorate, decSiteVertexInfo, alwaysDecorated, appProd}
 {
   -- TODO: This is the ONLY use of .exprs  We could eliminate that, if we fix this.
   return implode(", ", map((.lazyTranslation), e.exprs));

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -78,10 +78,14 @@ ${makeIndexDcls(0, whatSig.inputElements)}
 	public static final String[] occurs_local = new String[num_local_attrs];
 
 	public static final common.Lazy[][] childInheritedAttributes = new common.Lazy[${toString(length(whatSig.inputElements))}][];
+    public static final common.Lazy[][][] childTransInheritedAttributes = new common.Lazy[${toString(length(whatSig.inputElements))}][][];
+    public static final common.Lazy[][] childTransDecSites = new common.Lazy[${toString(length(whatSig.inputElements))}][];
 
 	public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
     public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
 	public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
+    public static final common.Lazy[][][] localTransInheritedAttributes = new common.Lazy[num_local_attrs][][];
+    public static final common.Lazy[][] localTransDecSites = new common.Lazy[num_local_attrs][];
 
 ${whatSig.inhOccursIndexDecls}
 
@@ -120,7 +124,7 @@ ${implode("", map(makeChildAccessCaseLazy, whatSig.inputElements))}
 	@Override
 	public common.Lazy getChildDecSite(final int index) {
 		switch(index) {
-${implode("", map(makeChildDecSiteAccessCase(env, flowEnv, whatSig.fullName, _), whatSig.inputElements))}
+${implode("", map(makeChildDecSiteAccessCase(env, flowEnv, whatSig.outputElement.typerep.typeName, whatSig.fullName, _), whatSig.inputElements))}
             default: return null;
         }
     }
@@ -141,6 +145,26 @@ ${flatMap(makeInhOccursContextAccess(whatSig.freeVariables, whatSig.contextInhOc
 ${flatMap(makeInhOccursContextAccess(whatSig.freeVariables, whatSig.contextInhOccurs, "childInhContextTypeVars", "childInheritedAttributes", _), whatSig.inhOccursContextTypes)}
 		return childInheritedAttributes[key];
 	}
+
+    @Override
+    public common.Lazy[][] getLocalTransInheritedAttributes(final int key) {
+        return localTransInheritedAttributes[key];
+    }
+
+    @Override
+    public common.Lazy[][] getChildTransInheritedAttributes(final int key) {
+        return childTransInheritedAttributes[key];
+    }
+
+    @Override
+    public common.Lazy[] getLocalTransDecSite(final int key) {
+        return localTransDecSites[key];
+    }
+
+    @Override
+    public common.Lazy[][] getChildTransDecSite(final int key) {
+        return childTransDecSites[key];
+    }
 
 	@Override
 	public common.Lazy getLocal(final int key) {

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -157,12 +157,12 @@ ${flatMap(makeInhOccursContextAccess(whatSig.freeVariables, whatSig.contextInhOc
     }
 
     @Override
-    public common.Lazy[] getLocalTransDecSite(final int key) {
+    public common.Lazy[] getLocalTransDecSites(final int key) {
         return localTransDecSites[key];
     }
 
     @Override
-    public common.Lazy[][] getChildTransDecSite(final int key) {
+    public common.Lazy[] getChildTransDecSites(final int key) {
         return childTransDecSites[key];
     }
 
@@ -266,7 +266,7 @@ public class Main {
 
 		try {
 			common.Node rv = (common.Node) ${if isIOValReturn then invocationIOVal else invokationEvalIO};
-			common.DecoratedNode drv = rv.decorate(common.TopNode.singleton, (common.Lazy[])null);
+			common.DecoratedNode drv = rv.decorate();
 			drv.synthesized(silver.core.Init.silver_core_io__ON__silver_core_IOVal); // demand the io token
 			System.exit( (Integer)drv.synthesized(silver.core.Init.silver_core_iovalue__ON__silver_core_IOVal) );
 		} catch(Throwable t) {

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -79,13 +79,11 @@ ${makeIndexDcls(0, whatSig.inputElements)}
 
 	public static final common.Lazy[][] childInheritedAttributes = new common.Lazy[${toString(length(whatSig.inputElements))}][];
     public static final common.Lazy[][][] childTransInheritedAttributes = new common.Lazy[${toString(length(whatSig.inputElements))}][][];
-    public static final common.Lazy[][] childTransDecSites = new common.Lazy[${toString(length(whatSig.inputElements))}][];
 
 	public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
     public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
 	public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
     public static final common.Lazy[][][] localTransInheritedAttributes = new common.Lazy[num_local_attrs][][];
-    public static final common.Lazy[][] localTransDecSites = new common.Lazy[num_local_attrs][];
 
 ${whatSig.inhOccursIndexDecls}
 
@@ -154,16 +152,6 @@ ${flatMap(makeInhOccursContextAccess(whatSig.freeVariables, whatSig.contextInhOc
     @Override
     public common.Lazy[][] getChildTransInheritedAttributes(final int key) {
         return childTransInheritedAttributes[key];
-    }
-
-    @Override
-    public common.Lazy[] getLocalTransDecSites(final int key) {
-        return localTransDecSites[key];
-    }
-
-    @Override
-    public common.Lazy[] getChildTransDecSites(final int key) {
-        return childTransDecSites[key];
     }
 
 	@Override

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -78,12 +78,10 @@ ${makeIndexDcls(0, whatSig.inputElements)}
 	public static final String[] occurs_local = new String[num_local_attrs];
 
 	public static final common.Lazy[][] childInheritedAttributes = new common.Lazy[${toString(length(whatSig.inputElements))}][];
-    public static final common.Lazy[][][] childTransInheritedAttributes = new common.Lazy[${toString(length(whatSig.inputElements))}][][];
 
 	public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
     public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
 	public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
-    public static final common.Lazy[][][] localTransInheritedAttributes = new common.Lazy[num_local_attrs][][];
 
 ${whatSig.inhOccursIndexDecls}
 
@@ -143,16 +141,6 @@ ${flatMap(makeInhOccursContextAccess(whatSig.freeVariables, whatSig.contextInhOc
 ${flatMap(makeInhOccursContextAccess(whatSig.freeVariables, whatSig.contextInhOccurs, "childInhContextTypeVars", "childInheritedAttributes", _), whatSig.inhOccursContextTypes)}
 		return childInheritedAttributes[key];
 	}
-
-    @Override
-    public common.Lazy[][] getLocalTransInheritedAttributes(final int key) {
-        return localTransInheritedAttributes[key];
-    }
-
-    @Override
-    public common.Lazy[][] getChildTransInheritedAttributes(final int key) {
-        return childTransInheritedAttributes[key];
-    }
 
 	@Override
 	public common.Lazy getLocal(final int key) {

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -265,8 +265,7 @@ s"""private Object child_${n};
     if lookupBy(typeNameEq, ty, top.sigInhOccurs).isJust
     then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[count_inh__ON__${ntType.transTypeName}];\n"
     else if ty.isNonterminal || ty.isUniqueDecorated && ntType.isNonterminal
-    then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_inh_attrs];\n" ++
-      s"\t\tchildTransInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_syn_attrs][];\n"
+    then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_inh_attrs];\n"
     else "";
 
   top.typeChildren := [(ty, top.childRefElem)];

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -266,8 +266,7 @@ s"""private Object child_${n};
     then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[count_inh__ON__${ntType.transTypeName}];\n"
     else if ty.isNonterminal || ty.isUniqueDecorated && ntType.isNonterminal
     then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_inh_attrs];\n" ++
-      s"\t\tchildTransInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_syn_attrs][];\n" ++
-      s"\t\tchildTransDecSites[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_syn_attrs];\n"
+      s"\t\tchildTransInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_syn_attrs][];\n"
     else "";
 
   top.typeChildren := [(ty, top.childRefElem)];

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -265,7 +265,9 @@ s"""private Object child_${n};
     if lookupBy(typeNameEq, ty, top.sigInhOccurs).isJust
     then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[count_inh__ON__${ntType.transTypeName}];\n"
     else if ty.isNonterminal || ty.isUniqueDecorated && ntType.isNonterminal
-    then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_inh_attrs];\n"
+    then s"\t\tchildInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_inh_attrs];\n" ++
+      s"\t\tchildTransInheritedAttributes[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_syn_attrs][];\n" ++
+      s"\t\tchildTransDecSites[i_${n}] = new common.Lazy[${makeNTName(ntType.typeName)}.num_syn_attrs];\n"
     else "";
 
   top.typeChildren := [(ty, top.childRefElem)];
@@ -326,16 +328,16 @@ String ::= n::NamedSignatureElement
   return s"\t\t\tcase i_${n.elementName}: return child_${n.elementName};\n";
 }
 function makeChildDecSiteAccessCase
-String ::= env::Decorated Env flowEnv::FlowEnv prodName::String n::NamedSignatureElement
+String ::= env::Decorated Env flowEnv::FlowEnv lhsNtName::String prodName::String n::NamedSignatureElement
 {
   return
-    case lookupRefDecSite(prodName, n.elementName, flowEnv) of
-    | [v] -> s"\t\t\tcase i_${n.elementName}: return (context) -> ${refAccessTranslation(env, flowEnv, v)};\n"
-    | _ -> ""
+    case lookupUniqueRefs(prodName, n.elementName, flowEnv), lookupRefDecSite(prodName, n.elementName, flowEnv) of
+    | [u], [v] -> s"\t\t\tcase i_${n.elementName}: return (context) -> ${refAccessTranslation(env, flowEnv, u.sourceGrammar, lhsNtName, v)};\n"
+    | _, _ -> ""
     end;
 }
 function refAccessTranslation
-String ::= env::Decorated Env flowEnv::FlowEnv v::VertexType
+String ::= env::Decorated Env flowEnv::FlowEnv grammarName::String ntName::String v::VertexType
 {
   return
     case v of
@@ -346,10 +348,13 @@ String ::= env::Decorated Env flowEnv::FlowEnv v::VertexType
       | dcl :: _ -> s"context.localDecorated(${dcl.attrOccursIndex})"
       | [] -> error("Couldn't find decl for local " ++ fName)
       end
+    | transAttrVertexType(lhsVertexType_real(), transAttr) ->
+      s"context.translation(${makeName(grammarName)}.Init.${makeIdName(transAttr)}__ON__${makeIdName(ntName)})"
+    | transAttrVertexType(_, transAttr) -> error("trans attr on non-lhs can't be a ref decoration site")
     | forwardVertexType_real() -> s"context.forward()"
     | anonVertexType(_) -> error("dec site projection shouldn't happen with anon decorate")
     | subtermVertexType(parent, prodName, sigName) ->
-      s"${refAccessTranslation(env, flowEnv, parent)}.childDecorated(${makeProdName(prodName)}.i_${sigName})"
+      s"${refAccessTranslation(env, flowEnv, grammarName, ntName, parent)}.childDecorated(${makeProdName(prodName)}.i_${sigName})"
     end;
 }
 

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -330,12 +330,12 @@ String ::= env::Decorated Env flowEnv::FlowEnv lhsNtName::String prodName::Strin
 {
   return
     case lookupUniqueRefs(prodName, n.elementName, flowEnv), lookupRefDecSite(prodName, n.elementName, flowEnv) of
-    | [u], [v] -> s"\t\t\tcase i_${n.elementName}: return (context) -> ${refAccessTranslation(env, flowEnv, u.sourceGrammar, lhsNtName, v)};\n"
+    | [u], [v] -> s"\t\t\tcase i_${n.elementName}: return (context) -> ${refAccessTranslation(env, flowEnv, lhsNtName, v)};\n"
     | _, _ -> ""
     end;
 }
 function refAccessTranslation
-String ::= env::Decorated Env flowEnv::FlowEnv grammarName::String ntName::String v::VertexType
+String ::= env::Decorated Env flowEnv::FlowEnv lhsNtName::String v::VertexType
 {
   return
     case v of
@@ -347,14 +347,14 @@ String ::= env::Decorated Env flowEnv::FlowEnv grammarName::String ntName::Strin
       | [] -> error("Couldn't find decl for local " ++ fName)
       end
     | transAttrVertexType(lhsVertexType_real(), transAttr) ->
-      let transIndexName::String = s"${makeName(grammarName)}.Init.${makeIdName(transAttr)}__ON__${makeIdName(ntName)}"
+      let transIndexName::String = head(getOccursDcl(transAttr, lhsNtName, env)).attrGlobalOccursInitIndex
       in s"context.translation(${transIndexName}, ${transIndexName}_inhs, ${transIndexName}_dec_site)"
       end
     | transAttrVertexType(_, transAttr) -> error("trans attr on non-lhs can't be a ref decoration site")
     | forwardVertexType_real() -> s"context.forward()"
     | anonVertexType(_) -> error("dec site projection shouldn't happen with anon decorate")
     | subtermVertexType(parent, prodName, sigName) ->
-      s"${refAccessTranslation(env, flowEnv, grammarName, ntName, parent)}.childDecorated(${makeProdName(prodName)}.i_${sigName})"
+      s"${refAccessTranslation(env, flowEnv, lhsNtName, parent)}.childDecorated(${makeProdName(prodName)}.i_${sigName})"
     end;
 }
 

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -348,7 +348,7 @@ String ::= env::Decorated Env flowEnv::FlowEnv grammarName::String ntName::Strin
       end
     | transAttrVertexType(lhsVertexType_real(), transAttr) ->
       let transIndexName::String = s"${makeName(grammarName)}.Init.${makeIdName(transAttr)}__ON__${makeIdName(ntName)}"
-      in s"context.translation(${transIndexName}, ${transIndexName}_dec_site)"
+      in s"context.translation(${transIndexName}, ${transIndexName}_inhs, ${transIndexName}_dec_site)"
       end
     | transAttrVertexType(_, transAttr) -> error("trans attr on non-lhs can't be a ref decoration site")
     | forwardVertexType_real() -> s"context.forward()"

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -347,7 +347,9 @@ String ::= env::Decorated Env flowEnv::FlowEnv grammarName::String ntName::Strin
       | [] -> error("Couldn't find decl for local " ++ fName)
       end
     | transAttrVertexType(lhsVertexType_real(), transAttr) ->
-      s"context.translation(${makeName(grammarName)}.Init.${makeIdName(transAttr)}__ON__${makeIdName(ntName)})"
+      let transIndexName::String = s"${makeName(grammarName)}.Init.${makeIdName(transAttr)}__ON__${makeIdName(ntName)}"
+      in s"context.translation(${transIndexName}, ${transIndexName}_dec_site)"
+      end
     | transAttrVertexType(_, transAttr) -> error("trans attr on non-lhs can't be a ref decoration site")
     | forwardVertexType_real() -> s"context.forward()"
     | anonVertexType(_) -> error("dec site projection shouldn't happen with anon decorate")

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -150,73 +150,73 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		// This should never happen.
 		@Override
 		public common.Lazy getChildDecSite(final int child) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public common.Lazy[] getChildInheritedAttributes(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public int getNumberOfLocalAttrs() {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public String getNameOfLocalAttr(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public common.Lazy getLocal(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public common.Lazy getLocalDecSite(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public boolean getLocalIsForward(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public common.Lazy[] getLocalInheritedAttributes(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public boolean hasForward() {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public common.Node evalForward(final common.DecoratedNode context) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public common.Node evalUndecorate(final common.DecoratedNode context) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public common.Lazy[] getForwardInheritedAttributes() {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		@Override
 		public common.Lazy getSynthesized(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 
 		${if wantsTracking then s"""
 		@Override
 		public ${className} duplicate(common.Node redex, common.ConsCell notes) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should not exist in undecorated tree!");
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should not exist in tree after undecoration!\n");
 		}
 
 		@Override

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -105,13 +105,13 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		}
 
 		@Override
-		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs) {
-			return ref.decorate(parent, inhs);
+		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs, final common.Lazy[] transDecSites) {
+			return ref.decorate(parent, inhs, transInhs, transDecSites);
 		}
 
 		@Override
-		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.DecoratedNode fwdParent) {
-			return ref.decorate(parent, inhs, fwdParent);
+		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs, final common.Lazy[] transDecSites, final common.DecoratedNode fwdParent, final boolean fwdTrans) {
+			return ref.decorate(parent, inhs, transInhs, transDecSites, fwdParent, fwdTrans);
 		}
 
 		// Accessors used in reflection and debugging.
@@ -159,6 +159,16 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		}
 
 		@Override
+		public common.Lazy[][] getChildTransInheritedAttributes(final int index) {
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+		}
+
+		@Override
+		public common.Lazy[] getChildTransDecSites(final int index) {
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+		}
+
+		@Override
 		public int getNumberOfLocalAttrs() {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
 		}
@@ -185,6 +195,16 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 
 		@Override
 		public common.Lazy[] getLocalInheritedAttributes(final int index) {
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+		}
+
+		@Override
+		public common.Lazy[][] getLocalTransInheritedAttributes(final int index) {
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
+		}
+
+		@Override
+		public common.Lazy[] getLocalTransDecSites(final int index) {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
 		}
 

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -110,8 +110,8 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		}
 
 		@Override
-		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs, final common.DecoratedNode fwdParent, final boolean fwdTrans) {
-			return ref.decorate(parent, inhs, transInhs, fwdParent, fwdTrans);
+		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs, final common.DecoratedNode fwdParent, final boolean prodFwrd) {
+			return ref.decorate(parent, inhs, transInhs, fwdParent, prodFwrd);
 		}
 
 		// Accessors used in reflection and debugging.

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -214,7 +214,7 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		}
 
 		@Override
-		public common.Lazy getForwardInheritedAttributes(final int index) {
+		public common.Lazy[] getForwardInheritedAttributes() {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
 		}
 

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -105,13 +105,13 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		}
 
 		@Override
-		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs) {
-			return ref.decorate(parent, inhs, transInhs);
+		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs) {
+			return ref.decorate(parent, inhs);
 		}
 
 		@Override
-		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs, final common.DecoratedNode fwdParent, final boolean prodFwrd) {
-			return ref.decorate(parent, inhs, transInhs, fwdParent, prodFwrd);
+		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.DecoratedNode fwdParent, final boolean prodFwrd) {
+			return ref.decorate(parent, inhs, fwdParent, prodFwrd);
 		}
 
 		// Accessors used in reflection and debugging.
@@ -159,11 +159,6 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		}
 
 		@Override
-		public common.Lazy[][] getChildTransInheritedAttributes(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
-		}
-
-		@Override
 		public int getNumberOfLocalAttrs() {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
 		}
@@ -190,11 +185,6 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 
 		@Override
 		public common.Lazy[] getLocalInheritedAttributes(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
-		}
-
-		@Override
-		public common.Lazy[][] getLocalTransInheritedAttributes(final int index) {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
 		}
 

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -105,13 +105,13 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		}
 
 		@Override
-		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs, final common.Lazy[] transDecSites) {
-			return ref.decorate(parent, inhs, transInhs, transDecSites);
+		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs) {
+			return ref.decorate(parent, inhs, transInhs);
 		}
 
 		@Override
-		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs, final common.Lazy[] transDecSites, final common.DecoratedNode fwdParent, final boolean fwdTrans) {
-			return ref.decorate(parent, inhs, transInhs, transDecSites, fwdParent, fwdTrans);
+		public common.DecoratedNode decorate(final common.DecoratedNode parent, final common.Lazy[] inhs, final common.Lazy[][] transInhs, final common.DecoratedNode fwdParent, final boolean fwdTrans) {
+			return ref.decorate(parent, inhs, transInhs, fwdParent, fwdTrans);
 		}
 
 		// Accessors used in reflection and debugging.
@@ -164,11 +164,6 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 		}
 
 		@Override
-		public common.Lazy[] getChildTransDecSites(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
-		}
-
-		@Override
 		public int getNumberOfLocalAttrs() {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
 		}
@@ -200,11 +195,6 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 
 		@Override
 		public common.Lazy[][] getLocalTransInheritedAttributes(final int index) {
-			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
-		}
-
-		@Override
-		public common.Lazy[] getLocalTransDecSites(final int index) {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be driectly decorated!");
 		}
 

--- a/grammars/silver/compiler/translation/java/core/OccursDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/OccursDcl.sv
@@ -30,8 +30,8 @@ top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::
 
   top.valueWeaving <-
     if at.lookupAttribute.dcl.isTranslation then
-      s"public static final int ${head(occursCheck).attrOccursIndexName}_dec_site = " ++
-      s"${makeName(ntgrammar)}.Init.count_inh__ON__${ntname}++;\n"
+      s"public static final int ${head(occursCheck).attrOccursIndexName}_dec_site = ${makeName(ntgrammar)}.Init.count_inh__ON__${ntname}++;\n" ++
+      s"public static final int ${head(occursCheck).attrOccursIndexName}_inhs = ${makeName(ntgrammar)}.Init.count_inh__ON__${ntname}++;\n"
     else "";
 }
 

--- a/grammars/silver/compiler/translation/java/core/OccursDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/OccursDcl.sv
@@ -27,6 +27,12 @@ top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::
     else
       s"public static final int ${head(occursCheck).attrOccursIndexName} = " ++
       s"${makeName(ntgrammar)}.Init.count_${occursType}__ON__${ntname}++;\n";
+
+  top.valueWeaving <-
+    if at.lookupAttribute.dcl.isTranslation then
+      s"public static final int ${head(occursCheck).attrOccursIndexName}_dec_site = " ++
+      s"${makeName(ntgrammar)}.Init.count_inh__ON__${ntname}++;\n"
+    else "";
 }
 
 aspect production errorAttributionDcl

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -113,8 +113,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
       if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
       then
         s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n" ++
-        s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs][];\n" ++
-        s"\t\t${top.frame.className}.localTransDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs];\n"
+        s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs][];\n"
       else s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n"
     else "";
 
@@ -145,8 +144,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
       if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
       then
         s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n" ++
-        s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs][];\n" ++
-        s"\t\t${top.frame.className}.localTransDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs];\n"
+        s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs][];\n"
       else s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n"
     else "";
 
@@ -174,8 +172,7 @@ top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name ';'
     s"\t\t//${top.unparse}\n" ++
     s"\t\t${top.frame.className}.localIsForward[${ugh_dcl_hack.attrOccursInitIndex}] = true;\n" ++ 
     s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_inh_attrs];\n" ++
-    s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_syn_attrs][];\n" ++
-    s"\t\t${top.frame.className}.localTransDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_syn_attrs];\n";
+    s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_syn_attrs][];\n";
 
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
 

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -112,8 +112,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
       s"\t\t//${top.unparse}\n" ++
       if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
       then
-        s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n" ++
-        s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs][];\n"
+        s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n"
       else s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n"
     else "";
 
@@ -143,8 +142,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
       s"\t\t//${top.unparse}\n" ++
       if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
       then
-        s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n" ++
-        s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs][];\n"
+        s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n"
       else s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n"
     else "";
 
@@ -171,8 +169,7 @@ top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name ';'
   top.setupInh :=
     s"\t\t//${top.unparse}\n" ++
     s"\t\t${top.frame.className}.localIsForward[${ugh_dcl_hack.attrOccursInitIndex}] = true;\n" ++ 
-    s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_inh_attrs];\n" ++
-    s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_syn_attrs][];\n";
+    s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_inh_attrs];\n";
 
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
 
@@ -219,15 +216,21 @@ top::DefLHS ::= q::Decorated! QName
 aspect production childTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  top.translation = s"${top.frame.className}.childTransInheritedAttributes[${top.frame.className}.i_${q.lookupValue.fullName}][${attr.attrOccursIndex}]";
-  top.initTransInh = s"if (${top.translation} == null) ${top.translation} = new common.Lazy[${makeNTName(attr.typerep.typeName)}.num_inh_attrs];\n";
+  local transArray::String = s"${top.frame.className}.childTransInheritedAttributes[${top.frame.className}.i_${q.lookupValue.fullName}]";
+  top.translation = s"${transArray}[${attr.attrOccursIndex}]";
+  top.initTransInh =
+    s"\t\tif (${transArray} == null) ${transArray} = new common.Lazy[${makeNTName(q.lookupValue.typeScheme.typeName)}.num_syn_attrs];\n" ++
+    s"\t\tif (${top.translation} == null) ${top.translation} = new common.Lazy[${makeNTName(attr.typerep.typeName)}.num_inh_attrs];\n";
 }
 
 aspect production localTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  top.translation = s"${top.frame.className}.localTransInheritedAttributes[${q.lookupValue.dcl.attrOccursIndex}][${attr.attrOccursIndex}]";
-  top.initTransInh = s"if (${top.translation} == null) ${top.translation} = new common.Lazy[${makeNTName(attr.typerep.typeName)}.num_inh_attrs];\n";
+  local transArray::String = s"${top.frame.className}.localTransInheritedAttributes[${top.frame.className}.i_${q.lookupValue.fullName}]";
+  top.translation = s"${transArray}[${attr.attrOccursIndex}]";
+  top.initTransInh =
+    s"\t\tif (${transArray} == null) ${transArray} = new common.Lazy[${makeNTName(q.lookupValue.typeScheme.typeName)}.num_syn_attrs];\n" ++
+    s"\t\tif (${top.translation} == null) ${top.translation} = new common.Lazy[${makeNTName(attr.typerep.typeName)}.num_inh_attrs];\n";
 }
 
 aspect production errorTransAttrDefLHS

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -57,7 +57,7 @@ top::ProductionStmt ::=
 aspect production forwardsTo
 top::ProductionStmt ::= 'forwards' 'to' e::Expr ';'
 {
-  top.translation = "";
+  top.translation = e.initTransDecSites;
 }
 
 aspect production forwardingWith
@@ -173,8 +173,9 @@ top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name ';'
   top.setupInh :=
     s"\t\t//${top.unparse}\n" ++
     s"\t\t${top.frame.className}.localIsForward[${ugh_dcl_hack.attrOccursInitIndex}] = true;\n" ++ 
-    s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = " ++ 
-    s"new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_inh_attrs];\n";
+    s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_inh_attrs];\n" ++
+    s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_syn_attrs][];\n" ++
+    s"\t\t${top.frame.className}.localTransDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_syn_attrs];\n";
 
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
 
@@ -249,7 +250,7 @@ top::ProductionStmt ::= dl::Decorated! DefLHS  attr::Decorated! QNameAttrOccur  
 {
   top.translation = 
     s"\t\t// ${dl.unparse}.${attr.unparse} = ${e.unparse}\n" ++
-    dl.initTransInh ++
+    dl.initTransInh ++ e.initTransDecSites ++
     s"\t\t${dl.translation}[${attr.attrOccursInitIndex}] = ${wrapLazy(e)};\n";
 }
 
@@ -274,6 +275,7 @@ top::ProductionStmt ::= val::Decorated! QName  e::Expr
 {
   top.translation =
 	s"\t\t// ${val.unparse} = ${e.unparse}\n" ++
+  e.initTransDecSites ++
 	s"\t\t${top.frame.className}.localAttributes[${val.lookupValue.dcl.attrOccursInitIndex}] = ${wrapLazy(e)};\n";
 }
 

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -216,21 +216,21 @@ top::DefLHS ::= q::Decorated! QName
 aspect production childTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  local transArray::String = s"${top.frame.className}.childTransInheritedAttributes[${top.frame.className}.i_${q.lookupValue.fullName}]";
-  top.translation = s"${transArray}[${attr.attrOccursIndex}]";
+  top.translation = s"((TransInhs)${top.frame.className}.childInheritedAttributes[${attr.attrOccursIndex}_inhs]).inhs";
   top.initTransInh =
-    s"\t\tif (${transArray} == null) ${transArray} = new common.Lazy[${makeNTName(q.lookupValue.typeScheme.typeName)}.num_syn_attrs];\n" ++
-    s"\t\tif (${top.translation} == null) ${top.translation} = new common.Lazy[${makeNTName(attr.typerep.typeName)}.num_inh_attrs];\n";
+    s"\t\tif (${top.frame.className}.childInheritedAttributes[${attr.attrOccursIndex}_inhs] == null) {\n" ++
+    s"\t\t\t${top.translation} = new common.TransInhs(${makeNTName(attr.typerep.typeName)}.num_inh_attrs);\n" ++
+    "\t\t}\n";
 }
 
 aspect production localTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  local transArray::String = s"${top.frame.className}.localTransInheritedAttributes[${top.frame.className}.i_${q.lookupValue.fullName}]";
-  top.translation = s"${transArray}[${attr.attrOccursIndex}]";
+  top.translation = s"((TransInhs)${top.frame.className}.localInheritedAttributes[${attr.attrOccursIndex}_inhs]).inhs";
   top.initTransInh =
-    s"\t\tif (${transArray} == null) ${transArray} = new common.Lazy[${makeNTName(q.lookupValue.typeScheme.typeName)}.num_syn_attrs];\n" ++
-    s"\t\tif (${top.translation} == null) ${top.translation} = new common.Lazy[${makeNTName(attr.typerep.typeName)}.num_inh_attrs];\n";
+    s"\t\tif (${top.frame.className}.localInheritedAttributes[${attr.attrOccursIndex}_inhs] == null) {\n" ++
+    s"\t\t\t${top.translation} = new common.TransInhs(${makeNTName(attr.typerep.typeName)}.num_inh_attrs);\n" ++
+    "\t\t}\n";
 }
 
 aspect production errorTransAttrDefLHS

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -123,7 +123,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
     | [u], [v] ->
         s"\t\t//${top.unparse}\n" ++
         s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = " ++
-        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, u.sourceGrammar, top.frame.lhsNtName, v)};\n"
+        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, top.frame.lhsNtName, v)};\n"
     | _, _ -> ""
     end;
 }
@@ -153,7 +153,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
     | [u], [v] ->
         s"\t\t//${top.unparse}\n" ++
         s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = " ++
-        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, u.sourceGrammar, top.frame.lhsNtName, v)};\n"
+        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, top.frame.lhsNtName, v)};\n"
     | _, _ -> ""
     end;
 }

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -125,7 +125,7 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
     | [u], [v] ->
         s"\t\t//${top.unparse}\n" ++
         s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = " ++
-        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, u.sourceGrammar, top.frame.fullName, v)};\n"
+        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, u.sourceGrammar, top.frame.lhsNtName, v)};\n"
     | _, _ -> ""
     end;
 }
@@ -157,7 +157,7 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
     | [u], [v] ->
         s"\t\t//${top.unparse}\n" ++
         s"\t\t${top.frame.className}.localDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = " ++
-        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, u.sourceGrammar, top.frame.fullName, v)};\n"
+        s"(context) -> ${refAccessTranslation(top.env, top.flowEnv, u.sourceGrammar, top.frame.lhsNtName, v)};\n"
     | _, _ -> ""
     end;
 }

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -216,20 +216,22 @@ top::DefLHS ::= q::Decorated! QName
 aspect production childTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  top.translation = s"((TransInhs)${top.frame.className}.childInheritedAttributes[${attr.attrOccursIndex}_inhs]).inhs";
+  local inhsIndex::String = s"${top.frame.className}.childInheritedAttributes[${top.frame.className}.i_${q.lookupValue.fullName}][${attr.attrOccursIndex}_inhs]";
+  top.translation = s"((common.TransInhs)${inhsIndex}).inhs";
   top.initTransInh =
-    s"\t\tif (${top.frame.className}.childInheritedAttributes[${attr.attrOccursIndex}_inhs] == null) {\n" ++
-    s"\t\t\t${top.translation} = new common.TransInhs(${makeNTName(attr.typerep.typeName)}.num_inh_attrs);\n" ++
+    s"\t\tif (${inhsIndex} == null) {\n" ++
+    s"\t\t\t${inhsIndex} = new common.TransInhs(${makeNTName(attr.typerep.typeName)}.num_inh_attrs);\n" ++
     "\t\t}\n";
 }
 
 aspect production localTransAttrDefLHS
 top::DefLHS ::= q::Decorated! QName  attr::Decorated! QNameAttrOccur
 {
-  top.translation = s"((TransInhs)${top.frame.className}.localInheritedAttributes[${attr.attrOccursIndex}_inhs]).inhs";
+  local inhsIndex::String = s"${top.frame.className}.localInheritedAttributes[${q.lookupValue.dcl.attrOccursIndex}][${attr.attrOccursIndex}_inhs]";
+  top.translation = s"((common.TransInhs)${inhsIndex}).inhs";
   top.initTransInh =
-    s"\t\tif (${top.frame.className}.localInheritedAttributes[${attr.attrOccursIndex}_inhs] == null) {\n" ++
-    s"\t\t\t${top.translation} = new common.TransInhs(${makeNTName(attr.typerep.typeName)}.num_inh_attrs);\n" ++
+    s"\t\tif (${inhsIndex} == null) {\n" ++
+    s"\t\t\t${inhsIndex} = new common.TransInhs(${makeNTName(attr.typerep.typeName)}.num_inh_attrs);\n" ++
     "\t\t}\n";
 }
 

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -113,8 +113,8 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
       if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
       then
         s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n" ++
-        s"\t\tchildTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.num_syn_attrs][];\n" ++
-        s"\t\tchildTransDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.num_syn_attrs];\n"
+        s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs][];\n" ++
+        s"\t\t${top.frame.className}.localTransDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs];\n"
       else s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n"
     else "";
 
@@ -145,8 +145,8 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
       if te.typerep.isNonterminal || te.typerep.isUniqueDecorated
       then
         s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_inh_attrs];\n" ++
-        s"\t\tchildTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.num_syn_attrs][];\n" ++
-        s"\t\tchildTransDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.num_syn_attrs];\n"
+        s"\t\t${top.frame.className}.localTransInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs][];\n" ++
+        s"\t\t${top.frame.className}.localTransDecSites[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(te.typerep.typeName)}.num_syn_attrs];\n"
       else s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${top.frame.className}.count_inh__ON__${makeIdName(transTypeNameWith(te.typerep, top.frame.signature.freeVariables))}];\n"
     else "";
 

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -83,14 +83,12 @@ ${makeIndexDcls(0, namedSig.inputElements)}
     public static final common.Lazy[] synthesizedAttributes = new common.Lazy[${fnnt}.num_syn_attrs];
     public static final common.Lazy[][] childInheritedAttributes = new common.Lazy[${toString(length(namedSig.inputElements))}][];
     public static final common.Lazy[][][] childTransInheritedAttributes = new common.Lazy[${toString(length(namedSig.inputElements))}][][];
-    public static final common.Lazy[][] childTransDecSites = new common.Lazy[${toString(length(namedSig.inputElements))}][];
 
     public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
     public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
     public static final boolean[] localIsForward = new boolean[num_local_attrs];
     public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
     public static final common.Lazy[][][] localTransInheritedAttributes = new common.Lazy[num_local_attrs][][];
-    public static final common.Lazy[][] localTransDecSites = new common.Lazy[num_local_attrs][];
 
 ${namedSig.inhOccursIndexDecls}
 
@@ -182,16 +180,6 @@ ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInh
     @Override
     public common.Lazy[][] getChildTransInheritedAttributes(final int key) {
         return childTransInheritedAttributes[key];
-    }
-
-    @Override
-    public common.Lazy[] getLocalTransDecSites(final int key) {
-        return localTransDecSites[key];
-    }
-
-    @Override
-    public common.Lazy[] getChildTransDecSites(final int key) {
-        return childTransDecSites[key];
     }
 
     @Override

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -185,12 +185,12 @@ ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInh
     }
 
     @Override
-    public common.Lazy[] getLocalTransDecSite(final int key) {
+    public common.Lazy[] getLocalTransDecSites(final int key) {
         return localTransDecSites[key];
     }
 
     @Override
-    public common.Lazy[][] getChildTransDecSite(final int key) {
+    public common.Lazy[] getChildTransDecSites(final int key) {
         return childTransDecSites[key];
     }
 

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -82,13 +82,11 @@ ${makeIndexDcls(0, namedSig.inputElements)}
 
     public static final common.Lazy[] synthesizedAttributes = new common.Lazy[${fnnt}.num_syn_attrs];
     public static final common.Lazy[][] childInheritedAttributes = new common.Lazy[${toString(length(namedSig.inputElements))}][];
-    public static final common.Lazy[][][] childTransInheritedAttributes = new common.Lazy[${toString(length(namedSig.inputElements))}][][];
 
     public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
     public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
     public static final boolean[] localIsForward = new boolean[num_local_attrs];
     public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
-    public static final common.Lazy[][][] localTransInheritedAttributes = new common.Lazy[num_local_attrs][][];
 
 ${namedSig.inhOccursIndexDecls}
 
@@ -170,16 +168,6 @@ ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInh
     public common.Lazy[] getChildInheritedAttributes(final int key) {
 ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInhOccurs, "childInhContextTypeVars", "childInheritedAttributes", _), namedSig.inhOccursContextTypes)}
         return childInheritedAttributes[key];
-    }
-
-    @Override
-    public common.Lazy[][] getLocalTransInheritedAttributes(final int key) {
-        return localTransInheritedAttributes[key];
-    }
-
-    @Override
-    public common.Lazy[][] getChildTransInheritedAttributes(final int key) {
-        return childTransInheritedAttributes[key];
     }
 
     @Override

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -216,8 +216,8 @@ ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInh
     }
 
     @Override
-    public common.Lazy getForwardInheritedAttributes(final int index) {
-        return forwardInheritedAttributes[index];
+    public common.Lazy[] getForwardInheritedAttributes() {
+        return forwardInheritedAttributes;
     }
 
     @Override

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -82,11 +82,15 @@ ${makeIndexDcls(0, namedSig.inputElements)}
 
     public static final common.Lazy[] synthesizedAttributes = new common.Lazy[${fnnt}.num_syn_attrs];
     public static final common.Lazy[][] childInheritedAttributes = new common.Lazy[${toString(length(namedSig.inputElements))}][];
+    public static final common.Lazy[][][] childTransInheritedAttributes = new common.Lazy[${toString(length(namedSig.inputElements))}][][];
+    public static final common.Lazy[][] childTransDecSites = new common.Lazy[${toString(length(namedSig.inputElements))}][];
 
     public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
     public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
     public static final boolean[] localIsForward = new boolean[num_local_attrs];
     public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
+    public static final common.Lazy[][][] localTransInheritedAttributes = new common.Lazy[num_local_attrs][][];
+    public static final common.Lazy[][] localTransDecSites = new common.Lazy[num_local_attrs][];
 
 ${namedSig.inhOccursIndexDecls}
 
@@ -143,7 +147,7 @@ ${implode("", map(makeChildAccessCaseLazy, namedSig.inputElements))}
 	@Override
 	public common.Lazy getChildDecSite(final int index) {
 		switch(index) {
-${implode("", map(makeChildDecSiteAccessCase(body.env, top.flowEnv, fName, _), namedSig.inputElements))}
+${implode("", map(makeChildDecSiteAccessCase(body.env, top.flowEnv, body.frame.lhsNtName, fName, _), namedSig.inputElements))}
             default: return null;
         }
     }
@@ -168,6 +172,26 @@ ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInh
     public common.Lazy[] getChildInheritedAttributes(final int key) {
 ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInhOccurs, "childInhContextTypeVars", "childInheritedAttributes", _), namedSig.inhOccursContextTypes)}
         return childInheritedAttributes[key];
+    }
+
+    @Override
+    public common.Lazy[][] getLocalTransInheritedAttributes(final int key) {
+        return localTransInheritedAttributes[key];
+    }
+
+    @Override
+    public common.Lazy[][] getChildTransInheritedAttributes(final int key) {
+        return childTransInheritedAttributes[key];
+    }
+
+    @Override
+    public common.Lazy[] getLocalTransDecSite(final int key) {
+        return localTransDecSites[key];
+    }
+
+    @Override
+    public common.Lazy[][] getChildTransDecSite(final int key) {
+        return childTransDecSites[key];
     }
 
     @Override

--- a/language-server/launcher/.classpath
+++ b/language-server/launcher/.classpath
@@ -31,6 +31,19 @@
 			<attribute name="m2e-apt" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
 			<attribute name="optional" value="true"/>

--- a/runtime/java/src/common/Decorable.java
+++ b/runtime/java/src/common/Decorable.java
@@ -15,10 +15,10 @@ public interface Decorable {
 	 * @param inhs A map from inh attribute indexes to Lazys that define them.
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs A map from trans (syn) attribute indexes, to maps from inh attribute indexes to Lazys that define them. 
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
 	 *   access the decorated translation attribute through its decoration site.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @return A DecoratedNode with the attributes supplied.
 	 */
 	public DecoratedNode decorate(
@@ -34,11 +34,11 @@ public interface Decorable {
 	 * @param inhs Overrides for inherited attributes that should not be computed via forwarding.
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs Overrides for inherited attributes on translation attributes that should not be computed via forwarding.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
 	 *   access the decorated translation attribute through its decoration site.
 	 *   These override any decoration sites from forwardParent, when fwdTrans is true.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param fwdParent The DecoratedNode that forwards to the one we are about to create.
 	 *   We will pass inherited attribute access requests to this node.
 	 * @param fwdTrans Do translation attributes on this node have decoration sites in fwdParent?

--- a/runtime/java/src/common/Decorable.java
+++ b/runtime/java/src/common/Decorable.java
@@ -16,16 +16,12 @@ public interface Decorable {
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs A map from trans (syn) attribute indexes, to maps from inh attribute indexes to Lazys that define them. 
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
-	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
-	 *   access the decorated translation attribute through its decoration site.
-	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @return A DecoratedNode with the attributes supplied.
 	 */
 	public DecoratedNode decorate(
 		final DecoratedNode parent,
 		final Lazy[] inhs,
-		final Lazy[][] transInhs,
-		final Lazy[] transDecSites);
+		final Lazy[][] transInhs);
 
 	/**
 	 * Decorate this node with a forward parent.
@@ -34,10 +30,6 @@ public interface Decorable {
 	 * @param inhs Overrides for inherited attributes that should not be computed via forwarding.
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs Overrides for inherited attributes on translation attributes that should not be computed via forwarding.
-	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
-	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
-	 *   access the decorated translation attribute through its decoration site.
-	 *   These override any decoration sites from forwardParent, when fwdTrans is true.
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param fwdParent The DecoratedNode that forwards to the one we are about to create.
 	 *   We will pass inherited attribute access requests to this node.
@@ -49,7 +41,6 @@ public interface Decorable {
 		final DecoratedNode parent,
 		final Lazy[] inhs,
 		final Lazy[][] transInhs,
-		final Lazy[] transDecSites,
 		final DecoratedNode fwdParent,
 		final boolean fwdTrans);
 }

--- a/runtime/java/src/common/Decorable.java
+++ b/runtime/java/src/common/Decorable.java
@@ -14,22 +14,15 @@ public interface Decorable {
 	 * @param parent The DecoratedNode creating this one. (Whether this is a child or a local (or other) of that node.)
 	 * @param inhs A map from inh attribute indexes to Lazys that define them.
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
-	 * @param transInhs A map from trans (syn) attribute indexes, to maps from inh attribute indexes to Lazys that define them. 
-	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @return A DecoratedNode with the attributes supplied.
 	 */
-	public DecoratedNode decorate(
-		final DecoratedNode parent,
-		final Lazy[] inhs,
-		final Lazy[][] transInhs);
+	public DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs);
 
 	/**
 	 * Decorate this node with a forward parent.
 	 * 
 	 * @param parent The "true parent" of this node (same as the fwdParent's parent) 
 	 * @param inhs Overrides for inherited attributes that should not be computed via forwarding.
-	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
-	 * @param transInhs Overrides for inherited attributes on translation attributes that should not be computed via forwarding.
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param fwdParent The DecoratedNode that forwards to the one we are about to create.
 	 *   We will pass inherited attribute access requests to this node.
@@ -39,7 +32,6 @@ public interface Decorable {
 	public DecoratedNode decorate(
 		final DecoratedNode parent,
 		final Lazy[] inhs,
-		final Lazy[][] transInhs,
 		final DecoratedNode fwdParent,
 		final boolean prodFwrd);
 }

--- a/runtime/java/src/common/Decorable.java
+++ b/runtime/java/src/common/Decorable.java
@@ -33,8 +33,7 @@ public interface Decorable {
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param fwdParent The DecoratedNode that forwards to the one we are about to create.
 	 *   We will pass inherited attribute access requests to this node.
-	 * @param fwdTrans Do translation attributes on this node have decoration sites in fwdParent?
-	 * 	 (This is false for forward production attributes.)
+	 * @param prodFwrd Is this the forward for fwdParent's prod?  False for forward prod attributes.
 	 * @return A DecoratedNode with the attributes supplied.
 	 */
 	public DecoratedNode decorate(
@@ -42,5 +41,5 @@ public interface Decorable {
 		final Lazy[] inhs,
 		final Lazy[][] transInhs,
 		final DecoratedNode fwdParent,
-		final boolean fwdTrans);
+		final boolean prodFwrd);
 }

--- a/runtime/java/src/common/Decorable.java
+++ b/runtime/java/src/common/Decorable.java
@@ -12,18 +12,44 @@ public interface Decorable {
 	 * Decorate this node with additional inherited attributes.
 	 * 
 	 * @param parent The DecoratedNode creating this one. (Whether this is a child or a local (or other) of that node.)
-	 * @param inhs A map from attribute names to Lazys that define them.  These Lazys will be supplied with 'parent' as their context for evaluation.
+	 * @param inhs A map from inh attribute indexes to Lazys that define them.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
+	 * @param transInhs A map from trans (syn) attribute indexes, to maps from inh attribute indexes to Lazys that define them. 
+	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
+	 *   access the decorated translation attribute through its decoration site.
+	 *   These Lazys will be supplied with 'this' as their context for evaluation.
 	 * @return A DecoratedNode with the attributes supplied.
 	 */
-	public DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs);
+	public DecoratedNode decorate(
+		final DecoratedNode parent,
+		final Lazy[] inhs,
+		final Lazy[][] transInhs,
+		final Lazy[] transDecSites);
 
 	/**
 	 * Decorate this node with a forward parent.
 	 * 
-	 * @param parent The DecoratedNode creating this one. (Whether this is a child or a local (or other) of that node.)
-	 * @param inhs Overrides for inherited attributes that should not be computed via forwarding.  These Lazys will be supplied with 'parent' as their context for evaluation.
-	 * @param fwdParent The DecoratedNode that forwards to the one we are about to create. We will pass inherited attribute access requests to this node.
+	 * @param parent The "true parent" of this node (same as the fwdParent's parent) 
+	 * @param inhs Overrides for inherited attributes that should not be computed via forwarding.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
+	 * @param transInhs Overrides for inherited attributes on translation attributes that should not be computed via forwarding.
+	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
+	 *   access the decorated translation attribute through its decoration site.
+	 *   These override any decoration sites from forwardParent, when fwdTrans is true.
+	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 * @param fwdParent The DecoratedNode that forwards to the one we are about to create.
+	 *   We will pass inherited attribute access requests to this node.
+	 * @param fwdTrans Do translation attributes on this node have decoration sites in fwdParent?
+	 * 	 (This is false for forward production attributes.)
 	 * @return A DecoratedNode with the attributes supplied.
 	 */
-	public DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final DecoratedNode fwdParent);
+	public DecoratedNode decorate(
+		final DecoratedNode parent,
+		final Lazy[] inhs,
+		final Lazy[][] transInhs,
+		final Lazy[] transDecSites,
+		final DecoratedNode fwdParent,
+		final boolean fwdTrans);
 }

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -137,8 +137,8 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @param forwardParent  The node to request inherited attributes from if not supplied in 'inhs'.
 	 * @param isProdForward  Is this the forward for forwardParent's prod?  False for forward prod attributes.
 	 * 
-	 * @see Node#decorate(DecoratedNode, Lazy[], Lazy[][], Lazy[])
-	 * @see Node#decorate(DecoratedNode, Lazy[], Lazy[][], Lazy[], DecoratedNode, boolean)
+	 * @see Node#decorate(DecoratedNode, Lazy[])
+	 * @see Node#decorate(DecoratedNode, Lazy[], DecoratedNode, boolean)
 	 */
 	DecoratedNode(
 			final int cc, final int ic, final int sc, final int lc,

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -262,7 +262,7 @@ public class DecoratedNode implements Decorable, Typed {
 							transInheritedAttributes[transAttribute] = new Lazy[transInhs[transAttribute].length];
 						}
 						for(int j = 0; j < transInhs[transAttribute].length; j++) {
-							final int attribute = i;
+							final int attribute = j;
 							if(transInhs[transAttribute][attribute] != null && transInheritedAttributes[transAttribute][attribute] == null) {
 								transInheritedAttributes[transAttribute][attribute] = (context) -> transInhs[transAttribute][attribute].eval(parent);
 							}

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -270,13 +270,15 @@ public class DecoratedNode implements Decorable, Typed {
 				}
 				for(int i = 0; i < transInhs.length; i++) {
 					final int transAttribute = i;
-					if (transInheritedAttributes[transAttribute] == null && transInhs[transAttribute] != null) {
-						transInheritedAttributes[transAttribute] = new Lazy[transInhs[transAttribute].length];
-					}
-					for(int j = 0; j < transInhs[i].length; j++) {
-						final int attribute = i;
-						if(transInhs[transAttribute][attribute] != null && transInheritedAttributes[transAttribute][attribute] == null) {
-							transInheritedAttributes[transAttribute][attribute] = (context) -> transInhs[transAttribute][attribute].eval(parent);
+					if(transInhs[transAttribute] != null) {
+						if(transInheritedAttributes[transAttribute] == null) {
+							transInheritedAttributes[transAttribute] = new Lazy[transInhs[transAttribute].length];
+						}
+						for(int j = 0; j < transInhs[transAttribute].length; j++) {
+							final int attribute = i;
+							if(transInhs[transAttribute][attribute] != null && transInheritedAttributes[transAttribute][attribute] == null) {
+								transInheritedAttributes[transAttribute][attribute] = (context) -> transInhs[transAttribute][attribute].eval(parent);
+							}
 						}
 					}
 				}

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -237,10 +237,10 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @param inhs Overrides for inherited attributes that should not be computed via forwarding.
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs Overrides for inherited attributes on translation attributes that should not be computed via forwarding.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
 	 *   access the decorated translation attribute through its decoration site.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @return A DecoratedNode with the additional attributes supplied, referencing this DecoratedNode as 'base'.
 	 */
 	@Override
@@ -307,11 +307,11 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @param parent The "true parent" of this node (same as the fwdParent's parent) 
 	 * @param inhs A map from attribute names to Lazys that define them.  These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs Overrides for inherited attributes on translation attributes that should not be computed via forwarding.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
 	 *   access the decorated translation attribute through its decoration site.
 	 *   These override any decoration sites from forwardParent, when fwdTrans is true.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param fwdParent The DecoratedNode that forwards to the one we are about to create. We will pass inherited attribute access requests to this node.
 	 * @param fwdTrans Do translation attributes on this node have decoration sites in fwdParent?
 	 * 	 (This is false for forward production attributes.)
@@ -609,7 +609,7 @@ public class DecoratedNode implements Decorable, Typed {
 	private final DecoratedNode obtainDecoratedTrans(final int attribute) { 
 		Lazy decSite = transDecorationSites == null? null : transDecorationSites[attribute];
 		if(decSite != null) {
-			return (DecoratedNode)decSite.eval(this);
+			return (DecoratedNode)decSite.eval(parent);
 		} else if(forwardParent != null && forwardTrans) {
 			return forwardParent.obtainDecoratedTrans(attribute);
 		} else {
@@ -656,7 +656,7 @@ public class DecoratedNode implements Decorable, Typed {
 			}
 		}
 		DecoratedNode result =
-			d.decorate(this, transInheritedAttributes == null? null : transInheritedAttributes[attribute], null, null);
+			d.decorate(parent, transInheritedAttributes == null? null : transInheritedAttributes[attribute], null, null);
 		transCreated[attribute] = true;
 		return result;
 	}

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -579,7 +579,7 @@ public class DecoratedNode implements Decorable, Typed {
 		if(decSite != null) {
 			return (DecoratedNode)decSite.eval(parent);
 		} else if(forwardParent != null && forwardTrans) {
-			return forwardParent.obtainDecoratedTrans(attribute, decSiteAttribute);  // TODO: Not cached, should this be .translation?  
+			return forwardParent.translation(attribute, decSiteAttribute);
 		} else {
 			return evalTrans(attribute);
 		}

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -2,7 +2,6 @@ package common;
 
 import java.util.Arrays;
 
-import common.exceptions.CycleException;
 import common.exceptions.MissingDefinitionException;
 import common.exceptions.SilverException;
 import common.exceptions.SilverInternalError;
@@ -528,7 +527,6 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @param decSiteAttribute The index of the attribute's decoration site attribute
 	 * @return The value of the attribute.
 	 */
-	@SuppressWarnings("unchecked")
 	public DecoratedNode translation(final int attribute, final int inhsAttribute, final int decSiteAttribute) {
 		// common.Util.stackProbe();
 		// System.err.println("TRACE: " + getDebugID() + " demanding trans attribute: " + self.getNameOfSynAttr(attribute));

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -10,7 +10,7 @@ import common.exceptions.TraceException;
  * 
  * <p>Here be dragons, unfortunately. Don't modify at all without running it past me.
  * 
- * @author tedinski
+ * @author tedinski, krame505
  * @see Node
  */
 public class DecoratedNode implements Decorable, Typed {
@@ -41,8 +41,6 @@ public class DecoratedNode implements Decorable, Typed {
 	/**
 	 * The node that forwards to this one. (May be null)
 	 * Not final, because we may set this when forwarding to a decorated tree via a unique reference.
-	 * 
-	 * @see #inheritedForwarded(String)
 	 */
 	protected DecoratedNode forwardParent;
 	/**
@@ -722,8 +720,6 @@ public class DecoratedNode implements Decorable, Typed {
 	 * 
 	 * @param attribute The full name of the attribute.
 	 * @return The value of the attribute.
-	 * 
-	 * @see #inheritedForwarded(String)
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> T inherited(final int attribute) {

--- a/runtime/java/src/common/FunctionNode.java
+++ b/runtime/java/src/common/FunctionNode.java
@@ -50,7 +50,7 @@ public abstract class FunctionNode extends Node {
 	}
 
 	@Override
-	public final Lazy getForwardInheritedAttributes(final int index) {
+	public final Lazy[] getForwardInheritedAttributes() {
 		throw new SilverInternalError("Functions do not forward!");
 	}
 

--- a/runtime/java/src/common/IOToken.java
+++ b/runtime/java/src/common/IOToken.java
@@ -151,9 +151,10 @@ public final class IOToken implements Typed {
 	public IOToken writeByteFile(StringCatter filename, byte[] content) {
 		try {
 			File outputFile = new File(filename.toString());
-			FileOutputStream outputStream = new FileOutputStream(outputFile);
-			outputStream.write(content);
-			outputStream.flush();
+			try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
+				outputStream.write(content);
+				outputStream.flush();
+			}
 			return this;
 		} catch (Exception e) {
 			throw new RuntimeException(e);

--- a/runtime/java/src/common/Lazy.java
+++ b/runtime/java/src/common/Lazy.java
@@ -13,6 +13,16 @@ public interface Lazy {
 	// TODO: probably make this Lazy<T>...
 	public Object eval(DecoratedNode context);
 
+    /**
+     * Create a Lazy that evaluates in some context and ignores the supplied one.
+     * 
+     * @param context The context to evaluate in.
+     * @return A Lazy that evaluates in the supplied context.
+     */
+    public default Lazy withContext(final DecoratedNode context) {
+        return (ignoredNewContext) -> eval(context);
+    }
+
     public static class Trap implements Lazy {
         String m;
 

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -29,10 +29,10 @@ public abstract class Node implements Decorable, Typed {
 	 * @param parent The DecoratedNode creating this one. (Whether this is a child or a local (or other) of that node.)
 	 * @param inhs A map from attribute names to Lazys that define them.  These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs A map from trans (syn) attribute indexes, to maps from inh attribute indexes to Lazys that define them. 
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
 	 *   access the decorated translation attribute through its decoration site.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @return A "decorated" form of this Node
 	 */
 	@Override
@@ -54,11 +54,11 @@ public abstract class Node implements Decorable, Typed {
 	 * @param inhs Overrides for inherited attributes that should not be computed via forwarding.
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs Overrides for inherited attributes on translation attributes that should not be computed via forwarding.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
 	 *   access the decorated translation attribute through its decoration site.
 	 *   These override any decoration sites from forwardParent, when fwdTrans is true.
-	 *   These Lazys will be supplied with 'this' as their context for evaluation.
+	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param fwdParent The DecoratedNode that forwards to the one we are about to create.
 	 *   We will pass inherited attribute access requests to this node.
 	 * @param fwdTrans Do translation attributes on this node have decoration sites in fwdParent?

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -30,20 +30,16 @@ public abstract class Node implements Decorable, Typed {
 	 * @param inhs A map from attribute names to Lazys that define them.  These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs A map from trans (syn) attribute indexes, to maps from inh attribute indexes to Lazys that define them. 
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
-	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
-	 *   access the decorated translation attribute through its decoration site.
-	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @return A "decorated" form of this Node
 	 */
 	@Override
 	public DecoratedNode decorate(
-		final DecoratedNode parent,
-		final Lazy[] inhs, final Lazy[][] transInhs, final Lazy[] transDecSites) {
+		final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs) {
 		return new DecoratedNode(getNumberOfChildren(),
 				                 getNumberOfInhAttrs(),
 				                 getNumberOfSynAttrs(),
 				                 getNumberOfLocalAttrs(),
-				                 this, parent, inhs, transInhs, transDecSites, null, false);
+				                 this, parent, inhs, transInhs, null, false);
 	}
 
 	/**
@@ -67,14 +63,13 @@ public abstract class Node implements Decorable, Typed {
 	 */
 	@Override
 	public DecoratedNode decorate(
-		final DecoratedNode parent,
-		final Lazy[] inhs,  final Lazy[][] transInhs, final Lazy[] transDecSites,
+		final DecoratedNode parent, final Lazy[] inhs,  final Lazy[][] transInhs,
 		final DecoratedNode fwdParent, final boolean forwardTrans) {
 		return new DecoratedNode(getNumberOfChildren(),
                                  getNumberOfInhAttrs(),
                                  getNumberOfSynAttrs(),
                                  getNumberOfLocalAttrs(),
-                                 this, parent, inhs, transInhs, transDecSites, fwdParent, forwardTrans);
+                                 this, parent, inhs, transInhs, fwdParent, forwardTrans);
 	}
 
 	/**
@@ -84,7 +79,7 @@ public abstract class Node implements Decorable, Typed {
 	 * @return  A node decorated with no inherited attributes, without a parent.
 	 */
 	public DecoratedNode decorate() {
-		return decorate(TopNode.singleton, null, null, null);
+		return decorate(TopNode.singleton, null, null);
 	}
 
 	private Node undecoratedValue = null;
@@ -218,16 +213,6 @@ public abstract class Node implements Decorable, Typed {
 	public abstract Lazy[][] getChildTransInheritedAttributes(final int index);
 
 	/**
-	 * Access the decorated form of a child's translation attribute through its reference decoration site, if it has one.
-	 * 
-	 * @param index The child index to look up the translation attribute decoration sites.
-	 * @return An array of Lazys to evaluate on a decorated form of this Node,
-	 *  to get the decorated trees for the translation attributes,
-	 * 	or null if it has no reference decoration site.
-	 */
-	public abstract Lazy[] getChildTransDecSites(final int index);
-
-	/**
 	 * Used to create arrays of appropriate size in DecoratedNode.
 	 * 
 	 * @return The number of local and production attributes that occur on this <b>production</b>
@@ -275,16 +260,6 @@ public abstract class Node implements Decorable, Typed {
 	 * @return An array containing inherited attributes supplied to translation attributes on that child 
 	 */
 	public abstract Lazy[][] getLocalTransInheritedAttributes(final int index);
-
-	/**
-	 * Access the decorated form of a local's translation attribute through its reference decoration site, if it has one.
-	 * 
-	 * @param index The index for a local, to look up the translation attribute decoration sites.
-	 * @return An array of Lazys to evaluate on a decorated form of this Node,
-	 *  to get the decorated trees for the translation attributes,
-	 * 	or null if it has no reference decoration site.
-	 */
-	public abstract Lazy[] getLocalTransDecSites(final int index);
 	
 	/**
 	 * Reports whether or not this production forwards.

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -34,12 +34,12 @@ public abstract class Node implements Decorable, Typed {
 	 */
 	@Override
 	public DecoratedNode decorate(
-		final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs) {
+		final DecoratedNode parent, final Lazy[] inhs) {
 		return new DecoratedNode(getNumberOfChildren(),
 				                 getNumberOfInhAttrs(),
 				                 getNumberOfSynAttrs(),
 				                 getNumberOfLocalAttrs(),
-				                 this, parent, inhs, transInhs, null, false);
+				                 this, parent, inhs, null, false);
 	}
 
 	/**
@@ -58,13 +58,13 @@ public abstract class Node implements Decorable, Typed {
 	 */
 	@Override
 	public DecoratedNode decorate(
-		final DecoratedNode parent, final Lazy[] inhs,  final Lazy[][] transInhs,
+		final DecoratedNode parent, final Lazy[] inhs,
 		final DecoratedNode fwdParent, final boolean isProdForward) {
 		return new DecoratedNode(getNumberOfChildren(),
                                  getNumberOfInhAttrs(),
                                  getNumberOfSynAttrs(),
                                  getNumberOfLocalAttrs(),
-                                 this, parent, inhs, transInhs, fwdParent, isProdForward);
+                                 this, parent, inhs, fwdParent, isProdForward);
 	}
 
 	/**
@@ -74,7 +74,7 @@ public abstract class Node implements Decorable, Typed {
 	 * @return  A node decorated with no inherited attributes, without a parent.
 	 */
 	public DecoratedNode decorate() {
-		return decorate(TopNode.singleton, null, null);
+		return decorate(TopNode.singleton, null);
 	}
 
 	private Node undecoratedValue = null;
@@ -199,13 +199,6 @@ public abstract class Node implements Decorable, Typed {
 	 * @return An array containing the inherited attributes supplied to that child 
 	 */
 	public abstract Lazy[] getChildInheritedAttributes(final int index);
-	
-	/**
-	 * @param index The child index to look up the translation attribute inherited attributes.
-	 * @param attribute The translation attribute to look up inherited attributes.
-	 * @return An array containing the inherited attributes supplied to translation attributes that child 
-	 */
-	public abstract Lazy[][] getChildTransInheritedAttributes(final int index);
 
 	/**
 	 * Used to create arrays of appropriate size in DecoratedNode.
@@ -248,13 +241,6 @@ public abstract class Node implements Decorable, Typed {
 	 * @return An array containing the inherited attributes supplied to that local 
 	 */
 	public abstract Lazy[] getLocalInheritedAttributes(final int index);
-	
-	/**
-	 * @param index The index for a local, to look up the translation attribute inherited attributes.
-	 * @param attribute The translation attribute to look up inherited attributes.
-	 * @return An array containing inherited attributes supplied to translation attributes on that child 
-	 */
-	public abstract Lazy[][] getLocalTransInheritedAttributes(final int index);
 	
 	/**
 	 * Reports whether or not this production forwards.

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -51,25 +51,20 @@ public abstract class Node implements Decorable, Typed {
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs Overrides for inherited attributes on translation attributes that should not be computed via forwarding.
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
-	 * @param transDecSites A map from trans (syn) attribute indexes, to Lazys that when evaluated,
-	 *   access the decorated translation attribute through its decoration site.
-	 *   These override any decoration sites from forwardParent, when fwdTrans is true.
-	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param fwdParent The DecoratedNode that forwards to the one we are about to create.
 	 *   We will pass inherited attribute access requests to this node.
-	 * @param fwdTrans Do translation attributes on this node have decoration sites in fwdParent?
-	 * 	 (This is false for forward production attributes.)
+	 * @param prodFwrd  Is this the forward for fwdParent's prod?  False for forward prod attributes.
 	 * @return A "decorated" form of this Node 
 	 */
 	@Override
 	public DecoratedNode decorate(
 		final DecoratedNode parent, final Lazy[] inhs,  final Lazy[][] transInhs,
-		final DecoratedNode fwdParent, final boolean forwardTrans) {
+		final DecoratedNode fwdParent, final boolean isProdForward) {
 		return new DecoratedNode(getNumberOfChildren(),
                                  getNumberOfInhAttrs(),
                                  getNumberOfSynAttrs(),
                                  getNumberOfLocalAttrs(),
-                                 this, parent, inhs, transInhs, fwdParent, forwardTrans);
+                                 this, parent, inhs, transInhs, fwdParent, isProdForward);
 	}
 
 	/**

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -27,7 +27,7 @@ public abstract class Node implements Decorable, Typed {
 	 * (child and local)
 	 * 
 	 * @param parent The DecoratedNode creating this one. (Whether this is a child or a local (or other) of that node.)
-	 * @param inhs A map from attribute names to Lazys that define them.  These Lazys will be supplied with 'parent' as their context for evaluation.
+	 * @param inhs A map from attribute indexes to Lazys that define them.  These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @param transInhs A map from trans (syn) attribute indexes, to maps from inh attribute indexes to Lazys that define them. 
 	 *   These Lazys will be supplied with 'parent' as their context for evaluation.
 	 * @return A "decorated" form of this Node
@@ -283,10 +283,9 @@ public abstract class Node implements Decorable, Typed {
 	/**
 	 * Get any overridden attributes for this node's forward.  (e.g. forwarding with { inh = foo; })
 	 * 
-	 * @param index The inherited attribute requested by a forwarded-to Node. 
 	 * @return A Lazy to evaluate on a decorated form of this Node, to get the value of this attribute provided to the forward.
 	 */
-	public abstract Lazy getForwardInheritedAttributes(final int index);
+	public abstract Lazy[] getForwardInheritedAttributes();
 
 	/**
 	 * @param index Any synthesized attribute on this Node

--- a/runtime/java/src/common/OriginContext.java
+++ b/runtime/java/src/common/OriginContext.java
@@ -2,10 +2,6 @@ package common;
 
 import silver.core.*;
 
-import java.util.*;
-
-import common.exceptions.*;
-
 
 /**
  * Implementation of "the stuff on the left of the turnstile" that needs to be

--- a/runtime/java/src/common/Reflection.java
+++ b/runtime/java/src/common/Reflection.java
@@ -281,7 +281,7 @@ public final class Reflection {
 		FunctionTypeRep fnType = (FunctionTypeRep)a;
 		List<TypeRep> params = typeArgs.subList(0, fnType.params);
 		List<TypeRep> namedParamTypes = typeArgs.subList(fnType.params, fnType.params + fnType.namedParams.length);
-		TypeRep resultType = typeArgs.get(fnType.params + fnType.namedParams.length);
+		//TypeRep resultType = typeArgs.get(fnType.params + fnType.namedParams.length);
 
 		final ConsCell rules = ctx.rulesAsSilverList();
 		
@@ -450,7 +450,7 @@ public final class Reflection {
 			if (prodset.size() > 1<<15) throw new NativeSerializationException("Too many productions for native serialize");
 			o.writeShort(prodset.size()); // Write lookup table size
 
-			for (RTTIManager.Prodleton p : prodset) { // Write lookup table. For each prod:
+			for (RTTIManager.Prodleton<?> p : prodset) { // Write lookup table. For each prod:
 				o.writeUTF(p.getName());              //  fully qualified silver prod name 
 				o.writeUTF(p.getTypeUnparse());       //  opaque typerep
 			}

--- a/runtime/java/src/common/Terminal.java
+++ b/runtime/java/src/common/Terminal.java
@@ -42,7 +42,7 @@ public abstract class Terminal implements Typed {
 	// It'd be nice to just directly access its children, but we don't actually know
 	// that our NLocation is Ploc. :(
 	private Object getFromLoc(int syn) {
-		DecoratedNode d = location.decorate(TopNode.singleton, (Lazy[])null);
+		DecoratedNode d = location.decorate();
 		return d.synthesized(syn);
 	}
 	public Integer getLine() {
@@ -69,8 +69,8 @@ public abstract class Terminal implements Typed {
 	
 	// This is a utility that I put here because why not. Perhaps it should be moved?
 	public static NLocation span(final NLocation a, final NLocation b) {
-		final DecoratedNode x = a.decorate(TopNode.singleton, (Lazy[])null);
-		final DecoratedNode y = b.decorate(TopNode.singleton, (Lazy[])null);
+		final DecoratedNode x = a.decorate();
+		final DecoratedNode y = b.decorate();
 		
 		return new Ploc(x.synthesized(silver.core.Init.silver_core_filename__ON__silver_core_Location),
 				x.synthesized(silver.core.Init.silver_core_line__ON__silver_core_Location),

--- a/runtime/java/src/common/TopNode.java
+++ b/runtime/java/src/common/TopNode.java
@@ -17,17 +17,17 @@ public class TopNode extends DecoratedNode{ // TODO: this should become a Node!
 	public static final TopNode singleton = new TopNode();
 	
 	private TopNode() {
-		super(0,0,0,0,null,null,null,null,null,false);
+		super(0,0,0,0,null,null,null,null,false);
 		this.originCtx = OriginContext.GLOBAL_CONTEXT;
 	}
 
 	@Override
-	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs) {
+	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs) {
 		throw new SilverInternalError("TopNode cannot be decorated.");
 	}
 
 	@Override
-	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs, final DecoratedNode fwdParent, final boolean prodFwrd) {
+	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final DecoratedNode fwdParent, final boolean prodFwrd) {
 		throw new SilverInternalError("TopNode cannot be decorated.");
 	}
 

--- a/runtime/java/src/common/TopNode.java
+++ b/runtime/java/src/common/TopNode.java
@@ -17,17 +17,17 @@ public class TopNode extends DecoratedNode{ // TODO: this should become a Node!
 	public static final TopNode singleton = new TopNode();
 	
 	private TopNode() {
-		super(0,0,0,0,null,null,null,null,null,null,false);
+		super(0,0,0,0,null,null,null,null,null,false);
 		this.originCtx = OriginContext.GLOBAL_CONTEXT;
 	}
 
 	@Override
-	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs, final Lazy[] transDecSites) {
+	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs) {
 		throw new SilverInternalError("TopNode cannot be decorated.");
 	}
 
 	@Override
-	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs, final Lazy[] transDecSites, final DecoratedNode fwdParent, final boolean fwdTrans) {
+	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs, final DecoratedNode fwdParent, final boolean fwdTrans) {
 		throw new SilverInternalError("TopNode cannot be decorated.");
 	}
 

--- a/runtime/java/src/common/TopNode.java
+++ b/runtime/java/src/common/TopNode.java
@@ -27,7 +27,7 @@ public class TopNode extends DecoratedNode{ // TODO: this should become a Node!
 	}
 
 	@Override
-	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs, final DecoratedNode fwdParent, final boolean fwdTrans) {
+	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs, final DecoratedNode fwdParent, final boolean prodFwrd) {
 		throw new SilverInternalError("TopNode cannot be decorated.");
 	}
 

--- a/runtime/java/src/common/TopNode.java
+++ b/runtime/java/src/common/TopNode.java
@@ -17,12 +17,17 @@ public class TopNode extends DecoratedNode{ // TODO: this should become a Node!
 	public static final TopNode singleton = new TopNode();
 	
 	private TopNode() {
-		super(0,0,0,0,null,null,null,null);
+		super(0,0,0,0,null,null,null,null,null,null,false);
 		this.originCtx = OriginContext.GLOBAL_CONTEXT;
 	}
 
 	@Override
-	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs) {
+	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs, final Lazy[] transDecSites) {
+		throw new SilverInternalError("TopNode cannot be decorated.");
+	}
+
+	@Override
+	public final DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy[][] transInhs, final Lazy[] transDecSites, final DecoratedNode fwdParent, final boolean fwdTrans) {
 		throw new SilverInternalError("TopNode cannot be decorated.");
 	}
 

--- a/runtime/java/src/common/TransInhs.java
+++ b/runtime/java/src/common/TransInhs.java
@@ -1,0 +1,33 @@
+package common;
+
+import common.exceptions.SilverInternalError;
+
+/**
+ * Represents the inherited attributes supplied to a translation attribute.
+ * 
+ * <p>This class pretends to be a Lazy, so that it can hide in the inherited
+ * attribute array passed for decoration. But it should never be evaluated!
+ * 
+ * @author krame505
+ */
+public class TransInhs implements Lazy {
+    public final Lazy[] inhs;
+
+    public TransInhs(final int ni) {
+        inhs = new Lazy[ni];
+    }
+
+    @Override
+    public Object eval(DecoratedNode context) {
+        throw new SilverInternalError("TransInhs should never be evaluated!");
+    }
+    
+    @Override
+    public TransInhs withContext(final DecoratedNode context) {
+        TransInhs result = new TransInhs(inhs.length);
+        for(int i = 0; i < inhs.length; i++) {
+            result.inhs[i] = inhs[i].withContext(context);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
# Changes
This adds support for translation attributes.  This involved some significant changes in the flow analysis and runtime.  

This branch includes changes from #763 and #767, and should be reviewed after those are merged.

There is unfortunately a small but meaningful (~10%) performance regression with this change, even in specifications that don't use translation attributes.  I think this is due to the overhead of creating and passing around some extra arrays for inherited attributes supplied to translation attributes, not sure how this can be realistically avoided.  

# Documentation
Translation attributes are discussed in our submitted SLE paper.  Not sure if we should push on adding docs for translation attributes now, as this will need to be updated with the changes in #751. We may want to consider a more comprehensive restructuring of our documentation on decorated vs. undecorated trees in the future.  