### PR TITLE
Adds uniq and uniqBy.

### DIFF
--- a/grammars/silver/core/List.sv
+++ b/grammars/silver/core/List.sv
@@ -236,7 +236,7 @@ fun containsBy Boolean ::= eq::(Boolean ::= a a)  elem::a  lst::[a] =
 fun contains Eq a => Boolean ::= elem::a  lst::[a] = containsBy(eq, elem, lst);
 
 @{--
- - Removes all duplicates from a list.
+ - Removes all duplicates from a list. O(n^2).
  -
  - @param eq  The equality function to use
  - @param xs  The list to remove duplicates from
@@ -247,12 +247,45 @@ fun nubBy [a] ::= eq::(Boolean ::= a a)  xs::[a] =
   else head(xs) :: nubBy(eq, removeBy(eq, head(xs), tail(xs)));
 
 @{--
- - Removes all duplicates from a list.
+ - Removes all duplicates from a list. O(n^2).
  -
  - @param xs  The list to remove duplicates from
  - @return  A list containing no duplicates, according to ==.
  -}
 fun nub Eq a => [a] ::= xs::[a] = nubBy(eq, xs);
+
+@{--
+ - Removes all consecutive duplicates from a list. O(n).
+ -
+ - This can be used with `sortBy` to perform the same task as `nubBy`, but more
+   efficiently.
+ -
+ - @param eq  The equality function to use
+ - @param xs  The list to remove duplicates from
+ - @return  A list containing no duplicates, according to the equality function.
+ -}
+fun uniqBy [a] ::= eq::(Boolean ::= a a)  xs::[a] =
+  case xs of
+  | [] -> []
+  | hd :: tl ->
+      if null(tl) then
+        xs
+      else if eq(hd, head(tl)) then
+        uniqBy(eq, tl)
+      else
+        hd :: uniqBy(eq, tl)
+  end;
+
+@{--
+ - Removes all consecutive duplicates from a list. O(n).
+ -
+ - This can be used with `sort` to perform the same task as `nub`, but more
+   efficiently.
+ -
+ - @param xs  The list to remove consecutive duplicates from
+ - @return  A list containing no consecutive duplicates, according to ==.
+ -}
+fun uniq Eq a => [a] ::= xs::[a] = uniqBy(eq, xs);
 
 @{--
  - Removes all instances of an element from a list.

--- a/test/stdlib/List.sv
+++ b/test/stdlib/List.sv
@@ -64,6 +64,16 @@ equalityTest ( nub ([1,2,3,4]), [1,2,3,4],
 equalityTest ( nub ([ ]), [ ], 
                [Integer], core_tests ) ;
 
+-- uniq tests
+equalityTest ( uniq ([1,2,3,3,2,1,1,2]), [1,2,3,2,1,2], 
+               [Integer], core_tests ) ;
+
+equalityTest ( uniq ([1,2,3,4]), [1,2,3,4], 
+               [Integer], core_tests ) ;
+
+equalityTest ( uniq ([ ]), [ ], 
+               [Integer], core_tests ) ;
+
 -- remove tests
 equalityTest ( remove (2, [1,2,3,4,3,2,1]), [1,3,4,3,1],
                [Integer], core_tests ) ;


### PR DESCRIPTION
These allow doing the same task as nub and nubBy in O(n log n), if you have an Ord instance. (Adding a warning when using nub on Ord types could be a fun lint :p)

Written to try to reduce allocation, which is why I didn't do more pattern-matching.

# Changes

# Documentation
Please briefly describe the documentation you have written in the following categories, or why you didn't write documentation for a category:
* what general comments you have added
  - none, it's not scarier than other uncommented things in that file
* what doc comments you have added
  - one per function
* what documentation you have added to the website for users of Silver
  - none, not a feature worth advertising
* what documentation you have added to the website for developers of Silver
  - none, it's not scarier than other things in that file

# Testing
Please briefly describe the tests you have written for the changes included in this pull request, or why it is not possible to test the changes.

Added three simple tests. Also about to use it in an ableC change.

*Please remove all the prefilled text other than the headings before submitting your pull request.*
