### PR TITLE
Fix Tuple Selector Error Message

### DIFF
--- a/grammars/silver/compiler/extension/tuple/Tuple.sv
+++ b/grammars/silver/compiler/extension/tuple/Tuple.sv
@@ -62,7 +62,7 @@ top::Expr ::= tuple::Expr '.' a::IntConst
   local len::Integer = length(ty.tupleElems);
   
   forwards to if (accessIndex > len || accessIndex < 1) then
-      errorExpr([errFromOrigin(top, "Invalid tuple selector index.")])
+      errorExpr(tuple.errors ++ [errFromOrigin(top, "Invalid tuple selector index.")])
     -- @ prevents exponential type checking
     else select(@tuple, 1, accessIndex, len);
 

--- a/test/silver_features/Tuple.sv
+++ b/test/silver_features/Tuple.sv
@@ -248,6 +248,17 @@ String ::=
 }
 
 }
+-- to test the branch in concrete production selector: accessIndex > len || accessIndex < 1
+-- that the index is "out of bounds"
+wrongCode "Undeclared value 'notdefined'" {
+
+function fun
+String ::=
+{
+  return notdefined.2;
+}
+
+}
 
 -- polymorphism
 function thirdOfFive


### PR DESCRIPTION
…or issue #845

# Changes
Accessing undeclared value's tuple index now shows "Undeclared value" instead of "Invalid tuple selector index."

# Testing
Example
```
fun main IO<Integer> ::= largs::[String] =
do {
  return x.2;
}
```
Output
Main.sv:18:9: error: Invalid tuple selector index.
Main.sv:18:9: error: Undeclared value 'x'.
