### PR TITLE
Avoid including extension expressions in interface files

### DIFF
--- a/grammars/silver/compiler/extension/strategyattr/DclInfo.sv
+++ b/grammars/silver/compiler/extension/strategyattr/DclInfo.sv
@@ -30,13 +30,14 @@ top::AttributeDclInfo ::=
   containsErrors::Boolean liftedStrategyNames::[String]
   givenRecVarNameEnv::[Pair<String String>] givenRecVarTotalEnv::[Pair<String Boolean>]
   partialRefs::[String] totalRefs::[String] containsTraversal::Boolean
-  e::StrategyExpr
+  eAST::AST
 {
   top.fullName = fn;
   propagate compareKey;
   top.isEqual =
     case top.compareTo of
-    | strategyDcl(ofn, oIsTotal, _, _, _, _, _, _, _, oe) -> fn == ofn && isTotal == oIsTotal && ^e == ^oe
+    | strategyDcl(ofn, oIsTotal, _, _, _, _, _, _, _, _) ->
+      fn == ofn && isTotal == oIsTotal && top.strategyExpr == top.compareTo.strategyExpr
     | _ -> false
     end;
 
@@ -63,5 +64,5 @@ top::AttributeDclInfo ::=
   top.partialRefs := partialRefs;
   top.totalRefs := totalRefs;
   top.containsTraversal := containsTraversal;
-  top.strategyExpr = ^e;
+  top.strategyExpr = reifyUnchecked(^eAST);
 }

--- a/grammars/silver/compiler/extension/strategyattr/Project.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Project.sv
@@ -2,6 +2,8 @@ grammar silver:compiler:extension:strategyattr;
 
 imports silver:core hiding id, sequence, fail;
 
+imports silver:reflect;
+
 imports silver:compiler:definition:core;
 imports silver:compiler:definition:env;
 imports silver:compiler:definition:type;

--- a/grammars/silver/compiler/extension/strategyattr/Strategy.sv
+++ b/grammars/silver/compiler/extension/strategyattr/Strategy.sv
@@ -58,7 +58,8 @@ top::AGDcl ::=
           defaultEnvItem(
             strategyDcl(
               fName, isTotal,
-              !null(top.errors), map(fst, e.liftedStrategies), recVarNameEnv, recVarTotalEnv, e.partialRefs, e.totalRefs, e.containsTraversal, ^e,
+              !null(top.errors), map(fst, e.liftedStrategies), recVarNameEnv, recVarTotalEnv,
+              e.partialRefs, e.totalRefs, e.containsTraversal, reflect(^e),
               sourceGrammar=top.grammarName, sourceLocation=a.nameLoc)))]);
   
   forwards to appendAGDcl(@liftedStrategyDecls,


### PR DESCRIPTION
# Changes
Currently, deserializing an interface file can fail if it contains a strategy attribute declaration using extended syntax (e.g. `ableC_Expr` in a rule.)  This means that when a grammar that was built with an extended version of Silver, one may also need to use the extended Silver for anything depending on that grammar, even if the strategy wasn't used for anything, such as in an artifact grammar.  This makes build scripts for complex projects (e.g. for ableC) slightly more annoying.

Instead, just put a reflected version of the strategy in the interface file, to avoid needing to directly deserialize syntax that we don't know about.

# Documentation
N/A

# Testing
It builds ableC and extensions.  
