### PR TITLE
Avoid traversing monomorphic children when constructing the runtime type representation of a term

### DIFF
--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -399,7 +399,7 @@ String ::= i::Integer s::[NamedSignatureElement]
 function makeChildUnify
 String ::= fn::String n::NamedSignatureElement
 {
-  return
+  return if null(n.typerep.freeVariables) then "" else
 s"""try {
 			if (!common.TypeRep.unify(${transFreshTypeRep(n.typerep)}, common.Reflection.getType(getChild_${n.elementName}()))) {
 				throw new common.exceptions.SilverInternalError("Unification failed.");


### PR DESCRIPTION
# Changes
Apparently, getType on Node was traversing the entire term, even when not needed with monomorphic nonterminals.  This fixes that and hopefully provides a bit of speedup with reify/nativeDeserialize.  

# Documentation
Not really needed
