### PR TITLE
Fix bug with uniqueness analysis for let bindings

### DIFF
--- a/grammars/silver/compiler/analysis/uniqueness/Expr.sv
+++ b/grammars/silver/compiler/analysis/uniqueness/Expr.sv
@@ -282,15 +282,7 @@ top::Expr ::= q::Decorated! QName  fi::Maybe<VertexType>  fd::[FlowVertex]  rs::
     | _, _ -> []
     end;
   
-  top.uniqueRefs <- map(
-    \ r::(String, UniqueRefSite) ->
-      (r.1, uniqueRefSite(
-          refSet=r.2.refSet,
-          refFlowDeps=top.flowDeps,
-          sourceGrammar=top.grammarName,
-          sourceLocation=top.location
-        )),
-    rs);
+  top.uniqueRefs <- rs;
   top.accessUniqueRefs = [];
 }
 

--- a/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/VarBinders.sv
@@ -151,6 +151,7 @@ top::VarBinder ::= n::Name
     then map(anonVertexType(fName).inhVertex, fromMaybe([], refSet))
     else [];
 
+  -- Unique refs are forbidden in the scrutinee.
   top.defs <- [lexicalLocalDef(top.grammarName, n.location, fName, ty, vt, deps, [])];
   top.boundNames <- [n.name];
 


### PR DESCRIPTION
# Changes
Fix handling of let bindings in the uniqueness analysis.  The unique references for a lexical local reference should be just the unique references of the binding.  I think the way I wrote it previously was an attempt at getting better error messages, but this had unintended consiquences when looking up all the unique references to a particular child/local that was referenced in a let binding.

# Documentation
Added a comment.  This is just a bug fix.

# Testing
This fixes a bug that was causing some error messages to report the wrong location for a unique error message.  Not worth trying to extract into a seperate regression test IMO.  