### PR TITLE
Permit transattr.decorate in flowtype specs

### DIFF
--- a/grammars/silver/compiler/definition/flow/env/DecSites.sv
+++ b/grammars/silver/compiler/definition/flow/env/DecSites.sv
@@ -89,7 +89,7 @@ DecSiteTree ::= prodName::String vt::VertexType flowEnv::FlowEnv realEnv::Env
                 lookupRefDecSite(prodName, transAttrVertexType(vt, attrName), flowEnv))
             | _ -> []
             end,
-          getHostSynsFor(ntName, flowEnv))));
+          getSynAttrsOn(ntName, realEnv))));
 }
 
 {--
@@ -186,7 +186,7 @@ State<([(String, VertexType)], [(String, String)]) DecSiteTree> ::=
               lookupRefPossibleDecSites(prodName, transAttrVertexType(vt, attrName), flowEnv))
           | _ -> pure([])
           end,
-          getHostSynsFor(ntName, flowEnv));
+          getSynAttrsOn(ntName, realEnv));
       return
         -- Direct inherited equation at a decoration site
         (if vt.isInhDefVertex


### PR DESCRIPTION
# Changes
When writing flow types for a nonterminal with translation attributes, we often want "all the attributes in the trans attr's nonterminal on the trans attr" - for example:
```
translation attribute transform::Decl;

nonterminal ADTDecl with pp, errors, adtGivenName, givenRefId, transform, ...;
flowtype ADTDecl =  decorate {
    givenRefId, adtGivenName,
    transform.env, transform.isTopLevel, transform.controlStmtContext
  },
  errors {decorate}, ...;
```
it would be nicer if we could just write
```
flowtype ADTDecl =  decorate {givenRefId, adtGivenName, transform.decorate}, ...
```

There might _technically_ be a way to create a circularity that would crash the compiler here, if a cycle of translation attributes back to the same nonterminal existed, and one defined their reference sets to all depend on each other.  But that would be a strange thing to do in the first place, and actually checking for this would be rather annoying, so I'm not going to worry about it until someone complains.  

Also fix a minor bug in decoration site tree construction, I forgot that extensions can introduce translation attributes on host NTs (only ever sharing extension-introduced prod attributes, though.)

# Documentation
Translation attributes themselves aren't documented yet... this will come as a part of a documentation revamp project in concert with my thesis.

# Testing
Used this feature in the ableC-algebraic-data-types extension.