### PR TITLE
Fixes bug with undeclared lambda parameter type declarations

### DIFF
--- a/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
+++ b/grammars/silver/compiler/modification/lambda_fn/Lambda.sv
@@ -57,12 +57,12 @@ top::Expr ::= params::LambdaRHS e::Expr
 tracked nonterminal LambdaRHS with 
   givenLambdaParamIndex, givenLambdaId, env, grammarName, flowEnv, 
   lambdaBoundVars, lambdaDefs, lexicalTypeVariables, lexicalTyVarKinds, 
-  inputElements, unparse, elementCount;
+  inputElements, unparse, elementCount, errors;
 
 tracked nonterminal LambdaRHSElem with 
   givenLambdaParamIndex, givenLambdaId, grammarName, deterministicCount, env, 
   flowEnv, lambdaBoundVars, lambdaDefs, unparse, lexicalTypeVariables, 
-  inputElements, lexicalTyVarKinds;
+  inputElements, lexicalTyVarKinds, errors;
 
 
 monoid attribute lambdaDefs::[Def];
@@ -80,7 +80,7 @@ flowtype lambdaBoundVars {} on LambdaRHS;
 flowtype lambdaBoundVars {deterministicCount} on LambdaRHSElem;
 
 propagate lambdaDefs, lambdaBoundVars on LambdaRHS;
-propagate flowEnv, env, grammarName, givenLambdaId, lexicalTyVarKinds on LambdaRHS, LambdaRHSElem;
+propagate flowEnv, env, grammarName, givenLambdaId, lexicalTyVarKinds, errors on LambdaRHS, LambdaRHSElem;
 propagate lexicalTypeVariables on LambdaRHS, LambdaRHSElem excluding lambdaRHSCons;
 
 
@@ -132,6 +132,7 @@ top::LambdaRHSElem ::= id::Name '::' t::TypeExpr
   top.inputElements = [namedSignatureElement(id.name, t.typerep, false)];
   
   top.unparse = id.unparse ++ "::" ++ t.unparse;
+
 }
 
 {--

--- a/test/silver_features/Lambda.sv
+++ b/test/silver_features/Lambda.sv
@@ -52,7 +52,8 @@ function failsLambdaType
 -- See Issue #825
 
 
-global errLambda::(String ::= Integer) = \x::SomeUndefinedType -> "s";
-
+wrongCode
+  "Undeclared type 'SomeUndefinedType'"
+  {global errLambda::(String ::= Integer) = \x::SomeUndefinedType -> "s";}
 
 -- End Issue #825

--- a/test/silver_features/Lambda.sv
+++ b/test/silver_features/Lambda.sv
@@ -47,3 +47,12 @@ function failsLambdaType
     return (\ f::LambdaType -> case f of lambdaType() -> "str" end);
 }
 -- End Issue #209
+
+-----------------
+-- See Issue #825
+
+
+global errLambda::(String ::= Integer) = \x::SomeUndefinedType -> "s";
+
+
+-- End Issue #825


### PR DESCRIPTION
# Changes
Addressing issue #825.

Adding occurrence and propagate declarations for attribute `errors` on `LambdaRHS` and `LambdaRHSElem`

# Documentation
None added - simple addition of `errors` attribute occurrence.

# Testing
Added `wrongCode` test to https://github.com/melt-umn/silver/blob/develop/test/silver_features/Lambda.sv