### PR TITLE
No annotations can have the same short name on nonterminal

### DIFF
--- a/grammars/silver/compiler/definition/core/OccursDcl.sv
+++ b/grammars/silver/compiler/definition/core/OccursDcl.sv
@@ -117,6 +117,13 @@ top::AGDcl ::= at::QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOp
     then [errFromOrigin(at, "Attribute '" ++ at.name ++ "' already occurs on '" ++ nt.name ++ "'.")]
     else [];
 
+  -- Make sure that no two annotations with the same short name (but different full names) can be declared on the same nonterminal
+  local snat :: String = last(explode(":", at.name)); -- short name of annotation
+  top.errors <-
+    if at.lookupAttribute.dcl.isAnnotation && length(filter((.isAnnotation), getOccursDclBySN(snat, nt.lookupType.fullName, top.env))) > 1
+    then [errFromOrigin(at, "Annotation with the same short name '" ++ snat ++ "' already occurs on '" ++ nt.name ++ "'.")]
+    else [];
+
   top.errors <-
     if nt.lookupType.found && (!nt.lookupType.dcl.isType || !ntTypeScheme.typerep.isNonterminal)
     then [errFromOrigin(nt, nt.name ++ " is not a nonterminal. Attributes can only occur on nonterminals.")]

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -180,6 +180,14 @@ fun occursOnHelp [OccursDclInfo] ::= i::[OccursDclInfo] fnat::String =
        then head(i) :: occursOnHelp(tail(i), fnat)
        else occursOnHelp(tail(i), fnat);
 
+fun getOccursDclBySN [OccursDclInfo] ::= snat::String fnnt::String e::Env = 
+  occursOnSNHelp(getAttrOccursOn(fnnt, e), snat);
+fun occursOnSNHelp [OccursDclInfo] ::= i::[OccursDclInfo] snat::String =
+  if null(i) then []
+  else if endsWith(":" ++ snat, head(i).attrOccurring) -- check if the full name of the attribute ends with :snat
+      then head(i) :: occursOnSNHelp(tail(i), snat)
+      else occursOnSNHelp(tail(i), snat);
+
 -- Determines whether a type is automatically promoted to a decorated type
 -- and whether a type may be supplied with inherited attributes.
 -- Used by expression (id refs), decorate type checking, and translations.

--- a/test/silver_features/AnnoSNTest.sv
+++ b/test/silver_features/AnnoSNTest.sv
@@ -1,0 +1,24 @@
+-- Test to ensure that no two annotations occuring on the same nonterminal can have the same shortname
+
+imports silver_features:anno_short_names:a as a;
+imports silver_features:anno_short_names:b as b;
+imports silver_features:anno_short_names:c as c;
+
+wrongCode "already occurs on" {
+    nonterminal Thing1 ;
+    annotation a:foo occurs on Thing1;
+    annotation b:foo occurs on Thing1;
+}
+
+wrongCode "already occurs on" {
+    nonterminal Thing2 with a:foo;
+    annotation b:foo occurs on Thing2;
+}
+
+wrongCode "already occurs on" {
+    nonterminal Thing3 with a:foo, b:foo;
+}
+
+-- no error here
+nonterminal Thing4 with a:foo, c:foo;
+nonterminal Thing5 with a:baz, b:baz;

--- a/test/silver_features/anno_short_names/a/a.sv
+++ b/test/silver_features/anno_short_names/a/a.sv
@@ -1,0 +1,4 @@
+grammar silver_features:anno_short_names:a;
+
+annotation foo :: String;
+synthesized attribute baz :: String;

--- a/test/silver_features/anno_short_names/b/b.sv
+++ b/test/silver_features/anno_short_names/b/b.sv
@@ -1,0 +1,4 @@
+grammar silver_features:anno_short_names:b;
+
+annotation foo :: String;
+synthesized attribute baz :: String;

--- a/test/silver_features/anno_short_names/c/c.sv
+++ b/test/silver_features/anno_short_names/c/c.sv
@@ -1,0 +1,3 @@
+grammar silver_features:anno_short_names:c;
+
+synthesized attribute foo :: String;


### PR DESCRIPTION
# Changes
Add checks so that two annotations with the same short name occurring on the same nonterminal will cause a compilation error. See #815 

# Documentation
Please briefly describe the documentation you have written in the following categories, or why you didn't write documentation for a category:
* what general comments you have added: N/A
* what doc comments you have added: N/A
* what documentation you have added to the website for users of Silver: Should we add this to the website?

# Testing
Added tests for both `occurs on` and `with` syntax.