### PR TITLE
Revert "Disable comparison of dataness/trackedness in NT unification"

### DIFF
--- a/grammars/silver/compiler/definition/type/Unification.sv
+++ b/grammars/silver/compiler/definition/type/Unification.sv
@@ -109,7 +109,7 @@ top::Type ::= fn::String ks::[Kind] data::Boolean tracked::Boolean
   top.unify = 
     case top.unifyWith of
     | nonterminalType(ofn, oks, odata, otracked) ->
-        if fn == ofn --&& data == odata && tracked == otracked  -- Mismatched data/tractness can happen when comparing interface files
+        if fn == ofn && data == odata && tracked == otracked  -- Mismatched data/tractness can happen when comparing interface files
         then if ks == oks
           then emptySubst()
           else error("kind mismatch during unification for " ++ prettyType(^top) ++ " and " ++ prettyType(top.unifyWith)) -- Should be impossible

--- a/grammars/silver/compiler/extension/rewriting/Rewriting.sv
+++ b/grammars/silver/compiler/extension/rewriting/Rewriting.sv
@@ -51,7 +51,7 @@ top::Expr ::= 'traverse' n::QName '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   
   local numChildren::Integer = n.lookupValue.typeScheme.arity;
   local annotations::[String] = map(fst, n.lookupValue.typeScheme.typerep.namedTypes);
-  es.appExprTypereps = repeat(nonterminalType("silver:rewrite:Strategy", [], false, false), numChildren);
+  es.appExprTypereps = repeat(nonterminalType("silver:rewrite:Strategy", [], false, true), numChildren);
   es.appExprApplied = n.unparse;
   es.decSiteVertexInfo = nothing();
   es.dispatchFlowDeps = [];
@@ -59,7 +59,7 @@ top::Expr ::= 'traverse' n::QName '(' es::AppExprs ',' anns::AnnoAppExprs ')'
   es.appIndexOffset = 0;
   anns.appExprApplied = n.unparse;
   anns.funcAnnotations =
-    map(pair(fst=_, snd=nonterminalType("silver:rewrite:Strategy", [], false, false)), annotations);
+    map(pair(fst=_, snd=nonterminalType("silver:rewrite:Strategy", [], false, true)), annotations);
   anns.remainingFuncAnnotations = anns.funcAnnotations;
  
   local localErrors::[Message] =


### PR DESCRIPTION
# Changes
Fix #804.

This reverts commit 42e8abd94be637329107417828c11b640aa19801, from #773.  This sanity check no longer needs to be disabled, after completing bootstrapping of changes to the trackedness of Silver env items.

# Documentation
N/A

# Testing
Tested building on Jenkins