### PR TITLE
Add error message instead of silently doing nothing when JAVA_HOME isn't set

### DIFF
--- a/support/vs-code/silverlsp/package.json
+++ b/support/vs-code/silverlsp/package.json
@@ -2,7 +2,7 @@
   "name": "silverlsp",
   "displayName": "Silver LSP",
   "description": "Plugin for Silver Language Server Protocol support",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "vscode": "^1.67.0"
   },

--- a/support/vs-code/silverlsp/src/extension.ts
+++ b/support/vs-code/silverlsp/src/extension.ts
@@ -84,6 +84,8 @@ export function activate(context: vscode.ExtensionContext) {
 		client = new LanguageClient('silver-langserver', 'Language Support for Silver', serverOptions, clientOptions);
 
 		client.start();
+	} else {
+		vscode.window.showErrorMessage(`The JAVA_HOME environment variable must be set to use the Silver LSP extension.`);
 	}
 }
 


### PR DESCRIPTION
# Changes
Add a popup error message when `JAVA_HOME` is not set.

# Documentation
N/A

# Testing
I can't figure out how to unset `JAVA_HOME` to test this myself...