### PR TITLE
Avoid reading and deserializing interface files twice

### DIFF
--- a/grammars/silver/compiler/driver/CompileInterface.sv
+++ b/grammars/silver/compiler/driver/CompileInterface.sv
@@ -4,14 +4,13 @@ import silver:reflect;
 import silver:reflect:nativeserialize;
 
 {--
- - Find an interface file, if it exists, and it's valid (parsable and modification time is newer).
+ - Find an interface file, if it exists, and can be deserialized.
  -
  - @param grammarName    The grammar we're looking for an interface file for
  - @param silverHostGen  The search path to look for interface files within
- - @param grammarTime    The newest modification time of the source files, to compare against
  -}
 function compileInterface
-MaybeT<IO RootSpec> ::= grammarName::String  silverHostGen::[String]  grammarTime::Maybe<Integer>
+MaybeT<IO RootSpec> ::= grammarName::String  silverHostGen::[String]
 {
   local gramPath :: String = grammarToPath(grammarName);
 
@@ -41,12 +40,7 @@ MaybeT<IO RootSpec> ::= grammarName::String  silverHostGen::[String]  grammarTim
           "\n\tRecovering by parsing grammar...."));
         empty;
       }
-    | right(i) ->
-      case grammarTime of
-      -- Fail if the grammar sources are newer than the ones used to build the interface file
-      | just(t) when t > i.maybeGrammarTime.fromJust -> empty
-      | _ -> pure(interfaceRootSpec(i, gen))
-      end
+    | right(i) -> pure(interfaceRootSpec(i, gen))
     end;
   };
 }


### PR DESCRIPTION
# Changes
I discovered that we are loading interface files twice, and still loading them when doing a clean build, which adds unneded overhead.  This change refactors `compileGrammar` and `compileInterface` slightly to avoid these issues and shave a few seconds off of builds.

# Documentation
Internal change, added a couple comments.

# Testing
I verified this works by touching various files and manually rebuilding Silver a few times.
