### PR TITLE
Silver now reports its latest git tag as its version

### DIFF
--- a/grammars/silver/compiler/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/driver/BuildProcess.sv
@@ -54,7 +54,7 @@ fun computeEnv IOErrorable<(Decorated CmdArgs, BuildEnv)> ::= args::[String] =
     -- line decide to go do, but currently it's hard to re-use code if we do that.
     if a.displayVersion then
       throwRunError(127, -- error code so 'ant' isnt run
-        "Silver Version " ++ getSilverVersion() ++ "\n" ++
+        "Silver Version " ++ getJarVersion() ++ "\n" ++
         "SILVER_HOME = " ++ benv.silverHome ++ "\n" ++
         "SILVER_GEN = " ++ benv.silverGen ++ "\n" ++
         "GRAMMAR_PATH:\n" ++ implode("\n", benv.grammarPath))
@@ -185,10 +185,10 @@ type IOErrorable<a> = EitherT<RunError IO a>;
 
 fun throwRunError IOErrorable<a> ::= c::Integer m::String = throwError(runError(code=c, errMsg=m));
 
-function getSilverVersion
+function getJarVersion
 String ::=
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.Util.getSilverVersion()";
+  "java" : return "common.Util.getJarVersion(Init.class)";
 }

--- a/grammars/silver/compiler/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/driver/BuildProcess.sv
@@ -54,7 +54,7 @@ fun computeEnv IOErrorable<(Decorated CmdArgs, BuildEnv)> ::= args::[String] =
     -- line decide to go do, but currently it's hard to re-use code if we do that.
     if a.displayVersion then
       throwRunError(127, -- error code so 'ant' isnt run
-        "Silver Version 0.4.5-dev\n" ++
+        "Silver Version " ++ getSilverVersion() ++ "\n" ++
         "SILVER_HOME = " ++ benv.silverHome ++ "\n" ++
         "SILVER_GEN = " ++ benv.silverGen ++ "\n" ++
         "GRAMMAR_PATH:\n" ++ implode("\n", benv.grammarPath))
@@ -184,3 +184,11 @@ data RunError = runError
 type IOErrorable<a> = EitherT<RunError IO a>;
 
 fun throwRunError IOErrorable<a> ::= c::Integer m::String = throwError(runError(code=c, errMsg=m));
+
+function getSilverVersion
+String ::=
+{
+  return error("NYI");
+} foreign {
+  "java" : return "common.Util.getSilverVersion()";
+}

--- a/grammars/silver/compiler/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/driver/BuildProcess.sv
@@ -48,13 +48,14 @@ fun computeEnv IOErrorable<(Decorated CmdArgs, BuildEnv)> ::= args::[String] =
   | right(a) -> do {
     -- Figure out build env from environment and args
     benv::BuildEnv <- determineBuildEnv(a);
+    silverVersion::String <- lift(stateIO(getJarVersion));
     -- Because we want printing the version to work even if the environment is messed up
     -- we premptively handle that here. This is slightly unfortunate.
     -- Ideally, version printing would be just another thing we could have the command
     -- line decide to go do, but currently it's hard to re-use code if we do that.
     if a.displayVersion then
       throwRunError(127, -- error code so 'ant' isnt run
-        "Silver Version " ++ getJarVersion() ++ "\n" ++
+        "Silver Version " ++ silverVersion ++ "\n" ++
         "SILVER_HOME = " ++ benv.silverHome ++ "\n" ++
         "SILVER_GEN = " ++ benv.silverGen ++ "\n" ++
         "GRAMMAR_PATH:\n" ++ implode("\n", benv.grammarPath))
@@ -186,9 +187,9 @@ type IOErrorable<a> = EitherT<RunError IO a>;
 fun throwRunError IOErrorable<a> ::= c::Integer m::String = throwError(runError(code=c, errMsg=m));
 
 function getJarVersion
-String ::=
+IOVal<String> ::= i::IOToken
 {
   return error("NYI");
 } foreign {
-  "java" : return "common.Util.getJarVersion(Init.class)";
+  "java" : return "new silver.core.Pioval(%i%, common.Util.getJarVersion(Init.class))";
 }

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -14,7 +14,7 @@ synthesized attribute relativeJar :: Boolean occurs on CmdArgs;
 synthesized attribute includeRTJars :: [String] occurs on CmdArgs;
 -- TODO: Should this be a Maybe?
 synthesized attribute buildXmlLocation :: [String] occurs on CmdArgs;
-synthesized attribute silverVersion :: String occurs on CmdArgs;
+synthesized attribute jarImplVersion :: String occurs on CmdArgs;
 
 aspect production endCmdArgs
 top::CmdArgs ::= _
@@ -24,7 +24,7 @@ top::CmdArgs ::= _
   top.relativeJar = false;
   top.includeRTJars = [];
   top.buildXmlLocation = [];
-  top.silverVersion = "";
+  top.jarImplVersion = "";
 }
 abstract production dontTranslateFlag
 top::CmdArgs ::= rest::CmdArgs
@@ -56,10 +56,10 @@ top::CmdArgs ::= s::String rest::CmdArgs
   top.buildXmlLocation = s :: forward.buildXmlLocation;
   forwards to @rest;
 }
-abstract production silverVersionFlag
+abstract production jarImplVersionFlag
 top::CmdArgs ::= s::String rest::CmdArgs
 {
-  top.silverVersion = s;
+  top.jarImplVersion = s;
   forwards to @rest;
 }
 
@@ -84,9 +84,9 @@ Either<String  Decorated CmdArgs> ::= args::[String]
            , flagSpec(name="--build-xml-location", paramString=nothing(),
                help="sets the path the Ant build.xml will be saved to",
                flagParser=option(buildXmlFlag))
-           , flagSpec(name="--silver-version", paramString=nothing(),
-               help="set the silver version string displayed to the user in --version",
-               flagParser=option(silverVersionFlag))
+           , flagSpec(name="--jar-impl-version", paramString=nothing(),
+               help="set the Implementation-Version header in the JAR's manifest",
+               flagParser=option(jarImplVersionFlag))
            ];
 }
 aspect production compilation
@@ -142,12 +142,12 @@ top::Compilation ::= g::Grammars  _  buildGrammars::[String]  a::Decorated CmdAr
 
   classpathRuntime <- nub(g.includedJars);  -- TODO: include in classpathCompiler too?
 
-  local silverVersion :: String = if a.silverVersion == "" then "${TIME}" else a.silverVersion;
+  local jarImplVersion :: String = if a.jarImplVersion == "" then "${TIME}" else a.jarImplVersion;
 
   production attribute extraManifestAttributes :: [String] with ++;
   extraManifestAttributes := [
     "<attribute name='Built-By' value='${user.name}' />",
-    "<attribute name='Implementation-Version' value='" ++ silverVersion ++ "' />",
+    "<attribute name='Implementation-Version' value='" ++ jarImplVersion ++ "' />",
     "<attribute name='Main-Class' value='" ++ makeName(buildGrammar) ++ ".Main' />"]; -- TODO: we "should" make main depend on whether there is a main...
 
   extraManifestAttributes <-

--- a/make-compiler
+++ b/make-compiler
@@ -6,6 +6,8 @@
 set -euo pipefail
 
 silver_version=`git describe --tags`
+echo "Build version $silver_version"
+
 export SILVER_HOME=$PWD
 JVM_ARGS=(-Xss20M -Xmx6500M -jar ../jars/silver.compiler.composed.Default.jar --no-stdlib --include-jar ../jars/CopperCompiler.jar --include-jar ../jars/commonmark-0.17.1.jar --relative-jar "$@" --jar-impl-version "$silver_version")
 export GRAMMAR_PATH="../grammars"

--- a/make-compiler
+++ b/make-compiler
@@ -5,8 +5,9 @@
 
 set -euo pipefail
 
+silver_version=`git describe --tags`
 export SILVER_HOME=$PWD
-JVM_ARGS=(-Xss20M -Xmx6500M -jar ../jars/silver.compiler.composed.Default.jar --no-stdlib --include-jar ../jars/CopperCompiler.jar --include-jar ../jars/commonmark-0.17.1.jar --relative-jar "$@" --silver-version `git describe --tags`)
+JVM_ARGS=(-Xss20M -Xmx6500M -jar ../jars/silver.compiler.composed.Default.jar --no-stdlib --include-jar ../jars/CopperCompiler.jar --include-jar ../jars/commonmark-0.17.1.jar --relative-jar "$@" --jar-impl-version "$silver_version")
 export GRAMMAR_PATH="../grammars"
 export ANT_OPTS=-Xss10M
 

--- a/make-compiler
+++ b/make-compiler
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 export SILVER_HOME=$PWD
-JVM_ARGS=(-Xss20M -Xmx6500M -jar ../jars/silver.compiler.composed.Default.jar --no-stdlib --include-jar ../jars/CopperCompiler.jar --include-jar ../jars/commonmark-0.17.1.jar --relative-jar "$@")
+JVM_ARGS=(-Xss20M -Xmx6500M -jar ../jars/silver.compiler.composed.Default.jar --no-stdlib --include-jar ../jars/CopperCompiler.jar --include-jar ../jars/commonmark-0.17.1.jar --relative-jar "$@" --silver-version `git describe --tags`)
 export GRAMMAR_PATH="../grammars"
 export ANT_OPTS=-Xss10M
 

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -507,15 +507,15 @@ public final class Util {
 		return new StringCatter(home.getPath());
 	}
 
-	public static StringCatter getSilverVersion() {
-		String path = determineSilverHomePath(Util.class).toString()+"/jars/silver.compiler.composed.Default.jar";
-        try {
-            JarInputStream file = new JarInputStream(new FileInputStream(path));
-            return new StringCatter(file.getManifest().getMainAttributes().getValue(Name.IMPLEMENTATION_VERSION));
-        } catch (Throwable t) {
-            throw new RuntimeException("Failed to get Silver version.", t);
-        }
-    }
+	public static StringCatter getJarVersion(Class<?> clazz) {
+		try {
+			URI jarLocation = clazz.getProtectionDomain().getCodeSource().getLocation().toURI();
+			JarInputStream file = new JarInputStream(new FileInputStream(new File(jarLocation)));
+			return new StringCatter(file.getManifest().getMainAttributes().getValue(Name.IMPLEMENTATION_VERSION));
+		} catch (Throwable t) {
+			throw new RuntimeException("Failed to get jar version.", t);
+		}
+	}
 	
 	public static ConsCell bitSetToList(BitSet b) {
 		ConsCell result = ConsCell.nil;

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.net.URI;
+import java.util.jar.JarInputStream;
+import java.util.jar.Attributes.Name;
 
 import common.exceptions.*;
 import common.javainterop.ConsCellCollection;
@@ -504,6 +506,16 @@ public final class Util {
 		File home = new File(jarLocation).getParentFile().getParentFile();
 		return new StringCatter(home.getPath());
 	}
+
+	public static StringCatter getSilverVersion() {
+		String path = determineSilverHomePath(Util.class).toString()+"/jars/silver.compiler.composed.Default.jar";
+        try {
+            JarInputStream file = new JarInputStream(new FileInputStream(path));
+            return new StringCatter(file.getManifest().getMainAttributes().getValue(Name.IMPLEMENTATION_VERSION));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to get Silver version.", t);
+        }
+    }
 	
 	public static ConsCell bitSetToList(BitSet b) {
 		ConsCell result = ConsCell.nil;


### PR DESCRIPTION
# Changes
- Added getJarVersion() to io.common.Util that reads the "Implementation-Version" attribute from the compiler jar's manifest. 
- Added the command `--jar-impl-version` to silver that allows the attribute to be set when building the compiler
- When retrieving silver's version, silver calls getJarVersion(), and if it does not return, defaults to `$TIME ` as the version.

I had to build twice, first without passing `--jar-impl-version` flag inside `make-compiler`, then pass it in again. Otherwise the build fails as `--silver-version` flag is unrecognized. Not sure if this complicates Jenkins process