### PR TITLE
Feature/main concisefunction

### DIFF
--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -8,7 +8,7 @@ import silver:compiler:modification:concisefunctions;
 aspect production shortFunctionDcl
 top::AGDcl ::= 'fun' id::Name ns::FunctionSignature '=' e::Expr ';'
 {
-	-- For main functions which return IOVal<Integer>
+  -- For main functions which return IOVal<Integer>
   local attribute typeIOValFailed::Boolean = unify(namedSig.typerep,
     appTypes(
       functionType(2, []),
@@ -23,16 +23,16 @@ top::AGDcl ::= 'fun' id::Name ns::FunctionSignature '=' e::Expr ';'
         [appType(listCtrType(), stringType()),
           appType(nonterminalType("silver:core:IO", [starKind()], false, false), intType())])).failure;
 
-	top.genFiles <-
-		if id.name == "main"
-			then [("Main.java", generateMainClassString(top.grammarName, !typeIOValFailed))]
-			else [];
+  top.genFiles <-
+    if id.name == "main"
+      then [("Main.java", generateMainClassString(top.grammarName, !typeIOValFailed))]
+      else [];
 
-	top.errors <-
+  top.errors <-
     if id.name == "main" && typeIOValFailed && typeIOMonadFailed -- Neither legal main function type used
-			then [errFromOrigin(top, "main function must have type signature (IOVal<Integer> ::= [String] IOToken) " ++
-				"or (IO<Integer> ::= [String]). Instead it has type " ++ prettyType(namedSig.typerep))]
-			else [];
+      then [errFromOrigin(top, "main function must have type signature (IOVal<Integer> ::= [String] IOToken) " ++
+        "or (IO<Integer> ::= [String]). Instead it has type " ++ prettyType(namedSig.typerep))]
+      else [];
 }
 
 aspect production functionDcl

--- a/tutorials/hello/Hello.sv
+++ b/tutorials/hello/Hello.sv
@@ -1,10 +1,7 @@
 grammar hello;
 
-function main 
-IO<Integer> ::= largs::[String]
-{
-  return do {
+fun main IO<Integer> ::= largs::[String] =
+  do {
     print("Hello, world!\n");
     return 0;
   };
-}

--- a/tutorials/hello/silver-compile
+++ b/tutorials/hello/silver-compile
@@ -7,4 +7,3 @@ SRC=..  # cheating a bit. Current directory should be 'hello'
 GRAMMAR=hello
 
 silver -I $SRC $@ $GRAMMAR
-

--- a/tutorials/lambda/Main.sv
+++ b/tutorials/lambda/Main.sv
@@ -23,8 +23,6 @@ parser hostParse :: Root_c {
   lambda;
 } 
 
-function main 
-IOVal<Integer> ::= largs::[String] io_in::IOToken
-{
-  return driver(largs, hostParse, io_in) ;
-}
+fun main
+IOVal<Integer> ::= largs::[String] io_in::IOToken =
+  driver(largs, hostParse, io_in);

--- a/tutorials/simple/src/simple/arb/Main.sv
+++ b/tutorials/simple/src/simple/arb/Main.sv
@@ -7,8 +7,6 @@ generator generate :: simple:concretesyntax:Root {
   simple:host;
 }
 
-function main 
-IOVal<Integer> ::= args::[String] io_in::IOToken
-{
-  return ioval(arbDriver(args, io_in, generate), 0);
-}
+fun main
+IOVal<Integer> ::= args::[String] io_in::IOToken =
+  ioval(arbDriver(args, io_in, generate), 0);

--- a/tutorials/simple/src/simple/host/Main.sv
+++ b/tutorials/simple/src/simple/host/Main.sv
@@ -23,9 +23,6 @@ parser parse :: simple:concretesyntax:Root {
   simple:terminals;
 } 
 
-function main 
-IOVal<Integer> ::= args::[String] io_in::IOToken
-{
-  return ioval(driver(args, io_in, parse), 0);
-}
-
+fun main
+IOVal<Integer> ::= args::[String] io_in::IOToken =
+  ioval(driver(args, io_in, parse), 0);


### PR DESCRIPTION
# Changes
Resolves #799.

Introduced aspect for `shortFunctionDcl` in 460cb8308c1355eec2f8d0c5863bd331e08c41ef to define equations contributing to `genFiles` and `errors`, which generate a `Main` file and check the function signature respectively.

Refactored a number of existing `main` functions to the more concise form.

# Documentation
No code documentation needed for main function refactoring or aspect production declaration.

Accompanying update to the website at https://github.com/melt-umn/melt-website/pull/58.

# Testing
Concise main functions tested by refactoring main functions in select tutorial programs.