### PR TITLE
Fixes and cleanup to MWDA related to translation attributes

### DIFF
--- a/grammars/silver/compiler/analysis/typechecking/core/Checking.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Checking.sv
@@ -1,6 +1,7 @@
 grammar silver:compiler:analysis:typechecking:core;
 
 import silver:compiler:definition:type;
+import silver:compiler:definition:flow:env only splitTransAttrInh;
 
 synthesized attribute leftpp :: String;
 synthesized attribute rightpp :: String;
@@ -80,4 +81,17 @@ fun specializeRefSet Substitution ::= s::Substitution t::Type =
   case performSubstitution(t, s) of
   | decoratedType(_, varType(i)) -> composeSubst(s, subst(i, inhSetType([])))
   | _ -> s
+  end;
+
+fun specializeTransRefSet Substitution ::= s::Substitution t::Type base::Type transAttr::String =
+  case performSubstitution(base, s), performSubstitution(t, s) of
+  | decoratedType(_, inhSetType(inhs)), decoratedType(_, varType(i)) ->
+    composeSubst(s, subst(i, inhSetType(filterMap(dropTransAttrPrefix(transAttr, _), inhs))))
+  | _, _ -> s
+  end;
+
+fun dropTransAttrPrefix Maybe<String> ::= transAttr::String attr::String =
+  case splitTransAttrInh(attr) of
+  | just((t, i)) when t == transAttr -> just(i)
+  | _ -> nothing()
   end;

--- a/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/Expr.sv
@@ -58,7 +58,10 @@ top::Expr ::= @q::QName
 aspect production transDecoratedAccessHandler
 top::Expr ::= @e::Expr @q::QNameAttrOccur
 {
-  top.upSubst2 = specializeRefSet(top.downSubst2, top.typerep);
+  top.upSubst2 =
+    if q.attrFound
+    then specializeTransRefSet(top.downSubst2, top.typerep, e.typerep, q.attrDcl.fullName)
+    else specializeRefSet(top.downSubst2, top.typerep);
 }
 
 aspect production productionReference

--- a/grammars/silver/compiler/analysis/typechecking/core/OccursDcl.sv
+++ b/grammars/silver/compiler/analysis/typechecking/core/OccursDcl.sv
@@ -11,4 +11,11 @@ top::AGDcl ::= at::QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOp
     if at.lookupAttribute.found && at.lookupAttribute.dcl.isTranslation && checkNT.typeerror
     then [errFromOrigin(top, s"Occurrence of translation attribute ${at.lookupAttribute.fullName} must have a nonterminal type.  Instead it is of type " ++ checkNT.leftpp)]
     else [];
+  
+  local transTargets :: [String] = getTranslationAttrTargets([], protoatty, top.env);
+  top.errors <-
+    if nt.lookupType.found && at.lookupAttribute.found && at.lookupAttribute.dcl.isTranslation && !checkNT.typeerror
+    && contains(nt.lookupType.fullName, transTargets)
+    then [errFromOrigin(top, s"Cycle in translation attributes! ${at.lookupAttribute.fullName} translates ${nt.lookupType.fullName} to ${protoatty.typeName}, but this nonterminal has translation attributes to ${implode(", ", transTargets)}.")]
+    else [];
 }

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -569,7 +569,7 @@ top::DefLHS ::= @q::QName @attr::QNameAttrOccur
   top.errors <-
     if existingProblems then []
     else if !top.defLHSattr.attrDcl.isInherited
-    then [errFromOrigin(attr, s"Attribute '${attr.name}' is not inherited and cannot be defined on '${top.unparse}'")]
+    then [errFromOrigin(top.defLHSattr, s"Attribute '${top.defLHSattr.name}' is not inherited and cannot be defined on '${top.unparse}'")]
     else [];
   
   local ty::Type = q.lookupValue.typeScheme.monoType;
@@ -593,7 +593,7 @@ top::DefLHS ::= @q::QName @attr::QNameAttrOccur
   top.errors <-
     if existingProblems then []
     else if !top.defLHSattr.attrDcl.isInherited
-    then [errFromOrigin(attr, s"Attribute '${attr.name}' is not inherited and cannot be defined on '${top.unparse}'")]
+    then [errFromOrigin(top.defLHSattr, s"Attribute '${top.defLHSattr.name}' is not inherited and cannot be defined on '${top.unparse}'")]
     else [];
   
   local ty::Type = q.lookupValue.typeScheme.monoType;

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -180,6 +180,20 @@ fun occursOnHelp [OccursDclInfo] ::= i::[OccursDclInfo] fnat::String =
        then head(i) :: occursOnHelp(tail(i), fnat)
        else occursOnHelp(tail(i), fnat);
 
+-- Get all the nonterminals that may be reached by translation attributes on a nonterminal.
+fun getTranslationAttrTargets [String] ::= seen::[String] ntty::Type e::Env =
+  if contains(ntty.typeName, seen) then []
+  else ntty.typeName :: flatMap(
+    \ o::OccursDclInfo ->
+      getTranslationAttrTargets(ntty.typeName :: seen, determineAttributeType(o, ntty), e),
+    filter(
+      \ o::OccursDclInfo ->
+        case getAttrDcl(o.attrOccurring, e) of
+        | at :: _ -> at.isTranslation
+        | _ -> false
+        end,
+      getAttrOccursOn(ntty.typeName, e)));
+
 -- Determines whether a type is automatically promoted to a decorated type
 -- and whether a type may be supplied with inherited attributes.
 -- Used by expression (id refs), decorate type checking, and translations.

--- a/grammars/silver/compiler/definition/flow/ast/DecSiteTree.sv
+++ b/grammars/silver/compiler/definition/flow/ast/DecSiteTree.sv
@@ -153,7 +153,7 @@ fun prettyDecSites String ::= nest::Integer d::DecSiteTree =
         then " any of\n" ++ implode("\n", map(prettyDecSites(nest + 1, _), d.decSiteAlts))
         else if length(d.decSiteReqs) > 1
         then " all of\n" ++ implode("\n", map(prettyDecSites(nest + 1, _), d.decSiteReqs))
-        else " " ++ prettyDecSites(nest, ^d)
+        else " " ++ d.decSitePP
     | _ -> d.decSitePP
     end;
 

--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -342,7 +342,7 @@ top::FlowDef ::= prod::String  sigName::String  transAttr::String  attr::String 
 abstract production localTransInhEq
 top::FlowDef ::= prod::String  fName::String  transAttr::String  attr::String  deps::[FlowVertex]
 {
-  top.inhTreeContribs := [(crossnames(prod, crossnames(fName, s"${transAttr}.${attr}")), top)];
+  top.localInhTreeContribs := [(crossnames(prod, crossnames(fName, s"${transAttr}.${attr}")), top)];
   top.prodGraphContribs := [(prod, top)];
   top.flowEdges = map(pair(fst=localSynVertex(fName, s"${transAttr}.${attr}"), snd=_), deps);
 }

--- a/grammars/silver/compiler/definition/flow/driver/FlowTypes.sv
+++ b/grammars/silver/compiler/definition/flow/driver/FlowTypes.sv
@@ -56,7 +56,7 @@ fun fullySolveFlowTypes InferState<()> ::= prods::[ProdName] = do {
   traverse_(updateFlowType, prods);
 
   -- Just iterate until no new edges are added
-  doWhile_(do {
+  doWhile_(
     map(any, traverseA(
       \ prod::ProdName -> do {
         -- Update the production graph
@@ -66,8 +66,7 @@ fun fullySolveFlowTypes InferState<()> ::= prods::[ProdName] = do {
         when_(graphUpdated, updateFlowType(prod));
         return graphUpdated;
       },
-      prods));
-  });
+      prods)));
 };
 
 {--
@@ -110,19 +109,18 @@ fun expandVertexFilterTo [(String, String)] ::= ver::FlowVertex  graph::Producti
 {--
  - Filters vertexes down to just the names of inherited attributes on the LHS
  -}
-fun filterLhsInh [String] ::= f::[FlowVertex] = foldr(collectInhs, [], f);
+global filterLhsInh :: ([String] ::= [FlowVertex]) = flatMap(collectInhs, _);
 
 {--
  - Used to filter down to just the inherited attributes (on the LHS)
  - 
  - @param f  The flow vertex in question
- - @param l  The current set of inherited attribute dependencies
- - @return  {l} with {f} added to it
+ - @return  {f} if f is an LHS Inh vertex, otherwise {}
  -}
-fun collectInhs [String] ::= f::FlowVertex  l::[String] =
+fun collectInhs [String] ::= f::FlowVertex =
   case f of
-  | lhsInhVertex(a) -> a::l
-  | _ -> l
+  | lhsInhVertex(a) -> [a]
+  | _ -> []
   end;
 
 

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -131,6 +131,8 @@ fun vertexHasInhEq Boolean ::= prodName::String  vt::VertexType  attrName::Strin
   | rhsVertexType(sigName) -> !null(lookupInh(prodName, sigName, attrName, flowEnv))
   | localVertexType(fName) -> !null(lookupLocalInh(prodName, fName, attrName, flowEnv))
   | forwardVertexType_real() -> true
+  -- Note that we only support inh equations on trans attrs directly on a child/local,
+  -- and not chained trans attrs.
   | transAttrVertexType(rhsVertexType(sigName), transAttr) ->
     !null(lookupInh(prodName, sigName, s"${transAttr}.${attrName}", flowEnv))
   | transAttrVertexType(localVertexType(fName), transAttr) ->
@@ -144,7 +146,7 @@ fun vertexHasInhEq Boolean ::= prodName::String  vt::VertexType  attrName::Strin
   -- but here we are remotely looking for equations that might not be the direct dependency of
   -- anything in the prod flow graph.
   | lhsVertexType_real() -> false  -- Shouldn't ever be directly needed, since the LHS is never the dec site for another vertex.
-  | forwardParentVertexType() -> false  -- Same as LHS - the thing that forwared to us.
+  | forwardParentVertexType() -> false  -- Same as LHS - the thing that forwarded to us.
   end;
 
 -- used for duplicate equations checks

--- a/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
+++ b/grammars/silver/compiler/definition/flow/syntax/FlowSpec.sv
@@ -204,7 +204,7 @@ top::FlowSpecInh ::= transSyn::QNameAttrOccur '.' inh::FlowSpecInh
     if transSyn.attrFound
     then map(\ i -> s"${transSyn.attrDcl.fullName}.${i}", inh.inhList)
     else [];
-  top.refList := [];  -- TODO: Technically, we could have cycles involving translation attr flow specs
+  top.refList := [];  -- TODO: An (erroneous) cycle in translation attr occurrences could lead to a crash here.
 
   transSyn.attrFor = top.onNt;
   inh.onNt = transSyn.typerep;
@@ -212,9 +212,6 @@ top::FlowSpecInh ::= transSyn::QNameAttrOccur '.' inh::FlowSpecInh
   top.errors <-
     if !transSyn.found || transSyn.attrDcl.isSynthesized && transSyn.attrDcl.isTranslation then []
     else [errFromOrigin(transSyn, transSyn.name ++ " is not a translation attribute and so cannot be within a flow type")];
-  top.errors <-
-    if !any(map(\ i -> indexOf(".", i) != -1, inh.inhList)) then []
-    else [errFromOrigin(inh, "Chained translation attributes are not currently supported in flow types")];
 }
 
 {--

--- a/test/silver_features/TransAttr.sv
+++ b/test/silver_features/TransAttr.sv
@@ -1,0 +1,18 @@
+grammar silver_features;
+
+nonterminal TransNT1;
+nonterminal TransNT2;
+nonterminal TransNT3;
+
+translation attribute trans1::TransNT2 occurs on TransNT1;
+translation attribute trans2::TransNT3 occurs on TransNT2;
+
+wrongCode "Cycle in translation attributes! silver_features:trans3 translates silver_features:TransNT3 to silver_features:TransNT1, but this nonterminal has translation attributes to silver_features:TransNT1, silver_features:TransNT2, silver_features:TransNT3." {
+  translation attribute trans3::TransNT1 occurs on TransNT3;
+}
+
+translation attribute thing<a>::a;
+
+wrongCode "Occurrence of translation attribute silver_features:thing must have a nonterminal type.  Instead it is of type String" {
+  attribute thing<String> occurs on TransNT1;
+}


### PR DESCRIPTION
# Changes
* Add a check for cycles in translation attribute occurrences.  A translation attribute cannot (even indirectly) occur on its own nonterminal type, to avoid unbounded chains of translation attributes appearing in flow types (e.g. `x.trans.trans.trans.inh`).
* Better computation of the default reference set when taking a reference to an instance of a translation attribute.  For example if we have `x :: Decorated Expr with {env, host.env}`, and `translation attribute host :: HostExpr occurs on Expr`, then we want to infer the type of `x.host` as `Decorated HostExpr with {env}` and not the empty set.
* Fix to dependency collection for `local.trans.inh` equations.
* Fix to decoration site pretty-printing
* Unrelated cleanup/refactoring to flow type inference code

# Documentation
Added and updated some source comments.  Translation attributes as a whole still need documentation.

# Testing
Added tests for errors involving translation attribute occurrences.