### PR TITLE
Fix a few bugs with reflection-based unparse mechanism

### DIFF
--- a/grammars/silver/compiler/composed/Default/Main.sv
+++ b/grammars/silver/compiler/composed/Default/Main.sv
@@ -6,9 +6,4 @@ parser svParse::Root {
   silver:compiler:host;
 }
 
--- TODO: Change to a concise function
-function main 
-IOVal<Integer> ::= args::[String] ioin::IOToken
-{
-  return evalIO(cmdLineRun(args, svParse), ioin);
-}
+fun main IO<Integer> ::= args::[String] = cmdLineRun(args, svParse);

--- a/grammars/silver/compiler/modification/concisefunctions/DclInfo.sv
+++ b/grammars/silver/compiler/modification/concisefunctions/DclInfo.sv
@@ -29,14 +29,8 @@ top::ValueDclInfo ::= fn::String ty::Type
   top.transDefLHSDispatcher = errorTransAttrDefLHS;
 }
 
-function shortFunDef
-Def ::= sg::String sl::Location ns::NamedSignature
-{
-  return valueDef(defaultEnvItem(shortFunDcl(ns,sourceGrammar=sg,sourceLocation=sl)));
-}
+fun shortFunDef Def ::= sg::String sl::Location ns::NamedSignature =
+  valueDef(defaultEnvItem(shortFunDcl(ns,sourceGrammar=sg,sourceLocation=sl)));
 
-function shortFunParamDef
-Def ::= sg::String sl::Location fn::String ty::Type
-{
-  return valueDef(defaultEnvItem(shortFunParamDcl(fn,ty,sourceGrammar=sg,sourceLocation=sl)));
-}
+fun shortFunParamDef Def ::= sg::String sl::Location fn::String ty::Type =
+  valueDef(defaultEnvItem(shortFunParamDcl(fn,ty,sourceGrammar=sg,sourceLocation=sl)));

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -189,7 +189,7 @@ ${flatMap(makeInhOccursContextAccess(namedSig.freeVariables, namedSig.contextInh
 ${if isData then "" else s"""
     @Override
     public common.Node evalUndecorate(final common.DecoratedNode context) {
-    	${if !null(body.undecorateExpr)
+        ${if !null(body.undecorateExpr)
           then s"return (common.Node)${head(body.undecorateExpr).translation};"
           else if !null(decorableChildren)
           then s"return new ${className}(${implode(", ",

--- a/grammars/silver/langutil/pp/Document.sv
+++ b/grammars/silver/langutil/pp/Document.sv
@@ -286,35 +286,28 @@ top::Document ::=
 
 --------------------------------------------------------------------------------
 
-function prune
-Pair<dq:Deque<Pair<Integer [Boolean]>> [Boolean]> ::= p::Integer q::dq:Deque<Pair<Integer [Boolean]>>
-{
-  return if dq:isEmpty(q) then (q, [])
-         else let h::Pair<Integer [Boolean]> = dq:head(q)
-               in if p <= h.fst then (q, [])
-                  else let recur::Pair<dq:Deque<Pair<Integer [Boolean]>> [Boolean]> = prune(p, dq:tail(q))
-                        in (recur.fst, false :: (h.snd ++ recur.snd))
-                       end
-              end;
-}
+fun prune
+Pair<dq:Deque<Pair<Integer [Boolean]>> [Boolean]> ::= p::Integer q::dq:Deque<Pair<Integer [Boolean]>> =
+  if dq:isEmpty(q) then (q, [])
+  else let h::Pair<Integer [Boolean]> = dq:head(q)
+        in if p <= h.fst then (q, [])
+           else let recur::Pair<dq:Deque<Pair<Integer [Boolean]>> [Boolean]> = prune(p, dq:tail(q))
+                 in (recur.fst, false :: (h.snd ++ recur.snd))
+                end
+       end;
 
-function enter
-dq:Deque<Pair<Integer [Boolean]>> ::= p::Integer q::dq:Deque<Pair<Integer [Boolean]>>
-{
-  return dq:snoc(q, (p, []));
-}
+fun enter dq:Deque<Pair<Integer [Boolean]>> ::= p::Integer q::dq:Deque<Pair<Integer [Boolean]>> =
+  dq:snoc(q, (p, []));
 
-function leave
-Pair<dq:Deque<Pair<Integer [Boolean]>> [Boolean]> ::= p::Integer q::dq:Deque<Pair<Integer [Boolean]>>
-{
-  return if dq:isEmpty(q) then (q, [])
-         else let h1::Pair<Integer [Boolean]> = dq:last(q),
-                  t1::dq:Deque<Pair<Integer [Boolean]>> = dq:init(q)
-               in if dq:isEmpty(t1) then (t1, true :: h1.snd)
-                  else let h2::Pair<Integer [Boolean]> = dq:last(t1),
-                           t2::dq:Deque<Pair<Integer [Boolean]>> = dq:init(t1)
-                        in (dq:snoc(t2, (h2.fst, h2.snd ++ [p <= h1.fst] ++ h1.snd)), [])
-                       end
-              end;
-}
+fun leave
+Pair<dq:Deque<Pair<Integer [Boolean]>> [Boolean]> ::= p::Integer q::dq:Deque<Pair<Integer [Boolean]>> =
+  if dq:isEmpty(q) then (q, [])
+  else let h1::Pair<Integer [Boolean]> = dq:last(q),
+           t1::dq:Deque<Pair<Integer [Boolean]>> = dq:init(q)
+        in if dq:isEmpty(t1) then (t1, true :: h1.snd)
+           else let h2::Pair<Integer [Boolean]> = dq:last(t1),
+                    t2::dq:Deque<Pair<Integer [Boolean]>> = dq:init(t1)
+                 in (dq:snoc(t2, (h2.fst, h2.snd ++ [p <= h1.fst] ++ h1.snd)), [])
+                end
+       end;
 

--- a/grammars/silver/langutil/unparse/Unparse.sv
+++ b/grammars/silver/langutil/unparse/Unparse.sv
@@ -38,10 +38,10 @@ Document ::= origText::String  tree::a
   local postLayout::String = substring(parseTree.originLoc.endIndex, length(origText), origText);
 
   return
-    layoutPP(0, preLayout) ++
+    blobPP(0, preLayout) ++
     maybeNest(parseTree.indent,
       ast.unparseWithLayout ++
-      layoutPP(parseTree.indent, postLayout));
+      blobPP(parseTree.indent, postLayout));
 }
 
 @{--
@@ -181,7 +181,7 @@ top::AST ::= terminalName::String lexeme::String location::Location
 {
   top.originLoc = location;
 
-  top.unparseWithLayout = ppImplode(realLine(), map(text, explode("\n", lexeme)));
+  top.unparseWithLayout = blobPP(top.indent, lexeme);
 
   -- Map of terminal names to default layout after the terminal
   production attribute termPreLayout::[(String, Document)] with ++;
@@ -201,7 +201,7 @@ top::ASTs ::= h::AST t::ASTs
   top.origLayoutPP =
     case t of
     | consAST(h2, _) ->
-        layoutPP(h2.indent,
+        blobPP(h2.indent,
           substring(h.originLoc.endIndex, h2.originLoc.index, top.origText))
     | nilAST() -> pp""
     end;
@@ -282,9 +282,9 @@ top::ASTs ::=
 -- Count the number of spaces at the start of a line
 fun countIndent  Integer ::= s::String = length(takeWhile(eq(" ", _), explode("", s)));
 
-fun layoutPP  Document ::= indent::Integer layoutStr::String =
+fun blobPP  Document ::= indent::Integer str::String =
   concat(
-    case explode("\n", layoutStr) of
+    case explode("\n", str) of
     | [] -> []
     | pre :: lines -> text(pre) ::
         map(\ l::String ->

--- a/grammars/silver/langutil/unparse/Unparse.sv
+++ b/grammars/silver/langutil/unparse/Unparse.sv
@@ -181,6 +181,9 @@ top::AST ::= terminalName::String lexeme::String location::Location
 {
   top.originLoc = location;
 
+  -- If there is a *syntactic* newline, then force anything enclosing this to not be boxed.
+  top.indents <- if indexOf("\n", lexeme) != -1 then [-1] else [];
+
   top.unparseWithLayout = blobPP(top.indent, lexeme);
 
   -- Map of terminal names to default layout after the terminal


### PR DESCRIPTION
# Changes
Fix some issues with handling newlines in syntactic terminals, such as in multi-line doc comments and string templates.  Also refactor some functions added/changed since #822.

`./self-compile --refactor-concise-functions` is now clean when run on the Silver compiler, and does not perform any additional changes.

# Documentation
Added a comment.  This is a bug fix.

# Testing
Ran the concise functions refactoring pass on Silver and ableC, it now does not cause any superfluous indentation changes.
