### PR TITLE
Include annotations in native serialization format

### DIFF
--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -322,7 +322,7 @@ ${body.translation}
         public String getName(){ return "${fName}"; }
         public common.RTTIManager.Nonterminalton<${fnnt}> getNonterminalton(){ return ${fnnt}.nonterminalton; }
 
-        public String getTypeUnparse() { return "${escapeString(ns.unparse)}"; }
+        public String getTypeUnparse() { return "${escapeString(namedSig.typeScheme.typepp)}"; }
         public int getChildCount() { return ${toString(length(namedSig.inputElements))}; }
         public int getAnnoCount() { return ${toString(length(namedSig.namedInputElements))}; }
 


### PR DESCRIPTION
# Changes
Fix #628

# Documentation
This was fixing a bug, doesn't affect any behavior requiring documentation.

# Testing
Tested by changing annotations to things that go in interface files, and vertifying that the interface format is reported to have changed when deserializing.