### PR TITLE
Add syntax for function types with named parameters

### DIFF
--- a/grammars/silver/compiler/definition/type/PrettyPrinting.sv
+++ b/grammars/silver/compiler/definition/type/PrettyPrinting.sv
@@ -137,9 +137,10 @@ top::Type ::= c::Type a::Type
          else "_") ++ " ::= " ++
          implode(" ", map(prettyTypeWith(_, top.boundVariables), take(params, top.argTypes))) ++
          (if length(top.argTypes) < params then replicate(params - length(top.argTypes), " _") else "") ++
+         (if null(namedParams) then "" else ";") ++
          concat(
-           zipWith(\ np::String t::Type -> s"; ${np}::${prettyTypeWith(t, top.boundVariables)}", namedParams, drop(params, top.argTypes)) ++
-           map(\ np::String -> s"; ${np}::_", drop(length(top.argTypes) - (params + length(namedParams)), namedParams))) ++ ")" ++
+           zipWith(\ np::String t::Type -> s" ${np}::${prettyTypeWith(t, top.boundVariables)}", namedParams, drop(params, top.argTypes)) ++
+           map(\ np::String -> s" ${np}::_", drop(length(top.argTypes) - params, namedParams))) ++ ")" ++
          if length(top.argTypes) <= params + length(namedParams) + 1 then ""
          else "<" ++ implode(" ", map(prettyTypeWith(_, top.boundVariables), drop(params + length(namedParams) + 1, top.argTypes))) ++ ">"
     | _ -> prettyTypeWith(top.baseType, top.boundVariables) ++

--- a/grammars/silver/compiler/definition/type/Type.sv
+++ b/grammars/silver/compiler/definition/type/Type.sv
@@ -327,7 +327,7 @@ top::Type ::= nt::Type inhs::Type hidden::Type
 
 {--
  - Function type. (Whether production or function.)
- - Note that this is the *unapplied* type constructor for a nonterminal type,
+ - Note that this is the *unapplied* type constructor for a function type,
  - and argument types are provided before the result type;
  - e.g. `(Integer ::= String Boolean)` would be represented as
  - `apType(apType(apType(functionType(3, []), stringType()), booleanType()), integerType())`.

--- a/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
+++ b/grammars/silver/compiler/definition/type/syntax/TypeExpr.sv
@@ -12,6 +12,7 @@ nonterminal SignatureLHS with config, location, grammarName, errors, env, flowEn
 nonterminal TypeExprs with config, location, grammarName, errors, env, unparse, flowEnv, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, appArgKinds, appLexicalTyVarKinds, errorsTyVars, errorsKindStar, freeVariables, mentionedAliases;
 nonterminal BracketedTypeExprs with config, location, grammarName, errors, env, flowEnv, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, appArgKinds, appLexicalTyVarKinds, errorsTyVars, freeVariables, mentionedAliases, envBindingTyVars, initialEnv;
 nonterminal BracketedOptTypeExprs with config, location, grammarName, errors, env, flowEnv, unparse, types, missingCount, lexicalTypeVariables, lexicalTyVarKinds, appArgKinds, appLexicalTyVarKinds, errorsTyVars, freeVariables, mentionedAliases, envBindingTyVars, initialEnv;
+nonterminal NamedTypeExprs with config, location, grammarName, errors, env, unparse, flowEnv, namedTypes, lexicalTypeVariables, lexicalTyVarKinds, errorsKindStar, freeVariables, mentionedAliases;
 
 synthesized attribute maybeType :: Maybe<Type>;
 synthesized attribute types :: [Type];
@@ -58,13 +59,13 @@ flowtype typerep {grammarName, env, flowEnv} on TypeExpr, Signature;
 flowtype maybeType {grammarName, env, flowEnv} on SignatureLHS;
 flowtype types {grammarName, env, flowEnv} on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 
-propagate errors on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs excluding refTypeExpr, uniqueRefTypeExpr;
+propagate errors on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs, NamedTypeExprs excluding refTypeExpr, uniqueRefTypeExpr;
 propagate config, grammarName, env, flowEnv, lexicalTypeVariables, lexicalTyVarKinds
-  on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
+  on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs, NamedTypeExprs;
 propagate appLexicalTyVarKinds on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
 propagate errorsTyVars on TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
-propagate errorsKindStar on TypeExprs;
-propagate mentionedAliases on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs;
+propagate errorsKindStar on TypeExprs, NamedTypeExprs;
+propagate mentionedAliases on TypeExpr, Signature, SignatureLHS, TypeExprs, BracketedTypeExprs, BracketedOptTypeExprs, NamedTypeExprs;
 
 function addNewLexicalTyVars
 [Def] ::= gn::String sl::Location lk::[Pair<String Kind>] l::[String]
@@ -268,7 +269,7 @@ top::TypeExpr ::= ty::Decorated TypeExpr tl::BracketedTypeExprs
 {
   top.unparse = ty.unparse ++ tl.unparse;
 
-  top.typerep = appTypes(ty.typerep, tl.types);
+  top.typerep = if null(kindErrors) then appTypes(ty.typerep, tl.types) else errorType();
 
   top.mentionedAliases <- ty.mentionedAliases;
 
@@ -276,12 +277,13 @@ top::TypeExpr ::= ty::Decorated TypeExpr tl::BracketedTypeExprs
 
   local tlCount::Integer = length(tl.types) + tl.missingCount;
   local tlKinds::[Kind] = map((.kindrep), tl.types);
-  top.errors <-
+  local kindErrors::[Message] =
     if tlCount != length(ty.typerep.kindrep.argKinds)
     then [err(top.location, ty.unparse ++ " has kind " ++ prettyKind(ty.typerep.kindrep) ++ ", but there are " ++ toString(tlCount) ++ " type arguments supplied here.")]
     else if take(length(tlKinds), ty.typerep.kindrep.argKinds) != tlKinds
     then [err(top.location, ty.unparse ++ " has kind " ++ prettyKind(ty.typerep.kindrep) ++ ", but argument(s) have kind(s) " ++ implode(", ", map(prettyKind, tlKinds)))]
     else [];
+  top.errors <- kindErrors;
 
   tl.appArgKinds =
     case ty of
@@ -427,6 +429,42 @@ top::Signature ::= l::SignatureLHS '::=' list::TypeExprs
     else [];
 }
 
+concrete production signatureOnlyNamed
+top::Signature ::= l::SignatureLHS '::=' ';' namedList::NamedTypeExprs
+{
+  top.unparse = l.unparse ++ " ::= ; " ++ namedList.unparse;
+
+  local names::[String] = sort(map(fst, namedList.namedTypes));
+  top.typerep =
+    appTypes(
+      functionType(0, names),
+      map((.fromJust), map(lookup(_, namedList.namedTypes), names)) ++
+      case l.maybeType of just(t) -> [t] | nothing() -> [] end);
+
+  top.errors <- namedList.errorsKindStar;
+}
+
+concrete production signatureNamed
+top::Signature ::= l::SignatureLHS '::=' list::TypeExprs ';' namedList::NamedTypeExprs
+{
+  top.unparse = l.unparse ++ " ::= " ++ list.unparse ++ "; " ++ namedList.unparse;
+
+  local names::[String] = sort(map(fst, namedList.namedTypes));
+  top.typerep =
+    appTypes(
+      functionType(length(list.types) + list.missingCount, names),
+      list.types ++
+      map((.fromJust), map(lookup(_, namedList.namedTypes), names)) ++
+      case l.maybeType of just(t) -> [t] | nothing() -> [] end);
+  
+  top.errors <- list.errorsKindStar;
+  top.errors <- namedList.errorsKindStar;
+  top.errors <-
+    if list.missingCount > 0
+    then [err($1.location, "Named parameters cannot be present when argument types are missing")]
+    else [];
+}
+
 concrete production presentSignatureLhs
 top::SignatureLHS ::= t::TypeExpr
 {
@@ -555,4 +593,29 @@ top::TypeExprs ::= '_' list::TypeExprs
     if length(list.types) > 0
     then [err($1.location, "Missing type argument cannot be followed by a provided argument")]
     else [];
+}
+
+-- NamedTypeExprs -------------------------------------------------------------------
+
+abstract production namedTypeListNone
+top::NamedTypeExprs ::=
+{
+  top.unparse = "";
+  top.namedTypes = [];
+  top.freeVariables = [];
+}
+
+concrete production namedTypeListSingle
+top::NamedTypeExprs ::= n::Name '::' t::TypeExpr
+{
+  top.unparse = t.unparse;
+  forwards to namedTypeListCons(n, $2, t, namedTypeListNone(location=top.location), location=top.location);
+}
+
+concrete production namedTypeListCons
+top::NamedTypeExprs ::= n::Name '::' t::TypeExpr list::NamedTypeExprs
+{
+  top.unparse = n.unparse ++ "::" ++ t.unparse ++ " " ++ list.unparse;
+  top.namedTypes = (n.name, t.typerep) :: list.namedTypes;
+  top.freeVariables = t.freeVariables ++ list.freeVariables;
 }

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -325,3 +325,29 @@ wrongCode "Type incorrect in aspect signature. Expected: silver:core:Maybe<a>  G
   top::Maybe<String> ::= x::String
   {}
 }
+
+-------------------------------------- Named function params
+annotation a1<a>::a;
+annotation a2<a>::a;
+nonterminal AnnoPairThing<a b> with a1<a>, a2<b>;
+production annoPair top::AnnoPairThing<a b> ::=  {}
+production annoThing top::AnnoPairThing<a Integer> ::= Boolean {}
+
+global mkPair::(AnnoPairThing<a b> ::= ; a1::a a2::b) = annoPair;
+wrongCode "(silver_features:AnnoPairThing<a b> ::= ; a1::b a2::a) has initialization expression with type (silver_features:AnnoPairThing<b a> ::= ; a1::b a2::a)" {
+  global mkPairFlipped::(AnnoPairThing<a b> ::= ; a2::a a1::b) = annoPair;
+}
+
+global mkIntStringPair::(AnnoPairThing<Integer String> ::= ; a1::Integer a2::String) = annoPair;
+global mkStringIntPair::(AnnoPairThing<String Integer> ::= ; a2::Integer a1::String) = annoPair;
+global mkThing::(AnnoPairThing<Float Integer> ::= Boolean; a1::Float a2::Integer) = annoThing;
+
+type AnnoPairCtr<(n :: * -> * -> *) a b> = (n<a b> ::= ; a1::a a2::(b :: *));
+global mkPair2::AnnoPairCtr<AnnoPairThing a b> = annoPair;
+
+type IntStringPairCtr = (_ ::= ; a1::Integer a2::String);
+global mkIntStringPair1::IntStringPairCtr<AnnoPairThing<Integer String>> = annoPair;
+
+wrongCode "Named parameters cannot be present when argument types are missing" {
+  type NamedAfterMissing = (_ ::= _; x::Integer);
+}


### PR DESCRIPTION
# Changes
This adds syntax for function types with named parameters; these types existed already but there was no way of writing them explicitly.  For example one could now write
```
synthesized attribute addProd::(Expr ::= Expr Expr; location::Location);

production intType
top::Type ::=
{
  top.addProd = addInt;  -- Instead of addInt(_, _, location=_);
}
```

# Documentation
https://github.com/melt-umn/melt-website/pull/53
