### PR TITLE
Implement conditional and guarded choice strategies

### DIFF
--- a/grammars/silver/compiler/definition/core/Expr.sv
+++ b/grammars/silver/compiler/definition/core/Expr.sv
@@ -725,7 +725,6 @@ top::Expr ::= 'decorate' e::Expr 'with' '{' inh::ExprInhs '}'
   production eType::Type = performSubstitution(e.typerep, inh.downSubst);  -- Specialize e.typerep
   production ntType::Type = if eType.isDecorated then eType.decoratedType else @eType;
 
-  -- TODO: This _could_ be uniqueDecoratedType, but we use decorate in a ton of places where we expect a decoratedType
   top.typerep = decoratedType(^ntType, inhSetType(sort(nub(inh.suppliedInhs ++ eType.inhSetMembers))));
   e.isRoot = false;
   

--- a/grammars/silver/compiler/definition/flow/env/DecSites.sv
+++ b/grammars/silver/compiler/definition/flow/env/DecSites.sv
@@ -303,7 +303,6 @@ partial strategy attribute resolveDecSiteStep =
   elimCycleDecSiteStep <+ lookupDecSiteStep <+ reduceDecSiteStep <+
   -- Short-circuit alternatives to potentially avoid building the entire tree
   altDec(resolveDecSiteStep, id) <+
-  -- TODO: above potentially being retried after failure
   some(resolveDecSiteStep)
   occurs on DecSiteTree;
 
@@ -319,10 +318,8 @@ partial strategy attribute cleanupDecSiteStep =
   someTopDown(reduceDecSiteStep <+ elimRedundantDecSiteStep)
   occurs on DecSiteTree;
 
-strategy attribute resolveDecSite = repeat(
-  -- TODO: workaround to prevent something from being inlined in a way that causes extra recomputation.
-  rule on DecSiteTree of d -> ^d end <*
-  resolveDecSiteStep) <* repeat(cleanupDecSiteStep)
+strategy attribute resolveDecSite =
+  repeat(resolveDecSiteStep) <* repeat(cleanupDecSiteStep)
   occurs on DecSiteTree;
 
 propagate

--- a/grammars/silver/compiler/extension/strategyattr/ConcreteSyntax.sv
+++ b/grammars/silver/compiler/extension/strategyattr/ConcreteSyntax.sv
@@ -45,6 +45,14 @@ concrete productions top::StrategyExpr_c
   s1.givenGenName = top.givenGenName ++ "_left";
   s2.givenGenName = top.givenGenName ++ "_right";
 }
+| s1::StrategyExpr_c '<' s2::StrategyExpr_c '+' s3::StrategyExpr_c
+{
+  top.unparse = s"(${s1.unparse} < ${s2.unparse} + ${s3.unparse})";
+  top.ast = guardedChoice(s1.ast, s2.ast, s3.ast, genName=top.givenGenName);
+  s1.givenGenName = top.givenGenName ++ "_cond";
+  s2.givenGenName = top.givenGenName ++ "_then";
+  s3.givenGenName = top.givenGenName ++ "_else";
+}
 | 'all' '(' s::StrategyExpr_c ')'
 {
   top.unparse = s"all(${s.unparse})";

--- a/grammars/silver/compiler/extension/strategyattr/ConcreteSyntax.sv
+++ b/grammars/silver/compiler/extension/strategyattr/ConcreteSyntax.sv
@@ -53,6 +53,21 @@ concrete productions top::StrategyExpr_c
   s2.givenGenName = top.givenGenName ++ "_then";
   s3.givenGenName = top.givenGenName ++ "_else";
 }
+| 'if' s1::StrategyExpr_c 'then' s2::StrategyExpr_c 'else' s3::StrategyExpr_c
+{
+  top.unparse = s"if ${s1.unparse} then ${s2.unparse} else ${s3.unparse}";
+  top.ast = ifThenElseComb(s1.ast, s2.ast, s3.ast, genName=top.givenGenName);
+  s1.givenGenName = top.givenGenName ++ "_cond";
+  s2.givenGenName = top.givenGenName ++ "_then";
+  s3.givenGenName = top.givenGenName ++ "_else";
+}
+| 'if' s1::StrategyExpr_c 'then' s2::StrategyExpr_c 'end'
+{
+  top.unparse = s"if ${s1.unparse} then ${s2.unparse} end";
+  top.ast = ifThenEndComb(s1.ast, s2.ast, genName=top.givenGenName);
+  s1.givenGenName = top.givenGenName ++ "_cond";
+  s2.givenGenName = top.givenGenName ++ "_then";
+}
 | 'all' '(' s::StrategyExpr_c ')'
 {
   top.unparse = s"all(${s.unparse})";

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -32,7 +32,6 @@ top::AGDcl ::=
 
   e.recVarNameEnv = recVarNameEnv;
   e.recVarTotalEnv = recVarTotalEnv;
-  e.recVarTotalNoEnvEnv = recVarTotalEnv;
   e.outerAttr = a.name;
   e.isOutermost = true;
   
@@ -50,7 +49,7 @@ top::AGDcl ::=
         \ d::(String, Decorated StrategyExpr with LiftedInhs) ->
           strategyAttributeDcl(
             d.snd.isTotalNoEnv, name(d.fst),
-            d.snd.recVarNameEnv, d.snd.recVarTotalNoEnvEnv,
+            d.snd.recVarNameEnv, d.snd.recVarTotalEnv,
             new(d.snd)),
         e.liftedStrategies));
   

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -7,7 +7,7 @@ top::AGDcl ::=
   e::StrategyExpr
 {
   top.unparse = (if isTotal then "" else "partial ") ++ "strategy attribute " ++ a.unparse ++ "=" ++ e.unparse ++ ";";
-  propagate grammarName, config, env, flowEnv;
+  propagate grammarName, config, flowEnv;
 
   top.occursDefs := [];
   top.specDefs := [];
@@ -34,17 +34,12 @@ top::AGDcl ::=
   e.recVarTotalEnv = recVarTotalEnv;
   e.outerAttr = a.name;
   e.isOutermost = true;
-  
-  nondecorated local fwrd::AGDcl =
+
+  -- Component strategies that are lifted for the translation of e.
+  -- This does not depend on e.env
+  local liftedStrategyDecls::AGDcl =
     foldr(
-      appendAGDcl,
-      defsAGDcl(
-        [attrDef(
-           defaultEnvItem(
-             strategyDcl(
-               fName, isTotal,
-               !null(top.errors), map(fst, e.liftedStrategies), recVarNameEnv, recVarTotalEnv, e.partialRefs, e.totalRefs, e.containsTraversal, ^e,
-               sourceGrammar=top.grammarName, sourceLocation=a.nameLoc)))]),
+      appendAGDcl, emptyAGDcl(),
       map(
         \ d::(String, Decorated StrategyExpr with LiftedInhs) ->
           strategyAttributeDcl(
@@ -53,10 +48,24 @@ top::AGDcl ::=
             new(d.snd)),
         e.liftedStrategies));
   
-  -- Uncomment for debugging
-  --forwards to unsafeTrace(fwrd, printT(a.name ++ " = " ++ e.unparse ++ "; lifted  " ++ implode(",  ", map(fst, e.liftedStrategies)) ++ "\n\n", unsafeIO()));
-
-  forwards to fwrd;
+  -- Supply e with the environment containing the lifted strategy declarations,
+  -- for error checking purposes.
+  e.env = newScopeEnv(liftedStrategyDecls.defs, top.env);
+  
+  nondecorated local fwrd::AGDcl =
+    defsAGDcl(
+      [attrDef(
+          defaultEnvItem(
+            strategyDcl(
+              fName, isTotal,
+              !null(top.errors), map(fst, e.liftedStrategies), recVarNameEnv, recVarTotalEnv, e.partialRefs, e.totalRefs, e.containsTraversal, ^e,
+              sourceGrammar=top.grammarName, sourceLocation=a.nameLoc)))]);
+  
+  forwards to appendAGDcl(@liftedStrategyDecls,
+    -- Uncomment for debugging
+    --unsafeTrace(fwrd, eprintT((if isTotal then "total" else "partial") ++ " " ++ a.name ++ " = " ++ e.unparse ++ "; lifted  " ++ implode(",  ", map(fst, e.liftedStrategies)) ++ "\n\n", unsafeIO()))
+    fwrd
+  );
 }
 
 abstract production strategyAttributionDcl implements AttributionDcl
@@ -172,7 +181,7 @@ top::ProductionStmt ::= includeShared::Boolean @attr::QName
         attr.lookupAttribute.dcl.liftedStrategyNames));
   
   -- Uncomment for debugging
-  --forwards to unsafeTrace(propagateImpl(includeShared, attr, fwrd), printT(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ e2.unparse ++ ";\n\n", unsafeIO()));
-  --forwards to unsafeTrace(propagateImpl(includeShared, attr, fwrd), printT(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ (if isTotal then e2.totalTranslation else e2.partialTranslation).unparse ++ ";\n\n", unsafeIO()));
+  --forwards to unsafeTrace(propagateImpl(includeShared, attr, fwrd), eprintT(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ e2.unparse ++ ";\n\n", unsafeIO()));
+  --forwards to unsafeTrace(propagateImpl(includeShared, attr, fwrd), eprintT(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ (if isTotal then e2.totalTranslation else e2.partialTranslation).unparse ++ ";\n\n", unsafeIO()));
   forwards to propagateImpl(includeShared, attr, fwrd);
 }

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -43,7 +43,7 @@ top::AGDcl ::=
       map(
         \ d::(String, Decorated StrategyExpr with LiftedInhs) ->
           strategyAttributeDcl(
-            d.snd.isTotalNoEnv, name(d.fst),
+            d.snd.isTotalInf, name(d.fst),
             d.snd.recVarNameEnv, d.snd.recVarTotalEnv,
             new(d.snd)),
         e.liftedStrategies));

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -907,10 +907,8 @@ top::StrategyExprs ::= h::StrategyExpr t::StrategyExprs
   top.unparse = s"${h.unparse}, ${t.unparse}";
 
   top.liftedStrategies :=
-    -- Slight hack: when h is id (common case for prod traversals), there is no need for a new attribute.
+    -- When h is id (common case for prod traversals), there is no need for a new attribute.
     -- However this can't be avoided during the optimization phase, which happens after lifting.
-    -- So, just don't lift the strategy, and we won't find the occurence of the non-existant attribute
-    -- during translation - which means we will treat it as id anyway!
     (if h.attrRefName.isJust || h.isId
      then []
      else [(h.genName, h)]) ++
@@ -930,7 +928,7 @@ top::StrategyExprs ::= h::StrategyExpr t::StrategyExprs
   
   top.containsFail <- h.isFail;
   top.allId <- h.isId;
-  top.allTotal <- !null(top.givenInputElements) && attrMatch && h.isTotal;
+  top.allTotal <- !null(top.givenInputElements) && (h.isId || attrMatch) && h.isTotal;
   
   h.isOutermost = false;
   t.givenInputElements =

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -9,19 +9,18 @@ import silver:compiler:driver:util;
 
 annotation genName::String; -- Used to generate the names of lifted strategy attributes
 
-inherited attribute recVarNameEnv::[Pair<String String>]; -- name, (isTotal, genName)
-inherited attribute recVarTotalEnv::[Pair<String Boolean>]; -- name, (isTotal, genName)
-inherited attribute recVarTotalNoEnvEnv::[Pair<String Boolean>]; -- same as above but doesn't depend on env
+inherited attribute recVarNameEnv::[Pair<String String>]; -- name, genName
+inherited attribute recVarTotalEnv::[Pair<String Boolean>]; -- name, isTotal
 inherited attribute isOutermost::Boolean;
 inherited attribute outerAttr::String;
 inherited attribute inlinedStrategies::[String];
-type LiftedInhs = {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr, isOutermost};
+type LiftedInhs = {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost};
 monoid attribute liftedStrategies::[(String, Decorated StrategyExpr with LiftedInhs)];
 synthesized attribute attrRefName::Maybe<String>;
 synthesized attribute isId::Boolean;
 synthesized attribute isFail::Boolean;
 synthesized attribute isTotal::Boolean;
-synthesized attribute isTotalNoEnv::Boolean; -- same as above but doesn't depend on env
+synthesized attribute isTotalNoEnv::Boolean; -- same as above but doesn't depend on env, used only in initial pass for totality of lifted strategies
 synthesized attribute isTotalInProd::Boolean; -- can use env and frame
 inherited attribute givenInputElements::[NamedSignatureElement];
 synthesized attribute attrRefNames::[Maybe<String>];
@@ -34,7 +33,6 @@ monoid attribute totalRefs::[String];
 monoid attribute matchesFrame::Boolean with false, ||;
 monoid attribute containsTraversal::Boolean with false, ||;
 
--- TODO: Merge these into a translation attribute
 synthesized attribute partialTranslation<a>::a; -- Maybe<a> on a
 synthesized attribute totalTranslation<a>::a; -- a on a, can raise a runtime error if demanded on partial strategy expression
 
@@ -125,14 +123,14 @@ strategy attribute optimize =
 
 tracked nonterminal StrategyExpr with
   config, grammarName, env, unparse, errors, frame, compiledGrammars, flowEnv, -- Normal expression stuff
-  genName, outerAttr, isOutermost, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, liftedStrategies, attrRefName,
+  genName, outerAttr, isOutermost, recVarNameEnv, recVarTotalEnv, liftedStrategies, attrRefName,
   isId, isFail, isTotal, isTotalNoEnv, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
   partialTranslation<Expr>, totalTranslation<Expr>, matchesFrame, isTotalInProd, -- Frame-dependent attrs
   inlinedStrategies, genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize; -- Optimization stuff
 
 tracked nonterminal StrategyExprs with
   config, grammarName, env, unparse, errors, compiledGrammars, flowEnv, -- Normal expression stuff
-  outerAttr, recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, givenInputElements, liftedStrategies, attrRefNames,
+  outerAttr, recVarNameEnv, recVarTotalEnv, givenInputElements, liftedStrategies, attrRefNames,
   containsFail, allId, allTotal, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
   inlinedStrategies, genericSimplify; -- Optimization stuff
 
@@ -142,7 +140,7 @@ flowtype StrategyExpr =
   -- Normal expression stuff
   unparse {}, errors {decorate, compiledGrammars, flowEnv},
   -- Frame-independent attrs
-  liftedStrategies {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr, isOutermost}, isTotalNoEnv {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr, isOutermost},
+  liftedStrategies {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost}, isTotalNoEnv {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost},
   attrRefName {recVarNameEnv}, isId {}, isFail {},
   isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate}, containsTraversal {decorate, flowEnv},
   genericStep {decorate, inlinedStrategies}, genericSimplify {decorate, inlinedStrategies},
@@ -156,14 +154,14 @@ flowtype StrategyExprs =
   forward {},
   -- Normal expression stuff
   -- Frame-independent attrs
-  liftedStrategies {recVarNameEnv, recVarTotalNoEnvEnv, outerAttr},
+  liftedStrategies {recVarNameEnv, recVarTotalEnv, outerAttr},
   attrRefNames {env, recVarNameEnv, givenInputElements},
   containsFail {}, allId {}, allTotal {decorate, givenInputElements}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate};
 
 propagate grammarName, config, compiledGrammars, env, flowEnv, outerAttr, partialRefs, totalRefs, containsTraversal on StrategyExpr, StrategyExprs;
 propagate errors on StrategyExpr, StrategyExprs excluding partialRef, totalRef, rewriteRule;
 propagate containsFail, allId, allTotal on StrategyExprs;
-propagate recVarNameEnv, recVarTotalEnv, recVarTotalNoEnvEnv, freeRecVars on StrategyExpr, StrategyExprs excluding recComb;
+propagate recVarNameEnv, recVarTotalEnv, freeRecVars on StrategyExpr, StrategyExprs excluding recComb;
 propagate inlinedStrategies on StrategyExpr, StrategyExprs excluding inlined;
 propagate genericSimplify on StrategyExprs;
 propagate genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize on StrategyExpr;
@@ -834,7 +832,6 @@ top::StrategyExpr ::= n::Name s::StrategyExpr
   -- See Fig 4 of the strategy attributes paper (https://www-users.cse.umn.edu/~evw/pubs/kramer20sle/kramer20sle.pdf)
   local s2::StrategyExpr = ^s;
   s2.recVarTotalEnv = (n.name, true) :: s.recVarTotalEnv;
-  s2.recVarTotalNoEnvEnv = (n.name, true) :: s.recVarTotalNoEnvEnv;
   s2.frame = s.frame;
   s2.env = s.env;
   s2.config = s.config;
@@ -848,23 +845,25 @@ top::StrategyExpr ::= n::Name s::StrategyExpr
   
   s.frame = top.frame;
   s.recVarNameEnv = (n.name, sName) :: top.recVarNameEnv;
-  s.recVarTotalEnv = (n.name, top.isTotal) :: top.recVarTotalEnv;
-  s.recVarTotalNoEnvEnv = (n.name, top.isTotalNoEnv) :: top.recVarTotalNoEnvEnv;
+  s.recVarTotalEnv = (n.name, top.isTotalNoEnv) :: top.recVarTotalEnv;
   s.isOutermost = top.isOutermost;
   
   local sTotal::Boolean = attrIsTotal(top.env, sName);
+  nondecorated local attrRef::Expr = Silver_Expr {
+    $name{top.frame.signature.outputElement.elementName}.$name{sName}
+  };
   top.partialTranslation =
     if top.isOutermost
     then s.partialTranslation
     else if sTotal
-    then asPartial(top.totalTranslation)
-    else Silver_Expr { $name{top.frame.signature.outputElement.elementName}.$name{sName} };
+    then asPartial(attrRef)
+    else attrRef;
   top.totalTranslation =
     if top.isOutermost
     then s.totalTranslation
     else if sTotal
-    then Silver_Expr { $name{top.frame.signature.outputElement.elementName}.$name{sName} }
-    else asTotal(top.frame.signature.outputElement.typerep, top.partialTranslation);
+    then attrRef
+    else asTotal(top.frame.signature.outputElement.typerep, attrRef);
 }
 
 -- Rules
@@ -1077,7 +1076,7 @@ top::StrategyExpr ::= id::QName
   top.attrRefName = just(fromMaybe(id.name, lookup(id.name, top.recVarNameEnv)));
   top.isId = false;
   top.isFail = false;
-  top.isTotalNoEnv = fromMaybe(false, lookup(id.name, top.recVarTotalNoEnvEnv));
+  top.isTotalNoEnv = fromMaybe(false, lookup(id.name, top.recVarTotalEnv));
   
   nondecorated local attrDcl::AttributeDclInfo = id.lookupAttribute.dcl;
   forwards to
@@ -1107,17 +1106,18 @@ top::StrategyExpr ::= id::Decorated QName
   
   propagate liftedStrategies;
   top.attrRefName = lookup(id.name, top.recVarNameEnv);
-  top.isTotal = lookup(id.name, top.recVarTotalEnv).fromJust;
+  top.isTotalNoEnv = lookup(id.name, top.recVarTotalEnv).fromJust;
+  top.isTotal = attrIsTotal(top.env, top.attrRefName.fromJust);
+  top.isTotalInProd = attrIsTotal(top.env, top.attrRefName.fromJust);
   top.freeRecVars <- [id.name];
   
+  nondecorated local attrRef::Expr = Silver_Expr {
+    $name{top.frame.signature.outputElement.elementName}.$qName{top.attrRefName.fromJust}
+  };
   top.partialTranslation =
-    if attrIsTotal(top.env, top.attrRefName.fromJust)
-    then asPartial(top.totalTranslation)
-    else Silver_Expr { $name{top.frame.signature.outputElement.elementName}.$qName{top.attrRefName.fromJust} };
+    if top.isTotal then asPartial(attrRef) else attrRef;
   top.totalTranslation =
-    if attrIsTotal(top.env, top.attrRefName.fromJust)
-    then Silver_Expr { $name{top.frame.signature.outputElement.elementName}.$qName{top.attrRefName.fromJust} }
-    else asTotal(top.frame.signature.outputElement.typerep, top.partialTranslation);
+    if top.isTotal then attrRef else asTotal(top.frame.signature.outputElement.typerep, attrRef);
 }
 abstract production partialRef
 top::StrategyExpr ::= attr::QNameAttrOccur

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -19,10 +19,13 @@ monoid attribute liftedStrategies::[(String, Decorated StrategyExpr with LiftedI
 synthesized attribute attrRefName::Maybe<String>;
 synthesized attribute isId::Boolean;
 synthesized attribute isFail::Boolean;
+-- Initial pass, doesn't depend on env,
+-- used only in initial pass for totality of lifted strategies
+synthesized attribute isTotalInf::Boolean;
+-- Depends on lifted attributes in env
 synthesized attribute isTotal::Boolean;
--- TODO: rename isTotalNoEnv to isTotalInferred
-synthesized attribute isTotalNoEnv::Boolean; -- same as above but doesn't depend on env, used only in initial pass for totality of lifted strategies
-synthesized attribute isTotalInProd::Boolean; -- can use env and frame
+-- Same as above, but also depends on frame
+synthesized attribute isTotalInProd::Boolean;
 inherited attribute givenInputElements::[NamedSignatureElement];
 synthesized attribute attrRefNames::[Maybe<String>];
 monoid attribute containsFail::Boolean with false, ||;
@@ -126,7 +129,7 @@ strategy attribute optimize =
 tracked nonterminal StrategyExpr with
   config, grammarName, env, unparse, errors, frame, compiledGrammars, flowEnv, -- Normal expression stuff
   genName, outerAttr, isOutermost, recVarNameEnv, recVarTotalEnv, liftedStrategies, attrRefName,
-  isId, isFail, isTotal, isTotalNoEnv, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
+  isId, isFail, isTotalInf, isTotal, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
   isSuccessTranslation<Expr>, partialTranslation<Expr>, totalTranslation<Expr>, matchesFrame, isTotalInProd, -- Frame-dependent attrs
   inlinedStrategies, genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize; -- Optimization stuff
 
@@ -143,7 +146,7 @@ flowtype StrategyExpr =
   unparse {}, errors {decorate, compiledGrammars, flowEnv},
   -- Frame-independent attrs
   liftedStrategies {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost},
-  isTotalNoEnv {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost},
+  isTotalInf {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost},
   attrRefName {recVarNameEnv}, isId {}, isFail {},
   isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate}, containsTraversal {decorate, flowEnv},
   genericStep {decorate, inlinedStrategies}, genericSimplify {decorate, inlinedStrategies},
@@ -194,8 +197,8 @@ top::StrategyExpr ::=
   top.matchesFrame := true; -- Consulted only when attrRefName is just(...)
   top.isId = false;
   top.isFail = false;
+  top.isTotalInf = false;
   top.isTotal = false;
-  top.isTotalNoEnv = false;
   top.isTotalInProd = false;
 }
 
@@ -206,8 +209,8 @@ top::StrategyExpr ::=
   top.unparse = "id";
   propagate liftedStrategies;
   top.isId = true;
+  top.isTotalInf = true;
   top.isTotal = true;
-  top.isTotalNoEnv = true;
   top.isTotalInProd = true;
   top.isSuccessTranslation = Silver_Expr { true };
   top.totalTranslation =
@@ -241,8 +244,8 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
     if s2.attrRefName.isJust
     then []
     else [(s2Name, s2)];
+  top.isTotalInf = s1.isTotalInf && s2.isTotalInf;
   top.isTotal = s1.isTotal && s2AttrTotal;
-  top.isTotalNoEnv = s1.isTotalNoEnv && s2.isTotalNoEnv;
   top.isTotalInProd = s1.isTotalInProd && s2AttrTotal;
   
   s1.isOutermost = false;
@@ -317,8 +320,8 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 {
   top.unparse = s"(${s1.unparse} <+ ${s2.unparse})";
   propagate frame, liftedStrategies;
+  top.isTotalInf = s1.isTotalInf || s2.isTotalInf;
   top.isTotal = s1.isTotal || s2.isTotal;
-  top.isTotalNoEnv = s1.isTotalNoEnv || s2.isTotalNoEnv;
   top.isTotalInProd = s1.isTotalInProd || s2.isTotalInProd;
   
   s1.isOutermost = false;
@@ -353,8 +356,8 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
     if s2.attrRefName.isJust
     then []
     else [(s2Name, s2)];
+  top.isTotalInf = s2.isTotalInf && (s1.isTotalInf || s3.isTotalInf);
   top.isTotal = s2AttrTotal && (s1.isTotal || s3.isTotal);
-  top.isTotalNoEnv = s2.isTotalNoEnv && (s1.isTotalNoEnv || s3.isTotalNoEnv);
   top.isTotalInProd = s2AttrTotal && (s1.isTotalInProd || s3.isTotalInProd);
   
   s1.isOutermost = false;
@@ -443,8 +446,8 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
   top.unparse = s"if ${s1.unparse} then ${s2.unparse} else ${s3.unparse}";
   propagate frame, liftedStrategies;
 
+  top.isTotalInf = s2.isTotalInf && (s1.isTotalInf || s3.isTotalInf);
   top.isTotal = s2.isTotal && (s1.isTotal || s3.isTotal);
-  top.isTotalNoEnv = s2.isTotalNoEnv && (s1.isTotalNoEnv || s3.isTotalNoEnv);
   top.isTotalInProd = s2.isTotal && (s1.isTotalInProd || s3.isTotalInProd);
   
   s1.isOutermost = false;
@@ -496,8 +499,8 @@ top::StrategyExpr ::= s::StrategyExpr
     if s.attrRefName.isJust
     then []
     else [(sName, s)];
+  top.isTotalInf = s.isTotalInf;
   top.isTotal = s.isTotal;
-  top.isTotalNoEnv = s.isTotalNoEnv;
   top.isTotalInProd = s.isTotal;
 
   top.containsTraversal <- true;
@@ -953,21 +956,19 @@ top::StrategyExpr ::= n::Name s::StrategyExpr
   -- See Fig 4 of the strategy attributes paper (https://www-users.cse.umn.edu/~evw/pubs/kramer20sle/kramer20sle.pdf)
   local s2::StrategyExpr = ^s;
   s2.recVarTotalEnv = (n.name, true) :: s.recVarTotalEnv;
-  s2.frame = s.frame;
-  s2.env = s.env;
-  s2.config = s.config;
-  s2.grammarName = s.grammarName;
   s2.recVarNameEnv = s.recVarNameEnv;
   s2.outerAttr = s.outerAttr;
   s2.isOutermost = top.isOutermost;
-  top.isTotal = s2.isTotal;
-  top.isTotalNoEnv = s2.isTotalNoEnv;
-  top.isTotalInProd = s2.isTotalInProd;
-  
+
+  top.isTotalInf = s2.isTotalInf;
+
   s.frame = top.frame;
   s.recVarNameEnv = (n.name, sName) :: top.recVarNameEnv;
-  s.recVarTotalEnv = (n.name, top.isTotalNoEnv) :: top.recVarTotalEnv;
+  s.recVarTotalEnv = (n.name, top.isTotalInf) :: top.recVarTotalEnv;
   s.isOutermost = top.isOutermost;
+
+  top.isTotal = s.isTotal;
+  top.isTotalInProd = s.isTotalInProd;
   
   local sAttrTotal::Boolean = attrIsTotal(top.env, sName);
   nondecorated local attrRef::Expr = Silver_Expr {
@@ -1205,7 +1206,7 @@ top::StrategyExpr ::= id::QName
   top.attrRefName = just(fromMaybe(id.name, lookup(id.name, top.recVarNameEnv)));
   top.isId = false;
   top.isFail = false;
-  top.isTotalNoEnv = fromMaybe(false, lookup(id.name, top.recVarTotalEnv));
+  top.isTotalInf = fromMaybe(false, lookup(id.name, top.recVarTotalEnv));
   
   nondecorated local attrDcl::AttributeDclInfo = id.lookupAttribute.dcl;
   forwards to
@@ -1236,7 +1237,7 @@ top::StrategyExpr ::= id::Decorated QName
   
   propagate liftedStrategies;
   top.attrRefName = lookup(id.name, top.recVarNameEnv);
-  top.isTotalNoEnv = lookup(id.name, top.recVarTotalEnv).fromJust;
+  top.isTotalInf = lookup(id.name, top.recVarTotalEnv).fromJust;
   top.isTotal = attrIsTotal(top.env, top.attrRefName.fromJust);
   top.isTotalInProd = attrIsTotal(top.env, top.attrRefName.fromJust);
   top.freeRecVars <- [id.name];
@@ -1316,8 +1317,8 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   propagate liftedStrategies;
   top.attrRefName = just(attr.name);
   top.matchesFrame := attr.matchesFrame;
+  top.isTotalInf = true;
   top.isTotal = true;
-  top.isTotalNoEnv = true;
   top.isTotalInProd = true;
   top.totalRefs <- [attrDcl.fullName];
   

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -135,22 +135,24 @@ tracked nonterminal StrategyExprs with
   inlinedStrategies, genericSimplify; -- Optimization stuff
 
 flowtype StrategyExpr =
-  decorate {env, grammarName, config, recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost}, -- NOT frame
+  decorate {env, grammarName, config, recVarNameEnv, outerAttr, isOutermost}, -- NOT frame or recVarTotalEnv
   forward {decorate},
   -- Normal expression stuff
   unparse {}, errors {decorate, compiledGrammars, flowEnv},
   -- Frame-independent attrs
-  liftedStrategies {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost}, isTotalNoEnv {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost},
+  liftedStrategies {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost},
+  isTotalNoEnv {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost},
   attrRefName {recVarNameEnv}, isId {}, isFail {},
   isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate}, containsTraversal {decorate, flowEnv},
   genericStep {decorate, inlinedStrategies}, genericSimplify {decorate, inlinedStrategies},
   -- Frame-dependent attrs
-  partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame}, matchesFrame {decorate, frame}, isTotalInProd {decorate, frame},
+  partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame},
+  matchesFrame {decorate, frame}, isTotalInProd {decorate, frame},
   ntStep {decorate, inlinedStrategies, frame}, prodStep {decorate, inlinedStrategies, frame},
   ntSimplify {decorate, inlinedStrategies, frame}, optimize {decorate, inlinedStrategies, frame};
 
 flowtype StrategyExprs =
-  decorate {env, grammarName, config, recVarNameEnv, recVarTotalEnv, outerAttr}, -- NOT frame
+  decorate {env, grammarName, config, recVarNameEnv, outerAttr}, -- NOT frame or recVarTotalEnv
   forward {},
   -- Normal expression stuff
   -- Frame-independent attrs

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -336,9 +336,9 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
     if s2.attrRefName.isJust
     then []
     else [(s2Name, s2)];
-  top.isTotal = s1.isTotal && s2.isTotal || s3.isTotal;
-  top.isTotalNoEnv = s1.isTotalNoEnv && s2.isTotalNoEnv || s3.isTotalNoEnv;
-  top.isTotalInProd = s1.isTotalInProd && s2.isTotalInProd || s3.isTotalInProd;
+  top.isTotal = s2.isTotal && (s1.isTotal || s3.isTotal);
+  top.isTotalNoEnv = s2.isTotalNoEnv && (s1.isTotalNoEnv || s3.isTotalNoEnv);
+  top.isTotalInProd = s2.isTotal && (s1.isTotalInProd || s3.isTotalInProd);
   
   s1.isOutermost = false;
   s2.isOutermost = false;

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -33,6 +33,7 @@ monoid attribute totalRefs::[String];
 monoid attribute matchesFrame::Boolean with false, ||;
 monoid attribute containsTraversal::Boolean with false, ||;
 
+synthesized attribute isSuccessTranslation<a>::a;
 synthesized attribute partialTranslation<a>::a; -- Maybe<a> on a
 synthesized attribute totalTranslation<a>::a; -- a on a, can raise a runtime error if demanded on partial strategy expression
 
@@ -125,7 +126,7 @@ tracked nonterminal StrategyExpr with
   config, grammarName, env, unparse, errors, frame, compiledGrammars, flowEnv, -- Normal expression stuff
   genName, outerAttr, isOutermost, recVarNameEnv, recVarTotalEnv, liftedStrategies, attrRefName,
   isId, isFail, isTotal, isTotalNoEnv, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
-  partialTranslation<Expr>, totalTranslation<Expr>, matchesFrame, isTotalInProd, -- Frame-dependent attrs
+  isSuccessTranslation<Expr>, partialTranslation<Expr>, totalTranslation<Expr>, matchesFrame, isTotalInProd, -- Frame-dependent attrs
   inlinedStrategies, genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize; -- Optimization stuff
 
 tracked nonterminal StrategyExprs with
@@ -146,7 +147,7 @@ flowtype StrategyExpr =
   isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate}, containsTraversal {decorate, flowEnv},
   genericStep {decorate, inlinedStrategies}, genericSimplify {decorate, inlinedStrategies},
   -- Frame-dependent attrs
-  partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame},
+  isSuccessTranslation {decorate, flowEnv, frame}, partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame},
   matchesFrame {decorate, frame}, isTotalInProd {decorate, frame},
   ntStep {decorate, inlinedStrategies, frame}, prodStep {decorate, inlinedStrategies, frame},
   ntSimplify {decorate, inlinedStrategies, frame}, optimize {decorate, inlinedStrategies, frame};
@@ -207,6 +208,7 @@ top::StrategyExpr ::=
   top.isTotal = true;
   top.isTotalNoEnv = true;
   top.isTotalInProd = true;
+  top.isSuccessTranslation = Silver_Expr { true };
   top.totalTranslation =
     if top.frame.signature.outputElement.typerep.isData
     then Silver_Expr { $name{top.frame.signature.outputElement.elementName} }
@@ -219,6 +221,7 @@ top::StrategyExpr ::=
   top.unparse = "fail";
   propagate liftedStrategies;
   top.isFail = true;
+  top.isSuccessTranslation = Silver_Expr { false };
   top.partialTranslation = Silver_Expr { silver:core:nothing() };
 }
 
@@ -251,6 +254,16 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   -- the incoming tree and the result of s1 get re-decorated.
   nondecorated local allInhs::ExprInhs = allOccursExprInhs(top.frame, top.env);
 
+  top.isSuccessTranslation = 
+    case s1.isTotalInProd, s2Total of
+    | true, true -> Silver_Expr { true }
+    | true, false -> Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust }
+    | false, true -> s1.isSuccessTranslation
+    | false, false ->
+      Silver_Expr {
+        $Expr{s1.isSuccessTranslation} && $Expr{top.partialTranslation}.silver:core:isJust
+      }
+    end;
   top.partialTranslation =
     -- Optimizations when one or both of these is total, in this case a
     -- monadic bind may not be required.
@@ -310,6 +323,9 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   s1.isOutermost = false;
   s2.isOutermost = false;
   
+  top.isSuccessTranslation = Silver_Expr {
+    $Expr{s1.isSuccessTranslation} || $Expr{s2.isSuccessTranslation}
+  };
   top.partialTranslation =
     Silver_Expr {
       silver:core:orElse($Expr{s1.partialTranslation}, $Expr{s2.partialTranslation})
@@ -347,6 +363,24 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
   -- See comments in sequence.
   nondecorated local allInhs::ExprInhs = allOccursExprInhs(top.frame, top.env);
   
+  top.isSuccessTranslation = 
+    case s1.isTotalInProd, s2Total of
+    | true, true -> Silver_Expr { true }
+    | true, false -> Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust }
+    | false, true ->
+      Silver_Expr {
+        $Expr{s1.isSuccessTranslation} || $Expr{s3.isSuccessTranslation}
+      }
+    | false, false ->
+      Silver_Expr {
+        case $Expr{s1.partialTranslation} of
+        | silver:core:just(res) ->
+          decorate res with { $ExprInhs{allInhs} }.$name{s2Name}.silver:core:isJust
+        | silver:core:nothing() -> $Expr{s3.isSuccessTranslation}
+        end
+      }
+    end;
+
   top.partialTranslation =
     case s1.isTotalInProd, s2Total of
     | true, true ->
@@ -402,6 +436,53 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
     end;
 }
 
+abstract production ifThenElseComb
+top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
+{
+  top.unparse = s"if ${s1.unparse} then ${s2.unparse} else ${s3.unparse}";
+  propagate frame, liftedStrategies;
+
+  top.isTotal = s2.isTotal && (s1.isTotal || s3.isTotal);
+  top.isTotalNoEnv = s2.isTotalNoEnv && (s1.isTotalNoEnv || s3.isTotalNoEnv);
+  top.isTotalInProd = s2.isTotal && (s1.isTotalInProd || s3.isTotalInProd);
+  
+  s1.isOutermost = false;
+  s2.isOutermost = false;
+  s3.isOutermost = false;
+
+  top.isSuccessTranslation = Silver_Expr {
+    if $Expr{s1.isSuccessTranslation}
+    then $Expr{s2.isSuccessTranslation}
+    else $Expr{s3.isSuccessTranslation}
+  };
+
+  top.partialTranslation =
+    if s1.isTotalInProd
+    then s2.partialTranslation
+    else Silver_Expr {
+      if $Expr{s1.isSuccessTranslation}
+      then $Expr{s2.partialTranslation}
+      else $Expr{s3.partialTranslation}
+    };
+
+  top.totalTranslation =
+    if s1.isTotalInProd
+    then s2.totalTranslation
+    else Silver_Expr {
+      if $Expr{s1.isSuccessTranslation}
+      then $Expr{s2.totalTranslation}
+      else $Expr{s3.totalTranslation}
+    };
+}
+
+abstract production ifThenEndComb
+top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
+{
+  top.unparse = s"if ${s1.unparse} then ${s2.unparse} end";
+
+  forwards to ifThenElseComb(@s1, @s2, id(genName=top.genName ++ "_else"), genName=top.genName);
+}
+
 -- Traversals
 abstract production allTraversal
 top::StrategyExpr ::= s::StrategyExpr
@@ -429,6 +510,18 @@ top::StrategyExpr ::= s::StrategyExpr
       \ e::NamedSignatureElement ->
         (e.elementName, isDecorable(e.typerep, top.env), attrMatchesFrame(top.env, sName, e.typerep)),
       top.frame.signature.inputElements);
+  top.isSuccessTranslation =
+    if sTotal
+    then Silver_Expr { true }
+    else foldr(
+      and(_, '&&', _),
+      trueConst('true'),
+      filterMap(
+        \ a::(String, Boolean, Boolean) ->
+          if a.3
+          then just(Silver_Expr { $name{a.1}.$name{sName}.silver:core:isJust })
+          else nothing(),
+        childAccesses));
   top.partialTranslation =
     if sTotal
     then asPartial(top.totalTranslation)
@@ -519,6 +612,15 @@ top::StrategyExpr ::= s::StrategyExpr
         (e.elementName, isDecorable(e.typerep, top.env), attrMatchesFrame(top.env, sName, e.typerep)),
       top.frame.signature.inputElements);
   local matchingChildren::[String] = map(fst, filter(\ a::(String, Boolean, Boolean) -> a.3, childAccesses));
+  top.isSuccessTranslation =
+    if sTotal
+    then if null(matchingChildren) then Silver_Expr { false } else Silver_Expr { true }
+    else foldr(
+      or(_, '||', _),
+      falseConst('false'),
+      map(
+        \ a::String -> Silver_Expr { $name{a}.$name{sName}.silver:core:isJust },
+        matchingChildren));
   top.partialTranslation =
     if sTotal
     then
@@ -532,13 +634,7 @@ top::StrategyExpr ::= s::StrategyExpr
            else nothing()
          Not sure of a clean way to do this with monads -}
       Silver_Expr {
-        if $Expr{
-          foldr(
-            or(_, '||', _),
-            falseConst('false'),
-            map(
-              \ a::String -> Silver_Expr { $name{a}.$name{sName}.isJust },
-              matchingChildren))}
+        if $Expr{top.isSuccessTranslation}
         then
           silver:core:just(
             $Expr{
@@ -564,7 +660,7 @@ top::StrategyExpr ::= s::StrategyExpr
   top.totalTranslation =
     if sTotal && !null(matchingChildren)
     then
-      {- When s is total, optimized translation of all(s) for prod::(Foo ::= a::Foo b::Integer c::Bar):
+      {- When s is total, optimized translation of some(s) for prod::(Foo ::= a::Foo b::Integer c::Bar):
            prod(a.s, b, c.s) -}
        mkFullFunctionInvocation(
          baseExpr(qName(top.frame.fullName)),
@@ -607,6 +703,15 @@ top::StrategyExpr ::= s::StrategyExpr
         (e.elementName, isDecorable(e.typerep, top.env), attrMatchesFrame(top.env, sName, e.typerep)),
       top.frame.signature.inputElements);
   local matchingChildren::[String] = map(fst, filter(\ a::(String, Boolean, Boolean) -> a.3, childAccesses));
+  top.isSuccessTranslation =
+    if sTotal
+    then if null(matchingChildren) then Silver_Expr { false } else Silver_Expr { true }
+    else foldr(
+      or(_, '||', _),
+      falseConst('false'),
+      map(
+        \ a::String -> Silver_Expr { $name{a}.$name{sName}.silver:core:isJust },
+        matchingChildren));
   top.partialTranslation =
     if sTotal
     then
@@ -718,6 +823,19 @@ top::StrategyExpr ::= prod::QName s::StrategyExprs
     top.frame.signature.inputNames,
     map(isDecorable(_, top.env), top.frame.signature.inputTypes),
     s.attrRefNames);
+  top.isSuccessTranslation =
+    if prod.lookupValue.fullName == top.frame.fullName
+    then foldr(
+      and(_, '&&', _),
+      trueConst('true'),
+      filterMap(
+        \ a::(String, Boolean, Maybe<String>) ->
+          case a.3 of
+          | just(attr) when !attrIsTotal(top.env, attr) -> just(Silver_Expr { $name{a.1}.$name{attr}.silver:core:isJust })
+          | _ -> nothing()
+          end,
+        childAccesses))
+    else Silver_Expr { false };
   top.partialTranslation = -- This is never total
     if prod.lookupValue.fullName == top.frame.fullName
     then
@@ -777,7 +895,7 @@ abstract production consStrategyExpr
 top::StrategyExprs ::= h::StrategyExpr t::StrategyExprs
 {
   top.unparse = s"${h.unparse}, ${t.unparse}";
-   
+
   top.liftedStrategies :=
     -- Slight hack: when h is id (common case for prod traversals), there is no need for a new attribute.
     -- However this can't be avoided during the optimization phase, which happens after lifting.
@@ -854,6 +972,12 @@ top::StrategyExpr ::= n::Name s::StrategyExpr
   nondecorated local attrRef::Expr = Silver_Expr {
     $name{top.frame.signature.outputElement.elementName}.$name{sName}
   };
+  top.isSuccessTranslation =
+    if top.isOutermost
+    then s.isSuccessTranslation
+    else if sTotal
+    then Silver_Expr { true }
+    else Silver_Expr { $Expr{attrRef}.silver:core:isJust };
   top.partialTranslation =
     if top.isOutermost
     then s.partialTranslation
@@ -922,7 +1046,9 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
     then [wrnFromOrigin(ty, "Only rules on nonterminals can have an effect")]
     else [];
   top.errors <- ty.errorsKindStar;
-  
+
+  top.isSuccessTranslation = Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust };
+
   nondecorated local partialRes::Expr =
     caseExpr(
       [Silver_Expr { $name{top.frame.signature.outputElement.elementName} }],
@@ -946,31 +1072,31 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
       in $Expr{partialRes}
       end
     };
-    nondecorated local totalRes::Expr =
-      caseExpr(
-        [Silver_Expr { $name{top.frame.signature.outputElement.elementName} }],
-        ml.totalTranslation, false,
-        Silver_Expr {
-          silver:core:error(
-            "Internal error: total rule did not match: " ++
-            $Expr{stringConst(terminal(String_t, s"\"${escapeString(top.unparse)}\""))})
-        },
-        ty.typerep);
-    top.totalTranslation =
-      if top.frame.signature.outputElement.elementName == id.name
-      then totalRes
-      else if top.frame.signature.outputElement.typerep.isData
-      then Silver_Expr {
-        let $Name{^id}::$TypeExpr{^ty} = $name{top.frame.signature.outputElement.elementName}
-        in $Expr{totalRes}
-        end
-      }
-      else Silver_Expr {
-        let $Name{^id}::$TypeExpr{typerepTypeExpr(ty.typerep.asDecoratedType)} =
-          $name{top.frame.signature.outputElement.elementName}
-        in $Expr{totalRes}
-        end
-      };
+  nondecorated local totalRes::Expr =
+    caseExpr(
+      [Silver_Expr { $name{top.frame.signature.outputElement.elementName} }],
+      ml.totalTranslation, false,
+      Silver_Expr {
+        silver:core:error(
+          "Internal error: total rule did not match: " ++
+          $Expr{stringConst(terminal(String_t, s"\"${escapeString(top.unparse)}\""))})
+      },
+      ty.typerep);
+  top.totalTranslation =
+    if top.frame.signature.outputElement.elementName == id.name
+    then totalRes
+    else if top.frame.signature.outputElement.typerep.isData
+    then Silver_Expr {
+      let $Name{^id}::$TypeExpr{^ty} = $name{top.frame.signature.outputElement.elementName}
+      in $Expr{totalRes}
+      end
+    }
+    else Silver_Expr {
+      let $Name{^id}::$TypeExpr{typerepTypeExpr(ty.typerep.asDecoratedType)} =
+        $name{top.frame.signature.outputElement.elementName}
+      in $Expr{totalRes}
+      end
+    };
 }
 
 -- Hack dummy expr with a given type
@@ -1099,6 +1225,7 @@ top::StrategyExpr ::= msg::[Message] id::Decorated QName
   top.attrRefName = just(id.name);
   
   top.errors <- msg;
+  top.isSuccessTranslation = Silver_Expr { false };
   top.partialTranslation = Silver_Expr { silver:core:nothing() };
 }
 abstract production recVarRef
@@ -1116,6 +1243,8 @@ top::StrategyExpr ::= id::Decorated QName
   nondecorated local attrRef::Expr = Silver_Expr {
     $name{top.frame.signature.outputElement.elementName}.$qName{top.attrRefName.fromJust}
   };
+  top.isSuccessTranslation =
+    if top.isTotal then Silver_Expr { true } else Silver_Expr { $Expr{attrRef}.silver:core:isJust };
   top.partialTranslation =
     if top.isTotal then asPartial(attrRef) else attrRef;
   top.totalTranslation =
@@ -1152,6 +1281,10 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   
   attr.attrFor = top.frame.signature.outputElement.typerep;
   
+  top.isSuccessTranslation =
+    if attr.matchesFrame
+    then Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust }
+    else Silver_Expr { false };
   top.partialTranslation =
     if attr.matchesFrame
     then Silver_Expr { $name{top.frame.signature.outputElement.elementName}.$QNameAttrOccur{^attr} }
@@ -1189,6 +1322,7 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   
   attr.attrFor = top.frame.signature.outputElement.typerep;
   
+  top.isSuccessTranslation = Silver_Expr { true };
   top.totalTranslation = Silver_Expr { $name{top.frame.signature.outputElement.elementName}.$QNameAttrOccur{^attr} };
 }
 
@@ -1201,6 +1335,10 @@ top::StrategyExpr ::= attr::Decorated QNameAttrOccur s::StrategyExpr
   top.attrRefName = just(attr.attrDcl.fullName);
   top.isTotal = s.isTotal;
   top.isTotalInProd = s.isTotalInProd;
+  top.isSuccessTranslation =
+    if attr.matchesFrame
+    then s.isSuccessTranslation
+    else Silver_Expr { false };
   top.partialTranslation =
     if attr.matchesFrame
     then s.partialTranslation

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -50,6 +50,10 @@ partial strategy attribute genericStep =
   | choice(fail(), s) -> ^s
   | choice(s, fail()) -> ^s
   | choice(s, _) when s.isTotal -> ^s
+  | guardedChoice(fail(), _, s) -> ^s
+  | guardedChoice(s1, s2, _) when s1.isTotal -> sequence(^s1, ^s2, genName=top.genName)
+  | guardedChoice(s1, id(), s2) -> choice(^s1, ^s2, genName=top.genName)
+  | guardedChoice(s1, s2, fail()) -> sequence(^s1, ^s2, genName=top.genName)
   | allTraversal(id()) -> id(genName=top.genName)
   | someTraversal(fail()) -> fail(genName=top.genName)
   | oneTraversal(fail()) -> fail(genName=top.genName)
@@ -77,6 +81,7 @@ partial strategy attribute ntStep =
 partial strategy attribute prodStep =
   rule on top::StrategyExpr of
   | choice(s, _) when s.isTotalInProd -> ^s
+  | guardedChoice(s1, s2, _) when s1.isTotalInProd -> sequence(^s1, ^s2, genName=top.genName)
   | allTraversal(s) when !attrMatchesChild(top.env, fromMaybe(s.genName, s.attrRefName), top.frame) -> id(genName=top.genName)
   | someTraversal(s) when !attrMatchesChild(top.env, fromMaybe(s.genName, s.attrRefName), top.frame) -> fail(genName=top.genName)
   | oneTraversal(s) when !attrMatchesChild(top.env, fromMaybe(s.genName, s.attrRefName), top.frame) -> fail(genName=top.genName)
@@ -96,6 +101,7 @@ strategy attribute genericSimplify = innermost(genericStep);
 strategy attribute ntSimplify =
   (sequence(ntSimplify, ntSimplify) <+
    choice(ntSimplify, ntSimplify) <+
+   guardedChoice(ntSimplify, ntSimplify, ntSimplify) <+
    allTraversal(genericSimplify) <+
    someTraversal(genericSimplify) <+
    oneTraversal(genericSimplify) <+
@@ -107,6 +113,7 @@ strategy attribute ntSimplify =
 strategy attribute optimize =
   (sequence(optimize, ntSimplify) <+
    choice(optimize, optimize) <+
+   guardedChoice(optimize, ntSimplify, optimize) <+
    allTraversal(genericSimplify) <+
    someTraversal(genericSimplify) <+
    oneTraversal(genericSimplify) <+

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -20,6 +20,7 @@ synthesized attribute attrRefName::Maybe<String>;
 synthesized attribute isId::Boolean;
 synthesized attribute isFail::Boolean;
 synthesized attribute isTotal::Boolean;
+-- TODO: rename isTotalNoEnv to isTotalInferred
 synthesized attribute isTotalNoEnv::Boolean; -- same as above but doesn't depend on env, used only in initial pass for totality of lifted strategies
 synthesized attribute isTotalInProd::Boolean; -- can use env and frame
 inherited attribute givenInputElements::[NamedSignatureElement];
@@ -234,28 +235,28 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   s2.frame = top.frame;  -- CAUTION when using s2.frame: wrong prod, but same nt
   
   local s2Name::String = fromMaybe(top.genName ++ "_snd", s2.attrRefName);
-  local s2Total::Boolean = attrIsTotal(top.env, s2Name); -- Can differ from s2.isTotal because we lift without env
+  local s2AttrTotal::Boolean = attrIsTotal(top.env, s2Name); -- Can differ from s2.isTotal because we lift without env
   top.liftedStrategies :=
     s1.liftedStrategies ++
     if s2.attrRefName.isJust
     then []
     else [(s2Name, s2)];
-  top.isTotal = s1.isTotal && s2.isTotal;
+  top.isTotal = s1.isTotal && s2AttrTotal;
   top.isTotalNoEnv = s1.isTotalNoEnv && s2.isTotalNoEnv;
-  top.isTotalInProd = s1.isTotalInProd && s2.isTotal;
+  top.isTotalInProd = s1.isTotalInProd && s2AttrTotal;
   
   s1.isOutermost = false;
   s2.isOutermost = false;
   
   -- Equations for all inh attributes on the nt that we know about.
   -- This is safe because the MWDA requires that all inh dependencies of a syn attribute
-  -- be exported by the syn occurence anyway.
+  -- be exported by the syn occurrence anyway.
   -- TODO - future optimization potential: this is where common sub-trees shared between
   -- the incoming tree and the result of s1 get re-decorated.
   nondecorated local allInhs::ExprInhs = allOccursExprInhs(top.frame, top.env);
 
   top.isSuccessTranslation = 
-    case s1.isTotalInProd, s2Total of
+    case s1.isTotalInProd, s2AttrTotal of
     | true, true -> Silver_Expr { true }
     | true, false -> Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust }
     | false, true -> s1.isSuccessTranslation
@@ -267,7 +268,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   top.partialTranslation =
     -- Optimizations when one or both of these is total, in this case a
     -- monadic bind may not be required.
-    case s1.isTotalInProd, s2Total of
+    case s1.isTotalInProd, s2AttrTotal of
     | true, true ->
       Silver_Expr {
         silver:core:just(decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name})
@@ -295,7 +296,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
     Silver_Expr {
       decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
     };
-  top.totalTranslation = if s2Total then totalTrans else asTotal(top.frame.signature.outputElement.typerep, totalTrans);
+  top.totalTranslation = if s2AttrTotal then totalTrans else asTotal(top.frame.signature.outputElement.typerep, totalTrans);
 }
 
 fun allOccursExprInhs ExprInhs ::= frame::BlockContext env::Env =
@@ -346,15 +347,15 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
   propagate frame;  -- CAUTION when using s2.frame: wrong prod, but same nt
   
   local s2Name::String = fromMaybe(top.genName ++ "_snd", s2.attrRefName);
-  local s2Total::Boolean = attrIsTotal(top.env, s2Name); -- Can differ from s2.isTotal because we lift without env
+  local s2AttrTotal::Boolean = attrIsTotal(top.env, s2Name); -- Can differ from s2.isTotal because we lift without env
   top.liftedStrategies :=
     s1.liftedStrategies ++ s3.liftedStrategies ++
     if s2.attrRefName.isJust
     then []
     else [(s2Name, s2)];
-  top.isTotal = s2.isTotal && (s1.isTotal || s3.isTotal);
+  top.isTotal = s2AttrTotal && (s1.isTotal || s3.isTotal);
   top.isTotalNoEnv = s2.isTotalNoEnv && (s1.isTotalNoEnv || s3.isTotalNoEnv);
-  top.isTotalInProd = s2.isTotal && (s1.isTotalInProd || s3.isTotalInProd);
+  top.isTotalInProd = s2AttrTotal && (s1.isTotalInProd || s3.isTotalInProd);
   
   s1.isOutermost = false;
   s2.isOutermost = false;
@@ -364,7 +365,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
   nondecorated local allInhs::ExprInhs = allOccursExprInhs(top.frame, top.env);
   
   top.isSuccessTranslation = 
-    case s1.isTotalInProd, s2Total of
+    case s1.isTotalInProd, s2AttrTotal of
     | true, true -> Silver_Expr { true }
     | true, false -> Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust }
     | false, true ->
@@ -382,7 +383,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
     end;
 
   top.partialTranslation =
-    case s1.isTotalInProd, s2Total of
+    case s1.isTotalInProd, s2AttrTotal of
     | true, true ->
       Silver_Expr {
         silver:core:just(decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name})
@@ -410,7 +411,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
     end;
 
   top.totalTranslation =
-    case s1.isTotalInProd, s2Total of
+    case s1.isTotalInProd, s2AttrTotal of
     | true, true ->
       Silver_Expr {
         decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
@@ -490,7 +491,7 @@ top::StrategyExpr ::= s::StrategyExpr
   top.unparse = s"all(${s.unparse})";
   
   local sName::String = fromMaybe(top.genName ++ "_all_arg", s.attrRefName);
-  local sTotal::Boolean = attrIsTotal(top.env, sName); -- Can differ from s.isTotal because we lift without env
+  local sAttrTotal::Boolean = attrIsTotal(top.env, sName); -- Can differ from s.isTotal because we lift without env
   top.liftedStrategies :=
     if s.attrRefName.isJust
     then []
@@ -511,7 +512,7 @@ top::StrategyExpr ::= s::StrategyExpr
         (e.elementName, isDecorable(e.typerep, top.env), attrMatchesFrame(top.env, sName, e.typerep)),
       top.frame.signature.inputElements);
   top.isSuccessTranslation =
-    if sTotal
+    if sAttrTotal
     then Silver_Expr { true }
     else foldr(
       and(_, '&&', _),
@@ -523,7 +524,7 @@ top::StrategyExpr ::= s::StrategyExpr
           else nothing(),
         childAccesses));
   top.partialTranslation =
-    if sTotal
+    if sAttrTotal
     then asPartial(top.totalTranslation)
     else
       {- Translation of all(s) for prod::(Foo ::= a::Foo b::Integer c::Bar):
@@ -568,7 +569,7 @@ top::StrategyExpr ::= s::StrategyExpr
         Silver_Expr { silver:core:nothing() },
         appType(nonterminalType("silver:core:Maybe", [starKind()], true, false), top.frame.signature.outputElement.typerep));
   top.totalTranslation =
-    if sTotal
+    if sAttrTotal
     then
       {- When s is total, optimized translation of all(s) for prod::(Foo ::= a::Foo b::Integer c::Bar):
            prod(a.s, b, c.s) -}
@@ -594,7 +595,7 @@ top::StrategyExpr ::= s::StrategyExpr
   top.unparse = s"some(${s.unparse})";
   
   local sName::String = fromMaybe(top.genName ++ "_some_arg", s.attrRefName);
-  local sTotal::Boolean = attrIsTotal(top.env, sName); -- Can differ from s.isTotal because we lift without env
+  local sAttrTotal::Boolean = attrIsTotal(top.env, sName); -- Can differ from s.isTotal because we lift without env
   top.liftedStrategies :=
     if s.attrRefName.isJust
     then []
@@ -613,7 +614,7 @@ top::StrategyExpr ::= s::StrategyExpr
       top.frame.signature.inputElements);
   local matchingChildren::[String] = map(fst, filter(\ a::(String, Boolean, Boolean) -> a.3, childAccesses));
   top.isSuccessTranslation =
-    if sTotal
+    if sAttrTotal
     then if null(matchingChildren) then Silver_Expr { false } else Silver_Expr { true }
     else foldr(
       or(_, '||', _),
@@ -622,7 +623,7 @@ top::StrategyExpr ::= s::StrategyExpr
         \ a::String -> Silver_Expr { $name{a}.$name{sName}.silver:core:isJust },
         matchingChildren));
   top.partialTranslation =
-    if sTotal
+    if sAttrTotal
     then
       if !null(matchingChildren)
       then asPartial(top.totalTranslation)
@@ -658,7 +659,7 @@ top::StrategyExpr ::= s::StrategyExpr
         else silver:core:nothing()
       };
   top.totalTranslation =
-    if sTotal && !null(matchingChildren)
+    if sAttrTotal && !null(matchingChildren)
     then
       {- When s is total, optimized translation of some(s) for prod::(Foo ::= a::Foo b::Integer c::Bar):
            prod(a.s, b, c.s) -}
@@ -684,7 +685,7 @@ top::StrategyExpr ::= s::StrategyExpr
   top.unparse = s"one(${s.unparse})";
   
   local sName::String = fromMaybe(top.genName ++ "_one_arg", s.attrRefName);
-  local sTotal::Boolean = attrIsTotal(top.env, sName); -- Can differ from s.isTotal because we lift without env
+  local sAttrTotal::Boolean = attrIsTotal(top.env, sName); -- Can differ from s.isTotal because we lift without env
   top.liftedStrategies :=
     if s.attrRefName.isJust
     then []
@@ -704,7 +705,7 @@ top::StrategyExpr ::= s::StrategyExpr
       top.frame.signature.inputElements);
   local matchingChildren::[String] = map(fst, filter(\ a::(String, Boolean, Boolean) -> a.3, childAccesses));
   top.isSuccessTranslation =
-    if sTotal
+    if sAttrTotal
     then if null(matchingChildren) then Silver_Expr { false } else Silver_Expr { true }
     else foldr(
       or(_, '||', _),
@@ -713,7 +714,7 @@ top::StrategyExpr ::= s::StrategyExpr
         \ a::String -> Silver_Expr { $name{a}.$name{sName}.silver:core:isJust },
         matchingChildren));
   top.partialTranslation =
-    if sTotal
+    if sAttrTotal
     then
       if !null(matchingChildren)
       then asPartial(top.totalTranslation)
@@ -773,7 +774,7 @@ top::StrategyExpr ::= s::StrategyExpr
         Silver_Expr { silver:core:nothing() },
         appType(nonterminalType("silver:core:Maybe", [starKind()], true, false), top.frame.signature.outputElement.typerep));
   top.totalTranslation =
-    if sTotal && !null(matchingChildren)
+    if sAttrTotal && !null(matchingChildren)
     then
       {- When s is total, optimized translation of one(s) for prod::(Foo ::= a::Foo b::Integer c::Bar):
            prod(a.s, b, c) -}
@@ -968,26 +969,26 @@ top::StrategyExpr ::= n::Name s::StrategyExpr
   s.recVarTotalEnv = (n.name, top.isTotalNoEnv) :: top.recVarTotalEnv;
   s.isOutermost = top.isOutermost;
   
-  local sTotal::Boolean = attrIsTotal(top.env, sName);
+  local sAttrTotal::Boolean = attrIsTotal(top.env, sName);
   nondecorated local attrRef::Expr = Silver_Expr {
     $name{top.frame.signature.outputElement.elementName}.$name{sName}
   };
   top.isSuccessTranslation =
     if top.isOutermost
     then s.isSuccessTranslation
-    else if sTotal
+    else if sAttrTotal
     then Silver_Expr { true }
     else Silver_Expr { $Expr{attrRef}.silver:core:isJust };
   top.partialTranslation =
     if top.isOutermost
     then s.partialTranslation
-    else if sTotal
+    else if sAttrTotal
     then asPartial(attrRef)
     else attrRef;
   top.totalTranslation =
     if top.isOutermost
     then s.totalTranslation
-    else if sTotal
+    else if sAttrTotal
     then attrRef
     else asTotal(top.frame.signature.outputElement.typerep, attrRef);
 }
@@ -1367,7 +1368,7 @@ Boolean ::= env::Env attrName::String
   local dcls::[AttributeDclInfo] = getAttrDcl(attrName, env);
   return
     case dcls of
-    | [] -> false
+    | [] -> error(s"Attribute ${attrName} not found")
     | d :: _ ->
       case d.typeScheme.typerep of
       | appType(nonterminalType("silver:core:Maybe", _, _, _), _) -> false

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -242,17 +242,8 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   -- be exported by the syn occurence anyway.
   -- TODO - future optimization potential: this is where common sub-trees shared between
   -- the incoming tree and the result of s1 get re-decorated.
-  nondecorated local allInhs::ExprInhs =
-    foldr(
-      exprInhsCons(_, _),
-      exprInhsEmpty(),
-      map(
-        \ attr::String ->
-          -- TODO: translation attributes!
-          Silver_ExprInh {
-            $name{attr} = $name{top.frame.signature.outputElement.elementName}.$name{attr};
-          },
-        getInhAttrsOn(top.frame.lhsNtName, top.env)));
+  nondecorated local allInhs::ExprInhs = allOccursExprInhs(top.frame, top.env);
+
   top.partialTranslation =
     -- Optimizations when one or both of these is total, in this case a
     -- monadic bind may not be required.
@@ -287,6 +278,19 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   top.totalTranslation = if s2Total then totalTrans else asTotal(top.frame.signature.outputElement.typerep, totalTrans);
 }
 
+fun allOccursExprInhs ExprInhs ::= frame::BlockContext env::Env =
+  foldr(
+    exprInhsCons(_, _),
+    exprInhsEmpty(),
+    map(
+      \ attr::String ->
+        -- TODO: translation attributes!
+        Silver_ExprInh {
+          $name{attr} = $name{frame.signature.outputElement.elementName}.$name{attr};
+        },
+      getInhAttrsOn(frame.lhsNtName, env)));
+
+
 abstract production choice
 top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
 {
@@ -310,6 +314,85 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
       Silver_Expr {
         silver:core:fromMaybe($Expr{s2.totalTranslation}, $Expr{s1.partialTranslation})
       };
+}
+
+abstract production guardedChoice
+top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
+{
+  top.unparse = s"(${s1.unparse} < ${s2.unparse} + ${s3.unparse})";
+  propagate frame;  -- CAUTION when using s2.frame: wrong prod, but same nt
+  
+  local s2Name::String = fromMaybe(top.genName ++ "_snd", s2.attrRefName);
+  local s2Total::Boolean = attrIsTotal(top.env, s2Name); -- Can differ from s2.isTotal because we lift without env
+  top.liftedStrategies :=
+    s1.liftedStrategies ++ s3.liftedStrategies ++
+    if s2.attrRefName.isJust
+    then []
+    else [(s2Name, s2)];
+  top.isTotal = s1.isTotal && s2.isTotal || s3.isTotal;
+  top.isTotalNoEnv = s1.isTotalNoEnv && s2.isTotalNoEnv || s3.isTotalNoEnv;
+  top.isTotalInProd = s1.isTotalInProd && s2.isTotalInProd || s3.isTotalInProd;
+  
+  s1.isOutermost = false;
+  s2.isOutermost = false;
+  s3.isOutermost = false;
+
+  -- See comments in sequence.
+  nondecorated local allInhs::ExprInhs = allOccursExprInhs(top.frame, top.env);
+  
+  top.partialTranslation =
+    case s1.isTotalInProd, s2Total of
+    | true, true ->
+      Silver_Expr {
+        silver:core:just(decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name})
+      }
+    | true, false ->
+      Silver_Expr {
+        decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
+      }
+    | false, true ->
+      Silver_Expr {
+        case $Expr{s1.partialTranslation} of
+        | silver:core:just(res) ->
+          silver:core:just(decorate res with { $ExprInhs{allInhs} }.$name{s2Name})
+        | silver:core:nothing() -> $Expr{s3.partialTranslation}
+        end
+      }
+    | false, false ->
+      Silver_Expr {
+        case $Expr{s1.partialTranslation} of
+        | silver:core:just(res) ->
+          decorate res with { $ExprInhs{allInhs} }.$name{s2Name}
+        | silver:core:nothing() -> $Expr{s3.partialTranslation}
+        end
+      }
+    end;
+
+  top.totalTranslation =
+    case s1.isTotalInProd, s2Total of
+    | true, true ->
+      Silver_Expr {
+        decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
+      }
+    | true, false -> asTotal(top.frame.signature.outputElement.typerep,
+      Silver_Expr {
+        decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
+      })
+    | false, true ->
+      Silver_Expr {
+        case $Expr{s1.partialTranslation} of
+        | silver:core:just(res) -> decorate res with { $ExprInhs{allInhs} }.$name{s2Name}
+        | silver:core:nothing() -> $Expr{s3.totalTranslation}
+        end
+      }
+    | false, false -> asTotal(top.frame.signature.outputElement.typerep,
+      Silver_Expr {
+        case $Expr{s1.partialTranslation} of
+        | silver:core:just(res) -> decorate res with { $ExprInhs{allInhs} }.$name{s2Name}
+        | silver:core:nothing() -> $Expr{s3.partialTranslation}
+        end
+      })
+    end;
 }
 
 -- Traversals

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -57,6 +57,9 @@ partial strategy attribute genericStep =
   | guardedChoice(s1, s2, _) when s1.isTotal -> sequence(^s1, ^s2, genName=top.genName)
   | guardedChoice(s1, id(), s2) -> choice(^s1, ^s2, genName=top.genName)
   | guardedChoice(s1, s2, fail()) -> sequence(^s1, ^s2, genName=top.genName)
+  | ifThenElseComb(fail(), _, s) -> ^s
+  | ifThenElseComb(s1, s2, _) when s1.isTotal -> ^s2
+  | ifThenElseComb(_, s1, s2) when ^s1 == ^s2 -> ^s1
   | allTraversal(id()) -> id(genName=top.genName)
   | someTraversal(fail()) -> fail(genName=top.genName)
   | oneTraversal(fail()) -> fail(genName=top.genName)
@@ -85,6 +88,7 @@ partial strategy attribute prodStep =
   rule on top::StrategyExpr of
   | choice(s, _) when s.isTotalInProd -> ^s
   | guardedChoice(s1, s2, _) when s1.isTotalInProd -> sequence(^s1, ^s2, genName=top.genName)
+  | ifThenElseComb(s1, s2, _) when s1.isTotalInProd -> ^s2
   | allTraversal(s) when !attrMatchesChild(top.env, fromMaybe(s.genName, s.attrRefName), top.frame) -> id(genName=top.genName)
   | someTraversal(s) when !attrMatchesChild(top.env, fromMaybe(s.genName, s.attrRefName), top.frame) -> fail(genName=top.genName)
   | oneTraversal(s) when !attrMatchesChild(top.env, fromMaybe(s.genName, s.attrRefName), top.frame) -> fail(genName=top.genName)
@@ -105,6 +109,7 @@ strategy attribute ntSimplify =
   (sequence(ntSimplify, ntSimplify) <+
    choice(ntSimplify, ntSimplify) <+
    guardedChoice(ntSimplify, ntSimplify, ntSimplify) <+
+   ifThenElseComb(ntSimplify, ntSimplify, ntSimplify) <+
    allTraversal(genericSimplify) <+
    someTraversal(genericSimplify) <+
    oneTraversal(genericSimplify) <+
@@ -117,6 +122,7 @@ strategy attribute optimize =
   (sequence(optimize, ntSimplify) <+
    choice(optimize, optimize) <+
    guardedChoice(optimize, ntSimplify, optimize) <+
+   ifThenElseComb(optimize, optimize, optimize) <+
    allTraversal(genericSimplify) <+
    someTraversal(genericSimplify) <+
    oneTraversal(genericSimplify) <+

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -26,6 +26,8 @@ synthesized attribute isTotalInf::Boolean;
 synthesized attribute isTotal::Boolean;
 -- Same as above, but also depends on frame
 synthesized attribute isTotalInProd::Boolean;
+-- Can this strategy be evaluated twice without incurring any additional computation?
+synthesized attribute isSimple::Boolean;
 inherited attribute givenInputElements::[NamedSignatureElement];
 synthesized attribute attrRefNames::[Maybe<String>];
 monoid attribute containsFail::Boolean with false, ||;
@@ -135,7 +137,7 @@ strategy attribute optimize =
 tracked nonterminal StrategyExpr with
   config, grammarName, env, unparse, errors, frame, compiledGrammars, flowEnv, -- Normal expression stuff
   genName, outerAttr, isOutermost, recVarNameEnv, recVarTotalEnv, liftedStrategies, attrRefName,
-  isId, isFail, isTotalInf, isTotal, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
+  isId, isFail, isTotalInf, isTotal, isSimple, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
   isSuccessTranslation<Expr>, partialTranslation<Expr>, totalTranslation<Expr>, matchesFrame, isTotalInProd, -- Frame-dependent attrs
   inlinedStrategies, genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize; -- Optimization stuff
 
@@ -154,7 +156,7 @@ flowtype StrategyExpr =
   liftedStrategies {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost},
   isTotalInf {recVarNameEnv, recVarTotalEnv, outerAttr, isOutermost},
   attrRefName {recVarNameEnv}, isId {}, isFail {},
-  isTotal {decorate}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate}, containsTraversal {decorate, flowEnv},
+  isTotal {decorate}, isSimple {}, freeRecVars {decorate}, partialRefs {decorate}, totalRefs {decorate}, containsTraversal {decorate, flowEnv},
   genericStep {decorate, inlinedStrategies}, genericSimplify {decorate, inlinedStrategies},
   -- Frame-dependent attrs
   isSuccessTranslation {decorate, flowEnv, frame}, partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame},
@@ -206,6 +208,7 @@ top::StrategyExpr ::=
   top.isTotalInf = false;
   top.isTotal = false;
   top.isTotalInProd = false;
+  top.isSimple = false;
 }
 
 -- Basic combinators
@@ -218,6 +221,7 @@ top::StrategyExpr ::=
   top.isTotalInf = true;
   top.isTotal = true;
   top.isTotalInProd = true;
+  top.isSimple = true;
   top.isSuccessTranslation = Silver_Expr { true };
   top.totalTranslation =
     if top.frame.signature.outputElement.typerep.isData
@@ -231,6 +235,7 @@ top::StrategyExpr ::=
   top.unparse = "fail";
   propagate liftedStrategies;
   top.isFail = true;
+  top.isSimple = true;
   top.isSuccessTranslation = Silver_Expr { false };
   top.partialTranslation = Silver_Expr { silver:core:nothing() };
 }
@@ -1211,6 +1216,7 @@ top::StrategyExpr ::= id::QName
   top.isId = false;
   top.isFail = false;
   top.isTotalInf = fromMaybe(false, lookup(id.name, top.recVarTotalEnv));
+  top.isSimple = true;
   
   nondecorated local attrDcl::AttributeDclInfo = id.lookupAttribute.dcl;
   forwards to
@@ -1244,6 +1250,7 @@ top::StrategyExpr ::= id::Decorated QName
   top.isTotalInf = lookup(id.name, top.recVarTotalEnv).fromJust;
   top.isTotal = attrIsTotal(top.env, top.attrRefName.fromJust);
   top.isTotalInProd = attrIsTotal(top.env, top.attrRefName.fromJust);
+  top.isSimple = true;
   top.freeRecVars <- [id.name];
   
   nondecorated local attrRef::Expr = Silver_Expr {
@@ -1283,6 +1290,7 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   top.attrRefName = just(attr.name);
   top.matchesFrame := attr.matchesFrame;
   top.isTotal = false;
+  top.isSimple = true;
   top.partialRefs <- [attrDcl.fullName];
   
   attr.attrFor = top.frame.signature.outputElement.typerep;
@@ -1324,6 +1332,7 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   top.isTotalInf = true;
   top.isTotal = true;
   top.isTotalInProd = true;
+  top.isSimple = true;
   top.totalRefs <- [attrDcl.fullName];
   
   attr.attrFor = top.frame.signature.outputElement.typerep;
@@ -1341,15 +1350,32 @@ top::StrategyExpr ::= attr::Decorated QNameAttrOccur s::StrategyExpr
   top.attrRefName = just(attr.attrDcl.fullName);
   top.isTotal = s.isTotal;
   top.isTotalInProd = s.isTotalInProd;
+  top.isSimple = true;
+
+  local attrTotal::Boolean = attrIsTotal(top.env, attr.attrDcl.fullName);
+  nondecorated local attrRef::Expr = Silver_Expr {
+    $name{top.frame.signature.outputElement.elementName}.$QNameAttrOccur{^attr}
+  };
   top.isSuccessTranslation =
     if attr.matchesFrame
-    then s.isSuccessTranslation
+    then
+      if s.isSimple || attrTotal
+      then s.isSuccessTranslation
+      else Silver_Expr { $Expr{attrRef}.silver:core:isJust }
     else Silver_Expr { false };
   top.partialTranslation =
     if attr.matchesFrame
-    then s.partialTranslation
+    then
+      if s.isSimple
+      then s.partialTranslation
+      else if attrTotal then asPartial(attrRef) else attrRef
     else Silver_Expr { silver:core:nothing() };
-  top.totalTranslation = s.totalTranslation;
+  top.totalTranslation =
+    if s.isSimple
+    then s.totalTranslation
+    else if attrTotal
+    then attrRef
+    else asTotal(top.frame.signature.outputElement.typerep, attrRef);
   
   s.isOutermost = top.isOutermost;
   s.inlinedStrategies = attr.attrDcl.fullName :: top.inlinedStrategies;

--- a/grammars/silver/compiler/extension/strategyattr/StrategyUtils.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyUtils.sv
@@ -11,6 +11,7 @@ top::StrategyExpr ::=
   
   propagate liftedStrategies;
   top.isTotal = true;
+  top.isSuccessTranslation = Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust };
   top.totalTranslation =
     Silver_Expr {
       silver:core:unsafeTracePrint(

--- a/test/silver_features/Strategy.sv
+++ b/test/silver_features/Strategy.sv
@@ -185,6 +185,38 @@ equalityTest(
   constSExpr(1),
   SExpr, silver_tests);
 
+strategy attribute elimIfIdOrInc =
+  if someTopDown(idSExpr(id))
+  then elimPlusZero
+  else incConsts
+  occurs on SStmt, SExpr;
+propagate elimIfIdOrInc on SStmt, SExpr;
+
+equalityTest(
+  addSExpr(constSExpr(2), constSExpr(0)).elimIfIdOrInc,
+  addSExpr(constSExpr(3), constSExpr(1)),
+  SExpr, silver_tests);
+equalityTest(
+  addSExpr(idSExpr("a"), constSExpr(0)).elimIfIdOrInc,
+  idSExpr("a"),
+  SExpr, silver_tests);
+
+strategy attribute incIfId =
+  if someTopDown(idSExpr(id))
+  then incConsts
+  end
+  occurs on SStmt, SExpr;
+propagate incIfId on SStmt, SExpr;
+
+equalityTest(
+  addSExpr(constSExpr(0), constSExpr(2)).incIfId,
+  addSExpr(constSExpr(0), constSExpr(2)),
+  SExpr, silver_tests);
+equalityTest(
+  addSExpr(constSExpr(0), idSExpr("a")).incIfId,
+  addSExpr(constSExpr(1), idSExpr("a")),
+  SExpr, silver_tests);
+
 -- Negative tests
 inherited attribute badInh<a>::a;
 wrongCode "cannot be used as a total strategy" {

--- a/test/silver_features/Strategy.sv
+++ b/test/silver_features/Strategy.sv
@@ -170,6 +170,21 @@ partial strategy attribute onlySExpr = rule on SExpr of constSExpr(i) -> constSE
 propagate onlySExpr on SExpr;
 equalityTest(assignSStmt("a", constSExpr(42)).onlySStmt, just(assignSStmt("a", constSExpr(43))), Maybe<SStmt>, silver_tests);
 
+strategy attribute elim42 =
+  someTopDown(rule on SExpr of constSExpr(42) -> constSExpr(0) end)
+  < elimPlusZero + incConsts
+  occurs on SStmt, SExpr;
+propagate elim42 on SStmt, SExpr;
+
+equalityTest(
+  addSExpr(constSExpr(1), constSExpr(2)).elim42,
+  addSExpr(constSExpr(2), constSExpr(3)),
+  SExpr, silver_tests);
+equalityTest(
+  addSExpr(constSExpr(1), constSExpr(42)).elim42,
+  constSExpr(1),
+  SExpr, silver_tests);
+
 -- Negative tests
 inherited attribute badInh<a>::a;
 wrongCode "cannot be used as a total strategy" {


### PR DESCRIPTION
Depends on #885.

# Changes
Implement the guarded choice (`s1 < s2 + s3`) and conditional (`if s1 then s2 else s3`, `if s1 then s2 end`) strategies [from Stratego](http://releases.strategoxt.org/strategoxt-manual/strategoxt-manual-0.17pre17783-1wbv0l6q/manual/chunk-chapter/stratego-strategy-combinators.html).  Also some cleanup to totality inference, renaming some attributes and removing unneeded dependencies.

# Documentation
Updated comments.  The website page on strategy attributes also needs to be revamped at some point.

# Testing
Added test cases in `silver_features`.