### PR TITLE
Update path used in upload-override-jars script

### DIFF
--- a/upload-override-jars
+++ b/upload-override-jars
@@ -18,7 +18,7 @@ commit_hash="$(git rev-parse HEAD)"
 #
 # Host foundry.remexre.xyz
 #   User nathan
-rsync -Pa jars/ foundry.remexre.xyz:/melt/jenkins/export-scratch/melt-jenkins/${commit_hash}-jars/
+rsync -Pa jars/ foundry.remexre.xyz:/export/scratch/melt-jenkins/${commit_hash}-jars/
 
 echo "Now go to https://foundry.remexre.xyz/jenkins/job/melt-umn/job/silver/job/$encoded_branch_name/build and"
 echo "pass /export/scratch/melt-jenkins/${commit_hash}-jars as OVERRIDE_JARS"


### PR DESCRIPTION
# Changes
Fix the path, since Jenkins got decontainerized on foundry.

# Documentation
Script fix, docs not really needed.