### PR TITLE
More refactoring to strategy attributes and flow analysis

### DIFF
--- a/fetch-jars
+++ b/fetch-jars
@@ -2,12 +2,13 @@
 
 set -eu
 
-# Usage: ./fetch-jars [rev-name] [--unstable] [--local] [--copper]
+# Usage: ./fetch-jars [rev-name] [--unstable] [--local] [--copper] [--keep-generated]
 # If a revision is not specified, the script fetches the latest jars from the current branch,
 # falling back to develop.
 # If --unstable is specified, always fetch from commit artifacts on foundry.
 # If --local is specified, only fetch jars from the local cache.
 # If --copper is specified, only fetch the Copper jars.
+# If --keep-generated is specified, do not delete the generated file cache.
 
 # Parse command line argumants.
 # Hacky, but getopts seems like overkill for this...
@@ -126,7 +127,7 @@ else
   done
 fi
 
-if [ -d generated/src ]; then
+if [[ $* != *--keep-generated* && -d generated/src ]]; then
   echo "Deleting stale generated file cache..."
   for file in generated/*/*; do
     echo $file

--- a/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Inh.sv
@@ -904,7 +904,7 @@ top::Expr ::= '@' e::Expr
   -- Inherited attributes on the shared tree that might be depended upon by dispatching.
   local dispatchDepsOnRef :: [String] =
     case e.flowVertexInfo of
-    | just(localVertexType(fName)) when isForwardProdAttr(fName, top.env) -> []
+    | just(localVertexType(fName)) when isForwardProdAttr(top.frame.fullName, fName, top.flowEnv) -> []
     | just(vt) -> filter(\ i::String ->
         set:contains(vt.inhVertex(i), dispatchDeps) &&
         !vertexHasInhEq(top.frame.fullName, vt, i, top.flowEnv),
@@ -928,10 +928,10 @@ top::Expr ::= '@' e::Expr
     if top.config.warnMissingInh
     then
       case e.flowVertexInfo of
-      | just(localVertexType(fName)) when isForwardProdAttr(fName, top.env) ->
+      | just(localVertexType(fName)) when isForwardProdAttr(top.frame.fullName, fName, top.flowEnv) ->
         case top.decSiteVertexInfo of
         | just(forwardVertexType_real()) -> []
-        | just(localVertexType(dSiteFName)) when isForwardProdAttr(dSiteFName, top.env) -> []
+        | just(localVertexType(dSiteFName)) when isForwardProdAttr(top.frame.fullName, dSiteFName, top.flowEnv) -> []
         | _ -> [mwdaWrnFromOrigin(top, s"Forward production attribute ${fName} may only be shared in a forward decoration site")]
         end
       | _ -> []
@@ -956,7 +956,7 @@ top::AppExpr ::= e::Expr
   -- Inherited attributes on the shared tree that might be depended upon by dispatching.
   local dispatchDepsOnRef :: [String] =
     case e.flowVertexInfo of
-    | just(localVertexType(fName)) when isForwardProdAttr(fName, top.env) -> []
+    | just(localVertexType(fName)) when isForwardProdAttr(top.frame.fullName, fName, top.flowEnv) -> []
     | just(vt) -> filter(\ i::String ->
         set:contains(vt.inhVertex(i), dispatchDeps) &&
         !vertexHasInhEq(top.frame.fullName, vt, i, top.flowEnv),
@@ -980,10 +980,10 @@ top::AppExpr ::= e::Expr
     if top.config.warnMissingInh && sigIsShared && isForwardParam
     then
       case e.flowVertexInfo of
-      | just(localVertexType(fName)) when isForwardProdAttr(fName, top.env) ->
+      | just(localVertexType(fName)) when isForwardProdAttr(top.frame.fullName, fName, top.flowEnv) ->
         case top.decSiteVertexInfo of
         | just(forwardVertexType_real()) -> []
-        | just(localVertexType(dSiteFName)) when isForwardProdAttr(dSiteFName, top.env) -> []
+        | just(localVertexType(dSiteFName)) when isForwardProdAttr(top.frame.fullName, dSiteFName, top.flowEnv) -> []
         | _ -> [mwdaWrnFromOrigin(top, s"Forward production attribute ${fName} may only be shared in a forward decoration site")]
         end
       | _ -> []

--- a/grammars/silver/compiler/analysis/warnings/flow/Sharing.sv
+++ b/grammars/silver/compiler/analysis/warnings/flow/Sharing.sv
@@ -49,7 +49,8 @@ top::Expr ::= @q::QName
     then []
     else case top.appDecSiteVertexInfo of
     | just(forwardVertexType_real()) -> []
-    | just(localVertexType(fName)) when isForwardProdAttr(fName, top.env) -> []
+    | just(localVertexType(fName))
+        when isForwardProdAttr(top.frame.fullName, fName, top.flowEnv) -> []
     | _ -> [mwdaWrnFromOrigin(top, s"Non-dispatch production ${q.name} has shared children in its signature, and can only be referenced by applying it in the root position of a forward or forward production attribute equation.")]
     end;
 }
@@ -65,7 +66,8 @@ top::Expr ::= @e::Expr @es::AppExprs @anns::AnnoAppExprs
       | dispatchType(ns) when any(map((.elementShared), ns.inputElements)) ->
         case top.decSiteVertexInfo of
         | just(forwardVertexType_real()) -> []
-        | just(localVertexType(fName)) when isForwardProdAttr(fName, top.env) -> []
+        | just(localVertexType(fName))
+            when isForwardProdAttr(top.frame.fullName, fName, top.flowEnv) -> []
         | _ -> [mwdaWrnFromOrigin(e, s"Dispatch ${ns.fullName} has shared children in its signature, and can only be applied in the root position of a forward or forward production attribute equation.")]
         end
       | _ -> []

--- a/grammars/silver/compiler/definition/core/ProductionBody.sv
+++ b/grammars/silver/compiler/definition/core/ProductionBody.sv
@@ -117,6 +117,14 @@ top::ProductionStmt ::=
   top.unparse = "";
 }
 
+instance Semigroup ProductionStmt {
+  append = productionStmtAppend;
+}
+
+instance Monoid ProductionStmt {
+  mempty = emptyProductionStmt();
+}
+
 --------------------------------------------------------------------------------
 
 aspect default production

--- a/grammars/silver/compiler/definition/env/Env.sv
+++ b/grammars/silver/compiler/definition/env/Env.sv
@@ -378,12 +378,3 @@ Maybe<[String]> ::= t::Type e::Env
     | _ -> just([])
     end;
 }
-
--- Check if a production attribute is a forward production attribute.
--- Note this expects the local env for the production!
--- If looking up in another prod, need to get the prod attr defs for the prod.
-fun isForwardProdAttr Boolean ::= a::String  e::Env =
-  case getValueDclAll(a, e) of
-  | d :: _ -> d.hasForward
-  | _ -> false
-  end;

--- a/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
+++ b/grammars/silver/compiler/definition/flow/driver/ProductionGraph.sv
@@ -465,8 +465,7 @@ fun addDefEqs
    case d of
    | refDecSiteEq(prod, nt, ref, decSite, isAlwaysDec) when
         case ref of
-        | localVertexType(fName) -> !isForwardProdAttr(fName,
-            newScopeEnv(flatMap((.prodDefs), getProdAttrs(prod, realEnv)), emptyEnv()))
+        | localVertexType(fName) -> !isForwardProdAttr(prod, fName, flowEnv)
         | _ -> true
         end ->
       filterMap(

--- a/grammars/silver/compiler/definition/flow/env/DecSites.sv
+++ b/grammars/silver/compiler/definition/flow/env/DecSites.sv
@@ -53,10 +53,8 @@ DecSiteTree ::= prodName::String vt::VertexType flowEnv::FlowEnv realEnv::Env
       -- Via forwarding
       | forwardVertexType_real() -> forwardDec(prodName, nothing())
       | localVertexType("forward") -> forwardDec(prodName, nothing())
-      | localVertexType(fName) when
-          isForwardProdAttr(fName,
-            newScopeEnv(flatMap((.prodDefs), getProdAttrs(prodName, realEnv)), emptyEnv())) ->
-        forwardDec(prodName, just(fName))
+      | localVertexType(fName) when isForwardProdAttr(prodName, fName, flowEnv) ->
+          forwardDec(prodName, just(fName))
       -- Via projected remote equation
       | subtermVertexType(parent, prodOrSig, sigName) ->
          (if !null(getValueDcl(prodOrSig, realEnv))
@@ -157,10 +155,8 @@ State<([(String, VertexType)], [(String, String)]) DecSiteTree> ::=
         -- Via forwarding
         | forwardVertexType_real() -> pure(forwardDec(prodName, nothing()))
         | localVertexType("forward") -> pure(forwardDec(prodName, nothing()))
-        | localVertexType(fName) when
-            isForwardProdAttr(fName,
-              newScopeEnv(flatMap((.prodDefs), getProdAttrs(prodName, realEnv)), emptyEnv())) ->
-          pure(forwardDec(prodName, just(fName)))
+        | localVertexType(fName) when isForwardProdAttr(prodName, fName, flowEnv) ->
+            pure(forwardDec(prodName, just(fName)))
         -- Via projected remote equation
         | subtermVertexType(parent, prodOrSig, sigName) -> map(
             -- Transitive dependencies of an attribute on the projection must be supplied

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -381,7 +381,7 @@ top::AppExpr ::= e::Expr
     -- Don't try to share if someone uses a signature sharing prod somewhere invalid.
     case top.decSiteVertexInfo of
     | just(forwardVertexType_real()) -> true
-    | just(localVertexType(fName)) when isForwardProdAttr(fName, top.env) -> true
+    | just(localVertexType(fName)) when isForwardProdAttr(top.frame.fullName, fName, top.flowEnv) -> true
     | _ -> false
     end;
   top.flowDefs <-

--- a/grammars/silver/compiler/definition/flow/env/Expr.sv
+++ b/grammars/silver/compiler/definition/flow/env/Expr.sv
@@ -386,7 +386,7 @@ top::AppExpr ::= e::Expr
     end;
   top.flowDefs <-
     case top.decSiteVertexInfo, top.appProd, e.flowVertexInfo of
-    | just(parent), just(ns), just(v) when sigIsShared && isForwardParam ->
+    | just(parent), just(ns), just(v) when sigIsShared ->
       refDecSiteEq(
         top.frame.fullName, e.finalType.typeName, v,
         subtermVertexType(parent, ns.fullName, sigName), top.alwaysDecorated) ::

--- a/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
+++ b/grammars/silver/compiler/definition/flow/env/FlowEnv.sv
@@ -174,6 +174,15 @@ fun countVertexEqs Integer ::= prodName::String  vt::VertexType  attrName::Strin
   | forwardVertexType_real() -> length(lookupFwdInh(prodName, attrName, flowEnv))
   end;
 
+-- Check if a production attribute is a forward production attribute.
+-- Note this expects the local env for the production!
+-- If looking up in another prod, need to get the prod attr defs for the prod.
+fun isForwardProdAttr Boolean ::= prod::String  fName::String  e::FlowEnv =
+  case lookupLocalEq(prod, fName, e) of
+  | localEq(_, _, _, _, isFwrd, _) :: _ -> isFwrd
+  | _ -> false
+  end;
+
 -- default set of inherited attributes required/assumed to exist for references
 fun getInhsForNtRef [[String]] ::= nt::String  e::FlowEnv = searchEnvTree(nt, e.refTree);
 

--- a/grammars/silver/compiler/extension/strategyattr/ConcreteSyntax.sv
+++ b/grammars/silver/compiler/extension/strategyattr/ConcreteSyntax.sv
@@ -125,6 +125,12 @@ concrete productions top::StrategyExpr_c
   top.unparse = s"printTerm";
   top.ast = printTerm(genName=top.givenGenName);
 }
+| 'when' '(' s::StrategyExpr_c ')'
+{
+  top.unparse = s"when(${s.unparse})";
+  top.ast = whenS(s.ast, genName=top.givenGenName);
+  s.givenGenName = top.givenGenName ++ "_when_arg";
+}
 | 'try' '(' s::StrategyExpr_c ')'
 {
   top.unparse = s"try(${s.unparse})";

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -165,23 +165,25 @@ top::ProductionStmt ::= includeShared::Boolean @attr::QName
        any(map(null, map(getOccursDcl(_, top.frame.signature.outputElement.typerep.typeName, top.env), attr.lookupAttribute.dcl.totalRefs))))
     then []
     else forward.errors;
-  
-  nondecorated local fwrd::ProductionStmt =
-    foldr(
-      productionStmtAppend(_, _),
-      attributeDef(
-        concreteDefLHS(qName(top.frame.signature.outputElement.elementName)),
-        '.',
-        qNameAttrOccur(^attr),
-        '=',
-        if isTotal then e2.totalTranslation else e2.partialTranslation,
-        ';'),
-      map(
-        \ n::String -> propagateOneAttr(if includeShared then elemShared('@') else elemNotShared(), qName(n)),
-        attr.lookupAttribute.dcl.liftedStrategyNames));
+
+  local liftedProdStmts::ProductionStmt = e2.liftedProdStmts;
+  local fwrd::ProductionStmt = productionStmtAppend(
+    @liftedProdStmts,
+    attributeDef(
+      concreteDefLHS(qName(top.frame.signature.outputElement.elementName)),
+      '.',
+      qNameAttrOccur(^attr),
+      '=',
+      if isTotal then e2.totalTranslation else e2.partialTranslation,
+      ';') ++
+    flatMap(
+      \ n::String -> propagateOneAttr(if includeShared then elemShared('@') else elemNotShared(), qName(n)),
+      attr.lookupAttribute.dcl.liftedStrategyNames));
+  -- defs from here are ignored due to circular dependency workaround in propagateOneAttr
+  forward.env = newScopeEnv(liftedProdStmts.defs ++ liftedProdStmts.productionAttributes, top.env);
   
   -- Uncomment for debugging
-  --forwards to unsafeTrace(propagateImpl(includeShared, attr, fwrd), eprintT(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ e2.unparse ++ ";\n\n", unsafeIO()));
-  --forwards to unsafeTrace(propagateImpl(includeShared, attr, fwrd), eprintT(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ (if isTotal then e2.totalTranslation else e2.partialTranslation).unparse ++ ";\n\n", unsafeIO()));
-  forwards to propagateImpl(includeShared, attr, fwrd);
+  --top.errors <- unsafeTrace([], eprintT(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ e2.unparse ++ ";\n\n", unsafeIO()));
+  --top.errors <- unsafeTrace([], eprintT(attr.name ++ " on " ++ top.frame.fullName ++ " = " ++ (if isTotal then e2.totalTranslation else e2.partialTranslation).unparse ++ ";" ++ e2.liftedProdStmts.unparse ++ "\n\n", unsafeIO()));
+  forwards to propagateImpl(includeShared, attr, @fwrd);
 }

--- a/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyExpr.sv
@@ -7,6 +7,8 @@ import silver:compiler:definition:flow:ast only lhsVertexType;
 import silver:compiler:definition:flow:driver only ProductionGraph, FlowType, constructAnonymousGraph;
 import silver:compiler:driver:util;
 
+import silver:compiler:extension:convenience;
+
 annotation genName::String; -- Used to generate the names of lifted strategy attributes
 
 inherited attribute recVarNameEnv::[Pair<String String>]; -- name, genName
@@ -42,6 +44,7 @@ monoid attribute containsTraversal::Boolean with false, ||;
 synthesized attribute isSuccessTranslation<a>::a;
 synthesized attribute partialTranslation<a>::a; -- Maybe<a> on a
 synthesized attribute totalTranslation<a>::a; -- a on a, can raise a runtime error if demanded on partial strategy expression
+monoid attribute liftedProdStmts::ProductionStmt;
 
 -- Nonterminal-independent algebraic simplifications
 -- Theoretically these could be applied to the strategy before lifting/propagation,
@@ -138,7 +141,7 @@ tracked nonterminal StrategyExpr with
   config, grammarName, env, unparse, errors, frame, compiledGrammars, flowEnv, -- Normal expression stuff
   genName, outerAttr, isOutermost, recVarNameEnv, recVarTotalEnv, liftedStrategies, attrRefName,
   isId, isFail, isTotalInf, isTotal, isSimple, freeRecVars, partialRefs, totalRefs, containsTraversal, -- Frame-independent attrs
-  isSuccessTranslation<Expr>, partialTranslation<Expr>, totalTranslation<Expr>, matchesFrame, isTotalInProd, -- Frame-dependent attrs
+  isSuccessTranslation<Expr>, partialTranslation<Expr>, totalTranslation<Expr>, liftedProdStmts, matchesFrame, isTotalInProd, -- Frame-dependent attrs
   inlinedStrategies, genericStep, ntStep, prodStep, genericSimplify, ntSimplify, optimize; -- Optimization stuff
 
 tracked nonterminal StrategyExprs with
@@ -160,6 +163,7 @@ flowtype StrategyExpr =
   genericStep {decorate, inlinedStrategies}, genericSimplify {decorate, inlinedStrategies},
   -- Frame-dependent attrs
   isSuccessTranslation {decorate, flowEnv, frame}, partialTranslation {decorate, flowEnv, frame}, totalTranslation {decorate, flowEnv, frame},
+  liftedProdStmts {decorate, frame, flowEnv},
   matchesFrame {decorate, frame}, isTotalInProd {decorate, frame},
   ntStep {decorate, inlinedStrategies, frame}, prodStep {decorate, inlinedStrategies, frame},
   ntSimplify {decorate, inlinedStrategies, frame}, optimize {decorate, inlinedStrategies, frame};
@@ -222,6 +226,7 @@ top::StrategyExpr ::=
   top.isTotal = true;
   top.isTotalInProd = true;
   top.isSimple = true;
+  propagate liftedProdStmts;
   top.isSuccessTranslation = Silver_Expr { true };
   top.totalTranslation =
     if top.frame.signature.outputElement.typerep.isData
@@ -236,6 +241,7 @@ top::StrategyExpr ::=
   propagate liftedStrategies;
   top.isFail = true;
   top.isSimple = true;
+  propagate liftedProdStmts;
   top.isSuccessTranslation = Silver_Expr { false };
   top.partialTranslation = Silver_Expr { silver:core:nothing() };
 }
@@ -248,6 +254,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   s1.frame = top.frame;
   s2.frame = top.frame;  -- CAUTION when using s2.frame: wrong prod, but same nt
   
+  local s1Name::String = top.genName ++ "_fst";
   local s2Name::String = fromMaybe(top.genName ++ "_snd", s2.attrRefName);
   local s2AttrTotal::Boolean = attrIsTotal(top.env, s2Name); -- Can differ from s2.isTotal because we lift without env
   top.liftedStrategies :=
@@ -262,21 +269,25 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   s1.isOutermost = false;
   s2.isOutermost = false;
   
-  -- Equations for all inh attributes on the nt that we know about.
-  -- This is safe because the MWDA requires that all inh dependencies of a syn attribute
-  -- be exported by the syn occurrence anyway.
-  -- TODO - future optimization potential: this is where common sub-trees shared between
-  -- the incoming tree and the result of s1 get re-decorated.
-  nondecorated local allInhs::ExprInhs = allOccursExprInhs(top.frame, top.env);
-
+  top.liftedProdStmts := s1.liftedProdStmts ++
+    -- As a result of optimizations, a lifted strategy may introduce the same prod attr
+    -- as the strategy that lifted it. There isn't a great way to avoid this,
+    -- so check the environment first to avoid duplicates. Because every strategy expression
+    -- is given a unique id, we know that the same name is always the same strategy.
+    -- This check is not circular due to the forward.env override in propagateStrategy.
+    if null(getValueDcl(s1Name, top.env))
+    then Silver_ProductionStmt {
+      forward $name{s1Name} = $Expr{s1.totalTranslation};
+    }
+    else emptyProductionStmt();
   top.isSuccessTranslation = 
     case s1.isTotalInProd, s2AttrTotal of
     | true, true -> Silver_Expr { true }
-    | true, false -> Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust }
+    | true, false -> Silver_Expr { $name{s1Name}.$name{s2Name}.silver:core:isJust }
     | false, true -> s1.isSuccessTranslation
     | false, false ->
       Silver_Expr {
-        $Expr{s1.isSuccessTranslation} && $Expr{top.partialTranslation}.silver:core:isJust
+        $Expr{s1.isSuccessTranslation} && $name{s1Name}.$name{s2Name}.silver:core:isJust
       }
     end;
   top.partialTranslation =
@@ -285,46 +296,28 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
     case s1.isTotalInProd, s2AttrTotal of
     | true, true ->
       Silver_Expr {
-        silver:core:just(decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name})
+        silver:core:just($name{s1Name}.$name{s2Name})
       }
     | true, false ->
       Silver_Expr {
-        decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
+        $name{s1Name}.$name{s2Name}
       }
     | false, true ->
       Silver_Expr {
-        silver:core:map(
-          \ res::$TypeExpr{typerepTypeExpr(top.frame.signature.outputElement.typerep)} ->
-            decorate res with { $ExprInhs{allInhs} }.$name{s2Name},
-          $Expr{s1.partialTranslation})
+        if $Expr{s1.isSuccessTranslation}
+        then silver:core:just($name{s1Name}.$name{s2Name})
+        else silver:core:nothing()
       }
     | false, false ->
       Silver_Expr {
-        silver:core:bind(
-          $Expr{s1.partialTranslation},
-          \ res::$TypeExpr{typerepTypeExpr(top.frame.signature.outputElement.typerep)} ->
-            decorate res with { $ExprInhs{allInhs} }.$name{s2Name})
+        if $Expr{s1.isSuccessTranslation}
+        then $name{s1Name}.$name{s2Name}
+        else silver:core:nothing()
       }
     end;
-  nondecorated local totalTrans::Expr =
-    Silver_Expr {
-      decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
-    };
+  nondecorated local totalTrans::Expr = Silver_Expr { $name{s1Name}.$name{s2Name} };
   top.totalTranslation = if s2AttrTotal then totalTrans else asTotal(top.frame.signature.outputElement.typerep, totalTrans);
 }
-
-fun allOccursExprInhs ExprInhs ::= frame::BlockContext env::Env =
-  foldr(
-    exprInhsCons(_, _),
-    exprInhsEmpty(),
-    map(
-      \ attr::String ->
-        -- TODO: translation attributes!
-        Silver_ExprInh {
-          $name{attr} = $name{frame.signature.outputElement.elementName}.$name{attr};
-        },
-      getInhAttrsOn(frame.lhsNtName, env)));
-
 
 abstract production choice
 top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
@@ -338,6 +331,7 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr
   s1.isOutermost = false;
   s2.isOutermost = false;
   
+  propagate liftedProdStmts;
   top.isSuccessTranslation = Silver_Expr {
     $Expr{s1.isSuccessTranslation} || $Expr{s2.isSuccessTranslation}
   };
@@ -360,7 +354,8 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
   top.unparse = s"(${s1.unparse} < ${s2.unparse} + ${s3.unparse})";
   propagate frame;  -- CAUTION when using s2.frame: wrong prod, but same nt
   
-  local s2Name::String = fromMaybe(top.genName ++ "_snd", s2.attrRefName);
+  local s1Name::String = top.genName ++ "_cond";
+  local s2Name::String = fromMaybe(top.genName ++ "_then", s2.attrRefName);
   local s2AttrTotal::Boolean = attrIsTotal(top.env, s2Name); -- Can differ from s2.isTotal because we lift without env
   top.liftedStrategies :=
     s1.liftedStrategies ++ s3.liftedStrategies ++
@@ -375,79 +370,67 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
   s2.isOutermost = false;
   s3.isOutermost = false;
 
-  -- See comments in sequence.
-  nondecorated local allInhs::ExprInhs = allOccursExprInhs(top.frame, top.env);
-  
+  top.liftedProdStmts := s1.liftedProdStmts ++ s3.liftedProdStmts ++
+    -- See the comments on sequence for why we check the environment here
+    if null(getValueDcl(s1Name, top.env))
+    then Silver_ProductionStmt {
+      forward $name{s1Name} = $Expr{s1.totalTranslation};
+    }
+    else emptyProductionStmt();
+
   top.isSuccessTranslation = 
     case s1.isTotalInProd, s2AttrTotal of
     | true, true -> Silver_Expr { true }
-    | true, false -> Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust }
+    | true, false -> Silver_Expr { $name{s1Name}.$name{s2Name}.silver:core:isJust }
     | false, true ->
       Silver_Expr {
         $Expr{s1.isSuccessTranslation} || $Expr{s3.isSuccessTranslation}
       }
     | false, false ->
       Silver_Expr {
-        case $Expr{s1.partialTranslation} of
-        | silver:core:just(res) ->
-          decorate res with { $ExprInhs{allInhs} }.$name{s2Name}.silver:core:isJust
-        | silver:core:nothing() -> $Expr{s3.isSuccessTranslation}
-        end
+        if $Expr{s1.isSuccessTranslation}
+        then $name{s1Name}.$name{s2Name}.silver:core:isJust
+        else $Expr{s3.isSuccessTranslation}
       }
     end;
 
   top.partialTranslation =
     case s1.isTotalInProd, s2AttrTotal of
-    | true, true ->
-      Silver_Expr {
-        silver:core:just(decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name})
-      }
-    | true, false ->
-      Silver_Expr {
-        decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
-      }
+    | true, true -> Silver_Expr { silver:core:just($name{s1Name}.$name{s2Name}) }
+    | true, false -> Silver_Expr { $name{s1Name}.$name{s2Name} }
     | false, true ->
       Silver_Expr {
-        case $Expr{s1.partialTranslation} of
-        | silver:core:just(res) ->
-          silver:core:just(decorate res with { $ExprInhs{allInhs} }.$name{s2Name})
-        | silver:core:nothing() -> $Expr{s3.partialTranslation}
-        end
+        if $Expr{s1.isSuccessTranslation}
+        then silver:core:just($name{s1Name}.$name{s2Name})
+        else $Expr{s3.partialTranslation}
       }
     | false, false ->
       Silver_Expr {
-        case $Expr{s1.partialTranslation} of
-        | silver:core:just(res) ->
-          decorate res with { $ExprInhs{allInhs} }.$name{s2Name}
-        | silver:core:nothing() -> $Expr{s3.partialTranslation}
-        end
+        if $Expr{s1.isSuccessTranslation}
+        then $name{s1Name}.$name{s2Name}
+        else $Expr{s3.partialTranslation}
       }
     end;
 
+  nondecorated local s2AsTotal::Expr = asTotal(
+    top.frame.signature.outputElement.typerep,
+    Silver_Expr { $name{s1Name}.$name{s2Name} });
   top.totalTranslation =
     case s1.isTotalInProd, s2AttrTotal of
-    | true, true ->
-      Silver_Expr {
-        decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
-      }
-    | true, false -> asTotal(top.frame.signature.outputElement.typerep,
-      Silver_Expr {
-        decorate $Expr{s1.totalTranslation} with { $ExprInhs{allInhs} }.$name{s2Name}
-      })
+    | true, true -> Silver_Expr { $name{s1Name}.$name{s2Name} }
+    | true, false -> s2AsTotal
     | false, true ->
       Silver_Expr {
-        case $Expr{s1.partialTranslation} of
-        | silver:core:just(res) -> decorate res with { $ExprInhs{allInhs} }.$name{s2Name}
-        | silver:core:nothing() -> $Expr{s3.totalTranslation}
-        end
+        if $Expr{s1.isSuccessTranslation}
+        then $name{s1Name}.$name{s2Name}
+        else $Expr{s3.totalTranslation}
       }
-    | false, false -> asTotal(top.frame.signature.outputElement.typerep,
+    | false, false ->
       Silver_Expr {
-        case $Expr{s1.partialTranslation} of
-        | silver:core:just(res) -> decorate res with { $ExprInhs{allInhs} }.$name{s2Name}
-        | silver:core:nothing() -> $Expr{s3.partialTranslation}
-        end
-      })
+        if $Expr{s1.isSuccessTranslation}
+        then $Expr{s2AsTotal}
+        else $Expr{s3.totalTranslation}
+      }
     end;
 }
 
@@ -464,6 +447,8 @@ top::StrategyExpr ::= s1::StrategyExpr s2::StrategyExpr s3::StrategyExpr
   s1.isOutermost = false;
   s2.isOutermost = false;
   s3.isOutermost = false;
+
+  propagate liftedProdStmts;
 
   top.isSuccessTranslation = Silver_Expr {
     if $Expr{s1.isSuccessTranslation}
@@ -518,6 +503,8 @@ top::StrategyExpr ::= s::StrategyExpr
 
   s.isOutermost = false;
   
+  top.liftedProdStmts := emptyProductionStmt();
+
   local sBaseName::String = last(explode(":", sName));
   -- (child name, child decorable, attr occurs on child)
   local childAccesses::[(String, Boolean, Boolean)] =
@@ -619,6 +606,8 @@ top::StrategyExpr ::= s::StrategyExpr
   top.containsTraversal <- true;
 
   s.isOutermost = false;
+
+  top.liftedProdStmts := emptyProductionStmt();
   
   -- (child name, child decorable, attr occurs on child)
   local childAccesses::[(String, Boolean, Boolean)] =
@@ -709,6 +698,8 @@ top::StrategyExpr ::= s::StrategyExpr
   top.containsTraversal <- true;
   
   s.isOutermost = false;
+
+  top.liftedProdStmts := emptyProductionStmt();
   
   local sBaseName::String = last(explode(":", sName));
   -- (child name, child decorable, attr occurs on child)
@@ -832,6 +823,8 @@ top::StrategyExpr ::= prod::QName s::StrategyExprs
     else [];
   
   top.containsTraversal <- true;
+
+  propagate liftedProdStmts;
   
   -- (child name, child decorable, if attr occurs on child then just(attr name) else nothing())
   local childAccesses::[(String, Boolean, Maybe<String>)] = zip3(
@@ -979,6 +972,9 @@ top::StrategyExpr ::= n::Name s::StrategyExpr
   top.isTotal = s.isTotal;
   top.isTotalInProd = s.isTotalInProd;
   
+  top.liftedProdStmts :=
+    if top.isOutermost then s.liftedProdStmts else emptyProductionStmt();
+
   local sAttrTotal::Boolean = attrIsTotal(top.env, sName);
   nondecorated local attrRef::Expr = Silver_Expr {
     $name{top.frame.signature.outputElement.elementName}.$name{sName}
@@ -1057,6 +1053,8 @@ top::StrategyExpr ::= id::Name ty::TypeExpr ml::MRuleList
     then [wrnFromOrigin(ty, "Only rules on nonterminals can have an effect")]
     else [];
   top.errors <- ty.errorsKindStar;
+  
+  top.liftedProdStmts := emptyProductionStmt();
 
   top.isSuccessTranslation = Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust };
 
@@ -1237,6 +1235,7 @@ top::StrategyExpr ::= msg::[Message] id::Decorated QName
   top.attrRefName = just(id.name);
   
   top.errors <- msg;
+  propagate liftedProdStmts;
   top.isSuccessTranslation = Silver_Expr { false };
   top.partialTranslation = Silver_Expr { silver:core:nothing() };
 }
@@ -1253,6 +1252,7 @@ top::StrategyExpr ::= id::Decorated QName
   top.isSimple = true;
   top.freeRecVars <- [id.name];
   
+  propagate liftedProdStmts;
   nondecorated local attrRef::Expr = Silver_Expr {
     $name{top.frame.signature.outputElement.elementName}.$qName{top.attrRefName.fromJust}
   };
@@ -1295,6 +1295,7 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   
   attr.attrFor = top.frame.signature.outputElement.typerep;
   
+  propagate liftedProdStmts;
   top.isSuccessTranslation =
     if attr.matchesFrame
     then Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust }
@@ -1323,7 +1324,7 @@ top::StrategyExpr ::= attr::QNameAttrOccur
       then [wrnFromOrigin(attr, s"Attribute ${attr.name} cannot be used as a total strategy, because it doesn't occur on its own nonterminal type ${nt}")]
       else []
     | errorType(), _ -> []
-    | _, _ -> [errFromOrigin(attr,   s"Attribute ${attr.name} cannot be used as a total strategy")]
+    | _, _ -> [errFromOrigin(attr, s"Attribute ${attr.name} cannot be used as a total strategy")]
     end;
   
   propagate liftedStrategies;
@@ -1337,6 +1338,7 @@ top::StrategyExpr ::= attr::QNameAttrOccur
   
   attr.attrFor = top.frame.signature.outputElement.typerep;
   
+  propagate liftedProdStmts;
   top.isSuccessTranslation = Silver_Expr { true };
   top.totalTranslation = Silver_Expr { $name{top.frame.signature.outputElement.elementName}.$QNameAttrOccur{^attr} };
 }
@@ -1356,6 +1358,7 @@ top::StrategyExpr ::= attr::Decorated QNameAttrOccur s::StrategyExpr
   nondecorated local attrRef::Expr = Silver_Expr {
     $name{top.frame.signature.outputElement.elementName}.$QNameAttrOccur{^attr}
   };
+  top.liftedProdStmts := emptyProductionStmt();
   top.isSuccessTranslation =
     if attr.matchesFrame
     then

--- a/grammars/silver/compiler/extension/strategyattr/StrategyUtils.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyUtils.sv
@@ -22,6 +22,15 @@ top::StrategyExpr ::=
 
 -- Utilities
 -- Note that for the translation to work properly, we need to maintain forward.genName == top.genName
+abstract production whenS
+top::StrategyExpr ::= s::StrategyExpr
+{
+  forwards to
+    Silver_StrategyExpr (top.genName) {
+      if $StrategyExpr{@s} then id else fail
+    };
+}
+
 abstract production try
 top::StrategyExpr ::= s::StrategyExpr
 {

--- a/grammars/silver/compiler/extension/strategyattr/StrategyUtils.sv
+++ b/grammars/silver/compiler/extension/strategyattr/StrategyUtils.sv
@@ -11,6 +11,7 @@ top::StrategyExpr ::=
   
   propagate liftedStrategies;
   top.isTotal = true;
+  propagate liftedProdStmts;
   top.isSuccessTranslation = Silver_Expr { $Expr{top.partialTranslation}.silver:core:isJust };
   top.totalTranslation =
     Silver_Expr {


### PR DESCRIPTION
# Changes
The main change here is in how strategy attributes are translated.  Instead of translating `s1 <* s2` as
```
top.foo = decorate top.s1 with {env = top.env; ...}.s2;
```
with all the inherited attributes known to occur on `top`, we can now use a forward production attribute:
```
forward foo_fst = top.s1;
top.foo = foo_fst.s2;
```
This gets slightly more gross if `s1` isn't total, since we can't use `bind`, or stick the forward prod attribute declaration inside a `case`:
```
forward foo_fst = top.s1.fromJust;
top.foo = if top.s1.isJust then foo_fst.s2 else nothing();
```

## Other changes
* Add `when(s)` strategy utility from Stratego  - alias for `if s then id else fail`.
* MWDA refactor, check if a prod attribute is a forward prod attribute by checking the flow env instead of the regular one.  This is probably how it should have been done in the first place, but this change was needed because production attributes created by propagate don't make it into the production's defs properly.  
* Tweak to `fetch-jars` script to allow keeping the generated files - useful in development if one wishes to reset the jars to the previous working version, but a clean build is not needed.

# Documentation
This is mostly an internal refactor - updated comments as needed.

# Testing
No new test cases are needed, passes the existing strategy attribute tests.
