### PR TITLE
A few fixes related to decoration sites translation attributes

### DIFF
--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -379,9 +379,6 @@ top::Expr ::= @e::Expr @q::QNameAttrOccur
 {
   -- TODO: Origin tracking?
     top.translation =
-    if !top.finalType.isDecorated then
-      s"((${top.finalType.transType})${e.translation}.translation(${q.attrOccursIndex}, ${q.attrOccursIndex}_inhs, ${q.attrOccursIndex}_dec_site).undecorate())"
-    else
       -- This may create the tree, or demand it via the remote decoration site if it has one.
       s"${e.translation}.translation(${q.attrOccursIndex}, ${q.attrOccursIndex}_inhs, ${q.attrOccursIndex}_dec_site)";
 

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -709,7 +709,12 @@ public class DecoratedNode implements Decorable, Typed {
 	private final Object evalInhViaDecSite(final int attribute) {
 		Lazy decSite = this.decorationSite;
 		this.decorationSite = null;
-		Object decSiteTree = decSite.eval(parent);
+		Object decSiteTree;
+		try {
+			decSiteTree = decSite.eval(parent);
+		} catch (Throwable t) {
+			throw new TraceException("While evaling inh '" + self.getNameOfInhAttr(attribute) + "' via decoration site of " + getDebugID() + " in " + parent.getDebugID(), t);
+		}
 		if(this != decSiteTree) {
 			throw new SilverInternalError("Decoration site for " + getDebugID() + " returned a different tree: " + decSiteTree.toString());
 		}

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -565,6 +565,8 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @return The decorated value of the translation attribute.
 	 */
 	private final DecoratedNode evalTrans(final int attribute, final int inhsAttribute, final int decSiteAttribute) {
+		// Evaluate the synthesized attribute to get the tree to decorate, somehow.
+		// This is usually undecorated, but can be decorated already if we are getting it from the forward.
 		Lazy l = self.getSynthesized(attribute);
 		Decorable d;
 		if(l != null) {
@@ -591,6 +593,24 @@ public class DecoratedNode implements Decorable, Typed {
 				throw new MissingDefinitionException("Translation attribute '" + self.getNameOfSynAttr(attribute) + "' not defined in " + getDebugID());
 			}
 		}
+		// Since the decoration site and direct inh equations for the translation attribute tree
+		// are passed down to this tree as inherited attributes, we need to ensure that
+		// any decoration sites for *this* tree are forced before looking at the inherited
+		// attributes here.
+		while(this.decorationSite != null) {
+			Lazy decSite = this.decorationSite;
+			this.decorationSite = null;
+			Object decSiteTree;
+			try {
+				decSiteTree = decSite.eval(parent);
+			} catch (Throwable t) {
+				throw new TraceException("While evaling decoration of trans '" + self.getNameOfSynAttr(attribute) + "' via decoration site of " + getDebugID() + " in " + parent.getDebugID(), t);
+			}
+			if(this != decSiteTree) {
+				throw new SilverInternalError("Decoration site for " + getDebugID() + " returned a different tree: " + decSiteTree.toString());
+			}
+		}
+		// Get the direct inherited attributes and decoration site for the translation attribute tree.
 		Lazy[] inhs = null;
 		if (inheritedAttributes != null && inheritedAttributes[inhsAttribute] != null) {
 			if (inheritedAttributes[inhsAttribute] instanceof TransInhs) {
@@ -603,6 +623,7 @@ public class DecoratedNode implements Decorable, Typed {
 		if(decSite == null && forwardParent != null && isProdForward && forwardParent.synthesizedValues[attribute] == null) {
 			decSite = (context) -> forwardParent.translation(attribute, inhsAttribute, decSiteAttribute);
 		}
+		// Decorate the tree that we computed earlier.
 		return d.decorate(parent, inhs, decSite);
 	}
 


### PR DESCRIPTION
# Changes
* Remove obsolete case in Java translation, since undecoration is now explicit.
* Add a trace message for errors occuring when evaluating the decoration site of some tree.
* Ensure that the decoration site of a tree is forced before accessing the inherited attributes supplying a translation attr's decoration site/direct inh equations.  This fixes one of the problematic cases I discovered where missing equations can occur for extensions passing the MWDA, due to the evaluation order.

# Documentation
Added source comments to `evalTrans`.  The user documentation for translation attributes has not been written yet.

# Testing
The bug fixed here only manifests under some rather complicated circumstances - when a translation attribute is demanded from a tree that is itself shared, without causing the original tree's decoration site to be demanded. I haven't been able to come up with a minimal reproduction. This does fix a crash I encountered in updating the ableC-prolog extension.