### PR TITLE
Fix overly-permissive exemption for cycles involving dispatch prods in inh completeness checks

### DIFF
--- a/grammars/silver/compiler/definition/flow/ast/DecSiteTree.sv
+++ b/grammars/silver/compiler/definition/flow/ast/DecSiteTree.sv
@@ -157,7 +157,13 @@ fun prettyDecSites String ::= nest::Integer d::DecSiteTree =
   then "all of\n" ++ implode("\n", map(prettyDecSites(nest + 1, _), d.decSiteReqs))
   else
     case d of
-    | depAttrDec(attrName, d) -> s"dependency ${attrName} supplied to ${prettyDecSites(nest, ^d)}"
+    | depAttrDec(attrName, d) ->
+        s"dependency ${attrName} supplied to" ++
+        if length(d.decSiteAlts) > 1
+        then " any of\n" ++ implode("\n", map(prettyDecSites(nest + 1, _), d.decSiteAlts))
+        else if length(d.decSiteReqs) > 1
+        then " all of\n" ++ implode("\n", map(prettyDecSites(nest + 1, _), d.decSiteReqs))
+        else " " ++ prettyDecSites(nest, ^d)
     | _ -> d.decSitePP
     end;
 

--- a/grammars/silver/compiler/definition/flow/ast/DecSiteTree.sv
+++ b/grammars/silver/compiler/definition/flow/ast/DecSiteTree.sv
@@ -80,16 +80,6 @@ top::DecSiteTree ::= prodName::String vt::VertexType d::DecSiteTree
   d.maxDepth = top.maxDepth - 1;
 }
 
-production viaDispatchDec
-top::DecSiteTree ::= dispatchSig::String sigName::String d::DecSiteTree
-{
-  top.decSitePP = d.decSitePP;
-  top.decSiteReqs = d.decSiteReqs;
-  top.decSiteAlts = d.decSiteAlts;
-  top.dbgPP = if top.maxDepth > 0 then s"via child ${sigName} of dispatch ${dispatchSig}: ${d.dbgPP}" else "...";
-  d.maxDepth = top.maxDepth - 1;
-}
-
 {--
  - An attribute can be supplied to a vertex type in some production.
  -}

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -669,4 +669,5 @@ top::PrimPattern ::= qn::QName '(' ns::VarBinders ')' _ e::Expr
   propagate flowDeps, flowDefs, flowEnv, decSiteVertexInfo, alwaysDecorated, scrutineeVertexType;
   top.flowDefs <-
     [patternRuleEq(top.frame.fullName, qn.lookupValue.fullName, top.scrutineeVertexType, ns.flowProjections)];
+  e.appDecSiteVertexInfo = nothing();
 }


### PR DESCRIPTION
# Changes
Previously, I was making a blanket exemption for any cycle involving a dispatch signature, when resolving the decoration site tree for an inh attribute instance.  This is actually way too permissive, and allows lots of missing inherited equation errors unrelated to dispatching, that don't actually manifest as cycles.  

The only case that actually needs to be exempted is for an implementation prod that forwards to an application of the same dispatch signature.  This actually simplifies the resolution logic a bit, since we don't need separate handling of cycles with dispatch application and other kinds of sharing.

# Documentation
The MWDA support for tree sharing is still under development, docs will be written as a part of thesis writing.

# Testing
Tested on Silver and ableC extensions.
