### PR TITLE
Make PatternVarProjection a data nonterminal

### DIFF
--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -391,10 +391,8 @@ top::FlowDef ::= prod::String  matchProd::String  scrutinee::VertexType  vars::[
   top.flowEdges = [];
 }
 
-nonterminal PatternVarProjection;
-abstract production patternVarProjection
-top::PatternVarProjection ::= child::String  typeName::String  patternVar::String
-{}
+data PatternVarProjection
+  = patternVarProjection child::String  typeName::String  patternVar::String;
 
 {--
  - A sub-term with a flow vertex, that has a known decoration site.

--- a/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
@@ -449,17 +449,14 @@ fun patternStitchPoints [StitchPoint] ::= realEnv::Env  defs::[FlowDef] =
       patternStitchPoints(realEnv, rest)
   | _ :: rest -> patternStitchPoints(realEnv, rest)
   end;
-function patVarStitchPoints
-[StitchPoint] ::= matchProd::String  scrutinee::VertexType  realEnv::Env  var::PatternVarProjection
-{
-  return case var of
+fun patVarStitchPoints [StitchPoint] ::= matchProd::String  scrutinee::VertexType  realEnv::Env  var::PatternVarProjection =
+  case var of
   | patternVarProjection(child, typeName, patternVar) -> 
       projectionStitchPoint(
         matchProd, anonVertexType(patternVar), scrutinee, rhsVertexType(child),
         getInhAndInhOnTransAttrsOn(typeName, realEnv)) ::
       nonterminalStitchPoints(realEnv, typeName, anonVertexType(patternVar))
   end;
-}
 fun subtermDecSiteStitchPoints [StitchPoint] ::= flowEnv::FlowEnv  realEnv::Env  defs::[FlowDef] =
   flatMap(\ d::FlowDef ->
     case d of


### PR DESCRIPTION
# Changes
While poking around in the MWDA internals I noticed `PatternVarProjection` had been missed in the refactor to use data nonterminals in the flow analysis.

# Documentation
None needed, this just makes a nonterminal into a data nonterminal.

# Testing
Jenkins