### PR TITLE
Avoid excessive laziness in production application

### DIFF
--- a/grammars/silver/compiler/modification/list/java/List.sv
+++ b/grammars/silver/compiler/modification/list/java/List.sv
@@ -19,3 +19,14 @@ top::Expr ::= '[' ']'
   top.translation = "(common.ConsCell)common.ConsCell.nil";
   top.lazyTranslation = top.translation;
 }
+
+aspect production consListOp
+top::Expr ::= h::Expr '::' t::Expr
+{
+  -- Also avoid an extra function call for `::` (remember, this is used in list literals)
+  top.translation = s"new common.ConsCell(${h.lazyTranslation}, ${t.lazyTranslation})";
+
+  -- Avoid wrapping the ConsCell constructor in an extra thunk.
+  -- This is analagous to the trick with invokeLazyTranslation on productionReference.
+  top.lazyTranslation = top.translation;
+}


### PR DESCRIPTION
# Changes
I noticed in the translation for large nested terms, every subterm production constructor call is being wrapped in a thunk.  This is a waste as the only work being deferred is the creation of the node; the arguments to a production are already lazy.  A similar situation exists for list literals.  

Instead, make the "lazy translation" of constructor calls and cons be eager.  This shouldn't affect the semantics or create cycles since any function calls/references to locals or attributes as the leaves of a term literal are still be lazy.  At the most this may mean we create some subterms that are never used, if only a portion of a specified term is demanded - but this is presumably fairly rare.  

I believe this mirrors what a lazy language with a more intelligent strictness analysis would do.  

# Documentation
Added some comments.