### PR TITLE
Feature/agnosis-utils

### DIFF
--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -671,5 +671,12 @@ String ::= e::Decorated Expr
   -- we have hit the 64K bytecode limit in the past, which is why `Init` farms
   -- initialization code out across each production. So who knows.
   local swizzleOrigins::String = if e.config.noOrigins then "" else "final common.OriginContext originCtx = context.originCtx;";
-  return s"new common.Lazy() { public final Object eval(final common.DecoratedNode context) { ${swizzleOrigins} return ${e.translation}; } }";
+  local loc::Location = getParsedOriginLocationOrFallback(e);
+  local fileName::String =
+    case searchEnvTree(e.grammarName, e.compiledGrammars) of
+    | r :: _ -> r.grammarSource
+    | [] -> ""
+    end ++ loc.filename;
+  local sourceLocationTrans::String = s"new silver.core.Ploc(\"${fileName}\", ${toString(loc.line)}, ${toString(loc.column)}, ${toString(loc.endLine)}, ${toString(loc.endColumn)}, ${toString(loc.index)}, ${toString(loc.endIndex)})";
+  return s"new common.Lazy() { public final Object eval(final common.DecoratedNode context) { ${swizzleOrigins} return ${e.translation}; } public final silver.core.NLocation getSourceLocation() { return ${sourceLocationTrans}; } }";
 }

--- a/runtime/java/src/common/CollectionAttribute.java
+++ b/runtime/java/src/common/CollectionAttribute.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import common.exceptions.MissingDefinitionException;
 import common.exceptions.TraceException;
 
+import silver.core.NLocation;
+
 /**
  * This class is a specialized Lazy that allows additional elements to be inserted
  * during start-up initialization.  These elements are then used by the custom
@@ -47,6 +49,10 @@ public abstract class CollectionAttribute implements Lazy {
 	}
 
 	public abstract Object eval(final DecoratedNode context);
+
+	public NLocation getSourceLocation() {
+	  return base.getSourceLocation();
+	}
 	
 	private static class BaseDefault implements Lazy {
 		private final int index;

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -783,6 +783,13 @@ public class DecoratedNode implements Decorable, Typed {
 		// Straight up use whatever thunk (or not!) is in the node.
 		return self.getChildLazy(child);
 	}
+	public final Object localLazy(final int index) {
+		if(localValues[index] != null)
+			return localValues[index];
+		
+		return new Thunk<Object>(() -> this.local(index));
+	
+	}
 	public final Object localDecoratedLazy(final int index) {
 		if(localValues[index] != null)
 			return localValues[index];

--- a/runtime/java/src/common/Lazy.java
+++ b/runtime/java/src/common/Lazy.java
@@ -1,5 +1,7 @@
 package common;
 
+import silver.core.NLocation;
+
 /**
  * Lazy is the interface used to create function pointers, essentially.
  * 
@@ -14,13 +16,30 @@ public interface Lazy {
 	public Object eval(DecoratedNode context);
 
     /**
+     * Get the source file location of the equation defining this Lazy.
+     * Null if this Lazy does not correspond to an equation.
+     * TODO: we should include this in stack traces.
+     * 
+     * @return The source location of the equation defining this Lazy, or null if it is not available.
+     */
+    public default NLocation getSourceLocation() {
+        return null;
+    }
+
+    /**
      * Create a Lazy that evaluates in some context and ignores the supplied one.
      * 
      * @param context The context to evaluate in.
      * @return A Lazy that evaluates in the supplied context.
      */
     public default Lazy withContext(final DecoratedNode context) {
-        return (ignoredNewContext) -> eval(context);
+        return new Lazy() {
+            @Override
+            public Object eval(DecoratedNode ignoredNewContext) { return Lazy.this.eval(context); }
+
+            @Override
+            public NLocation getSourceLocation() { return Lazy.this.getSourceLocation(); }
+        };
     }
 
     public static class Trap implements Lazy {
@@ -32,6 +51,10 @@ public interface Lazy {
 
         public Object eval(DecoratedNode context) {
             return Util.error(m);
+        }
+
+        public NLocation getSourceLocation() {
+            return null;
         }
     }
 }

--- a/runtime/java/src/common/TransInhs.java
+++ b/runtime/java/src/common/TransInhs.java
@@ -1,6 +1,7 @@
 package common;
 
 import common.exceptions.SilverInternalError;
+import silver.core.NLocation;
 
 /**
  * Represents the inherited attributes supplied to a translation attribute.
@@ -20,6 +21,11 @@ public class TransInhs implements Lazy {
     @Override
     public Object eval(DecoratedNode context) {
         throw new SilverInternalError("TransInhs should never be evaluated!");
+    }
+
+    @Override
+    public NLocation getSourceLocation() {
+        throw new SilverInternalError("TransInhs location should never be accessed!");
     }
     
     @Override


### PR DESCRIPTION
# Changes
Some utilities for use by the debugger folks.

This adds a `localLazy` method in `DecoratedNode`, and `getSourceLocation` on Lazy objects to get the source of locations.  For collection attributes, it just returns the location of the base equation for now.

# Documentation
Added doc comments.

# Testing
Inspected the generated code to see that locations are correct.  Otherwise, let me know if this doesn't work!