### PR TITLE
Rename 'unification' attributes -> 'biequality' attributes

### DIFF
--- a/grammars/silver/compiler/extension/autoattr/BiEquality.sv
+++ b/grammars/silver/compiler/extension/autoattr/BiEquality.sv
@@ -1,9 +1,9 @@
 grammar silver:compiler:extension:autoattr;
 
-concrete production unificationAttributeDcl
-top::AGDcl ::= 'unification' 'attribute' synPartial::Name ',' syn::Name 'with' inh::QName ';'
+concrete production biequalityAttributeDcl
+top::AGDcl ::= 'biequality' 'attribute' synPartial::Name ',' syn::Name 'with' inh::QName ';'
 {
-  top.unparse = s"unification attribute ${synPartial.unparse}, ${syn.unparse} with ${inh.unparse};";
+  top.unparse = s"biequality attribute ${synPartial.unparse}, ${syn.unparse} with ${inh.unparse};";
   top.moduleNames := [];
 
   propagate grammarName, env, flowEnv;
@@ -26,12 +26,12 @@ top::AGDcl ::= 'unification' 'attribute' synPartial::Name ',' syn::Name 'with' i
 
   forwards to
     defsAGDcl(
-      [attrDef(defaultEnvItem(unificationPartialDcl(inhFName, synPartialFName, synFName, sourceGrammar=top.grammarName, sourceLocation=synPartial.location))),
-       attrDef(defaultEnvItem(unificationDcl(inhFName, synPartialFName, synFName, sourceGrammar=top.grammarName, sourceLocation=syn.location)))],
+      [attrDef(defaultEnvItem(biequalityPartialDcl(inhFName, synPartialFName, synFName, sourceGrammar=top.grammarName, sourceLocation=synPartial.location))),
+       attrDef(defaultEnvItem(biequalityDcl(inhFName, synPartialFName, synFName, sourceGrammar=top.grammarName, sourceLocation=syn.location)))],
       location=top.location);
 }
 
-abstract production unificationInhAttributionDcl
+abstract production biequalityInhAttributionDcl
 top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOptTypeExprs
 {
   undecorates to attributionDcl('attribute', at, attl, 'occurs', 'on', nt, nttl, ';', location=top.location);
@@ -64,7 +64,7 @@ top::AGDcl ::= at::Decorated! QName attl::BracketedOptTypeExprs nt::QName nttl::
       location=top.location);
 }
 
-abstract production propagateUnificationSynPartial
+abstract production propagateBiequalitySynPartial
 top::ProductionStmt ::= inh::String synPartial::Decorated! QName syn::String
 {
   undecorates to propagateOneAttr(synPartial, location=top.location);
@@ -101,7 +101,7 @@ top::ProductionStmt ::= inh::String synPartial::Decorated! QName syn::String
     };
 }
 
-abstract production propagateUnificationSyn
+abstract production propagateBiequalitySyn
 top::ProductionStmt ::= inh::String synPartial::String syn::Decorated! QName
 {
   undecorates to propagateOneAttr(syn, location=top.location);

--- a/grammars/silver/compiler/extension/autoattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/autoattr/DclInfo.sv
@@ -128,7 +128,7 @@ top::AttributeDclInfo ::= inh::String keySyn::String syn::String
   top.propagateDispatcher = propagateOrdering(inh, keySyn, _, location=_);
 }
 
-abstract production unificationPartialDcl
+abstract production biequalityPartialDcl
 top::AttributeDclInfo ::= inh::String synPartial::String syn::String
 {
   top.fullName = synPartial;
@@ -141,10 +141,10 @@ top::AttributeDclInfo ::= inh::String synPartial::String syn::String
   top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
   top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
-  top.propagateDispatcher = propagateUnificationSynPartial(inh, _, syn, location=_);
+  top.propagateDispatcher = propagateBiequalitySynPartial(inh, _, syn, location=_);
 }
 
-abstract production unificationDcl
+abstract production biequalityDcl
 top::AttributeDclInfo ::= inh::String synPartial::String syn::String
 {
   top.fullName = syn;
@@ -157,7 +157,7 @@ top::AttributeDclInfo ::= inh::String synPartial::String syn::String
   top.undecoratedAccessHandler = accessBounceDecorate(synDecoratedAccessHandler(_, _, location=_), _, _, _);
   top.attrDefDispatcher = synthesizedAttributeDef(_, _, _, location=_); -- Allow normal syn equations
   top.attributionDispatcher = defaultAttributionDcl(_, _, _, _, location=_);
-  top.propagateDispatcher = propagateUnificationSyn(inh, synPartial, _, location=_);
+  top.propagateDispatcher = propagateBiequalitySyn(inh, synPartial, _, location=_);
 }
 
 abstract production threadedInhDcl

--- a/grammars/silver/compiler/extension/autoattr/Terminals.sv
+++ b/grammars/silver/compiler/extension/autoattr/Terminals.sv
@@ -10,5 +10,5 @@ terminal Monoid_kwd      'monoid'      lexer classes {KEYWORD};
 terminal Destruct_kwd    'destruct'    lexer classes {KEYWORD};
 terminal Equality_kwd    'equality'    lexer classes {KEYWORD};
 terminal Ordering_kwd    'ordering'    lexer classes {KEYWORD};
-terminal Unification_kwd 'unification' lexer classes {KEYWORD};
+terminal Biequality_kwd  'biequality'  lexer classes {KEYWORD};
 terminal Threaded_kwd    'threaded'    lexer classes {KEYWORD};

--- a/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
+++ b/grammars/silver/compiler/extension/autoattr/convenience/Convenience.sv
@@ -120,13 +120,13 @@ top::AGDcl ::= 'ordering' 'attribute' inh::Name ',' keySyn::Name ',' syn::Name '
       location=top.location);
 }
 
-concrete production unificationAttributeDclMultiple
-top::AGDcl ::= 'unification' 'attribute' synPartial::Name ',' syn::Name 'with' inh::QName 'occurs' 'on' qs::QNames ';'
+concrete production biequalityAttributeDclMultiple
+top::AGDcl ::= 'biequality' 'attribute' synPartial::Name ',' syn::Name 'with' inh::QName 'occurs' 'on' qs::QNames ';'
 {
-  top.unparse = "unification attribute " ++ synPartial.name ++ ", " ++ syn.name ++ " with " ++ inh.unparse ++ " occurs on " ++ qs.unparse ++ ";";
+  top.unparse = "biequality attribute " ++ synPartial.name ++ ", " ++ syn.name ++ " with " ++ inh.unparse ++ " occurs on " ++ qs.unparse ++ ";";
   forwards to
     appendAGDcl(
-      unificationAttributeDcl($1, $2, synPartial, ',', syn, 'with', inh, ';', location=top.location),
+      biequalityAttributeDcl($1, $2, synPartial, ',', syn, 'with', inh, ';', location=top.location),
       appendAGDcl(
         makeOccursDclsHelp($1.location, qNameWithTL(qNameId(synPartial, location=synPartial.location), botlNone(location=top.location)), qs.qnames),
         makeOccursDclsHelp($1.location, qNameWithTL(qNameId(syn, location=syn.location), botlNone(location=top.location)), qs.qnames),


### PR DESCRIPTION
# Changes
Rename `unification` attributes to `biequality` attributes.  This was a poorly-named experimental feature that is really useful for more than just unification.

# Documentation
Added docs in https://github.com/melt-umn/melt-website/pull/55, this feature was not previously documented

# Testing
This is used in meta-ocaml-lite.