### PR TITLE
Add MWDA check for dispatch depending on inh attributes supplied by the target production

### DIFF
--- a/grammars/silver/compiler/analysis/warnings/flow/OrphanedProduction.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/OrphanedProduction.sv
@@ -74,6 +74,7 @@ top::AGDcl ::= 'abstract' 'production' id::Name d::ProductionImplements ns::Prod
  -}
 monoid attribute isDispatchApplication :: (Boolean ::= NamedSignature) with pure(false), lift2(conj, _, _)
   occurs on Expr, PrimPatterns, PrimPattern;
+flowtype isDispatchApplication {decorate} on Expr;
 
 aspect isDispatchApplication on top::Expr using := of
 | dispatchApplication(e, es, _) -> \ dSig::NamedSignature ->

--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -18,7 +18,7 @@ tracked nonterminal ExprLHSExpr with
 flowtype unparse {} on Expr, Exprs, ExprInhs, ExprInh, ExprLHSExpr;
 flowtype freeVars {frame} on Expr, Exprs, ExprInhs, ExprInh, ExprLHSExpr;
 flowtype Expr =
-  forward {grammarName, env, flowEnv, downSubst, finalSubst, frame, isRoot, compiledGrammars, config, decSiteVertexInfo, appDecSiteVertexInfo},
+  forward {grammarName, env, flowEnv, downSubst, finalSubst, frame, isRoot, compiledGrammars, config, decSiteVertexInfo, appDecSiteVertexInfo, dispatchFlowDeps},
   decorate {forward, alwaysDecorated, originRules},
   errors {forward}, typerep {forward};
 
@@ -997,11 +997,11 @@ tracked nonterminal AppExprs with
 flowtype AppExprs =
   decorate {
     config, grammarName, env, frame, compiledGrammars, appExprTypereps, appExprApplied, originRules,
-    downSubst, finalSubst, flowEnv, appIndexOffset
+    downSubst, finalSubst, flowEnv, appIndexOffset, dispatchFlowDeps
   },
   errors {
     config, grammarName, env, frame, compiledGrammars, appExprTypereps, appExprApplied,
-    downSubst, finalSubst, flowEnv, decSiteVertexInfo, appProd, appIndexOffset
+    downSubst, finalSubst, flowEnv, decSiteVertexInfo, dispatchFlowDeps, appProd, appIndexOffset
   };
 
 tracked nonterminal AppExpr with
@@ -1010,11 +1010,11 @@ tracked nonterminal AppExpr with
 flowtype AppExpr =
   decorate {
     config, grammarName, env, frame, compiledGrammars, appExprIndex, appExprTyperep, appExprApplied, originRules,
-    downSubst, finalSubst, flowEnv, appIndexOffset
+    downSubst, finalSubst, flowEnv, appIndexOffset, dispatchFlowDeps
   },
   errors {
     config, grammarName, env, frame, compiledGrammars, appExprIndex, appExprTyperep, appExprApplied,
-    downSubst, finalSubst, flowEnv, decSiteVertexInfo, appProd, appIndexOffset
+    downSubst, finalSubst, flowEnv, decSiteVertexInfo, dispatchFlowDeps, appProd, appIndexOffset
   };
 
 propagate config, grammarName, env, freeVars, frame, compiledGrammars, errors, originRules on AppExprs, AppExpr;

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -249,7 +249,7 @@ fun getInhAttrsOn [String] ::= fnnt::String e::Env =
 
 {--
  - Returns the names of all inherited attributes known locally to occur on a nonterminal.
- - Also includes all inherited attributes occuring on translation attributes on the
+ - Also includes all inherited attributes occurring on translation attributes on the
  - nonterminal, when we want to treat these like inherited attributes.
  -}
 fun getInhAndInhOnTransAttrsOn [String] ::= fnnt::String e::Env =

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -48,7 +48,7 @@ inherited attribute decSiteVertexInfo :: Maybe<VertexType>;
  - foo.env = top.env;
  -
  - we know that e's decoration site vertex is foo, and e.env can depend on top.env,
- - but we can't gurantee that e.env is defined in case cond is false.
+ - but we can't guarantee that e.env is defined in case cond is false.
  -}
 inherited attribute alwaysDecorated :: Boolean;
 
@@ -68,6 +68,12 @@ attribute flowDeps, flowDefs, flowEnv, lexicalLocalDecSites, lexicalLocalAlwaysD
   occurs on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr;
 attribute flowVertexInfo occurs on Expr;
 
+{--
+ - The direct dependencies of applied dispatch signatures
+ - that have this expression as an argument.
+ -}
+inherited attribute dispatchFlowDeps :: [FlowVertex];
+
 flowtype flowVertexInfo {forward} on Expr;
 
 propagate flowDeps on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr
@@ -77,8 +83,8 @@ propagate flowDeps on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoApp
 propagate flowDefs, flowEnv, lexicalLocalDecSites, lexicalLocalAlwaysDecorated
   on Expr, ExprInhs, ExprInh, Exprs, AppExprs, AppExpr, AnnoAppExprs, AnnoExpr;
 
-attribute decSiteVertexInfo, alwaysDecorated occurs on Expr, AppExprs, AppExpr;
-propagate decSiteVertexInfo, alwaysDecorated on AppExprs;
+attribute decSiteVertexInfo, alwaysDecorated, dispatchFlowDeps occurs on Expr, AppExprs, AppExpr;
+propagate decSiteVertexInfo, alwaysDecorated, dispatchFlowDeps on AppExprs;
 
 attribute appDecSiteVertexInfo occurs on Expr;
 
@@ -183,11 +189,12 @@ aspect production application
 top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 {
   propagate flowEnv;
-  -- Seed flow graphs with deps on top.decSiteVertexInfo, top.alwaysDecorated,
+  -- Seed flow graphs with deps on top for decSiteVertexInfo, alwaysDecorated, dispatchFlowDeps
   -- needed to avoid hidden transitive deps for override eqs in curriedDispatchApplication.
   -- TODO: Perhaps possible to infer this by changing how projection stitch points work?
   e.decSiteVertexInfo = if true then nothing() else top.decSiteVertexInfo;
   e.alwaysDecorated = false && top.alwaysDecorated;
+  e.dispatchFlowDeps = [] ++ if false then top.dispatchFlowDeps else [];
 }
 
 aspect production errorApplication
@@ -198,6 +205,7 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
   es.alwaysDecorated = false;
   es.appProd = nothing();
   es.appIndexOffset = 0;
+  es.dispatchFlowDeps = [];
 }
 
 aspect production functionInvocation
@@ -220,6 +228,8 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
   e.appDecSiteVertexInfo = top.decSiteVertexInfo;
   es.decSiteVertexInfo = top.decSiteVertexInfo;
   es.alwaysDecorated = top.alwaysDecorated;
+  -- If sharing is permitted in es, then e is a prod reference and e.flowDeps must be empty.
+  es.dispatchFlowDeps = top.dispatchFlowDeps;
 }
 
 aspect production partialApplication
@@ -241,6 +251,7 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
   e.appDecSiteVertexInfo = nothing();
   es.decSiteVertexInfo = nothing();
   es.alwaysDecorated = false;
+  es.dispatchFlowDeps = [];
 }
 
 aspect production curriedDispatchApplication
@@ -255,6 +266,7 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
   es.appIndexOffset = 0;
   es.decSiteVertexInfo = top.decSiteVertexInfo;
   es.alwaysDecorated = top.alwaysDecorated;
+  es.dispatchFlowDeps = top.dispatchFlowDeps ++ e.flowDeps;
 
   -- We override these attributes in what we forward to, as a special case to
   -- be more precise about what production is being applied.
@@ -262,10 +274,12 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
   dispatchArgs.appIndexOffset = 0;
   dispatchArgs.decSiteVertexInfo = top.decSiteVertexInfo;
   dispatchArgs.alwaysDecorated = top.alwaysDecorated;
+  dispatchArgs.dispatchFlowDeps = es.dispatchFlowDeps;
   extraArgs.appProd = es.appProd;
   extraArgs.appIndexOffset = dispatchArgs.appExprSize;
   extraArgs.decSiteVertexInfo = top.decSiteVertexInfo;
   extraArgs.alwaysDecorated = top.alwaysDecorated;
+  extraArgs.dispatchFlowDeps = es.dispatchFlowDeps;
 }
 
 aspect production dispatchApplication
@@ -282,6 +296,7 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
   es.appIndexOffset = 0;
   es.decSiteVertexInfo = top.decSiteVertexInfo;
   es.alwaysDecorated = top.alwaysDecorated;
+  es.dispatchFlowDeps = top.dispatchFlowDeps ++ e.flowDeps;
 }
 
 aspect production annoExpr
@@ -291,6 +306,7 @@ top::AnnoExpr ::= qn::QName '=' e::AppExpr
   e.appProd = nothing();
   e.appIndexOffset = 0;
   e.alwaysDecorated = false;
+  e.dispatchFlowDeps = [];
 }
 
 aspect production presentAppExpr
@@ -321,6 +337,7 @@ top::AppExpr ::= e::Expr
     end;
   e.alwaysDecorated = top.alwaysDecorated && e.decSiteVertexInfo.isJust;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = top.dispatchFlowDeps;
 
   production inputSigIsShared::Boolean =
     case e.flowVertexInfo of
@@ -362,6 +379,8 @@ top::Expr ::= 'attachNote' note::Expr 'on' e::Expr 'end'
   e.alwaysDecorated = top.alwaysDecorated;
   note.appDecSiteVertexInfo = nothing();
   e.appDecSiteVertexInfo = top.appDecSiteVertexInfo;
+  note.dispatchFlowDeps = [];
+  e.dispatchFlowDeps = top.dispatchFlowDeps;
 }
 
 aspect production access
@@ -371,6 +390,7 @@ top::Expr ::= e::Expr '.' q::QNameAttrOccur
   e.alwaysDecorated = false;
   e.decSiteVertexInfo = nothing();
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 aspect production accessBouncer
@@ -380,6 +400,7 @@ top::Expr ::= e::Expr  @q::QNameAttrOccur target::Access
   e.alwaysDecorated = false;
   e.decSiteVertexInfo = nothing();
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 aspect production forwardAccess
@@ -393,6 +414,7 @@ top::Expr ::= e::Expr '.' 'forward'
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 
@@ -459,6 +481,7 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
   -- The type of decorate ... with ... is a normal reference for now, so this should always be false, but that could change.
   e.alwaysDecorated = top.alwaysDecorated;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 
   -- Finally, our standard flow deps mimic those of a local: "taking a reference"
   -- This are of course ignored when treated specially.
@@ -484,6 +507,7 @@ top::ExprInh ::= lhs::ExprLHSExpr '=' e1::Expr ';'
   e1.decSiteVertexInfo = nothing();
   e1.alwaysDecorated = false;
   e1.appDecSiteVertexInfo = nothing();
+  e1.dispatchFlowDeps = [];
 }
 
 aspect production decorationSiteExpr
@@ -493,6 +517,7 @@ top::Expr ::= '@' e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 
   top.flowDefs <-
     case e.flowVertexInfo, top.decSiteVertexInfo of
@@ -514,6 +539,10 @@ top::Expr ::= 'if' e1::Expr 'then' e2::Expr 'else' e3::Expr
   e1.appDecSiteVertexInfo = nothing();
   e2.appDecSiteVertexInfo = nothing();
   e3.appDecSiteVertexInfo = nothing();
+  e1.dispatchFlowDeps = [];
+  -- Nothing can depend on inhs supplied via sharing under a conditional.
+  e2.dispatchFlowDeps = [];
+  e3.dispatchFlowDeps = [];
 }
 
 aspect production terminalConstructor
@@ -525,6 +554,8 @@ top::Expr ::= 'terminal' '(' t::TypeExpr ',' es::Expr ',' el::Expr ')'
   el.alwaysDecorated = false;
   es.appDecSiteVertexInfo = nothing();
   el.appDecSiteVertexInfo = nothing();
+  es.dispatchFlowDeps = [];
+  el.dispatchFlowDeps = [];
 }
 
 aspect production exprsSingle
@@ -533,6 +564,7 @@ top::Exprs ::= e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production exprsCons
 top::Exprs ::= e1::Expr ',' e2::Exprs
@@ -540,6 +572,7 @@ top::Exprs ::= e1::Expr ',' e2::Exprs
   e1.decSiteVertexInfo = nothing();
   e1.alwaysDecorated = false;
   e1.appDecSiteVertexInfo = nothing();
+  e1.dispatchFlowDeps = [];
 }
 
 aspect production lambdap
@@ -548,6 +581,7 @@ top::Expr ::= params::LambdaRHS e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 -- FROM LET TODO
@@ -568,6 +602,7 @@ top::Expr ::= la::AssignExpr  e::Expr
   e.decSiteVertexInfo = top.decSiteVertexInfo;
   e.alwaysDecorated = top.alwaysDecorated;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = top.dispatchFlowDeps;
 }
 
 aspect production assignExpr
@@ -580,6 +615,7 @@ top::AssignExpr ::= id::Name '::' t::TypeExpr '=' e::Expr
     end;
   e.alwaysDecorated = lookupAll(fName, top.bodyAlwaysDecorated) == [true];
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 aspect production lexicalLocalReference
@@ -611,9 +647,9 @@ top::Expr ::= @q::QName  fi::Maybe<VertexType>  fd::[FlowVertex]
 
 
 -- FROM PATTERN TODO
-attribute flowDeps, flowDefs, flowEnv, decSiteVertexInfo, alwaysDecorated, appDecSiteVertexInfo, scrutineeVertexType
+attribute flowDeps, flowDefs, flowEnv, decSiteVertexInfo, alwaysDecorated, appDecSiteVertexInfo, dispatchFlowDeps, scrutineeVertexType
   occurs on PrimPatterns, PrimPattern;
-propagate flowDeps, flowDefs, flowEnv, decSiteVertexInfo, alwaysDecorated, appDecSiteVertexInfo, scrutineeVertexType
+propagate flowDeps, flowDefs, flowEnv, decSiteVertexInfo, alwaysDecorated, appDecSiteVertexInfo, dispatchFlowDeps, scrutineeVertexType
   on PrimPatterns, PrimPattern;
 
 inherited attribute scrutineeVertexType :: VertexType;
@@ -661,6 +697,9 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
   e.appDecSiteVertexInfo = nothing();
   pr.appDecSiteVertexInfo = nothing();
   f.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
+  pr.dispatchFlowDeps = [];
+  f.dispatchFlowDeps = [];
 }
 
 aspect production prodPattern
@@ -670,4 +709,5 @@ top::PrimPattern ::= qn::QName '(' ns::VarBinders ')' _ e::Expr
   top.flowDefs <-
     [patternRuleEq(top.frame.fullName, qn.lookupValue.fullName, top.scrutineeVertexType, ns.flowProjections)];
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -189,6 +189,7 @@ aspect production application
 top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 {
   propagate flowEnv;
+  e.appDecSiteVertexInfo = top.decSiteVertexInfo;
   -- Seed flow graphs with deps on top for decSiteVertexInfo, alwaysDecorated, dispatchFlowDeps
   -- needed to avoid hidden transitive deps for override eqs in curriedDispatchApplication.
   -- TODO: Perhaps possible to infer this by changing how projection stitch points work?
@@ -200,7 +201,6 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
 aspect production errorApplication
 top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
 {
-  e.appDecSiteVertexInfo = nothing();
   es.decSiteVertexInfo = nothing();
   es.alwaysDecorated = false;
   es.appProd = nothing();
@@ -225,7 +225,6 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
       else 0
     | _ -> 0
     end;
-  e.appDecSiteVertexInfo = top.decSiteVertexInfo;
   es.decSiteVertexInfo = top.decSiteVertexInfo;
   es.alwaysDecorated = top.alwaysDecorated;
   -- If sharing is permitted in es, then e is a prod reference and e.flowDeps must be empty.
@@ -248,7 +247,6 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
       else 0
     | _ -> 0
     end;
-  e.appDecSiteVertexInfo = nothing();
   es.decSiteVertexInfo = nothing();
   es.alwaysDecorated = false;
   es.dispatchFlowDeps = [];
@@ -257,7 +255,6 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
 aspect production curriedDispatchApplication
 top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
 {
-  e.appDecSiteVertexInfo = nothing();
   es.appProd =
     case e of
     | productionReference(q) -> just(q.lookupValue.dcl.namedSignature)
@@ -286,7 +283,6 @@ aspect production dispatchApplication
 top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
 {
   top.flowVertexInfo = top.decSiteVertexInfo;
-  e.appDecSiteVertexInfo = top.decSiteVertexInfo;
   es.appProd =
     case e, e.finalType of
     | productionReference(q), _ -> just(q.lookupValue.dcl.namedSignature)

--- a/grammars/silver/compiler/definition/flow/env/FunctionDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/FunctionDcl.sv
@@ -42,6 +42,7 @@ top::AGDcl ::= 'fun' id::Name ns::FunctionSignature '=' e::Expr ';'
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 
   -- oh no again!
   local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;

--- a/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionBody.sv
@@ -36,6 +36,7 @@ top::ProductionStmt ::= 'attachNote' note::Expr ';'
   note.decSiteVertexInfo = nothing();
   note.alwaysDecorated = false;
   note.appDecSiteVertexInfo = nothing();
+  note.dispatchFlowDeps = [];
 }
 
 aspect production forwardsTo
@@ -61,6 +62,7 @@ top::ProductionStmt ::= 'forwards' 'to' e::Expr ';'
   e.decSiteVertexInfo = just(forwardVertexType);
   e.alwaysDecorated = true;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production forwardInh
 top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
@@ -74,6 +76,7 @@ top::ForwardInh ::= lhs::ForwardLHSExpr '=' e::Expr ';'
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production returnDef
 top::ProductionStmt ::= 'return' e::Expr ';'
@@ -81,12 +84,14 @@ top::ProductionStmt ::= 'return' e::Expr ';'
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 aspect production attributeDef
 top::ProductionStmt ::= dl::DefLHS '.' attr::QNameAttrOccur '=' e::Expr ';'
 {
   propagate flowEnv;
+  e.dispatchFlowDeps = [];
 }
 aspect production errorAttributeDef
 top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr msg::[Message]
@@ -95,6 +100,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr msg::[Message]
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production synthesizedAttributeDef
 top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
@@ -117,6 +123,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
     else nothing();
   e.alwaysDecorated = attr.found && attr.attrDcl.isTranslation;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production inheritedAttributeDef
 top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
@@ -125,6 +132,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 -- The flow vertex type corresponding to attributes on this DefLHS
@@ -192,6 +200,7 @@ top::ProductionStmt ::= @val::QName e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 aspect production localValueDef
@@ -215,6 +224,7 @@ top::ProductionStmt ::= @val::QName e::Expr
   e.alwaysDecorated =
     isDecorable(e.finalType, top.env) && val.lookupValue.found && !val.lookupValue.dcl.isNondec;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 -- FROM COLLECTIONS TODO
@@ -232,6 +242,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur  {- <- -} e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 aspect production inhAppendColAttributeDef
@@ -241,6 +252,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur  {- <- -} e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production synBaseColAttributeDef
 top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
@@ -260,6 +272,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production inhBaseColAttributeDef
 top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
@@ -268,6 +281,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 aspect production baseCollectionValueDef
@@ -278,6 +292,7 @@ top::ProductionStmt ::= @val::QName e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production appendCollectionValueDef
 top::ProductionStmt ::= @val::QName e::Expr
@@ -302,6 +317,7 @@ top::ProductionStmt ::= @val::QName e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 -- TODO: flowDefs for Copper ProductionStmts
@@ -311,6 +327,7 @@ top::ProductionStmt ::= 'pluck' e::Expr ';'
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production printStmt
 top::ProductionStmt ::= 'print' e::Expr ';'
@@ -318,6 +335,7 @@ top::ProductionStmt ::= 'print' e::Expr ';'
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production parserAttributeValueDef
 top::ProductionStmt ::= @val::QName e::Expr
@@ -325,6 +343,7 @@ top::ProductionStmt ::= @val::QName e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production pushTokenStmt
 top::ProductionStmt ::= 'pushToken' '(' val::QName ',' lexeme::Expr ')' ';'
@@ -332,6 +351,7 @@ top::ProductionStmt ::= 'pushToken' '(' val::QName ',' lexeme::Expr ')' ';'
   lexeme.decSiteVertexInfo = nothing();
   lexeme.alwaysDecorated = false;
   lexeme.appDecSiteVertexInfo = nothing();
+  lexeme.dispatchFlowDeps = [];
 }
 aspect production insertSemanticTokenStmt
 top::ProductionStmt ::= 'insert' 'semantic' 'token' n::QNameType 'at' loc::Expr ';'
@@ -339,6 +359,7 @@ top::ProductionStmt ::= 'insert' 'semantic' 'token' n::QNameType 'at' loc::Expr 
   loc.decSiteVertexInfo = nothing();
   loc.alwaysDecorated = false;
   loc.appDecSiteVertexInfo = nothing();
+  loc.dispatchFlowDeps = [];
 }
 aspect production ifElseStmt
 top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt 'else' el::ProductionStmt
@@ -346,6 +367,7 @@ top::ProductionStmt ::= 'if' '(' condition::Expr ')' th::ProductionStmt 'else' e
   condition.decSiteVertexInfo = nothing();
   condition.alwaysDecorated = false;
   condition.appDecSiteVertexInfo = nothing();
+  condition.dispatchFlowDeps = [];
 }
 aspect production termAttrValueValueDef
 top::ProductionStmt ::= @val::QName e::Expr
@@ -353,6 +375,7 @@ top::ProductionStmt ::= @val::QName e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 -- We're in the unfortunate position of HAVING to compute values for 'flowDefs'

--- a/grammars/silver/compiler/definition/flow/env/Root.sv
+++ b/grammars/silver/compiler/definition/flow/env/Root.sv
@@ -27,4 +27,5 @@ top::AGDcl ::= 'global' id::Name '::' cl::ConstraintList '=>' t::TypeExpr '=' e:
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }

--- a/grammars/silver/compiler/definition/flow/env/TypeClasses.sv
+++ b/grammars/silver/compiler/definition/flow/env/TypeClasses.sv
@@ -13,6 +13,7 @@ top::ClassBodyItem ::= id::Name '::' cl::ConstraintList '=>' ty::TypeExpr '=' e:
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 aspect production instanceBodyItem
 top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
@@ -20,4 +21,5 @@ top::InstanceBodyItem ::= id::QName '=' e::Expr ';'
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }

--- a/grammars/silver/compiler/extension/autoattr/Destruct.sv
+++ b/grammars/silver/compiler/extension/autoattr/Destruct.sv
@@ -25,46 +25,42 @@ top::AGDcl ::= at::QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOp
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
   top.moduleNames := [];
 
-  local fwrdProd::AttributionDcl =
+  nondecorated local newAttl::BracketedOptTypeExprs =
     case attl.types of
     | [] ->
-      altParamAttributionDcl(
-        defaultAttributionDcl,
-        botlSome(
-          bTypeList(
-            '<',
-            typeListCons(
-              case nttl of
-              | botlSome(tl) -> 
-                appTypeExpr(
-                  nominalTypeExpr(nt.qNameType),
-                  ^tl)
-              | botlNone() -> nominalTypeExpr(nt.qNameType)
-              end,
-              typeListSingle(
-                typerepTypeExpr(inhSetType([])))),
-            '>')))
+      botlSome(
+        bTypeList(
+          '<',
+          typeListCons(
+            case nttl of
+            | botlSome(tl) -> 
+              appTypeExpr(
+                nominalTypeExpr(nt.qNameType),
+                ^tl)
+            | botlNone() -> nominalTypeExpr(nt.qNameType)
+            end,
+            typeListSingle(
+              typerepTypeExpr(inhSetType([])))),
+          '>'))
     | [i] ->
-      altParamAttributionDcl(
-        defaultAttributionDcl,
-        botlSome(
-          bTypeList(
-            '<',
-            typeListCons(
-              case nttl of
-              | botlSome(tl) -> 
-                appTypeExpr(
-                  nominalTypeExpr(nt.qNameType),
-                  ^tl)
-              | botlNone() -> nominalTypeExpr(nt.qNameType)
-              end,
-              typeListSingle(
-                typerepTypeExpr(i))),
-            '>')))
-    | _ -> defaultAttributionDcl
+      botlSome(
+        bTypeList(
+          '<',
+          typeListCons(
+            case nttl of
+            | botlSome(tl) -> 
+              appTypeExpr(
+                nominalTypeExpr(nt.qNameType),
+                ^tl)
+            | botlNone() -> nominalTypeExpr(nt.qNameType)
+            end,
+            typeListSingle(
+              typerepTypeExpr(i))),
+          '>'))
+    | _ -> ^attl
     end;
   
-  forwards to fwrdProd(@at, @attl, @nt, @nttl);
+  forwards to altParamAttributionDcl(@at, @attl, @nt, @nttl, defaultAttributionDcl, newAttl);
 }
 
 {--

--- a/grammars/silver/compiler/extension/autoattr/Functor.sv
+++ b/grammars/silver/compiler/extension/autoattr/Functor.sv
@@ -25,11 +25,10 @@ top::AGDcl ::= at::QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOp
   top.unparse = "attribute " ++ at.unparse ++ attl.unparse ++ " occurs on " ++ nt.unparse ++ nttl.unparse ++ ";";
   top.moduleNames := [];
 
-  local fwrdProd::AttributionDcl =
+  nondecorated local newAttl::BracketedOptTypeExprs =
     if length(attl.types) > 0
-    then defaultAttributionDcl
-    else altParamAttributionDcl(
-      defaultAttributionDcl,
+    then ^attl
+    else
       botlSome(
         bTypeList(
           '<',
@@ -41,9 +40,9 @@ top::AGDcl ::= at::QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOp
                 ^tl)
             | botlNone() -> nominalTypeExpr(nt.qNameType)
             end),
-          '>')));
-  
-  forwards to fwrdProd(@at, @attl, @nt, @nttl);
+          '>'));
+
+  forwards to altParamAttributionDcl(@at, @attl, @nt, @nttl, defaultAttributionDcl, newAttl);
 }
 
 {--

--- a/grammars/silver/compiler/extension/autoattr/Monoid.sv
+++ b/grammars/silver/compiler/extension/autoattr/Monoid.sv
@@ -56,6 +56,7 @@ top::AGDcl ::= 'monoid' 'attribute' a::Name tl::BracketedOptTypeExprs '::' te::T
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
   
   forwards to
     collectionAttributeDclSyn(

--- a/grammars/silver/compiler/extension/implicit_monads/Case.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Case.sv
@@ -107,6 +107,7 @@ top::Expr ::= 'case' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
   monadLocal.decSiteVertexInfo = nothing();
   monadLocal.alwaysDecorated = false;
   monadLocal.appDecSiteVertexInfo = nothing();
+  monadLocal.dispatchFlowDeps = [];
   monadLocal.isRoot = false;
   top.monadRewritten = monadLocal.monadRewritten;
   top.mtyperep = monadLocal.mtyperep;
@@ -121,7 +122,7 @@ top::Expr ::= 'case' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
                                      frame=top.frame; grammarName=top.grammarName; downSubst=top.mDownSubst;
                                      finalSubst=top.mDownSubst; compiledGrammars=top.compiledGrammars;
                                      config=top.config; decSiteVertexInfo = nothing(); alwaysDecorated = false;
-                                     appDecSiteVertexInfo = nothing(); flowEnv=top.flowEnv; expectedMonad=top.expectedMonad;
+                                     appDecSiteVertexInfo = nothing(); dispatchFlowDeps = []; flowEnv=top.flowEnv; expectedMonad=top.expectedMonad;
                                      isRoot=top.isRoot;}
              in if isMonad(a.mtyperep, top.env) && monadsMatch(a.mtyperep, top.expectedMonad, top.mDownSubst).fst &&
                    !isMonad(performSubstitution(x.snd, top.mDownSubst), top.env)
@@ -131,7 +132,7 @@ top::Expr ::= 'case' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
                                      config=top.config; flowEnv=top.flowEnv; monadicallyUsed=true;
                                      expectedMonad=top.expectedMonad;
                                      decSiteVertexInfo = nothing(); alwaysDecorated = false;
-                                     appDecSiteVertexInfo = nothing(); isRoot=top.isRoot;}.monadicNames
+                                     appDecSiteVertexInfo = nothing(); dispatchFlowDeps = []; isRoot=top.isRoot;}.monadicNames
                 else []
              end ++ l,
            monadLocal.monadicNames, zipWith(\x::Expr y::Type -> (x,y), es.rawExprs, ml.patternTypeList));
@@ -416,6 +417,7 @@ top::Expr ::= 'case_any' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
                   decSiteVertexInfo = nothing();
                   alwaysDecorated = false;
                   appDecSiteVertexInfo = nothing();
+                  dispatchFlowDeps = [];
                   isRoot = top.isRoot;
                  }.monadRewritten,
              caseExprs);
@@ -431,7 +433,7 @@ top::Expr ::= 'case_any' es::Exprs 'of' vbar::Opt_Vbar_t ml::MRuleList 'end'
                               compiledGrammars=top.compiledGrammars; grammarName=top.grammarName;
                               frame=top.frame; downSubst=top.mDownSubst; finalSubst=top.mDownSubst;
                               decSiteVertexInfo = top.decSiteVertexInfo;
-                              appDecSiteVertexInfo = top.appDecSiteVertexInfo; isRoot=top.isRoot;
+                              appDecSiteVertexInfo = top.appDecSiteVertexInfo; dispatchFlowDeps = []; isRoot=top.isRoot;
                              }.typerep
               in
                 if isMonad(ty, top.env) && monadsMatch(ty, top.expectedMonad, top.mDownSubst).fst
@@ -486,7 +488,8 @@ Expr ::= exprs::[Expr] names::[String] base::Expr
                               compiledGrammars=cg; config=c; flowEnv=fe;
                               expectedMonad=^em;
                               isRoot = iR; decSiteVertexInfo = nothing(); alwaysDecorated = false;
-                              appDecSiteVertexInfo = nothing(); }.mtyperep
+                              appDecSiteVertexInfo = nothing();
+                              dispatchFlowDeps = []; }.mtyperep
            in
              if isMonad(ety, env) && fst(monadsMatch(ety, ^em, sub))
              then buildApplication(
@@ -593,6 +596,7 @@ top::MatchRule ::= pt::PatternList arr::Arrow_kwd e::Expr
   ne.decSiteVertexInfo = nothing();
   ne.appDecSiteVertexInfo = nothing();
   ne.alwaysDecorated = false;
+  ne.dispatchFlowDeps = [];
   ne.isRoot = false;
 
   top.patternTypeList = pt.patternTypeList;
@@ -615,6 +619,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr arr::Arrow_kwd e::Expr
   ncond.decSiteVertexInfo = nothing();
   ncond.alwaysDecorated = false;
   ncond.appDecSiteVertexInfo = nothing();
+  ncond.dispatchFlowDeps = [];
   ncond.isRoot = false;
   local ne::Expr = ^e;
   ne.flowEnv = top.temp_flowEnv;
@@ -628,6 +633,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr arr::Arrow_kwd e::Expr
   ne.decSiteVertexInfo = nothing();
   ne.alwaysDecorated = false;
   ne.appDecSiteVertexInfo = nothing();
+  ne.dispatchFlowDeps = [];
   ne.isRoot = false;
 
   top.patternTypeList = pt.patternTypeList;
@@ -650,6 +656,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr 'matches' p::Pattern arr::A
   ncond.decSiteVertexInfo = nothing();
   ncond.alwaysDecorated = false;
   ncond.appDecSiteVertexInfo = nothing();
+  ncond.dispatchFlowDeps = [];
   ncond.isRoot = false;
   local ne::Expr = ^e;
   ne.flowEnv = top.temp_flowEnv;
@@ -663,6 +670,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr 'matches' p::Pattern arr::A
   ne.decSiteVertexInfo = nothing();
   ne.alwaysDecorated = false;
   ne.appDecSiteVertexInfo = nothing();
+  ne.dispatchFlowDeps = [];
   ne.isRoot = false;
 
   top.patternTypeList = pt.patternTypeList;
@@ -715,6 +723,7 @@ top::AbstractMatchRule ::= pl::[Decorated Pattern] cond::Maybe<(Expr, Maybe<Patt
   ne.decSiteVertexInfo = nothing();
   ne.alwaysDecorated = false;
   ne.appDecSiteVertexInfo = nothing();
+  ne.dispatchFlowDeps = [];
   ne.isRoot = false;
 
   ne.mDownSubst = top.mDownSubst;

--- a/grammars/silver/compiler/extension/implicit_monads/Expr.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Expr.sv
@@ -13,12 +13,12 @@ propagate @expectedMonad on Expr;
 
 
 type MonadInhs = {
-  downSubst, finalSubst, frame, grammarName, decSiteVertexInfo, alwaysDecorated, appDecSiteVertexInfo, isRoot,
+  downSubst, finalSubst, frame, grammarName, decSiteVertexInfo, alwaysDecorated, appDecSiteVertexInfo, dispatchFlowDeps, isRoot,
   compiledGrammars, config, env, flowEnv, expectedMonad, mDownSubst
 };
 
 flowtype merrors {
-  downSubst, finalSubst, frame, grammarName, decSiteVertexInfo, alwaysDecorated, appDecSiteVertexInfo, isRoot,
+  downSubst, finalSubst, frame, grammarName, decSiteVertexInfo, alwaysDecorated, appDecSiteVertexInfo, dispatchFlowDeps, isRoot,
   compiledGrammars, config, env, flowEnv, expectedMonad, mDownSubst
 } on Expr;
 
@@ -203,6 +203,7 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   ne.alwaysDecorated = false;
   ne.decSiteVertexInfo = nothing();
   ne.appDecSiteVertexInfo = nothing();
+  ne.dispatchFlowDeps = [];
   ne.isRoot = false;
   local nes::AppExprs = ^es;
   nes.mDownSubst = ne.mUpSubst;
@@ -216,6 +217,7 @@ top::Expr ::= e::Expr '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   nes.downSubst = top.downSubst;
   nes.alwaysDecorated = false;
   nes.decSiteVertexInfo = nothing();
+  nes.dispatchFlowDeps = [];
   nes.appProd = nothing();
   nes.appIndexOffset = 0;
   nes.appExprTypereps = reverse(performSubstitution(ne.mtyperep, ne.mUpSubst).inputTypes);
@@ -481,6 +483,7 @@ top::Expr ::= e::Expr '.' 'forward'
   ne.decSiteVertexInfo = nothing();
   ne.alwaysDecorated = false;
   ne.appDecSiteVertexInfo = nothing();
+  ne.dispatchFlowDeps = [];
   ne.isRoot = false;
   ne.monadicallyUsed = false; --this needs to change when we decorated monadic trees
 
@@ -497,6 +500,7 @@ top::Expr ::= e::Expr '.' 'forward'
   res_e.decSiteVertexInfo = nothing();
   res_e.alwaysDecorated = false;
   res_e.appDecSiteVertexInfo = nothing();
+  res_e.dispatchFlowDeps = [];
   res_e.isRoot = false;
   top.notExplicitAttributes := res_e.notExplicitAttributes;
 

--- a/grammars/silver/compiler/extension/implicit_monads/Let.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/Let.sv
@@ -22,6 +22,7 @@ top::Expr ::= la::AssignExpr  e::Expr
   ne.decSiteVertexInfo = top.decSiteVertexInfo;
   ne.alwaysDecorated = top.alwaysDecorated;
   ne.appDecSiteVertexInfo = nothing();
+  ne.dispatchFlowDeps = [];
   ne.isRoot = top.isRoot;
 
   la.mDownSubst = top.mDownSubst;

--- a/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
+++ b/grammars/silver/compiler/extension/implicit_monads/ProductionBody.sv
@@ -191,6 +191,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
   e.isRoot = true;
 
   top.containsPluck = false;
@@ -218,6 +219,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
   e.isRoot = true;
 
   top.containsPluck = false;
@@ -256,6 +258,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
   checkE.decSiteVertexInfo = nothing();
   checkE.alwaysDecorated = false;
   checkE.appDecSiteVertexInfo = nothing();
+  checkE.dispatchFlowDeps = [];
   checkE.isRoot = true;
   checkE.expectedMonad = attr.typerep;
 
@@ -296,6 +299,7 @@ top::ProductionStmt ::= @dl::DefLHS @attr::QNameAttrOccur e::Expr
   checkE.decSiteVertexInfo = nothing();
   checkE.alwaysDecorated = false;
   checkE.appDecSiteVertexInfo = nothing();
+  checkE.dispatchFlowDeps = [];
   checkE.isRoot = true;
   checkE.expectedMonad = attr.typerep;
 

--- a/grammars/silver/compiler/extension/rewriting/Pattern.sv
+++ b/grammars/silver/compiler/extension/rewriting/Pattern.sv
@@ -77,6 +77,7 @@ top::MatchRule ::= pt::PatternList _ e::Expr
   transE.decSiteVertexInfo = nothing();
   transE.alwaysDecorated = false;
   transE.appDecSiteVertexInfo = nothing();
+  transE.dispatchFlowDeps = [];
   transE.ruleEnv = newScopeEnv(pt.ruleDefs, emptyEnv());
 
   top.ruleErrors <- transE.errors;
@@ -118,6 +119,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr _ e::Expr
   transCond.decSiteVertexInfo = nothing();
   transCond.alwaysDecorated = false;
   transCond.appDecSiteVertexInfo = nothing();
+  transCond.dispatchFlowDeps = [];
   transCond.ruleEnv = newScopeEnv(pt.ruleDefs, emptyEnv());
 
   top.ruleErrors <- transCond.errors;
@@ -139,6 +141,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr _ e::Expr
   transE.decSiteVertexInfo = nothing();
   transE.alwaysDecorated = false;
   transE.appDecSiteVertexInfo = nothing();
+  transE.dispatchFlowDeps = [];
   transE.ruleEnv = transCond.ruleEnv;
 
   top.ruleErrors <- transE.errors;
@@ -184,6 +187,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr 'matches' p::Pattern _ e::E
   transCond.decSiteVertexInfo = nothing();
   transCond.alwaysDecorated = false;
   transCond.appDecSiteVertexInfo = nothing();
+  transCond.dispatchFlowDeps = [];
   transCond.ruleEnv = newScopeEnv(pt.ruleDefs, emptyEnv());
 
   top.ruleErrors <- transCond.errors;
@@ -201,6 +205,7 @@ top::MatchRule ::= pt::PatternList 'when' cond::Expr 'matches' p::Pattern _ e::E
   transE.decSiteVertexInfo = nothing();
   transE.alwaysDecorated = false;
   transE.appDecSiteVertexInfo = nothing();
+  transE.dispatchFlowDeps = [];
   transE.ruleEnv = newScopeEnv(p.ruleDefs, transCond.ruleEnv);
 
   top.ruleErrors <- transE.errors;

--- a/grammars/silver/compiler/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/compiler/extension/rewriting/Rewriting.sv
@@ -54,6 +54,7 @@ top::Expr ::= 'traverse' n::QName '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   es.appExprTypereps = repeat(nonterminalType("silver:rewrite:Strategy", [], false, false), numChildren);
   es.appExprApplied = n.unparse;
   es.decSiteVertexInfo = nothing();
+  es.dispatchFlowDeps = [];
   es.appProd = nothing();
   es.appIndexOffset = 0;
   anns.appExprApplied = n.unparse;

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -82,8 +82,9 @@ top::AGDcl ::= at::QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOp
   
   top.errors := if !null(localErrors) then localErrors else forward.errors;
 
-  local fwrdProd::AttributionDcl =
+  forwards to
     extraDclsAttributionDcl(
+      @at, @attl, @nt, @nttl,
       altParamAttributionDcl(
         defaultAttributionDcl,
         botlSome(
@@ -104,8 +105,6 @@ top::AGDcl ::= at::QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOp
             attributionDcl(
               'attribute', qName(n), ^attl, 'occurs', 'on', ^nt, ^nttl, ';'),
           at.lookupAttribute.dcl.liftedStrategyNames)));
-  
-  forwards to fwrdProd(@at, @attl, @nt, @nttl);
 }
 
 {--

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -808,6 +808,7 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
   checkExpr.decSiteVertexInfo = nothing();
   checkExpr.alwaysDecorated = false;
   checkExpr.appDecSiteVertexInfo = nothing();
+  checkExpr.dispatchFlowDeps = [];
   checkExpr.downSubst = emptySubst();
   checkExpr.downSubst2 = checkExpr.upSubst;
   checkExpr.finalSubst = checkExpr.upSubst2;

--- a/grammars/silver/compiler/extension/tuple/Tuple.sv
+++ b/grammars/silver/compiler/extension/tuple/Tuple.sv
@@ -51,6 +51,7 @@ top::Expr ::= tuple::Expr '.' a::IntConst
   propagate grammarName, config, compiledGrammars, frame, env, flowEnv, downSubst, upSubst, finalSubst, freeVars;
   tuple.decSiteVertexInfo = nothing();
   tuple.appDecSiteVertexInfo = nothing();
+  tuple.dispatchFlowDeps = [];
   tuple.isRoot = false;
 
   local accessIndex::Integer = toInteger(a.lexeme);

--- a/grammars/silver/compiler/modification/collection/Collection.sv
+++ b/grammars/silver/compiler/modification/collection/Collection.sv
@@ -53,6 +53,7 @@ top::NameOrBOperator ::= e::Expr
   e.decSiteVertexInfo = nothing();
   e.alwaysDecorated = false;
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
 }
 
 concrete production plusplusOperator

--- a/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
+++ b/grammars/silver/compiler/modification/primitivepattern/PrimitiveMatch.sv
@@ -59,6 +59,7 @@ top::Expr ::= e::Expr t::TypeExpr pr::PrimPatterns f::Expr
   propagate config, grammarName, env, freeVars, frame, compiledGrammars, finalSubst, originRules, flowEnv;
   e.decSiteVertexInfo = nothing();
   e.appDecSiteVertexInfo = nothing();
+  e.dispatchFlowDeps = [];
   e.isRoot = false;
 
   e.downSubst = top.downSubst;

--- a/test/flow/Dispatch.sv
+++ b/test/flow/Dispatch.sv
@@ -4,6 +4,7 @@ synthesized attribute errors1::Boolean;
 synthesized attribute errors2::Boolean;
 
 nonterminal UDExpr with env1, env2, errors1, errors2;
+flowtype UDExpr = forward {env1, env2}, decorate {env1, env2}, errors1 {env1}, errors2 {env1, env2};
 
 production directOverloadThing
 top::UDExpr ::= e::UDExpr
@@ -51,6 +52,7 @@ top::UDExpr ::= @e::UDExpr
 production dispatchThing3 implements DispatchOp
 top::UDExpr ::= @e::UDExpr i::Integer b::Boolean
 {
+  e.env2 = if b then [] else top.env2;
   top.errors1 = b;
   top.errors2 = i > 0;
 }
@@ -88,5 +90,42 @@ UDExpr ::= e::UDExpr
 {
   e.env1 = [];
   return shareThing(e);
+}
+}
+
+warnCode "Dispatching may require inherited attribute(s) flow:env2 on e, but these attribute(s) are supplied here after dispatching" {
+production dispatchCycle
+top::UDExpr ::= e::UDExpr
+{
+  e.env1 = top.env1;
+  local prod::DispatchOp = if null(e.env2) then dispatchThing1 else dispatchThing2;
+  forwards to prod(e);
+}
+}
+
+dispatch DispatchOp2 = UDExpr ::= e::UDExpr;
+production doimpl1 implements DispatchOp2
+top::UDExpr ::= e::UDExpr
+{
+  e.env1 = top.env1;
+  e.env2 = top.env2;
+  top.errors1 = e.errors1;
+  top.errors2 = !null(e.env1);
+}
+production doimpl2 implements DispatchOp2
+top::UDExpr ::= e::UDExpr
+{
+  e.env1 = top.env1;
+  e.env2 = top.env1;
+  top.errors1 = e.errors1;
+  top.errors2 = !null(e.env1);
+}
+
+warnCode "Dispatching may require inherited attribute(s) flow:env2 on e, but these attribute(s) are supplied here after dispatching" {
+production dispatchCycle2
+top::UDExpr ::= e::UDExpr
+{
+  local prod::DispatchOp2 = if null(e.env2) then doimpl1 else doimpl2;
+  forwards to prod(@e);
 }
 }


### PR DESCRIPTION
# Changes
This adds a check for missing inherited equations on a child of a dispatching production, when those equations are needed to resolve the dispatch to determine what production is supplying the attributes.  For example:
```
production negOp
top::Expr ::= e::Expr
{
  local prod::UnaryProd = e.typerep.negProd;
  forwards to prod(@e);
}

dispatch UnaryProd = Expr ::= e::Expr;
production intNeg implements UnaryProd
top::Expr ::= e::Expr
{
  e.env = top.env;
  ...
}
```
Here `e` in `negOp` has the application of `prod` as its decoration site, and `UnaryOp` is known to supply `env` to its child.  However `prod` depends on `e.typerep`, which depends on `e.env`, which has not yet been supplied when `prod` is being computed - thus this "circularity" manifests as a missing equation.

This change adds a check that the dependencies of any applied dispatch productions do not include any inherited attributes that will be supplied via a child shared in dispatching.  

# Documentation
Added source comments.  Dispatching as a feature is not yet documented.

# Testing
Added test cases in the test suite.  Also tested on Silver and ableC, fixed a few issues discovered in Silver.