### PR TITLE
Add utilities for use in debugger, to check whether a child/local is decorable

### DIFF
--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -79,6 +79,7 @@ ${makeIndexDcls(0, whatSig.inputElements)}
 
 	public static final common.Lazy[][] childInheritedAttributes = new common.Lazy[${toString(length(whatSig.inputElements))}][];
 
+    public static final boolean[] localDecorable = new boolean[num_local_attrs];
 	public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
     public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
 	public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
@@ -100,6 +101,14 @@ ${contexts.contextInitTrans}
 ${whatSig.childDecls}
 
 ${contexts.contextMemberDeclTrans}
+
+	@Override
+	public boolean isChildDecorable(final int index) {
+		switch(index) {
+${implode("", map(makeChildDecorableCase(env, _), whatSig.inputElements))}
+            default: return false;
+        }
+    }
 
 	@Override
 	public Object getChild(final int index) {
@@ -140,6 +149,11 @@ ${flatMap(makeInhOccursContextAccess(whatSig.freeVariables, whatSig.contextInhOc
 	public common.Lazy[] getChildInheritedAttributes(final int key) {
 ${flatMap(makeInhOccursContextAccess(whatSig.freeVariables, whatSig.contextInhOccurs, "childInhContextTypeVars", "childInheritedAttributes", _), whatSig.inhOccursContextTypes)}
 		return childInheritedAttributes[key];
+	}
+
+	@Override
+	public boolean isLocalDecorable(final int key) {
+		return localDecorable[key];
 	}
 
 	@Override

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -325,6 +325,11 @@ String ::= n::NamedSignatureElement
 {
   return s"\t\t\tcase i_${n.elementName}: return child_${n.elementName};\n";
 }
+function makeChildDecorableCase
+String ::= env::Env n::NamedSignatureElement
+{
+  return s"\t\t\tcase i_${n.elementName}: return ${toString(isDecorable(n.typerep, env))};\n";
+}
 function makeChildDecSiteAccessCase
 String ::= env::Env flowEnv::FlowEnv lhsNtName::String prodName::String n::NamedSignatureElement
 {

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -133,6 +133,11 @@ ${if quals.data then "" else s"""
 		}
 
 		@Override
+		public boolean isChildDecorable(final int child) {
+			return ref.getNode().isChildDecorable(child);
+		}
+
+		@Override
 		public Object getChild(final int child) {
 			return ref.getNode().getChild(child);
 		}
@@ -161,6 +166,11 @@ ${if quals.data then "" else s"""
 
 		@Override
 		public int getNumberOfLocalAttrs() {
+			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
+		}
+
+		@Override
+		public boolean isLocalDecorable(final int child) {
 			throw new common.exceptions.SilverInternalError("Decoration site wrapper node should never be directly decorated!");
 		}
 

--- a/grammars/silver/compiler/translation/java/core/ProductionBody.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionBody.sv
@@ -117,6 +117,10 @@ top::ProductionStmt ::= 'local' 'attribute' a::Name '::' te::TypeExpr ';'
     else "";
 
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
+  top.setupInh <-
+    if isDecorable(te.typerep, top.env)
+    then s"\t\t${top.frame.className}.localDecorable[${ugh_dcl_hack.attrOccursInitIndex}] = true;\n"
+    else "";
 
   top.translation = 
     case lookupLocalUniqueRefs(fName, top.flowEnv), lookupLocalRefDecSite(fName, top.flowEnv) of
@@ -147,6 +151,10 @@ top::ProductionStmt ::= 'production' 'attribute' a::Name '::' te::TypeExpr ';'
     else "";
 
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
+  top.setupInh <-
+    if isDecorable(te.typerep, top.env)
+    then s"\t\t${top.frame.className}.localDecorable[${ugh_dcl_hack.attrOccursInitIndex}] = true;\n"
+    else "";
 
   top.translation = 
     case lookupLocalUniqueRefs(fName, top.flowEnv), lookupLocalRefDecSite(fName, top.flowEnv) of
@@ -172,6 +180,7 @@ top::ProductionStmt ::= 'forward' 'production' 'attribute' a::Name ';'
     s"\t\t${top.frame.className}.localInheritedAttributes[${ugh_dcl_hack.attrOccursInitIndex}] = new common.Lazy[${makeNTName(top.frame.lhsNtName)}.num_inh_attrs];\n";
 
   top.setupInh <- s"\t\t${top.frame.className}.occurs_local[${ugh_dcl_hack.attrOccursInitIndex}] = \"${fName}\";\n";
+  top.setupInh <- s"\t\t${top.frame.className}.localDecorable[${ugh_dcl_hack.attrOccursInitIndex}] = true;\n";
 
   -- Decoration through a remote reference has no effect, since all inhs are supplied here via a forward parent
   top.translation = "";

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -82,6 +82,7 @@ ${makeIndexDcls(0, namedSig.inputElements)}
     public static final common.Lazy[] synthesizedAttributes = new common.Lazy[${fnnt}.num_syn_attrs];
     public static final common.Lazy[][] childInheritedAttributes = new common.Lazy[${toString(length(namedSig.inputElements))}][];
 
+    public static final boolean[] localDecorable = new boolean[num_local_attrs];
     public static final common.Lazy[] localAttributes = new common.Lazy[num_local_attrs];
     public static final common.Lazy[] localDecSites = new common.Lazy[num_local_attrs];
     public static final common.Lazy[][] localInheritedAttributes = new common.Lazy[num_local_attrs][];
@@ -126,6 +127,14 @@ ${contexts.contextInitTrans}
 ${namedSig.childDecls}
 
 ${contexts.contextMemberDeclTrans}
+
+	@Override
+	public boolean isChildDecorable(final int index) {
+		switch(index) {
+${implode("", map(makeChildDecorableCase(body.env, _), namedSig.inputElements))}
+            default: return false;
+        }
+    }
 
 	@Override
 	public Object getChild(final int index) {
@@ -216,6 +225,11 @@ ${if isData then "" else s"""
     public boolean getLocalIsForward(final int key) {
         return localIsForward[key];
     }"""}
+
+    @Override
+    public boolean isLocalDecorable(final int key) {
+        return localDecorable[key];
+    }
 
     @Override
     public common.Lazy getLocal(final int key) {

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -286,6 +286,23 @@ public class DecoratedNode implements Decorable, Typed {
 	}
 
 	/**
+	 * Returns the child of this DecoratedNode, decorating it if needed.
+	 * 
+	 * This may be useful for debugging/reflection but is not used in the translation;
+	 * prefer calling childAsIs/childDecorated directly for performance.
+	 * 
+	 * @param child The number of the child to obtain.
+	 * @return The value of the child.
+	 */
+	public Object child(final int child) {
+		if(self.isChildDecorable(child)) {
+			return childDecorated(child);
+		} else {
+			return childAsIs(child);
+		}
+	}
+
+	/**
 	 * Returns the child of this DecoratedNode, without potentially decorating it.
 	 * 
 	 * <p>Warning: do not mix {@link #childAsIs} and {@link #childDecorated} on the same child!
@@ -325,7 +342,7 @@ public class DecoratedNode implements Decorable, Typed {
 	 * Separate function to keep {@link #childDecorated} small and inlineable.
 	 * This is, after all, the "slow path."
 	 */
-	private final DecoratedNode obtainDecoratedChild(final int child) { 
+	private final DecoratedNode obtainDecoratedChild(final int child) {
 		Lazy decSite = self.getChildDecSite(child);
 		if(decSite == null) {
 			return createDecoratedChild(child);
@@ -343,12 +360,30 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @return The decorated value of the child.
 	 */
 	public final DecoratedNode createDecoratedChild(final int child) {
+		assert self.isChildDecorable(child);
 		if(childCreated[child]) {
 			throw new SilverInternalError("Decorated child " + child + " created more than once in " + getDebugID());
 		}
 		DecoratedNode result = ((Decorable)self.getChild(child)).decorate(this, self.getChildInheritedAttributes(child));
 		childCreated[child] = true;
 		return result;
+	}
+
+	/**
+	 * Returns the value of a local, decorating it if needed.
+	 * 
+	 * This may be useful for debugging/reflection but is not used in the translation;
+	 * prefer calling localAsIs/localDecorated directly for performance.
+	 * 
+	 * @param attribute The index of the local to obtain.
+	 * @return The value of the local.
+	 */
+	public Object local(final int attribute) {
+		if(self.isLocalDecorable(attribute)) {
+			return localDecorated(attribute);
+		} else {
+			return localAsIs(attribute);
+		}
 	}
 
 	/**
@@ -440,6 +475,7 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @return The decorated value of the local.
 	 */
 	public final DecoratedNode evalLocalDecorated(final int attribute) {
+		assert self.isLocalDecorable(attribute);
 		if(localCreated[attribute]) {
 			throw new SilverInternalError("Decorated local '" + self.getNameOfLocalAttr(attribute) + "' created more than once in " + getDebugID());
 		}

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -161,6 +161,14 @@ public abstract class Node implements Decorable, Typed {
 	public abstract int getNumberOfChildren();
 
 	/**
+	 * Determine if the child should be automatically decorated.
+	 * 
+	 * @param child A number in the range <code>0 - getNumberofChildren()</code>
+	 * @return True if the child has a decorable type in the signature.
+	 */
+	public abstract boolean isChildDecorable(final int child);
+
+	/**
 	 * Access a (raw) child of this Node.
 	 * 
 	 * @param child A number in the range <code>0 - getNumberofChildren()</code>
@@ -196,6 +204,14 @@ public abstract class Node implements Decorable, Typed {
 	 * @return The number of local and production attributes that occur on this <b>production</b>
 	 */
 	public abstract int getNumberOfLocalAttrs();
+
+	/**
+	 * Determine if the local should be automatically decorated.
+	 * 
+	 * @param index The index of a local or production attribute on this Node
+	 * @return True if the local is declared with a decorable type.
+	 */
+	public abstract boolean isLocalDecorable(final int index);
 	
 	/**
 	 * Used for debugging, stack traces especially.
@@ -206,7 +222,7 @@ public abstract class Node implements Decorable, Typed {
 	public abstract String getNameOfLocalAttr(final int index);
 
 	/**
-	 * @param name The index of a local or production attribute on this Node
+	 * @param index The index of a local or production attribute on this Node
 	 * @return A Lazy to evaluate on a decorated form of this Node, to get the value of the attribute
 	 */
 	public abstract Lazy getLocal(final int index);
@@ -227,7 +243,7 @@ public abstract class Node implements Decorable, Typed {
 	public abstract boolean getLocalIsForward(final int index);
 
 	/**
-	 * @param key The index for a local, to retrieve inherited attributes for.
+	 * @param index The index for a local, to retrieve inherited attributes for.
 	 * @return An array containing the inherited attributes supplied to that local 
 	 */
 	public abstract Lazy[] getLocalInheritedAttributes(final int index);


### PR DESCRIPTION
# Changes
Requested by Matthew, add a way to access children/locals on a DecoratedNode without knowing whether they should be decorated or not.  In the translation we always know this statically, and can call `getChildAsIs` or `getChildDecorated` where appropriate, but in the runtime this is not available e.g. for a debugger.  

This adds `isChildDecorable`/`isLocalDecorable` methods on `Node`, and `child`/`local` methods on `DecoratedNode` to do so.  These are not otherwise used in the Java translation so they shouldn't impose additional overhead.

# Documentation
Purely an internal change to the runtime API - added javadoc comments.  

# Testing
Added asserts on `createDecoratedChild`/`evalLocalDecorated` and ensured this works as expected when deep-rebuilding Silver.