### PR TITLE
Deriving mechanism for Eq/Ord

### DIFF
--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedOccurs.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedOccurs.sv
@@ -25,12 +25,6 @@ Either<String  Decorated CmdArgs> ::= args::[String]
 aspect production attributionDcl
 top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' nt::QName nttl::BracketedOptTypeExprs ';'
 {
-  local isClosedNt :: Boolean =
-    case nt.lookupType.dcls of
-    | ntDcl(_, _, closed, _) :: _ -> closed
-    | _ -> false -- default, if the lookup fails
-    end;
-
   top.errors <-
     if nt.lookupType.found && at.lookupAttribute.found
     && top.config.warnOrphaned
@@ -40,7 +34,7 @@ top::AGDcl ::= 'attribute' at::QName attl::BracketedOptTypeExprs 'occurs' 'on' n
     else [];
   
   top.errors <-
-    if !nt.lookupType.found || !at.lookupAttribute.found || !isClosedNt || !at.lookupAttribute.dcl.isSynthesized then []
+    if !nt.lookupType.found || !at.lookupAttribute.found || !nt.lookupType.dcl.isClosed || !at.lookupAttribute.dcl.isSynthesized then []
     -- For closed nt, either we're exported by only the nt, OR there MUST be a default!
     else if !isExportedBy(top.grammarName, [nt.lookupType.dcl.sourceGrammar], top.compiledGrammars)
          && null(lookupDef(nt.lookupType.fullName, at.lookupAttribute.fullName, top.flowEnv))

--- a/grammars/silver/compiler/definition/env/DclInfo.sv
+++ b/grammars/silver/compiler/definition/env/DclInfo.sv
@@ -18,6 +18,7 @@ synthesized attribute isType :: Boolean;
 synthesized attribute isTypeAlias :: Boolean;
 synthesized attribute isClass :: Boolean;
 synthesized attribute classMembers :: [Pair<String Boolean>];
+synthesized attribute isClosed :: Boolean;
 
 -- instances
 inherited attribute givenInstanceType :: Type;
@@ -150,7 +151,7 @@ top::ValueDclInfo ::= fn::String
 
 closed nonterminal TypeDclInfo with
   sourceGrammar, sourceLocation, fullName, compareTo, isEqual,
-  typeScheme, kindrep, givenNonterminalType, isType, isTypeAlias, mentionedAliases, isClass, classMembers, givenInstanceType, superContexts;
+  typeScheme, kindrep, givenNonterminalType, isType, isTypeAlias, mentionedAliases, isClass, classMembers, givenInstanceType, superContexts, isClosed;
 propagate isEqual, compareTo on TypeDclInfo excluding typeAliasDcl, clsDcl;
 
 aspect default production
@@ -163,6 +164,7 @@ top::TypeDclInfo ::=
   top.isClass = false;
   top.classMembers = [];
   top.superContexts = [];
+  top.isClosed = false;
 }
 
 abstract production ntDcl
@@ -173,6 +175,7 @@ top::TypeDclInfo ::= fn::String ks::[Kind] closed::Boolean tracked::Boolean
   top.typeScheme = monoType(nonterminalType(fn, ks, tracked));
   top.kindrep = foldr(arrowKind, starKind(), ks);
   top.isType = true;
+  top.isClosed = closed;
 }
 abstract production termDcl
 top::TypeDclInfo ::= fn::String regex::Regex easyName::Maybe<String> genRepeatProb::Maybe<Float>

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -103,6 +103,13 @@ top::TypeExpr ::= t::Type
   top.unparse = prettyType(t);
 
   top.typerep = t;
+
+  top.errorsTyVars :=
+    case t of
+    | varType(_) -> []
+    | skolemType(_) -> []
+    | _ -> [err(top.location, top.unparse ++ " is not permitted here, only type variables are")]
+    end;
 }
 
 concrete production integerTypeExpr

--- a/grammars/silver/compiler/extension/autoattr/Ordering.sv
+++ b/grammars/silver/compiler/extension/autoattr/Ordering.sv
@@ -80,7 +80,7 @@ top::ProductionStmt ::= inh::String keySyn::String syn::Decorated! QName
             else
               foldr1(
                 \ e1::Expr e2::Expr ->
-                  Silver_Expr { if $Expr{e1} == 0 then $Expr{e2} else $Expr{e1} },
+                  Silver_Expr { let res::Integer = $Expr{e1} in if res == 0 then $Expr{e2} else res end },
                 map(
                   \ ie::NamedSignatureElement ->
                     if null(getOccursDcl(syn.lookupAttribute.dcl.fullName, ie.typerep.typeName, top.env))

--- a/grammars/silver/compiler/extension/deriving/Derive.sv
+++ b/grammars/silver/compiler/extension/deriving/Derive.sv
@@ -1,0 +1,207 @@
+grammar silver:compiler:extension:deriving;
+
+import silver:compiler:extension:patternmatching only Arrow_kwd, Vbar_kwd;
+
+terminal Derive_t 'derive' lexer classes {KEYWORD};
+
+concrete production deriveTCsOnNTListDcl_c
+top::AGDcl ::= 'derive' tcs::NameList 'on' nts::NameList ';'
+{
+  top.unparse = s"derive ${tcs.unparse} on ${nts.unparse};";
+  
+  forwards to deriveTCsOnNTListDcl(tcs, nts, location=top.location);
+}
+
+production deriveTCsOnNTListDcl
+top::AGDcl ::= tcs::NameList nts::NameList
+{
+  top.unparse = s"derive ${tcs.unparse} on ${nts.unparse};";
+  
+  forwards to
+    case nts of
+    | nameListOne(n) -> deriveTCsOnOneNTDcl(tcs, n, location=n.location)
+    | nameListCons(n, _, rest) ->
+      appendAGDcl(
+        deriveTCsOnOneNTDcl(tcs, n, location=n.location),
+        deriveTCsOnNTListDcl(tcs, rest, location=top.location),
+        location=top.location)
+    end;
+}
+
+production deriveTCsOnOneNTDcl
+top::AGDcl ::= tcs::NameList nt::QName
+{
+  top.unparse = s"derive ${tcs.unparse} on ${nt.unparse};";
+  
+  forwards to
+    case tcs of
+    | nameListOne(tc) -> deriveDcl(tc, nt, location=top.location)
+    | nameListCons(tc, _, rest) ->
+      appendAGDcl(
+        deriveDcl(tc, nt, location=top.location),
+        deriveTCsOnOneNTDcl(rest, nt, location=top.location),
+        location=top.location)
+    end;
+}
+
+production deriveDcl
+top::AGDcl ::= tc::QName nt::QName
+{
+  top.unparse = s"derive ${tc.unparse} on ${nt.unparse};";
+  propagate env;
+
+  local localErrors::[Message] =
+    tc.lookupType.errors ++ nt.lookupType.errors ++
+    (if tc.lookupType.found && !tc.lookupType.dcl.isClass
+     then [err(tc.location, s"${tc.lookupType.fullName} is not a type class")]
+     else []) ++
+    (if nt.lookupType.found && !(nt.lookupType.dcl.isType && nt.lookupType.typeScheme.isNonterminal)
+     then [err(nt.location, s"${nt.lookupType.fullName} is not a nonterminal")]
+     else []) ++
+    (if nt.lookupType.found && nt.lookupType.dcl.isClosed
+     then [err(nt.location, s"Cannot derive instances for ${nt.lookupType.fullName}, since that nonterminal is closed")]
+     else []);
+  top.errors := if null(localErrors) then forward.errors else localErrors;
+
+  forwards to
+    -- TODO: Yuck, can't forward based on env here since we need the defs from the forward.
+    case "silver:core:" ++ tc.name of  -- tc.lookupType.fullName
+    | "silver:core:Eq" -> deriveEqDcl(nt, location=top.location)
+    --| "silver:core:Ord" -> deriveOrdDcl(nt, location=top.location)
+    | fn -> errorAGDcl([err(tc.location, s"Cannot derive type class ${fn}")], location=top.location)
+    end;
+}
+
+production deriveEqDcl
+top::AGDcl ::= nt::Decorated! QName
+{
+  undecorates to deriveDcl(qName(top.location, "silver:core:Eq"), nt, location=top.location);
+  top.unparse = s"derive silver:core:Eq on ${nt.unparse};";
+
+  local tvs::[TyVar] = map(freshTyVar, nt.lookupType.dcl.kindrep.argKinds);
+  local ntty::Type = appTypes(nt.lookupType.typeScheme.monoType, map(skolemType, tvs));
+  
+  local includedProds::[ValueDclInfo] =
+    filter(
+      \ d::ValueDclInfo -> !d.hasForward,
+      getKnownProds(nt.lookupType.fullName, top.env));
+  forwards to Silver_AGDcl {
+    instance $ConstraintList{
+      foldr(
+        consConstraint(_, ',', _, location=top.location),
+        nilConstraint(location=top.location),
+        map(
+          \ tv::TyVar ->
+            classConstraint(
+              qName(top.location, "silver:core:Eq").qNameType,
+              typerepTypeExpr(skolemType(tv), location=top.location),
+              location=top.location),
+          tvs))} => silver:core:Eq $TypeExpr{typerepTypeExpr(ntty, location=top.location)} {
+        eq = \ x::$TypeExpr{typerepTypeExpr(ntty, location=top.location)} y::$TypeExpr{typerepTypeExpr(ntty, location=top.location)} -> $Expr{
+          if null(includedProds) then Silver_Expr {true} else
+          foldr(
+            and(_, '&&', _, location=top.location),
+            matchPrimitive(
+              Silver_Expr {x},
+              Silver_TypeExpr {Boolean},
+              foldPrimPatterns(
+                map(
+                  \ prod::ValueDclInfo ->
+                    prodPattern(qName(top.location, prod.fullName), '(',
+                    foldr(
+                      consVarBinder(_, ',', _, location=top.location),
+                      nilVarBinder(location=top.location),
+                      map(\ i::Integer ->
+                        varVarBinder(name(s"a${toString(i)}", top.location), location=top.location),
+                        range(0, length(prod.namedSignature.inputElements)))), ')', '->',
+                    matchPrimitive(
+                      Silver_Expr {y},
+                      Silver_TypeExpr {Boolean},
+                      onePattern(
+                        prodPattern(qName(top.location, prod.fullName), '(',
+                          foldr(
+                            consVarBinder(_, ',', _, location=top.location),
+                            nilVarBinder(location=top.location),
+                            map(\ i::Integer ->
+                              varVarBinder(name(s"b${toString(i)}", top.location), location=top.location),
+                              range(0, length(prod.namedSignature.inputElements)))), ')', '->',
+                          foldr(
+                            and(_, '&&', _, location=top.location),
+                            Silver_Expr {true},
+                            map(
+                              \ i::Integer -> Silver_Expr { $name{s"a${toString(i)}"} == $name{s"b${toString(i)}"} },
+                              range(0, length(prod.namedSignature.inputElements)))),
+                          location=top.location),
+                        location=top.location),
+                      Silver_Expr {false},
+                      location=top.location),
+                    location=top.location),
+                  includedProds),
+                top.location),
+              Silver_Expr {error("Unexpected production in derived Eq instance!")},
+              location=top.location),
+            map(
+              \ anno::NamedSignatureElement ->
+                Silver_Expr { x.$name{anno.elementName} == y.$name{anno.elementName} },
+              annotationsForNonterminal(ntty, top.env)))};
+        neq = \ x::$TypeExpr{typerepTypeExpr(ntty, location=top.location)} y::$TypeExpr{typerepTypeExpr(ntty, location=top.location)} -> $Expr{
+          if null(includedProds) then Silver_Expr {false} else
+          foldr(
+            or(_, '||', _, location=top.location),
+            matchPrimitive(
+              Silver_Expr {x},
+              Silver_TypeExpr {Boolean},
+              foldPrimPatterns(
+                map(
+                  \ prod::ValueDclInfo ->
+                    prodPattern(qName(top.location, prod.fullName), '(',
+                    foldr(
+                      consVarBinder(_, ',', _, location=top.location),
+                      nilVarBinder(location=top.location),
+                      map(\ i::Integer ->
+                        varVarBinder(name(s"a${toString(i)}", top.location), location=top.location),
+                        range(0, length(prod.namedSignature.inputElements)))), ')', '->',
+                    matchPrimitive(
+                      Silver_Expr {y},
+                      Silver_TypeExpr {Boolean},
+                      onePattern(
+                        prodPattern(qName(top.location, prod.fullName), '(',
+                          foldr(
+                            consVarBinder(_, ',', _, location=top.location),
+                            nilVarBinder(location=top.location),
+                            map(\ i::Integer ->
+                              varVarBinder(name(s"b${toString(i)}", top.location), location=top.location),
+                              range(0, length(prod.namedSignature.inputElements)))), ')', '->',
+                          foldr(
+                            or(_, '||', _, location=top.location),
+                            Silver_Expr {false},
+                            map(
+                              \ i::Integer -> Silver_Expr { $name{s"a${toString(i)}"} != $name{s"b${toString(i)}"} },
+                              range(0, length(prod.namedSignature.inputElements)))),
+                          location=top.location),
+                        location=top.location),
+                      Silver_Expr {true},
+                      location=top.location),
+                    location=top.location),
+                  includedProds),
+                top.location),
+              Silver_Expr {error("Unexpected production in derived Eq instance!")},
+              location=top.location),
+            map(
+              \ anno::NamedSignatureElement ->
+                Silver_Expr { x.$name{anno.elementName} != y.$name{anno.elementName} },
+              annotationsForNonterminal(ntty, top.env)))};
+      }
+  };
+}
+
+function foldPrimPatterns
+PrimPatterns ::= ps::[PrimPattern]  loc::Location
+{
+  return
+    case ps of
+    | [h] -> onePattern(h, location=loc)
+    | h :: t -> consPattern(h, '|', foldPrimPatterns(t, loc), location=loc)
+    | [] -> error("empty patterns")
+    end;
+}

--- a/grammars/silver/compiler/extension/deriving/Derive.sv
+++ b/grammars/silver/compiler/extension/deriving/Derive.sv
@@ -48,6 +48,7 @@ production deriveDcl
 top::AGDcl ::= tc::QName nt::QName
 {
   top.unparse = s"derive ${tc.unparse} on ${nt.unparse};";
+  top.moduleNames := [];
   propagate env;
 
   local localErrors::[Message] =
@@ -77,6 +78,7 @@ top::AGDcl ::= nt::Decorated! QName
 {
   undecorates to deriveDcl(qName(top.location, "silver:core:Eq"), nt, location=top.location);
   top.unparse = s"derive silver:core:Eq on ${nt.unparse};";
+  top.moduleNames := [];
 
   local tvs::[TyVar] = map(freshTyVar, nt.lookupType.dcl.kindrep.argKinds);
   local ntty::Type = appTypes(nt.lookupType.typeScheme.monoType, map(skolemType, tvs));
@@ -203,6 +205,7 @@ top::AGDcl ::= nt::Decorated! QName
 {
   undecorates to deriveDcl(qName(top.location, "silver:core:Ord"), nt, location=top.location);
   top.unparse = s"derive silver:core:Ord on ${nt.unparse};";
+  top.moduleNames := [];
 
   local tvs::[TyVar] = map(freshTyVar, nt.lookupType.dcl.kindrep.argKinds);
   local ntty::Type = appTypes(nt.lookupType.typeScheme.monoType, map(skolemType, tvs));

--- a/grammars/silver/compiler/extension/deriving/Derive.sv
+++ b/grammars/silver/compiler/extension/deriving/Derive.sv
@@ -90,12 +90,15 @@ top::AGDcl ::= nt::Decorated! QName
       foldr(
         consConstraint(_, ',', _, location=top.location),
         nilConstraint(location=top.location),
-        map(
+        filterMap(
           \ tv::TyVar ->
-            classConstraint(
-              qName(top.location, "silver:core:Eq").qNameType,
-              typerepTypeExpr(skolemType(tv), location=top.location),
-              location=top.location),
+            if tv.kindrep == starKind()
+            then just(
+              classConstraint(
+                qName(top.location, "silver:core:Eq").qNameType,
+                typerepTypeExpr(skolemType(tv), location=top.location),
+                location=top.location))
+            else nothing(),
           tvs))} => silver:core:Eq $TypeExpr{typerepTypeExpr(ntty, location=top.location)} {
         eq = \ x::$TypeExpr{typerepTypeExpr(ntty, location=top.location)} y::$TypeExpr{typerepTypeExpr(ntty, location=top.location)} -> $Expr{
           if null(includedProds) then Silver_Expr {true} else
@@ -214,12 +217,15 @@ top::AGDcl ::= nt::Decorated! QName
       foldr(
         consConstraint(_, ',', _, location=top.location),
         nilConstraint(location=top.location),
-        map(
+        filterMap(
           \ tv::TyVar ->
-            classConstraint(
-              qName(top.location, "silver:core:Ord").qNameType,
-              typerepTypeExpr(skolemType(tv), location=top.location),
-              location=top.location),
+            if tv.kindrep == starKind()
+            then just(
+              classConstraint(
+                qName(top.location, "silver:core:Ord").qNameType,
+                typerepTypeExpr(skolemType(tv), location=top.location),
+                location=top.location))
+            else nothing(),
           tvs))} => silver:core:Ord $TypeExpr{typerepTypeExpr(ntty, location=top.location)} {
         compare = \ x::$TypeExpr{typerepTypeExpr(ntty, location=top.location)} y::$TypeExpr{typerepTypeExpr(ntty, location=top.location)} -> $Expr{
           if null(includedProds) then Silver_Expr { 0 } else

--- a/grammars/silver/compiler/extension/deriving/Project.sv
+++ b/grammars/silver/compiler/extension/deriving/Project.sv
@@ -6,5 +6,6 @@ imports silver:compiler:definition:type;
 imports silver:compiler:definition:type:syntax;
 imports silver:compiler:modification:collection;
 imports silver:compiler:modification:lambda_fn;
+imports silver:compiler:modification:let_fix;
 imports silver:compiler:modification:primitivepattern;
 imports silver:compiler:metatranslation;

--- a/grammars/silver/compiler/extension/deriving/Project.sv
+++ b/grammars/silver/compiler/extension/deriving/Project.sv
@@ -1,0 +1,10 @@
+grammar silver:compiler:extension:deriving;
+
+imports silver:compiler:definition:core;
+imports silver:compiler:definition:env;
+imports silver:compiler:definition:type;
+imports silver:compiler:definition:type:syntax;
+imports silver:compiler:modification:collection;
+imports silver:compiler:modification:lambda_fn;
+imports silver:compiler:modification:primitivepattern;
+imports silver:compiler:metatranslation;

--- a/grammars/silver/compiler/extension/silverconstruction/Syntax.sv
+++ b/grammars/silver/compiler/extension/silverconstruction/Syntax.sv
@@ -78,6 +78,14 @@ top::TypeExpr ::= '$TypeExpr' '{' e::Expr '}'
       location=top.location);
 }
 
+concrete production antiquoteConstraintList
+top::ConstraintList ::= '$ConstraintList' '{' e::Expr '}'
+{
+  top.unparse = s"$$ConstraintList{${e.unparse}}";
+  -- [err(top.location, "$ConstraintList should not occur outside of quoted Silver Literal.")]
+  forwards to nilConstraint(location=top.location);
+}
+
 concrete production antiquotePattern
 top::Pattern ::= '$Pattern' '{' e::Expr '}'
 {

--- a/grammars/silver/compiler/extension/silverconstruction/Terminals.sv
+++ b/grammars/silver/compiler/extension/silverconstruction/Terminals.sv
@@ -12,6 +12,7 @@ lexer class Antiquote extends SPECOP;
 terminal AntiquoteExpr_t              '$Expr'              lexer classes {Antiquote};
 terminal AntiquoteExprInhs_t          '$ExprInhs'          lexer classes {Antiquote};
 terminal AntiquoteTypeExpr_t          '$TypeExpr'          lexer classes {Antiquote};
+terminal AntiquoteConstraintList_t    '$ConstraintList'    lexer classes {Antiquote};
 terminal AntiquotePattern_t           '$Pattern'           lexer classes {Antiquote};
 terminal AntiquoteAspectRHS_t         '$AspectRHS'         lexer classes {Antiquote};
 terminal AntiquoteProductionStmt_t    '$ProductionStmt'    lexer classes {Antiquote};

--- a/grammars/silver/compiler/extension/silverconstruction/Translation.sv
+++ b/grammars/silver/compiler/extension/silverconstruction/Translation.sv
@@ -10,6 +10,7 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
     ["silver:compiler:extension:silverconstruction:antiquoteExpr",
      "silver:compiler:extension:silverconstruction:antiquoteExprInhs",
      "silver:compiler:extension:silverconstruction:antiquoteTypeExpr",
+     "silver:compiler:extension:silverconstruction:antiquoteConstraintList",
      "silver:compiler:extension:silverconstruction:antiquotePattern",
      "silver:compiler:extension:silverconstruction:antiquoteAspectRHS",
      "silver:compiler:extension:silverconstruction:antiquoteProductionStmt",

--- a/grammars/silver/compiler/host/Project.sv
+++ b/grammars/silver/compiler/host/Project.sv
@@ -49,6 +49,7 @@ exports silver:compiler:extension:regex;
 exports silver:compiler:extension:convenienceaspects;
 exports silver:compiler:extension:attrsection;
 exports silver:compiler:extension:implicit_monads;
+exports silver:compiler:extension:deriving;
 
 -- Other generally useful stuff:
 exports silver:compiler:translation:java;

--- a/test/silver_features/Deriving.sv
+++ b/test/silver_features/Deriving.sv
@@ -1,0 +1,33 @@
+grammar silver_features;
+
+annotation eqa::Integer;
+nonterminal EqThing<a> with eqa;
+production eqThingA
+top::EqThing<a> ::= x::a
+{}
+production eqThingB
+top::EqThing<a> ::= x::String y::Boolean
+{}
+global eqThingBInt::(EqThing<Integer> ::= String Boolean Integer) = eqThingB(_, _, eqa=_);
+
+derive Eq on EqThing;
+
+equalityTest(eqThingA(42, eqa=3) == eqThingA(42, eqa=3), true, Boolean, silver_tests);
+equalityTest(eqThingBInt("hello", true, 3) == eqThingBInt("hello", true, 3), true, Boolean, silver_tests);
+equalityTest(eqThingBInt("hello", true, 3) == eqThingBInt("hello", false, 3), false, Boolean, silver_tests);
+equalityTest(eqThingBInt("hello", true, 3) == eqThingBInt("hello", true, 123), false, Boolean, silver_tests);
+equalityTest(eqThingA(42, eqa=3) == eqThingA(4, eqa=3), false, Boolean, silver_tests);
+equalityTest(eqThingBInt("hello", false, 3) == eqThingA(42, eqa=3), false, Boolean, silver_tests);
+equalityTest(eqThingA(eqThingBInt("a", false, 3), eqa=3) == eqThingA(eqThingBInt("a", false, 3), eqa=3), true, Boolean, silver_tests);
+equalityTest(eqThingA(eqThingBInt("a", false, 3), eqa=3) == eqThingA(eqThingBInt("b", false, 3), eqa=3), false, Boolean, silver_tests);
+equalityTest(eqThingA(eqThingBInt("a", false, 3), eqa=3) == eqThingA(eqThingBInt("a", false, 31234), eqa=3), false, Boolean, silver_tests);
+
+equalityTest(eqThingA(42, eqa=3) != eqThingA(42, eqa=3), false, Boolean, silver_tests);
+equalityTest(eqThingBInt("hello", true, 3) != eqThingBInt("hello", true, 3), false, Boolean, silver_tests);
+equalityTest(eqThingBInt("hello", true, 3) != eqThingBInt("hello", false, 3), true, Boolean, silver_tests);
+equalityTest(eqThingBInt("hello", true, 3) != eqThingBInt("hello", true, 123), true, Boolean, silver_tests);
+equalityTest(eqThingA(42, eqa=3) != eqThingA(4, eqa=3), true, Boolean, silver_tests);
+equalityTest(eqThingBInt("hello", false, 3) != eqThingA(42, eqa=3), true, Boolean, silver_tests);
+equalityTest(eqThingA(eqThingBInt("a", false, 3), eqa=3) != eqThingA(eqThingBInt("a", false, 3), eqa=3), false, Boolean, silver_tests);
+equalityTest(eqThingA(eqThingBInt("a", false, 3), eqa=3) != eqThingA(eqThingBInt("b", false, 3), eqa=3), true, Boolean, silver_tests);
+equalityTest(eqThingA(eqThingBInt("a", false, 3), eqa=3) != eqThingA(eqThingBInt("a", false, 31234), eqa=3), true, Boolean, silver_tests);

--- a/test/silver_features/Deriving.sv
+++ b/test/silver_features/Deriving.sv
@@ -10,7 +10,7 @@ top::EqThing<a> ::= x::String y::Boolean
 {}
 global eqThingBInt::(EqThing<Integer> ::= String Boolean Integer) = eqThingB(_, _, eqa=_);
 
-derive Eq on EqThing;
+derive Eq, Ord on EqThing;
 
 equalityTest(eqThingA(42, eqa=3) == eqThingA(42, eqa=3), true, Boolean, silver_tests);
 equalityTest(eqThingBInt("hello", true, 3) == eqThingBInt("hello", true, 3), true, Boolean, silver_tests);
@@ -31,3 +31,19 @@ equalityTest(eqThingBInt("hello", false, 3) != eqThingA(42, eqa=3), true, Boolea
 equalityTest(eqThingA(eqThingBInt("a", false, 3), eqa=3) != eqThingA(eqThingBInt("a", false, 3), eqa=3), false, Boolean, silver_tests);
 equalityTest(eqThingA(eqThingBInt("a", false, 3), eqa=3) != eqThingA(eqThingBInt("b", false, 3), eqa=3), true, Boolean, silver_tests);
 equalityTest(eqThingA(eqThingBInt("a", false, 3), eqa=3) != eqThingA(eqThingBInt("a", false, 31234), eqa=3), true, Boolean, silver_tests);
+
+equalityTest(compare(eqThingA(42, eqa=3), eqThingA(42, eqa=3)), 0, Integer, silver_tests);
+equalityTest(compare(eqThingBInt("hello", true, 3), eqThingBInt("hello", true, 3)), 0, Integer, silver_tests);
+equalityTest(compare(eqThingBInt("hello", true, 3), eqThingBInt("goodbye", true, 3)), 1, Integer, silver_tests);
+equalityTest(compare(eqThingBInt("goodbye", true, 3), eqThingBInt("hello", true, 3)), -1, Integer, silver_tests);
+equalityTest(compare(eqThingBInt("hello", true, 3), eqThingBInt("hello", false, 3)), 1, Integer, silver_tests);
+equalityTest(compare(eqThingBInt("hello", false, 3), eqThingBInt("hello", true, 3)), -1, Integer, silver_tests);
+equalityTest(compare(eqThingBInt("hello", true, 3), eqThingBInt("hello", true, 123)), -120, Integer, silver_tests);
+equalityTest(compare(eqThingBInt("hello", true, 123), eqThingBInt("hello", true, 3)), 120, Integer, silver_tests);
+equalityTest(compare(eqThingA(4, eqa=3), eqThingA(42, eqa=3)), -38, Integer, silver_tests);
+equalityTest(compare(eqThingA(42, eqa=3), eqThingA(4, eqa=3)), 38, Integer, silver_tests);
+equalityTest(compare(eqThingBInt("hello", false, 3), eqThingA(42, eqa=3)), 1, Integer, silver_tests);
+equalityTest(compare(eqThingA(42, eqa=3), eqThingBInt("hello", false, 3)), -1, Integer, silver_tests);
+equalityTest(compare(eqThingA(eqThingBInt("a", false, 3), eqa=3), eqThingA(eqThingBInt("a", false, 3), eqa=3)), 0, Integer, silver_tests);
+equalityTest(compare(eqThingA(eqThingBInt("a", false, 3), eqa=3), eqThingA(eqThingBInt("b", false, 3), eqa=3)), -1, Integer, silver_tests);
+equalityTest(compare(eqThingA(eqThingBInt("a", false, 3), eqa=3), eqThingA(eqThingBInt("a", false, 543), eqa=3)), -540, Integer, silver_tests);


### PR DESCRIPTION
# Changes
Add support for deriving for `Eq` and `Ord`.  This is needed for #556 since datatypes don't have inh attributes, so equality/ordering attributes are no longer an option.  Also this handles polymorphic nonterminals like `Maybe` or `Pair`, where additional constraints are needed on the generated instance, where equality/ordering attributes were not an option.

# Documentation
https://github.com/melt-umn/melt-website/pull/51, also added tests.