### PR TITLE
Fix Jenkinsfile bug, avoid running fetch-jars when building a PR merge

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ melt.trynode('silver') {
         sh "cp ${source}/* jars/"
       }
     } else {
-      Boolean foundJars = false
+      def foundJars = false
       if (env.BRANCH_NAME == 'develop') {
         // For 'develop', detect pull request merges, and grab jars from the merged branch
         String branch = getMergedBranch()

--- a/fetch-jars
+++ b/fetch-jars
@@ -21,13 +21,22 @@ done
 
 COMMIT_ARTIFACTS="https://foundry.remexre.xyz/commit-artifacts/"
 
+if [[ $* == *--copper* ]]; then
+  # Only fetch the Copper jars, if requested
+  FILES="CopperCompiler.jar CopperRuntime.jar"
+else
+  FILES="CopperCompiler.jar CopperRuntime.jar commonmark-0.17.1.jar silver.core.jar silver.util.jar silver.langutil.jar silver.rewrite.jar silver.regex.jar silver.compiler.composed.Default.jar"
+fi
+
 args=$*
 function has_jars {
-  if [[ $args == *--local* ]]; then
-    [[ -d "JARS-BAK/$1" ]]
-  else
-    wget --spider -q "$COMMIT_ARTIFACTS/$1"
-  fi
+  for file in $FILES; do
+    if [[ $args == *--local* ]]; then
+      [[ -f "JARS-BAK/$1/$file" ]] || return 1
+    else
+      wget --spider -q "$COMMIT_ARTIFACTS/$1/$file" || return 1
+    fi
+  done
 }
 
 rev=""
@@ -68,7 +77,7 @@ if [[ $* == *--local* ]]; then
   LOCAL_STORE="JARS-BAK/$rev"
   REMOTE_STORE=
   JARS_BAK=
-elif [[ $* != *--unstable* && $* != *--local* && (-z $rev || $rev == "$DEVELOP") ]]; then
+elif [[ $* != *--unstable* && (-z $rev || $rev == "$DEVELOP") ]]; then
   echo "Fetching latest stable jars..."
   LOCAL_STORE=/web/research/melt.cs.umn.edu/downloads/silver-dev/jars
   REMOTE_STORE="https://melt.cs.umn.edu/downloads/silver-dev/jars"
@@ -76,7 +85,7 @@ elif [[ $* != *--unstable* && $* != *--local* && (-z $rev || $rev == "$DEVELOP")
 else
   git --no-pager show --quiet "$rev"
   if ! has_jars "$rev"; then
-    echo "Cound not find jars for commit"
+    echo "Could not find jars for commit"
     exit 1
   fi
   echo "Warning: Fetching unstable jars!"
@@ -84,14 +93,6 @@ else
   REMOTE_STORE="$COMMIT_ARTIFACTS/$rev"
   JARS_BAK="JARS-BAK/$rev"
 fi
-
-if [[ $* == *--copper* ]]; then
-  # Only fetch the Copper jars, if requested
-  FILES="CopperCompiler.jar CopperRuntime.jar"
-else
-  FILES="CopperCompiler.jar CopperRuntime.jar commonmark-0.17.1.jar silver.core.jar silver.util.jar silver.langutil.jar silver.rewrite.jar silver.regex.jar silver.compiler.composed.Default.jar"
-fi
-
 
 mkdir -p jars
 


### PR DESCRIPTION
# Changes
The logic for resolving jars for a Silver build was running `fetch-jars` unconditionally, then possibly overwriting them with the jars from a previous commit or another branch.  This is problematic if the set of jars expected to be downloaded by `fetch-jars` has changed in the pull request, as the build will fail when trying to pull the latest stable jars.  Instead, run `fetch-jars` only as a fallback.

# Documentation
Not really needed, updated comments.

# Testing
Tested that this passes on Jenkins.  Merge behavior can only be tested by merging this pull request.
