### PR TITLE
FIx bug with location of terminals in metatranslated ASTs

### DIFF
--- a/grammars/silver/compiler/metatranslation/Translation.sv
+++ b/grammars/silver/compiler/metatranslation/Translation.sv
@@ -182,15 +182,12 @@ top::AST ::= terminalName::String lexeme::String location::Location
   local locationAST::AST = reflect(location);
   locationAST.givenLocation = top.givenLocation;
 
-  top.translation =
-    terminalConstructor(
-      'terminal', '(',
-      nominalTypeExpr(makeQNameType(terminalName, top.givenLocation)),
-      ',',
-      stringConst(terminal(String_t, s"\"${escapeString(lexeme)}\"", top.givenLocation)),
-      ',',
-      locationAST.translation,
-      ')');
+  top.translation = Silver_Expr {
+    terminal(
+      $TypeExpr{nominalTypeExpr(makeQNameType(terminalName, top.givenLocation))},
+      $Expr{stringConst(terminal(String_t, s"\"${escapeString(lexeme)}\"", top.givenLocation))},
+      silver:core:fromMaybe($Expr{locationAST.translation}, silver:core:getParsedOriginLocation(silver:core:ambientOrigin())))
+  };
   
   -- TODO: What to do here- warn about this maybe?
   -- Shouldn't really be an issue unless matching against concrete syntax containing non-fixed terminals

--- a/grammars/silver/compiler/metatranslation/Translation.sv
+++ b/grammars/silver/compiler/metatranslation/Translation.sv
@@ -184,8 +184,12 @@ top::AST ::= terminalName::String lexeme::String location::Location
 
   top.translation = Silver_Expr {
     terminal(
+      -- The type expression from the name of the terminal
       $TypeExpr{nominalTypeExpr(makeQNameType(terminalName, top.givenLocation))},
+      -- The quoted lexeme
       $Expr{stringConst(terminal(String_t, s"\"${escapeString(lexeme)}\"", top.givenLocation))},
+      -- Try to get the location dynamically from the parsed origin location if tracking is available,
+      -- or else fall back to the compile-time AST location.
       silver:core:fromMaybe($Expr{locationAST.translation}, silver:core:getParsedOriginLocation(silver:core:ambientOrigin())))
   };
   


### PR DESCRIPTION
# Changes
Terminals have an associated location, analagous to the old location annotation, even when origin tracking is enabled on nonterminals.  When a production has terminal children, sometimes we use the terminal locations in error messages, rather than querying the parsed origin info.. 

When constructing terminals in an AST we should use the dynamic origin location rather than the compile-time one from the qutoted AST, if possible.

# Documentation
Added a few comments.

# Testing
Checked the `1 ++ 2` gives the correct error location.