### PR TITLE
Tweak to propagate behavior for unique references

### DIFF
--- a/grammars/silver/compiler/extension/autoattr/Inherited.sv
+++ b/grammars/silver/compiler/extension/autoattr/Inherited.sv
@@ -11,7 +11,11 @@ top::ProductionStmt ::= attr::Decorated! QName
     filter(
       \ input::NamedSignatureElement ->
         isDecorable(input.typerep, top.env) &&
-        !input.typerep.isUniqueDecorated &&  -- Don't copy on unique decorated children
+        -- Only propagate for unique decorated children that don't have the attribute
+        case getMaxRefSet(input.typerep, top.env) of
+        | just(inhs) -> !contains(attrFullName, inhs)
+        | nothing() -> false
+        end &&
         !null(getOccursDcl(attrFullName, input.typerep.typeName, top.env)),
       top.frame.signature.inputElements);
   forwards to

--- a/grammars/silver/compiler/extension/autoattr/Propagate.sv
+++ b/grammars/silver/compiler/extension/autoattr/Propagate.sv
@@ -48,6 +48,7 @@ top::AGDcl ::= attrs::NameList nt::QName ps::ProdNameList
   -- Ugh, workaround for circular dependency
   top.defs := [];
   top.occursDefs := [];
+  top.refDefs := [];
   top.moduleNames := [];
   top.specDefs := [];
   

--- a/grammars/silver/compiler/extension/autoattr/Threaded.sv
+++ b/grammars/silver/compiler/extension/autoattr/Threaded.sv
@@ -111,7 +111,11 @@ top::ProductionStmt ::= isCol::Boolean rev::Boolean inh::Decorated! QName syn::S
       filter(
         \ ie::NamedSignatureElement ->
           isDecorable(ie.typerep, top.env) &&
-          !ie.typerep.isUniqueDecorated &&  -- Don't thread on unique decorated children
+          -- Only propagate for unique decorated children that don't have the inh attribute
+          case getMaxRefSet(ie.typerep, top.env) of
+          | just(inhs) -> !contains(inh.lookupAttribute.fullName, inhs)
+          | nothing() -> false
+          end &&
           !null(getOccursDcl(inh.lookupAttribute.fullName, ie.typerep.typeName, top.env)) &&
           !null(getOccursDcl(syn, ie.typerep.typeName, top.env)),
         if null(getOccursDcl(syn, top.frame.lhsNtName, top.env)) && !null(top.frame.signature.inputElements)
@@ -145,7 +149,11 @@ top::ProductionStmt ::= isCol::Boolean rev::Boolean inh::String syn::Decorated! 
       filter(
         \ ie::NamedSignatureElement ->
           isDecorable(ie.typerep, top.env) &&
-          !ie.typerep.isUniqueDecorated &&  -- Don't thread on unique decorated children
+          -- Only propagate for unique decorated children that don't have the inh attribute
+          case getMaxRefSet(ie.typerep, top.env) of
+          | just(inhs) -> !contains(inh, inhs)
+          | nothing() -> false
+          end &&
           !null(getOccursDcl(inh, ie.typerep.typeName, top.env)) &&
           !null(getOccursDcl(syn.lookupAttribute.fullName, ie.typerep.typeName, top.env)),
         top.frame.signature.inputElements));

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -461,8 +461,6 @@ top::Expr ::= e::Expr '.' 'forward'
 aspect production errorAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
-  e.mDownSubst = top.mDownSubst;
-  e.expectedMonad = top.expectedMonad;
   e.monadicallyUsed = false; --this needs to change when we decorate monadic trees
   top.monadicNames = if top.monadicallyUsed
                      then [access(e, '.', q, location=top.location)] ++ e.monadicNames
@@ -537,7 +535,6 @@ aspect production annoAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
-  e.expectedMonad = top.expectedMonad;
   e.monadicallyUsed = false; --this needs to change when we decorate monadic trees
   top.monadicNames = if top.monadicallyUsed
                      then [access(e, '.', q, location=top.location)] ++ e.monadicNames
@@ -609,7 +606,6 @@ aspect production terminalAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
-  e.expectedMonad = top.expectedMonad;
 
   top.merrors := e.merrors;
   top.mUpSubst = top.mDownSubst;
@@ -658,7 +654,6 @@ aspect production synDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
-  e.expectedMonad = top.expectedMonad;
   e.monadicallyUsed = false; --this needs to change when we decorate monadic trees
   top.monadicNames = if top.monadicallyUsed
                      then [access(e, '.', q, location=top.location)] ++ e.monadicNames
@@ -730,7 +725,6 @@ aspect production inhDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
-  e.expectedMonad = top.expectedMonad;
   e.monadicallyUsed = false; --this needs to change when we decorate monadic trees
   top.monadicNames = if top.monadicallyUsed
                      then [access(e, '.', q, location=top.location)] ++ e.monadicNames
@@ -802,7 +796,6 @@ aspect production errorDecoratedAccessHandler
 top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
 {
   e.mDownSubst = top.mDownSubst;
-  e.expectedMonad = top.expectedMonad;
 
   top.monadicNames = [];
 

--- a/grammars/silver/compiler/extension/rewriting/Expr.sv
+++ b/grammars/silver/compiler/extension/rewriting/Expr.sv
@@ -117,9 +117,6 @@ aspect production errorApplication
 top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   top.transform = applyASTExpr(e.transform, es.transform, anns.transform);
-  e.boundVars = top.boundVars;
-  es.boundVars = top.boundVars;
-  anns.boundVars = top.boundVars;
 }
 
 aspect production functionInvocation
@@ -161,18 +158,12 @@ top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAp
 
     | _, _ -> applyASTExpr(e.transform, es.transform, anns.transform)
     end;
-  e.boundVars = top.boundVars;
-  es.boundVars = top.boundVars;
-  anns.boundVars = top.boundVars;
 }
 
 aspect production partialApplication
 top::Expr ::= e::Decorated! Expr es::Decorated! AppExprs anns::Decorated! AnnoAppExprs
 {
   top.transform = applyASTExpr(e.transform, es.transform, anns.transform);
-  e.boundVars = top.boundVars;
-  es.boundVars = top.boundVars;
-  anns.boundVars = top.boundVars;
 }
 
 aspect production forwardAccess
@@ -209,7 +200,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
-  e.boundVars = top.boundVars;
 }
 
 aspect production annoAccessHandler
@@ -224,7 +214,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
-  e.boundVars = top.boundVars;
 }
 
 aspect production terminalAccessHandler
@@ -239,7 +228,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
-  e.boundVars = top.boundVars;
 }
 
 
@@ -305,7 +293,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         consASTExpr(e.transform, nilASTExpr()),
         nilNamedASTExpr())
     end;
-  e.boundVars = top.boundVars;
 }
 
 aspect production inhDecoratedAccessHandler
@@ -328,7 +315,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
-  e.boundVars = top.boundVars;
 }
 
 aspect production errorDecoratedAccessHandler
@@ -351,7 +337,6 @@ top::Expr ::= e::Decorated! Expr  q::Decorated! QNameAttrOccur
         }),
       consASTExpr(e.transform, nilASTExpr()),
       nilNamedASTExpr());
-  e.boundVars = top.boundVars;
 }
 
 aspect production decorateExprWith


### PR DESCRIPTION
# Changes
Propagate for inherited and threaded attributes did not include unique reference children.  However this doesn't seem to be the desired behavior in practice - instead, we want to generate equations for these children as long as the inherited attribute is not already in the reference set.  

# Documentation
https://github.com/melt-umn/melt-website/pull/54
