### PR TITLE
Avoid crash when syntax AST is demanded from a grammar with errors

### DIFF
--- a/grammars/silver/compiler/modification/copper/Prefix.sv
+++ b/grammars/silver/compiler/modification/copper/Prefix.sv
@@ -173,7 +173,7 @@ top::ParserComponent ::= 'prefer' t::QName 'over' ts::TermList ';'
   pluckTAction.originRules = [];
   
   local tName::String = t.lookupType.dcl.fullName;
-  top.syntaxAst <-
+  top.syntaxAst <- if !t.lookupType.found then [] else
     -- Generate a disambiguation function for every combination of ts.
     -- TODO: we can't use Copper's subset disambiguation functions here unfourtunately,
     -- since we currently require those to be disjoint.

--- a/grammars/silver/compiler/modification/copper/TermList.sv
+++ b/grammars/silver/compiler/modification/copper/TermList.sv
@@ -38,7 +38,7 @@ top::TermList ::= h::QName t::TermList
 
   production fName::String = h.lookupType.dcl.fullName;
 
-  top.termList <- [fName];
+  top.termList <- if h.lookupType.found then [fName] else [];
   
   -- Itd be nice if we didnt need this guard
   top.defs := if null(h.lookupType.dcls) then t.defs 

--- a/grammars/silver/compiler/modification/copper/TerminalDcl.sv
+++ b/grammars/silver/compiler/modification/copper/TerminalDcl.sv
@@ -91,7 +91,7 @@ top::TermPrecList ::= h::QName t::TermPrecList
 
   production fName::String = if null(h.lookupType.dcls) then h.lookupLexerClass.dcl.fullName else h.lookupType.dcl.fullName;
 
-  top.precTermList <- [fName];
+  top.precTermList <- if h.lookupType.found || h.lookupLexerClass.found then [fName] else [];
   
   -- Since we're looking it up in two ways, do the errors ourselves
   top.errors <- if null(h.lookupType.dcls) && null(h.lookupLexerClass.dcls)
@@ -176,7 +176,7 @@ top::LexerClassList ::= n::QName t::LexerClassList
 
   top.errors <- n.lookupLexerClass.errors;
 
-  top.lexerClasses <- [n.lookupLexerClass.dcl.fullName];
+  top.lexerClasses <- if n.lookupLexerClass.found then [n.lookupLexerClass.dcl.fullName] else [];
 }
 
 abstract production lexerClassListNull


### PR DESCRIPTION
# Changes
In the regular Silver build process, we never generate interface files for a grammar with errors.  However in the LSP driver we always write out interfaces for all built grammars.  This mostly works but there were some assumptions in the Copper modification that we wouldn't try building a syntax AST (which is included in the interface file) when there are name errors.

# Documentation
Not really needed here, this is a bug fix.