### PR TITLE
Fix translation bug with dispatching

### DIFF
--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -348,8 +348,10 @@ ${contexts.contextInitTrans}
         public final ${fnnt} invoke(final common.OriginContext originCtx, final Object[] children, final Object[] annotations) {
             return new ${className}(
               ${implode(", ", (if wantsTracking then [newConstructionOriginUsingCtxRef] else []) ++
-              map(\ c::Context -> decorate c with {boundVariables = namedSig.freeVariables;}.contextRefElem, namedSig.contexts) ++
-              unpackChildren(0, namedSig.inputElements) ++ unpackAnnotations(0, namedSig.namedInputElements))});
+                -- If this prod implements a dispatch signature, then it *can* have shared children when invoked.
+                (if d.implementsSig.isJust then "true" else "false") ::
+                map(\ c::Context -> decorate c with {boundVariables = namedSig.freeVariables;}.contextRefElem, namedSig.contexts) ++
+                unpackChildren(0, namedSig.inputElements) ++ unpackAnnotations(0, namedSig.namedInputElements))});
         }
 		
         @Override

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -226,6 +226,9 @@ public class DecoratedNode implements Decorable, Typed {
 				}
 				copyInhOverrides(parent, inheritedAttributes, inhs);
 			}
+			// It's okay if we override the old decorationSite here if it wasn't null,
+			// that just means something else is directly demanding what would have been
+			// forced by the current decorationSite, first.
 			decorationSite = decSite != null? decSite.withContext(parent) : null;
 		}
 		return this;
@@ -710,7 +713,7 @@ public class DecoratedNode implements Decorable, Typed {
 		if(this != decSiteTree) {
 			throw new SilverInternalError("Decoration site for " + getDebugID() + " returned a different tree: " + decSiteTree.toString());
 		}
-		return inherited(attribute);
+		return evalInhSomehow(attribute);
 	}
 	private final Object evalInhViaFwdP(final int attribute) {
 		try {


### PR DESCRIPTION
# Changes
Every node tracks whether it contains shared children, that must be handled specially when the tree is undecorated.  When referencing a dispatch implementation production, we don't know if it will be supplied with shared children, but we need to assume so; unlike regular productions, a dispatch impl production can be indirectly constructed with shared children.

# Documentation
Added a comment; this is an implementation bug fix.

# Testing
Checks exist in the silver runtime that the result of undecorating a tree does not contain shared trees.  This was triggered in testing an ableC extension; this fix resolves the error.