### PR TITLE
Fix flow deps for taking a reference to an instance of a translation attribute

### DIFF
--- a/grammars/silver/compiler/definition/flow/ast/DecSiteTree.sv
+++ b/grammars/silver/compiler/definition/flow/ast/DecSiteTree.sv
@@ -24,7 +24,7 @@ top::DecSiteTree ::=
 
 {--
  - No attributes can be known to be supplied.
- - Primarilly, denotes a cycle in decoration site resolution.
+ - Primarily, denotes a cycle in decoration site resolution.
  -}
 production neverDec
 top::DecSiteTree ::= 

--- a/grammars/silver/compiler/definition/flow/env/DecSites.sv
+++ b/grammars/silver/compiler/definition/flow/env/DecSites.sv
@@ -116,7 +116,7 @@ DecSiteTree ::= prodName::String vt::VertexType flowEnv::FlowEnv realEnv::Env
  - This is used in checking for potentially hidden transitive dependencies.
  - This mirrors the above, but we also consider sites where a tree is only conditionally shared.
  - Since we only care if a vertex is *possibly* supplied with an attribute, we can memoize the
- - vertices visited in the enitre search (using a State monad) rather than just the current branch.
+ - vertices visited in the entire search (using a State monad) rather than just the current branch.
  -
  - @param prodName The name of the production containing the vertex type.
  - @param vt The vertex type to find decoration sites for.
@@ -283,6 +283,7 @@ partial strategy attribute lookupDecSiteStep =
           neverDec()
       | _ -> alwaysDec()
       end
+  -- This is safe as the tree is traversed top-down, so the current attrToResolve is the final one.
   | depAttrDec(attrName, d) when top.attrToResolve == attrName -> ^d
   | projectedDepsDec(prodName, sigName, d) ->
       product(map(depAttrDec(_, ^d), set:toList(onlyLhsInh(expandGraph(

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -424,7 +424,7 @@ top::Expr ::= @e::Expr @q::QNameAttrOccur
   top.flowDeps := 
     case e.flowVertexInfo of
     | just(vertex) -> vertex.synVertex(q.attrDcl.fullName) :: vertex.eqVertex ++
-      if top.finalType.isDecorated then map(vertex.inhVertex, fromMaybe([], refSet)) else []
+      map(transAttrVertexType(vertex, q.attrDcl.fullName).inhVertex, fromMaybe([], refSet))
     | nothing() -> e.flowDeps
     end;
 }


### PR DESCRIPTION
# Changes
When taking a reference to the decorated tree built by a translation attribute, the logic for computing the flow deps was just plain wrong, yielding inherited attributes on the vertex on which the trans attr is accessed, rather than on the trans attr vertex itself.

# Documentation
Fix unrelated typos in comments.

# Testing
Tested in not-yet-finished changes to ableC.