### PR TITLE
Include default production graphs in flow type inference

### DIFF
--- a/grammars/silver/compiler/definition/flow/ast/Flow.sv
+++ b/grammars/silver/compiler/definition/flow/ast/Flow.sv
@@ -187,7 +187,7 @@ abstract production defaultSynEq
 top::FlowDef ::= nt::String  attr::String  deps::[FlowVertex]
 {
   top.defTreeContribs := [(crossnames(nt, attr), top)];
-  top.prodGraphContribs := []; -- defaults don't show up in the prod graph!!
+  top.prodGraphContribs := [(nt ++ ":default", top)];
   top.flowEdges = map(pair(fst=lhsSynVertex(attr), snd=_), deps); -- but their edges WILL end up added to graphs in fixup-phase!!
 }
 

--- a/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
+++ b/grammars/silver/compiler/definition/flow/env/ProductionDcl.sv
@@ -85,3 +85,19 @@ top::AspectRHSElem ::= '@' id::Name '::' t::TypeExpr
 {
   propagate flowEnv;
 }
+
+aspect production aspectDefaultProduction
+top::AGDcl ::= 'aspect' 'default' 'production' ns::AspectDefaultProductionSignature body::ProductionBody
+{
+  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
+  local myGraphs :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
+
+  {-- Used by core to send down with .frame -}
+  production myFlowGraph :: ProductionGraph =
+    case searchEnvTree(ns.namedSignature.fullName, myGraphs) of
+    | g :: _ -> g
+    -- In case we didn't find the flow graph (the nonterminal doesn't exist?)
+    -- build an anonymous flow graph to use instead as a "best effort".
+    | [] -> constructAnonymousGraph(body.flowDefs, top.env, myGraphs, myFlow)
+    end;
+}

--- a/grammars/silver/compiler/driver/util/FlowTypes.sv
+++ b/grammars/silver/compiler/driver/util/FlowTypes.sv
@@ -33,10 +33,10 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  a::Decor
   
   -- Construct production graphs.
   production prodGraph :: [ProductionGraph] = 
-    computeAllProductionGraphs(allProds, allFlowEnv, allRealEnv) ++
+    map(constructProductionGraph(_, allFlowEnv, allRealEnv), allProds) ++
     -- Add in phantom, default and dispatch graphs
-    map(constructPhantomProductionGraph(_, allFlowEnv, allRealEnv), allNts) ++
-    map(constructDefaultProductionGraph(_, allFlowEnv, allRealEnv), allNts) ++
+    flatMap(constructPhantomProductionGraph(_, allFlowEnv, allRealEnv), allNts) ++
+    flatMap(constructDefaultProductionGraph(_, allFlowEnv, allRealEnv), allNts) ++
     map(constructDispatchGraph(_, allFlowEnv, allRealEnv), allDispatchSigs);
   
   local initialFT :: EnvTree<FlowType> =

--- a/grammars/silver/compiler/driver/util/FlowTypes.sv
+++ b/grammars/silver/compiler/driver/util/FlowTypes.sv
@@ -34,9 +34,10 @@ top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  a::Decor
   -- Construct production graphs.
   production prodGraph :: [ProductionGraph] = 
     computeAllProductionGraphs(allProds, allFlowEnv, allRealEnv) ++
-      -- Add in phantom and dispatch graphs
-      map(constructPhantomProductionGraph(_, allFlowEnv, allRealEnv), allNts) ++
-      map(constructDispatchGraph(_, allFlowEnv, allRealEnv), allDispatchSigs);
+    -- Add in phantom, default and dispatch graphs
+    map(constructPhantomProductionGraph(_, allFlowEnv, allRealEnv), allNts) ++
+    map(constructDefaultProductionGraph(_, allFlowEnv, allRealEnv), allNts) ++
+    map(constructDispatchGraph(_, allFlowEnv, allRealEnv), allDispatchSigs);
   
   local initialFT :: EnvTree<FlowType> =
     computeInitialFlowTypes(allSpecDefs);

--- a/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
+++ b/grammars/silver/compiler/modification/defaultattr/DefaultAttr.sv
@@ -26,13 +26,6 @@ top::AGDcl ::= 'aspect' 'default' 'production' ns::AspectDefaultProductionSignat
   
   local sigDefs :: [Def] = addNewLexicalTyVars(top.grammarName, ns.lexicalTyVarKinds, ns.lexicalTypeVariables);
 
-  -- oh no again!
-  local myFlow :: EnvTree<FlowType> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).grammarFlowTypes;
-  local myProds :: EnvTree<ProductionGraph> = head(searchEnvTree(top.grammarName, top.compiledGrammars)).productionFlowGraphs;
-
-  local myFlowGraph :: ProductionGraph = 
-    constructDefaultProductionGraph(ns.namedSignature, body.flowDefs, top.env, myProds, myFlow);
-
   ns.env = newScopeEnv(sigDefs, top.env);
 
   body.env = newScopeEnv(ns.defs, ns.env);
@@ -55,7 +48,7 @@ top::AspectDefaultProductionSignature ::= lhs::Name '::' te::TypeExpr '::='
   top.unparse = lhs.unparse ++ "::" ++ te.unparse ++ " ::=";
   top.defs := [defaultLhsDef(top.grammarName, lhs.nameLoc, lhs.name, te.typerep)];
   top.namedSignature =
-    namedSignature(top.grammarName ++ ":default" ++ te.typerep.typeName,
+    namedSignature(top.grammarName ++ ":" ++ te.typerep.typeName ++ ":default",
       nilContext(), nilNamedSignatureElement(),
       namedSignatureElement(lhs.name, te.typerep, false),
       foldNamedSignatureElements(annotationsForNonterminal(te.typerep, top.env)));

--- a/test/flow/Default.sv
+++ b/test/flow/Default.sv
@@ -1,0 +1,16 @@
+grammar flow;
+
+nonterminal DefaultDepNT with env1, errors1;
+
+aspect default production
+top::DefaultDepNT ::=
+{
+  top.errors1 = null(top.env1);
+}
+
+production defaultDep
+top::DefaultDepNT ::=
+{
+  top.errors1 = false;
+}
+


### PR DESCRIPTION
# Changes
Fix #820.

Currently, one can write an equa

# Documentation
Updated some comments.  This does not require external documentation, as it just fixes some unexpected behavior in flow type inference.

# Testing
Added a test case where a larger flow type should be inferred from a default equation.