### PR TITLE
Avoid build congestion by waiting for a free executor to spawn downstream builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,6 +101,8 @@ melt.trynode('silver') {
     sh "./self-compile --clean --mwda --dont-translate"
   }
 
+  waitUntil { melt.isExecutorAvailable() }
+
   stage("Test") {
     // These test cases and tutorials are run as seperate tasks to allow for parallelism
     def tests = ["silver_features", "copper_features", "patt", "flow", "stdlib", "performance", "csterrors", "silver_construction", "origintracking", "implicit_monads"]
@@ -124,6 +126,8 @@ melt.trynode('silver') {
     // Clean
     sh "rm -rf silver-latest"
   }
+
+  waitUntil { melt.isExecutorAvailable() }
 
   stage("Integration") {
     // Projects with 'develop' as main branch, we'll try to build specific branch names if they exist

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,6 +101,8 @@ melt.trynode('silver') {
     sh "./self-compile --clean --mwda --dont-translate"
   }
 
+  // Avoid deadlock condition from all executor slots being filled with builds
+  // that are waiting for downstream builds to finish.
   waitUntil { melt.isExecutorAvailable() }
 
   stage("Test") {
@@ -127,6 +129,8 @@ melt.trynode('silver') {
     sh "rm -rf silver-latest"
   }
 
+  // Avoid deadlock condition from all executor slots being filled with builds
+  // that are waiting for downstream builds to finish.
   waitUntil { melt.isExecutorAvailable() }
 
   stage("Integration") {


### PR DESCRIPTION
# Changes
This should (hopefully) fix the issue with multiple Silver builds started close to the same time causing all executor slots to get filled with builds waiting for other downstream builds to complete.

# Documentation
Added comments in Jenkinsfile and jenkins-lib.