### PR TITLE
Tweak to fetch-jars script to be slightly smarter about merge commits

### DIFF
--- a/fetch-jars
+++ b/fetch-jars
@@ -39,6 +39,8 @@ DEVELOP=$(git ls-remote https://github.com/melt-umn/silver develop | cut -f1)
 # Look for jars in the current commit and its parents.
 # First, check that we are inside a git repo.
 if [[ -z $rev ]] && git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/null; then
+  # Walk the history in topological order, fully exploring each chain of commits
+  # before newer commits from other merged chain.
   for commit in $(git rev-list --topo-order HEAD "^$DEVELOP"); do
     echo "Looking for jars from past commit $commit"
     if has_jars "$commit"; then

--- a/fetch-jars
+++ b/fetch-jars
@@ -39,7 +39,8 @@ DEVELOP=$(git ls-remote https://github.com/melt-umn/silver develop | cut -f1)
 # Look for jars in the current commit and its parents.
 # First, check that we are inside a git repo.
 if [[ -z $rev ]] && git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/null; then
-  for commit in $(git rev-list HEAD "^$DEVELOP"); do
+  for commit in $(git rev-list --topo-order HEAD "^$DEVELOP"); do
+    echo "Looking for jars from past commit $commit"
     if has_jars "$commit"; then
       echo "Found jars from past commit"
       rev=$commit
@@ -48,6 +49,7 @@ if [[ -z $rev ]] && git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/nul
   done
 fi
 
+# Figure out how to obtain the jars from the revision we chose.
 if [[ $* != *--unstable* && (-z $rev || $rev == "$DEVELOP") ]]; then
   echo "Fetching latest stable jars..."
   LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
@@ -72,13 +74,16 @@ else
   FILES="CopperCompiler.jar commonmark-0.17.1.jar silver.compiler.composed.Default.jar SilverRuntime.jar"
 fi
 
+
 mkdir -p jars
 
 if [[ -n "$LOCAL_STORE" && -d $LOCAL_STORE ]]; then
+  # We have downloaded the jars before, just go copy them.
   for file in $FILES; do
       cp "$LOCAL_STORE/$file" jars/
   done
 else
+  # Download the jars.
   # There's probably a better way to do this!
   # Using -r causes lots of pointless downloads of variations of the index.html
   # even if -A.jar is used they still get downloaded...
@@ -101,4 +106,3 @@ else
       cp "$JARS_BAK/$file" jars/
   done
 fi
-


### PR DESCRIPTION
# Changes
Tweak the order in which we explore the commit history looking for jars, using `--topo-order` to explore commits on the current chain first rather than purely chronological order.  This should (hopefully) make things work a bit nicer when merging new-jars PRs using the merge queue, which creates temporary branches containing merge commits from not-yet-merged pull requests.

# Documentation
Added some more comments to the script