### PR TITLE
Add missing error message for concise function return type mismatch

### DIFF
--- a/grammars/silver/compiler/modification/concisefunctions/ConciseFunctions.sv
+++ b/grammars/silver/compiler/modification/concisefunctions/ConciseFunctions.sv
@@ -23,6 +23,10 @@ top::AGDcl ::= 'fun' id::Name ns::FunctionSignature '=' e::Expr ';'
   top.defs := [shortFunDef(top.grammarName, id.nameLoc, namedSig)];
 
   local errCheck1 :: TypeCheck = check(e.typerep, namedSig.outputElement.typerep);
+  top.errors <-
+    if errCheck1.typeerror
+    then [errFromOrigin(e, s"Expected result type is ${errCheck1.rightpp}, but the expression has type ${errCheck1.leftpp}.")]
+    else [];
 
   e.downSubst = emptySubst();
   errCheck1.downSubst = e.upSubst;

--- a/test/silver_features/ConciseFunctions.sv
+++ b/test/silver_features/ConciseFunctions.sv
@@ -52,3 +52,7 @@ fun getInhKey2 {inhKey} subset i => String ::= x::Decorated TestBinding with i =
 fun getVal2 {inhKey} subset i, attribute val i occurs on a => Integer ::= thing::Decorated a with i = thing.val;
 
 equalityTest(getInhKey2(bnd), "key", String, silver_tests);
+
+wrongCode "Expected result type is Integer, but the expression has type Float." {
+  fun badRet Integer ::= s::String = 3.14;
+}


### PR DESCRIPTION
# Changes
Add missing error message when concise function body has the wrong type.

# Documentation
Bug fix, not needed.

# Testing
Added a test case for a concise function with the wrong type.