### PR TITLE
Fix bugs with occurs-on constraints

### DIFF
--- a/fetch-jars
+++ b/fetch-jars
@@ -20,8 +20,15 @@ done
 
 COMMIT_ARTIFACTS="https://foundry.remexre.xyz/commit-artifacts/"
 
+[[ $* == *--local* ]]
+LOCAL_JARS=$?
+
 function has_jars {
-  wget --spider -q "$COMMIT_ARTIFACTS/$1"
+  if [[ $LOCAL_JARS -eq 0 ]]; then
+    [[ -d "JARS-BAK/$1" ]]
+  else
+    wget --spider -q "$COMMIT_ARTIFACTS/$1"
+  fi
 }
 
 rev=""
@@ -34,7 +41,7 @@ fi
 # Get the hash of the latest commit on develop.
 # This always gives the latest commit regardless of if the repo is up to date,
 # and works in a Jenkins checkout.
-DEVELOP=$(git ls-remote https://github.com/melt-umn/silver develop | cut -f1)
+DEVELOP=$(git ls-remote https://github.com/melt-umn/silver develop | cut -f1 | head -n1)
 
 # Look for jars in the current commit and its parents.
 # First, check that we are inside a git repo.
@@ -51,8 +58,18 @@ if [[ -z $rev ]] && git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/nul
   done
 fi
 
+if [[ -z $rev ]]; then
+  echo "Failed to find jars for the specified revision or any of its ancestors."
+  exit 1
+fi
+
 # Figure out how to obtain the jars from the revision we chose.
-if [[ $* != *--unstable* && (-z $rev || $rev == "$DEVELOP") ]]; then
+if [[ $* == *--local* ]]; then
+  echo "Fetching local jars..."
+  LOCAL_STORE="JARS-BAK/$rev"
+  REMOTE_STORE=
+  JARS_BAK=
+elif [[ $* != *--unstable* && $* != *--local* && (-z $rev || $rev == "$DEVELOP") ]]; then
   echo "Fetching latest stable jars..."
   LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
   REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"

--- a/fetch-jars
+++ b/fetch-jars
@@ -57,13 +57,13 @@ if [[ -z $rev ]] && git rev-parse --is-inside-work-tree 1> /dev/null 2> /dev/nul
   done
 fi
 
-if [[ -z $rev ]]; then
-  echo "Failed to find jars for the specified revision or any of its ancestors."
-  exit 1
-fi
-
 # Figure out how to obtain the jars from the revision we chose.
 if [[ $* == *--local* ]]; then
+  if [[ -z $rev ]]; then
+    echo "Failed to find local jars for the specified revision."
+    exit 1
+  fi
+
   echo "Fetching local jars..."
   LOCAL_STORE="JARS-BAK/$rev"
   REMOTE_STORE=

--- a/fetch-jars
+++ b/fetch-jars
@@ -2,10 +2,11 @@
 
 set -eu
 
-# Usage: ./fetch-jars [rev-name] [--unstable] [--copper]
+# Usage: ./fetch-jars [rev-name] [--unstable] [--local] [--copper]
 # If a revision is not specified, the script fetches the latest jars from the current branch,
 # falling back to develop.
 # If --unstable is specified, always fetch from commit artifacts on foundry.
+# If --local is specified, only fetch jars from the local cache.
 # If --copper is specified, only fetch the Copper jars.
 
 # Parse command line argumants.
@@ -20,11 +21,9 @@ done
 
 COMMIT_ARTIFACTS="https://foundry.remexre.xyz/commit-artifacts/"
 
-[[ $* == *--local* ]]
-LOCAL_JARS=$?
-
+args=$*
 function has_jars {
-  if [[ $LOCAL_JARS -eq 0 ]]; then
+  if [[ $args == *--local* ]]; then
     [[ -d "JARS-BAK/$1" ]]
   else
     wget --spider -q "$COMMIT_ARTIFACTS/$1"

--- a/grammars/silver/compiler/analysis/typechecking/core/Context.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Context.sv
@@ -68,7 +68,9 @@ top::Context ::= attr::String args::[Type] atty::Type ntty::Type
     -- atty should never have free type variables if ntty does not, except in case of errors elsewhere.
     else {-if !null(atty.freeFlexibleVars)
     then error(s"got atty with free vars")
-    else-} if null(top.resolvedOccurs)
+    else-} if ntty.isDecorated
+    then [err(top.contextLoc, s"Could not find an instance for ${prettyContext(top)}; an undecorated type is expected here (arising from ${top.contextSource})")]
+    else if null(top.resolvedOccurs)
     then [err(top.contextLoc, s"Could not find an instance for ${prettyContext(top)} (arising from ${top.contextSource})")]
     else requiredContexts.contextErrors;
 

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -232,8 +232,10 @@ public class DecoratedNode implements Decorable, Typed {
 	}
 
 	private void copyInhOverrides(final DecoratedNode parent, final Lazy[] inhs, final Lazy[] newInhs) {
-		assert inhs.length == newInhs.length;
-		for(int i = 0; i < inhs.length; i++) {
+		// Arrays can differ in length if a tree is shared in a polymorphic decoration site.
+		// The new inh array should never be larger than the original one.
+		assert inhs.length >= newInhs.length;
+		for(int i = 0; i < newInhs.length; i++) {
 			if(newInhs[i] != null) {
 				Lazy newInh = newInhs[i].withContext(parent);
 				if(inhs[i] == null) {

--- a/test/silver_features/OccursContext.sv
+++ b/test/silver_features/OccursContext.sv
@@ -200,6 +200,10 @@ equalityTest(
   end, "blah", String, silver_tests);
 
 
+wrongCode "Could not find an instance for attribute silver_features:prodNameIn occurs on Decorated silver_features:OCThing with {}; an undecorated type is expected here (arising from the use of ocPolyWrap)" {
+global ocPolyWrapDecorated::OCPolyWrap = ocPolyWrap(decorate ocThing() with {});
+}
+
 nonterminal OCWrapDec<a> with prodName;
 
 production ocWrapDec


### PR DESCRIPTION
# Changes
Fixes #846.

Inherited occurs-on constraints should only be satisfied for *undecorated* types, since the constraint means that you can supply an equation for the attribute.  If there are only synthesized constraints, passing a reference is fine, because we will decorate it with no additional inherited attributes.  This adds an error message when attempting to resolve an inherited occurs-on constraint for a reference.

Also fix a bug introduced in #837, where supplying additional inherited attributes to a shared tree in a polymorphic context could crash if the new array of attributes is smaller.

Also make some tweaks to the fetch-jars script to allow grabbing the latest local jars for a branch - I'm on the road right now and can't feasibly download jars.

# Documentation
This is a bug fix, removing an inadvertent undocumented misfeature of satisfying inherited occurs-on constraints for references.  

# Testing
Added a test for the new error message.  Replicating the second problem is non-trivial and nondeterministic, depending on the indices that attributes are dynamically assigned.