### PR TITLE
Support for use of CodeProber with Silver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ tutorials/**/output.c
 
 # Useful spot to stash your experiments
 sandbox
+
+# Codeprober workspace states
+.cpr/

--- a/grammars/silver/compiler/composed/Default/Main.sv
+++ b/grammars/silver/compiler/composed/Default/Main.sv
@@ -7,3 +7,4 @@ parser svParse::File {
 }
 
 fun main IO<Integer> ::= args::[String] = cmdLineRun(args, svParse);
+fun codeProberParse IO<Compilation> ::= args::[String] = codeProberRun(args, svParse);

--- a/grammars/silver/compiler/driver/CodeProber.sv
+++ b/grammars/silver/compiler/driver/CodeProber.sv
@@ -1,0 +1,44 @@
+grammar silver:compiler:driver;
+
+-- Entry point driver function for debugging the Silver compiler with CodeProber
+fun codeProberRun
+IO<Compilation> ::= args::[String]  svParser::SVParser = do {
+  eprintln("codeProberRun " ++ implode(" ", args));
+  let fileName = last(args);
+  let svArgs = init(args); 
+
+  res::Either<RunError Compilation> <- cmdLineRunInitial(svArgs, svParser).run;
+  eprintln("codeProberRun finished");
+
+  comp::Compilation <-
+    case res of
+    | left(re) -> do { eprintln(re.errMsg); exit(re.code); }
+    | right(comp) -> pure(comp)
+    end;
+
+  setTreeIsInMainFile(false, comp);
+  traverse_(setTreeIsInMainFile(true, _),
+    flatMap(\ r::Decorated RootSpec ->
+      filter(\ f::Decorated File ->
+        isSameFile(r.grammarSource ++ "/" ++ getParsedOriginLocation(f).fromJust.filename, fileName),
+        r.files),
+      comp.recompiledGrammars));
+
+  return comp;
+};
+
+monoid attribute files::[Decorated File] occurs on RootSpec, Grammar;
+propagate files on RootSpec, Grammar;
+aspect production consGrammar
+top::Grammar ::= h::File _
+{
+  top.files <- [h];
+}
+
+function isSameFile
+Boolean ::= p1::String  p2::String
+{
+  return error("foreign function");
+} foreign {
+  "java": return "java.nio.file.Files.isSameFile(java.nio.file.Paths.get(%p1%.toString()), java.nio.file.Paths.get(%p2%.toString()))";
+}

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -23,16 +23,21 @@ top::AGDcl ::= 'fun' id::Name ns::FunctionSignature '=' e::Expr ';'
         [appType(listCtrType(), stringType()),
           appType(nonterminalType("silver:core:IO", [starKind()], false, false), intType())])).failure;
 
-  top.genFiles <-
-    if id.name == "main"
-      then [("Main.java", generateMainClassString(top.grammarName, !typeIOValFailed))]
-      else [];
-
   top.errors <-
     if id.name == "main" && typeIOValFailed && typeIOMonadFailed -- Neither legal main function type used
       then [errFromOrigin(top, "main function must have type signature (IOVal<Integer> ::= [String] IOToken) " ++
         "or (IO<Integer> ::= [String]). Instead it has type " ++ prettyType(namedSig.typerep))]
       else [];
+
+  nondecorated local codeProberParseType::Type =
+    appTypes(
+      functionType(1, []),
+        [appType(listCtrType(), stringType()),
+          appType(nonterminalType("silver:core:IO", [starKind()], false, false), decoratedType(freshType(), freshInhSet()))]);
+  top.errors <-
+    if id.name == "codeProberParse" && unify(namedSig.typerep, codeProberParseType).failure
+	  then [errFromOrigin(top, "codeProberParse function must have type signature (IO<Decorated a> ::= [String]). Instead it has type " ++ prettyType(namedSig.typerep))]
+	  else [];
 }
 
 aspect production functionDcl
@@ -56,10 +61,7 @@ s"""			final common.DecoratedNode context = new P${id.name}(${argsAccess}).decor
 """;
 
   top.genFiles :=
-    [(s"P${id.name}.java", generateFunctionClassString(body.env, top.flowEnv, top.grammarName, id.name, namedSig, funBody))] ++
-    if id.name == "main" 
-	then [("Main.java", generateMainClassString(top.grammarName, !typeIOValFailed))] -- !typeIOValFailed true if main type used was IOVal<Integer>
-    else [];
+    [(s"P${id.name}.java", generateFunctionClassString(body.env, top.flowEnv, top.grammarName, id.name, namedSig, funBody))];
 
   -- For main functions which return IOVal<Integer>
   local attribute typeIOValFailed::Boolean = unify(namedSig.typerep,
@@ -258,53 +260,3 @@ ${makeTyVarDecls(3, whatSig.typerep.freeVariables)}
 	};
 }""";
 }
-
-function generateMainClassString
-String ::= whatGrammar::String isIOValReturn::Boolean
-{
-  local attribute package :: String;
-  package = makeName(whatGrammar);
-
-  -- Code used if main function return type is IOVal<Integer>
-  local attribute invocationIOVal::String = package ++ 
-    ".Pmain.invoke(common.OriginContext.ENTRY_CONTEXT, cvargs(args), common.IOToken.singleton)";
-	
-  -- Code used if main function return type is IO<Integer>
-  local attribute invokationEvalIO::String = 
-    "silver.core.PevalIO.invoke(common.OriginContext.ENTRY_CONTEXT, " ++ package ++ 
-    ".Pmain.invoke(common.OriginContext.ENTRY_CONTEXT, cvargs(args)), common.IOToken.singleton)";
-
-  return s"""
-package ${package};
-
-import silver.core.*;
-
-public class Main {
-	public static void main(String[] args) {
-		common.Util.init();
-		${package}.Init.initAllStatics();
-		${package}.Init.init();
-		${package}.Init.postInit();
-
-		try {
-			common.Node rv = (common.Node) ${if isIOValReturn then invocationIOVal else invokationEvalIO};
-			common.DecoratedNode drv = rv.decorate();
-			drv.synthesized(silver.core.Init.silver_core_io__ON__silver_core_IOVal); // demand the io token
-			System.exit( (Integer)drv.synthesized(silver.core.Init.silver_core_iovalue__ON__silver_core_IOVal) );
-		} catch(Throwable t) {
-			Throwable rt = common.exceptions.SilverException.getRootCause(t);
-			if(rt instanceof common.exceptions.SilverExit)
-				System.exit(((common.exceptions.SilverExit)rt).getExitCode());
-			common.Util.printStackCauses(t);
-		}
-	}
-	public static common.ConsCell cvargs(String[] args) {
-		common.ConsCell result = common.ConsCell.nil;
-		for(int i = args.length - 1; i >= 0; i--) {
-			result = new common.ConsCell(new common.StringCatter(args[i]), result);
-		}
-		return result;
-	}
-}""";
-}
-

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -33,10 +33,14 @@ top::AGDcl ::= 'fun' id::Name ns::FunctionSignature '=' e::Expr ';'
     appTypes(
       functionType(1, []),
         [appType(listCtrType(), stringType()),
-          appType(nonterminalType("silver:core:IO", [starKind()], false, false), decoratedType(freshType(), freshInhSet()))]);
+          appType(nonterminalType("silver:core:IO", [starKind()], false, false), freshType())]);
+  nondecorated local codeProberParseResType::Type = head(namedSig.outputElement.typerep.argTypes);
+  local codeProberParseValidType::Boolean =
+	!unify(namedSig.typerep, codeProberParseType).failure &&
+	(codeProberParseResType.isDecorated || codeProberParseResType.isData);
   top.errors <-
-    if id.name == "codeProberParse" && unify(namedSig.typerep, codeProberParseType).failure
-	  then [errFromOrigin(top, "codeProberParse function must have type signature (IO<Decorated a> ::= [String]). Instead it has type " ++ prettyType(namedSig.typerep))]
+    if id.name == "codeProberParse" && !codeProberParseValidType
+	  then [errFromOrigin(top, "codeProberParse function must have type signature (IO<a> ::= [String]), where a is Decorated or a data nonterminal. Instead it has type " ++ prettyType(namedSig.typerep))]
 	  else [];
 }
 

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -137,7 +137,7 @@ ${whatSig.childDecls}
 ${contexts.contextMemberDeclTrans}
 
 	@Override
-	public String getChildName(final int index) {
+	public String getNameOfChild(final int index) {
 		switch(index) {
 ${implode("", map(makeChildNameCase, whatSig.inputElements))}
             default: return null;

--- a/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/FunctionDcl.sv
@@ -137,6 +137,14 @@ ${whatSig.childDecls}
 ${contexts.contextMemberDeclTrans}
 
 	@Override
+	public String getChildName(final int index) {
+		switch(index) {
+${implode("", map(makeChildNameCase, whatSig.inputElements))}
+            default: return null;
+        }
+    }
+
+	@Override
 	public boolean isChildDecorable(final int index) {
 		switch(index) {
 ${implode("", map(makeChildDecorableCase(env, _), whatSig.inputElements))}

--- a/grammars/silver/compiler/translation/java/core/NamedSignature.sv
+++ b/grammars/silver/compiler/translation/java/core/NamedSignature.sv
@@ -316,6 +316,11 @@ String ::= n::NamedSignatureElement
 {
   return s"\t\t\tcase i_${n.elementName}: return child_${n.elementName};\n";
 }
+function makeChildNameCase
+String ::= n::NamedSignatureElement
+{
+  return s"\t\t\tcase i_${n.elementName}: return \"${n.elementName}\";\n";
+}
 function makeChildDecorableCase
 String ::= env::Env n::NamedSignatureElement
 {

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -41,6 +41,8 @@ public abstract class ${className} extends ${if quals.data then "common.DataNode
 	public static final String[] occurs_inh = new String[num_inh_attrs];
 	public static final String[] occurs_syn = new String[num_syn_attrs];
 
+	public static final common.TransOccursInfo[] occurs_trans = new common.TransOccursInfo[num_syn_attrs];
+
 	public static final common.Lazy[] defaultSynthesizedAttributes = new common.Lazy[num_syn_attrs];
 
 	protected ${className}(${implode(", ",
@@ -72,6 +74,11 @@ ${implode("", map((.annoDeclElem), myAnnos))}
 	@Override
 	public final int getNumberOfSynAttrs() {
 		return num_syn_attrs;
+	}
+
+	@Override
+	public final common.TransOccursInfo getTransOccurs(final int index) {
+		return occurs_trans[index];
 	}
 
 	@Override

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -140,6 +140,11 @@ ${if quals.data then "" else s"""
 		}
 
 		@Override
+		public String getChildName(final int child) {
+			return ref.getNode().getChildName(child);
+		}
+
+		@Override
 		public boolean isChildDecorable(final int child) {
 			return ref.getNode().isChildDecorable(child);
 		}

--- a/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/NonTerminalDcl.sv
@@ -147,8 +147,8 @@ ${if quals.data then "" else s"""
 		}
 
 		@Override
-		public String getChildName(final int child) {
-			return ref.getNode().getChildName(child);
+		public String getNameOfChild(final int child) {
+			return ref.getNode().getNameOfChild(child);
 		}
 
 		@Override

--- a/grammars/silver/compiler/translation/java/core/OccursDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/OccursDcl.sv
@@ -33,6 +33,11 @@ top::AGDcl ::= at::QName attl::BracketedOptTypeExprs nt::QName nttl::BracketedOp
       s"public static final int ${head(occursCheck).attrOccursIndexName}_dec_site = ${makeName(ntgrammar)}.Init.count_inh__ON__${ntname}++;\n" ++
       s"public static final int ${head(occursCheck).attrOccursIndexName}_inhs = ${makeName(ntgrammar)}.Init.count_inh__ON__${ntname}++;\n"
     else "";
+  top.setupInh <-
+    if at.lookupAttribute.dcl.isTranslation then
+      s"\t\t${makeNTName(ntfn)}.occurs_trans[${head(occursCheck).attrGlobalOccursInitIndex}] = " ++
+      s"new common.TransOccursInfo(${head(occursCheck).attrOccursIndexName}_inhs, ${head(occursCheck).attrOccursIndexName}_dec_site);\n"
+    else "";
 }
 
 aspect production errorAttributionDcl

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -146,6 +146,14 @@ ${contexts.contextMemberDeclTrans}
     }
 
 	@Override
+	public String getChildName(final int index) {
+		switch(index) {
+${implode("", map(makeChildNameCase, namedSig.inputElements))}
+            default: return null;
+        }
+    }
+
+	@Override
 	public boolean isChildDecorable(final int index) {
 		switch(index) {
 ${implode("", map(makeChildDecorableCase(body.env, _), namedSig.inputElements))}

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -146,7 +146,7 @@ ${contexts.contextMemberDeclTrans}
     }
 
 	@Override
-	public String getChildName(final int index) {
+	public String getNameOfChild(final int index) {
 		switch(index) {
 ${implode("", map(makeChildNameCase, namedSig.inputElements))}
             default: return null;

--- a/grammars/silver/compiler/translation/java/core/RootSpec.sv
+++ b/grammars/silver/compiler/translation/java/core/RootSpec.sv
@@ -26,9 +26,12 @@ top::RootSpec ::= g::Grammar  _ _ _ _ _
     ("Silver.svi", serInterface)
   ];
 
-  top.genFiles := g.genFiles ++
-  [("Init.java", s"""
-package ${makeName(g.declaredName)};
+  top.genFiles := g.genFiles;
+
+  local package::String = makeName(g.declaredName);
+
+  top.genFiles <- [("Init.java", s"""
+package ${package};
 
 public class Init{
 	private static boolean preInit = false;
@@ -70,6 +73,78 @@ ${g.valueWeaving}
 ${g.initValues}
 }
 """)];
+
+  local hasMain::Boolean = !null(getValueDcl("main", g.env));
+  local isIOValReturn::Boolean =
+	case getValueDcl("main", g.env) of
+	| dcl :: _ -> dcl.typeScheme.typerep.outputType.typeName == "silver:core:IOVal"
+	| _ -> false
+	end;
+
+  -- Code used if main function return type is IOVal<Integer>
+  local invocationIOVal::String = package ++ 
+    ".Pmain.invoke(common.OriginContext.ENTRY_CONTEXT, cvargs(args), common.IOToken.singleton)";
+	
+  -- Code used if main function return type is IO<Integer>
+  local invocationEvalIO::String = 
+    "silver.core.PevalIO.invoke(common.OriginContext.ENTRY_CONTEXT, " ++ package ++ 
+    ".Pmain.invoke(common.OriginContext.ENTRY_CONTEXT, cvargs(args)), common.IOToken.singleton)";
+
+  local mainFunctionBody::String = 
+    if hasMain
+	  then s"""
+		common.Util.init();
+		${package}.Init.initAllStatics();
+		${package}.Init.init();
+		${package}.Init.postInit();
+
+		try {
+			silver.core.NIOVal rv = ${if isIOValReturn then invocationIOVal else invocationEvalIO};
+			rv.synthesized(silver.core.Init.silver_core_io__ON__silver_core_IOVal); // demand the io token
+			System.exit( (Integer)rv.synthesized(silver.core.Init.silver_core_iovalue__ON__silver_core_IOVal) );
+		} catch(Throwable t) {
+			Throwable rt = common.exceptions.SilverException.getRootCause(t);
+			if(rt instanceof common.exceptions.SilverExit)
+				System.exit(((common.exceptions.SilverExit)rt).getExitCode());
+			common.Util.printStackCauses(t);
+		}"""
+	  else s"""
+		System.err.println("No main function defined in main grammar ${g.declaredName}");
+		System.exit(1);""";
+
+  local hasCodeProberParse::Boolean = !null(getValueDcl("codeProberParse", g.env));
+
+  local codeProberParseFn::String =
+	if hasCodeProberParse then s"""
+	public static common.DecoratedNode CodeProber_parse(String[] args) {
+		common.Util.init();
+		${package}.Init.initAllStatics();
+		${package}.Init.init();
+		${package}.Init.postInit();
+
+		silver.core.NIOVal rv = silver.core.PevalIO.invoke(common.OriginContext.ENTRY_CONTEXT, ${package}.PcodeProberParse.invoke(common.OriginContext.ENTRY_CONTEXT, cvargs(args)), common.IOToken.singleton);
+		rv.synthesized(silver.core.Init.silver_core_io__ON__silver_core_IOVal); // demand the io token
+		return rv.synthesized(silver.core.Init.silver_core_iovalue__ON__silver_core_IOVal);
+	}""" else "";
+
+  top.genFiles <- if hasMain || hasCodeProberParse then [("Main.java", s"""
+package ${package};
+
+import silver.core.*;
+
+public class Main {
+	public static void main(String[] args) {
+${mainFunctionBody}
+	}
+${codeProberParseFn}
+	public static common.ConsCell cvargs(String[] args) {
+		common.ConsCell result = common.ConsCell.nil;
+		for(int i = args.length - 1; i >= 0; i--) {
+			result = new common.ConsCell(new common.StringCatter(args[i]), result);
+		}
+		return result;
+	}
+}""")] else [];
 }
 
 fun makeOthers String ::= others::[String] nme::String =

--- a/grammars/silver/compiler/translation/java/core/RootSpec.sv
+++ b/grammars/silver/compiler/translation/java/core/RootSpec.sv
@@ -117,6 +117,7 @@ ${g.initValues}
   local codeProberParseFn::String =
 	if hasCodeProberParse then s"""
 	public static common.DecoratedNode CodeProber_parse(String[] args) {
+		common.DecoratedNode.setCprMainFilePath(args[args.length - 1]);
 		common.Util.init();
 		${package}.Init.initAllStatics();
 		${package}.Init.init();

--- a/grammars/silver/compiler/translation/java/core/RootSpec.sv
+++ b/grammars/silver/compiler/translation/java/core/RootSpec.sv
@@ -117,6 +117,7 @@ ${g.initValues}
   local codeProberParseFn::String =
 	if hasCodeProberParse then s"""
 	public static common.DecoratedNode CodeProber_parse(String[] args) {
+		System.setProperty("cpr.type_identification_style", "NODE_LABEL");
 		common.DecoratedNode.setCprMainFilePath(args[args.length - 1]);
 		common.Util.init();
 		${package}.Init.initAllStatics();

--- a/grammars/silver/compiler/translation/java/core/RootSpec.sv
+++ b/grammars/silver/compiler/translation/java/core/RootSpec.sv
@@ -113,6 +113,8 @@ ${g.initValues}
 		System.exit(1);""";
 
   local hasCodeProberParse::Boolean = !null(getValueDcl("codeProberParse", g.env));
+  local isCodeProberParseRetData::Boolean =
+    head(head(getValueDcl("codeProberParse", g.env)).typeScheme.typerep.outputType.argTypes).isData;
 
   local codeProberParseFn::String =
 	if hasCodeProberParse then s"""
@@ -126,7 +128,10 @@ ${g.initValues}
 
 		silver.core.NIOVal rv = silver.core.PevalIO.invoke(common.OriginContext.ENTRY_CONTEXT, ${package}.PcodeProberParse.invoke(common.OriginContext.ENTRY_CONTEXT, cvargs(args)), common.IOToken.singleton);
 		rv.synthesized(silver.core.Init.silver_core_io__ON__silver_core_IOVal); // demand the io token
-		return rv.synthesized(silver.core.Init.silver_core_iovalue__ON__silver_core_IOVal);
+		return ${
+		  if isCodeProberParseRetData
+		  then "((common.DataNode)rv.synthesized(silver.core.Init.silver_core_iovalue__ON__silver_core_IOVal)).decorate()"
+		  else "rv.synthesized(silver.core.Init.silver_core_iovalue__ON__silver_core_IOVal)"};
 	}""" else "";
 
   top.genFiles <- if hasMain || hasCodeProberParse then [("Main.java", s"""

--- a/grammars/silver/core/CodeProber.sv
+++ b/grammars/silver/core/CodeProber.sv
@@ -1,0 +1,13 @@
+grammar silver:core;
+
+-- Mark this tree and its children as being in the main file or an external file for CodeProber.
+fun setTreeIsInMainFile IO<Unit> ::= b::Boolean x::a =
+  stateIOUnit(setTreeIsInMainFileT(b, x, _));
+
+function setTreeIsInMainFileT
+IOToken ::= b::Boolean x::a i::IOToken
+{
+  return error("foreign function");
+} foreign {
+  "java" : return "%i%.setTreeIsInMainFile(%x%, %b%)";
+}

--- a/runtime/java/src/common/CodeProberDiagnostic.java
+++ b/runtime/java/src/common/CodeProberDiagnostic.java
@@ -1,0 +1,52 @@
+package common;
+
+import silver.core.NLocation;
+import common.javainterop.ConsCellCollection;
+
+/**
+ * Representation of silver:langutil:Message values when returned to CodeProber.
+ */
+public class CodeProberDiagnostic {
+    private final String humanReadable;
+    private final String diagnostic;
+    private CodeProberDiagnostic(String humanReadable, String diagnostic) {
+      this.humanReadable = humanReadable;
+      this.diagnostic = diagnostic;
+    }
+
+    public String cpr_getOutput() { return humanReadable; }
+    public String cpr_getDiagnostic() { return diagnostic; }
+
+    public static CodeProberDiagnostic fromMessage(DataNode msg) {
+        NLocation where = null;
+        String output = null;
+        String noLocOutput = null;
+        int severity = -1;
+        for(int i = 0; i < msg.getNumberOfSynAttrs(); i++) {
+            switch(msg.getNameOfSynAttr(i)) {
+            case "silver:langutil:where":
+                where = (NLocation) msg.synthesized(i); break;
+            case "silver:langutil:output":
+                output = (String) msg.synthesized(i).toString(); break;
+            case "silver:langutil:noLocOutput":
+                noLocOutput = (String) msg.synthesized(i).toString(); break;
+            case "silver:langutil:severity":
+                severity = (Integer) msg.synthesized(i); break;
+            }
+        }
+        int line = where.synthesized(silver.core.Init.silver_core_line__ON__silver_core_Location);
+        int column = where.synthesized(silver.core.Init.silver_core_column__ON__silver_core_Location);
+        int endLine = where.synthesized(silver.core.Init.silver_core_endLine__ON__silver_core_Location);
+        int endColumn = where.synthesized(silver.core.Init.silver_core_endColumn__ON__silver_core_Location);
+        String sevString = severity == 0? "INFO" : severity == 1? "WARN" : severity == 2? "ERR" : "HINT";
+        return new CodeProberDiagnostic(
+            output,
+            String.format("%s@%d;%d;%s", sevString, (line << 12) + column, (endLine << 12) + endColumn, noLocOutput)
+        );
+    }
+    public static java.util.List<CodeProberDiagnostic> fromMessageList(ConsCell msgs) {
+        return new ConsCellCollection<>(msgs).stream()
+            .map(m -> fromMessage((DataNode)m))
+            .collect(java.util.stream.Collectors.toList());
+    }
+}

--- a/runtime/java/src/common/CodeProberDiagnostic.java
+++ b/runtime/java/src/common/CodeProberDiagnostic.java
@@ -5,6 +5,8 @@ import common.javainterop.ConsCellCollection;
 
 /**
  * Representation of silver:langutil:Message values when returned to CodeProber.
+ * 
+ * @author krame505
  */
 public class CodeProberDiagnostic {
     private final String humanReadable;

--- a/runtime/java/src/common/DataNode.java
+++ b/runtime/java/src/common/DataNode.java
@@ -53,7 +53,7 @@ public abstract class DataNode extends Node {
 	 * We might still need to produce a DecoratedNode in polymorphic contexts with synthesized occurs-on constraints.
 	 * 
 	 * @param inhs The inherited attributes supplied, should always be null.
-	 * @param transInhs The inherited attributes supplied on translation attributes, should always be null.
+	 * @param decSite The decoration site site where this tree is shared, should always be null.
 	 * @return The "decorated" form of this DataNode.
 	 */
 	@Override

--- a/runtime/java/src/common/Decorable.java
+++ b/runtime/java/src/common/Decorable.java
@@ -37,7 +37,7 @@ public interface Decorable {
 		final boolean prodFwrd);
 
 	/**
-	 * A convenience method unused by generate Silver code, but useful when working with
+	 * A convenience method unused by generated Silver code, but useful when working with
 	 * the Silver runtime from Java.
 	 * 
 	 * @return  A node decorated with no inherited attributes, without a parent.

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -628,6 +628,22 @@ public class DecoratedNode implements Decorable, Typed {
 	}
 
 	/**
+	 * Evaluate an attribute that may be either synthesized or translation.
+	 * This is only used for debugging.
+	 * 
+	 * @param attribute The index of the attribute to evaluate.
+	 * @return The value of the attribute.
+	 */
+	public Object synthesizedOrTranslation(final int attribute) {
+		TransOccursInfo transOccurs = self.getTransOccurs(attribute);
+		if(transOccurs == null) {
+			return synthesized(attribute);
+		} else {
+			return translation(attribute, transOccurs.inhsAttribute, transOccurs.decSiteAttribute);
+		}
+	}
+
+	/**
 	 * Get the forwarded-to DecoratedNode.  Cached.  There is no need for an "AsIs" vs "Decorated"
 	 * variant of this function, since we always know it's a Node.
 	 * 
@@ -1052,7 +1068,7 @@ public class DecoratedNode implements Decorable, Typed {
 		}
 		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
 			if (propName.equals(self.getNameOfSynAttr(i))) {
-				return makeCprInvokeResult(synthesized(i));
+				return makeCprInvokeResult(synthesizedOrTranslation(i));
 			}
 		}
 		String[] annoNames = self.getAnnoNames();

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -1044,20 +1044,25 @@ public class DecoratedNode implements Decorable, Typed {
 		return properties;
 	}
 
-	public List<String> cpr_extraAstReferences() {
-		List<String> properties = new ArrayList<>();
-		// Only display the forward and translation attributes in the tree view
-		if(self.hasForward()) {
-			properties.add("l:forward");
-		}
-		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
-			if(self.getTransOccurs(i) != null) {
-				properties.add("l:" + self.getNameOfSynAttr(i));
-			}
-		}
-		return properties;
-
-	}
+	// Can show the forward/prod/translation attrs in rendered trees.
+	// Disabled for now as this makes the trees larger and hard to read.
+	// public List<String> cpr_extraAstReferences() {
+	// 	List<String> properties = new ArrayList<>();
+	// 	if(self.hasForward()) {
+	// 		properties.add("l:forward");
+	// 	}
+	// 	for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
+	// 		if(self.getTransOccurs(i) != null) {
+	// 			properties.add("l:" + self.getNameOfSynAttr(i));
+	// 		}
+	// 	}
+	// 	for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
+	// 		if(self.isLocalDecorable(i)) {
+	// 			properties.add("l:" + self.getNameOfLocalAttr(i));
+	// 		}
+	// 	}
+	// 	return properties;
+	// }
 
 	public String cpr_lGetChildName(String name) {
 		for(int i = 0; i < self.getNumberOfChildren(); i++) {

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -1044,6 +1044,21 @@ public class DecoratedNode implements Decorable, Typed {
 		return properties;
 	}
 
+	public List<String> cpr_extraAstReferences() {
+		List<String> properties = new ArrayList<>();
+		// Only display the forward and translation attributes in the tree view
+		if(self.hasForward()) {
+			properties.add("l:forward");
+		}
+		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
+			if(self.getTransOccurs(i) != null) {
+				properties.add("l:" + self.getNameOfSynAttr(i));
+			}
+		}
+		return properties;
+
+	}
+
 	public String cpr_lGetChildName(String name) {
 		for(int i = 0; i < self.getNumberOfChildren(); i++) {
 			if (name.equals(self.getNameOfChild(i))) {

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -1027,7 +1027,10 @@ public class DecoratedNode implements Decorable, Typed {
 			properties.add("l:" + self.getNameOfSynAttr(i));
 		}
 		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
+			// Ignore auxillary inhs for translation attributes
+			if(self.getNameOfInhAttr(i) != null) {
 			properties.add("l:" + self.getNameOfInhAttr(i));
+			}
 		}
 		String[] annoNames = self.getAnnoNames();
 		for(int i = 0; i < annoNames.length; i++) {
@@ -1051,9 +1054,11 @@ public class DecoratedNode implements Decorable, Typed {
 				return getSourceFileName(self.getLocal(i));
 			}
 		}
+		if(inheritedAttributes != null) {
 		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
 			if (propName.equals(self.getNameOfInhAttr(i))) {
 				return getSourceFileName(inheritedAttributes[i]);
+				}
 			}
 		}
 		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -984,6 +984,28 @@ public class DecoratedNode implements Decorable, Typed {
 		String fullName = self.getName();
 		return fullName.substring(fullName.lastIndexOf(':') + 1);
 	}
+
+	public String cpr_astLabel() {
+		String pp = findPPOrUnparse();
+		if(pp == null) return null;
+		if(pp.length() > 20) {
+			pp = pp.substring(0, 17) + "...";
+		}
+		return pp;
+	}
+	private String findPPOrUnparse() {
+		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
+			if(self.getNameOfSynAttr(i).equals("silver:langutil:pp")) {
+				return Util.showDoc(synthesized(i), 80).toString();
+			}
+		}
+		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
+			if(self.getNameOfSynAttr(i).equals("silver:langutil:unparse")) {
+				return synthesized(i).toString();
+			}
+		}
+		return null;
+	}
   
 	public List<String> cpr_propertyListShow() {
 		List<String> properties = new ArrayList<>();
@@ -1013,7 +1035,16 @@ public class DecoratedNode implements Decorable, Typed {
 		}
 		return properties;
 	}
-  
+
+	public String cpr_lGetChildName(String name) {
+		for(int i = 0; i < self.getNumberOfChildren(); i++) {
+			if (name.equals(self.getChildName(i))) {
+				return self.getChildName(i);
+			}
+		}
+		return null;
+	}
+
 	public String cpr_lGetAspectName(String propName) {
 		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
 			if (propName.equals(self.getNameOfLocalAttr(i))) {
@@ -1090,7 +1121,7 @@ public class DecoratedNode implements Decorable, Typed {
 		// Render Document values as strings.
 		// This (annoyingly) must be done with reflection to avoid depending on silver:langutil.
 		if(o.getClass().getSuperclass().getName().equals("silver.langutil.pp.NDocument") ) {
-			return Util.showDoc(o).toString();
+			return Util.showDoc(o, 80).toString();
 		}
 		return Util.genericShow(o).toString();
 	}

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -908,12 +908,21 @@ public class DecoratedNode implements Decorable, Typed {
 		return parent;
 	}
   
+	static private String cprMainFilePath = null;
+	public static void setCprMainFilePath(String path) {
+		cprMainFilePath = path;
+	}
+
 	private boolean hasLocs = false;
-	private int startLine = -1, startColumn = -1, endLine = -1, endColumn = -1;
+	private boolean isExternal = false;
+	private int startLine = 0, startColumn = 0, endLine = 0, endColumn = 0;
 	private final void determineLocs() {
 		if (hasLocs) return; // Only determine once.
 		hasLocs = true;
 		silver.core.NLocation loc = null;
+		if(cprMainFilePath == null) {
+			throw new SilverInternalError("Code Prober main file path not set!");
+		}
 		if(self != null) {
 			if(self instanceof silver.core.Alocation) {
 				loc = ((silver.core.Alocation)self).getAnno_silver_core_location();
@@ -925,71 +934,137 @@ public class DecoratedNode implements Decorable, Typed {
 			}
 		}
 		if(loc != null) {
-			startLine = loc.synthesized(silver.core.Init.silver_core_line__ON__silver_core_Location);
-			startColumn = loc.synthesized(silver.core.Init.silver_core_column__ON__silver_core_Location);
-			endLine = loc.synthesized(silver.core.Init.silver_core_endLine__ON__silver_core_Location);
-			endColumn = loc.synthesized(silver.core.Init.silver_core_endColumn__ON__silver_core_Location);
-
-			// Code Prober expects the start/end ranges of a parent node to include the ranges of its children.
-			// Sometimes, the locations reported by origin tracking do not respect this,
-			// so we have to manually adjust the start and end lines/columns.
-			if(getNumChild() > 0) {
-				DecoratedNode firstChild = getChild(0);
-				firstChild.determineLocs();
-				if(startLine > firstChild.startLine) {
-					startLine = firstChild.startLine;
-					startColumn = firstChild.startColumn;
-				} else if(startLine == firstChild.startLine &&
-						startColumn > firstChild.startColumn) {
-					startColumn = firstChild.startColumn;
+			String fileName = loc.synthesized(silver.core.Init.silver_core_filename__ON__silver_core_Location).toString();
+			if(fileName.equals(cprMainFilePath)) {
+				startLine = loc.synthesized(silver.core.Init.silver_core_line__ON__silver_core_Location);
+				startColumn = loc.synthesized(silver.core.Init.silver_core_column__ON__silver_core_Location);
+				endLine = loc.synthesized(silver.core.Init.silver_core_endLine__ON__silver_core_Location);
+				endColumn = loc.synthesized(silver.core.Init.silver_core_endColumn__ON__silver_core_Location);
+	
+				// Code Prober expects the start/end ranges of a parent node to include the ranges of its children.
+				// Sometimes, the locations reported by origin tracking do not respect this,
+				// so we have to manually adjust the start and end lines/columns.
+				if(getNumChild() > 0) {
+					DecoratedNode firstChild = getChild(0);
+					firstChild.determineLocs();
+					if(startLine > firstChild.startLine) {
+						startLine = firstChild.startLine;
+						startColumn = firstChild.startColumn;
+					} else if(startLine == firstChild.startLine &&
+							startColumn > firstChild.startColumn) {
+						startColumn = firstChild.startColumn;
+					}
+					DecoratedNode lastChild = getChild(getNumChild() - 1);
+					lastChild.determineLocs();
+					if(endLine < lastChild.endLine) {
+						endLine = lastChild.endLine;
+						endColumn = lastChild.endColumn;
+					} else if(endLine == lastChild.endLine &&
+							endColumn < lastChild.endColumn) {
+						endColumn = lastChild.endColumn;
+					}
 				}
-				DecoratedNode lastChild = getChild(getNumChild() - 1);
-				lastChild.determineLocs();
-				if(endLine < lastChild.endLine) {
-					endLine = lastChild.endLine;
-					endColumn = lastChild.endColumn;
-				} else if(endLine == lastChild.endLine &&
-						endColumn < lastChild.endColumn) {
-					endColumn = lastChild.endColumn;
-				}
+			} else {
+				isExternal = true;
 			}
 		}
 	}
+	public boolean cpr_isInsideExternalFile() { determineLocs(); return isExternal; }
 	public int cpr_getStartLine() { determineLocs(); return startLine; }
 	public int cpr_getStartColumn() { determineLocs(); return startColumn; }
 	public int cpr_getEndLine() { determineLocs(); return endLine; }
 	public int cpr_getEndColumn() { determineLocs(); return endColumn; }
 
+	public boolean cpr_nodeListVisible() {
+		// Hide nodes from external files when creating a probe
+		determineLocs();
+		return !isExternal;
+	}
+
 	public String cpr_nodeLabel() {
-		return self.getName();
+		String fullName = self.getName();
+		return fullName.substring(fullName.lastIndexOf(':') + 1);
 	}
   
 	public List<String> cpr_propertyListShow() {
 		List<String> properties = new ArrayList<>();
+		properties.add("l:grammar");
 		properties.add("l:show");
-		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
-			properties.add("l:" + self.getNameOfInhAttr(i));
+		if(self.hasForward()) {
+			properties.add("l:forward");
+		}
+		if(forwardParent != null) {
+			properties.add("l:forwardParent");
 		}
 		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
 			properties.add("l:" + self.getNameOfSynAttr(i));
+		}
+		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
+			properties.add("l:" + self.getNameOfInhAttr(i));
+		}
+		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
+			properties.add("l:" + self.getNameOfLocalAttr(i));
 		}
 		return properties;
 	}
 
 	public Object cpr_lInvoke(String propName) {
+		if (propName.equals("grammar")) {
+			String fullName = self.getName();
+			return fullName.substring(0, fullName.lastIndexOf(':'));
+		}
 		if (propName.equals("show")) {
-			return Util.genericShow(this);
+			return Util.genericShow(self);
+		}
+		if (propName.equals("forward")) {
+			return Util.makeCprInvokeResult(forward());
+		}
+		if (propName.equals("forwardParent")) {
+			return Util.makeCprInvokeResult(forwardParent);
 		}
 		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
 			if (propName.equals(self.getNameOfInhAttr(i))) {
-				return Util.genericShow(inherited(i));
+				return Util.makeCprInvokeResult(inherited(i));
 			}
 		}
 		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
 			if (propName.equals(self.getNameOfSynAttr(i))) {
-				return Util.genericShow(synthesized(i));
+				return Util.makeCprInvokeResult(synthesized(i));
+			}
+		}
+		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
+			if (propName.equals(self.getNameOfLocalAttr(i))) {
+				return Util.makeCprInvokeResult(local(i));
 			}
 		}
 		throw new SilverInternalError("Unknown property '" + propName + "' for " + getDebugID());
+	}
+
+	public Object[] cpr_describeParentConnection() {
+		String parentPropertyName = determineParentPropertyName();
+		System.err.println("DEBUG: " + getDebugID() + " parent property name: " + parentPropertyName);
+		if (parentPropertyName == null) {
+			return null;
+		} else {
+			return new Object[] { "l:" + parentPropertyName };
+		}
+	}
+	private String determineParentPropertyName() {
+		if(isProdForward) {
+			return "forward";
+		}
+		for(int i = 0; i < parent.self.getNumberOfLocalAttrs(); i++) {
+			if (this == parent.localValues[i]) {
+				return parent.self.getNameOfLocalAttr(i);
+			}
+		}
+		// Translation attributes
+		for(int i = 0; i < parent.self.getNumberOfSynAttrs(); i++) {
+			if (this == parent.synthesizedValues[i]) {
+				return parent.self.getNameOfSynAttr(i);
+			}
+		}
+		// TODO: Anonymous decoration sites?
+		return null;
 	}
 }

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -1018,7 +1018,7 @@ public class DecoratedNode implements Decorable, Typed {
 			properties.add("l:forwardParent");
 		}
 		for(int i = 0; i < self.getNumberOfChildren(); i++) {
-			properties.add("l:" + self.getChildName(i));
+			properties.add("l:" + self.getNameOfChild(i));
 		}
 		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
 			properties.add("l:" + self.getNameOfLocalAttr(i));
@@ -1041,8 +1041,8 @@ public class DecoratedNode implements Decorable, Typed {
 
 	public String cpr_lGetChildName(String name) {
 		for(int i = 0; i < self.getNumberOfChildren(); i++) {
-			if (name.equals(self.getChildName(i))) {
-				return self.getChildName(i);
+			if (name.equals(self.getNameOfChild(i))) {
+				return self.getNameOfChild(i);
 			}
 		}
 		return null;
@@ -1088,7 +1088,7 @@ public class DecoratedNode implements Decorable, Typed {
 			return makeCprInvokeResult(forwardParent);
 		}
 		for(int i = 0; i < self.getNumberOfChildren(); i++) {
-			if (propName.equals(self.getChildName(i))) {
+			if (propName.equals(self.getNameOfChild(i))) {
 				return makeCprInvokeResult(child(i));
 			}
 		}
@@ -1148,7 +1148,7 @@ public class DecoratedNode implements Decorable, Typed {
 		}
 		for(int i = 0; i < parent.self.getNumberOfChildren(); i++) {
 			if(this == parent.childrenValues[i]) {
-				return self.getChildName(i);
+				return self.getNameOfChild(i);
 			}
 		}
 		for(int i = 0; i < parent.self.getNumberOfLocalAttrs(); i++) {

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -51,10 +51,11 @@ public class DecoratedNode implements Decorable, Typed {
 	 * 
 	 * <p> May be actual parent. Or production this is a local in. Or just a production that
 	 * called 'decorate' to create this one.
+	 * Effectively final, except it may be overridden by the CodeProber interface for data nonterminals.
 	 * 
 	 * @see TopNode
 	 */
-	protected final DecoratedNode parent;
+	protected DecoratedNode parent;
 	/**
 	 * Is this the forward for the production of forwardParent?
 	 * This is true for normal forwarding, where there will be syn copy equations,
@@ -887,22 +888,53 @@ public class DecoratedNode implements Decorable, Typed {
 	// Code Prober interface methods.
 	// These have certain names and signatures that Code Prober expects to call reflectively;
 	// otherwise these methods should not be used directly.
+
+	// Children that should appear in the Code Prober tree view.
+	// Currently, just decorable and data nonterminal children.
 	public int getNumChild() {
 		int res = 0;
 		for (int i = 0; i < self.getNumberOfChildren(); i++) {
-			if (self.isChildDecorable(i)) res++;
+			if (isChildTree(i)) res++;
 		}
 		return res;
 	}
 	public DecoratedNode getChild(int idx) {
 		int i = 0;
-		while (!self.isChildDecorable(i)) i++;
+		while (!isChildTree(i)) i++;
 		for (int j = 0; j < idx; j++) {
 			i++;
-			while (!self.isChildDecorable(i)) i++;
+			while (!isChildTree(i)) i++;
 		}
-		return childDecorated(i);
+		if (self.getChild(i) instanceof DataNode) {
+			return decorateDataNode((DataNode)self.getChild(i));
+		} else {
+			return childDecorated(i);
+		}
 	}
+
+	private boolean isChildTree(int idx) {
+		if(self.isChildDecorable(idx)) return true;
+		Object o = self.getChild(idx);
+		if(o instanceof DataNode) {
+			// For nodes with locations, only include data nonterminal children if they have locations,
+			// to avoid polluting node selection with lost of locationless nodes.
+			if(self instanceof silver.core.Alocation || self instanceof Tracked) {
+				return o instanceof silver.core.Alocation || o instanceof Tracked;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	// Data nonterminal trees have TopNode as their parent in the AST,
+	// however we need a proper parent for CodeProber to create a node locator.
+	// So here we override the parent of the tree to be the first tree that demands it.
+	private DecoratedNode decorateDataNode(DataNode d) {
+		DecoratedNode dn = d.decorate();
+		if(dn.parent == TopNode.singleton) dn.parent = this;
+		return dn;
+	}
+
 	public DecoratedNode getParent() {
 		if (parent instanceof TopNode || parent.self instanceof FunctionNode) {
 			return null;
@@ -1143,7 +1175,7 @@ public class DecoratedNode implements Decorable, Typed {
 	/**
 	* Turn the value of an attribute into a value understood by Code Prober.
 	*/
-	private static Object makeCprInvokeResult(Object o) {
+	private Object makeCprInvokeResult(Object o) {
 		// Decorated trees that have a fixed relationship to their parent can be recursively explored.
 		if(o instanceof DecoratedNode && ((DecoratedNode)o).determineParentPropertyName() != null) {
 			return o;
@@ -1156,6 +1188,10 @@ public class DecoratedNode implements Decorable, Typed {
 		// Lists of silver:langutil:Message are converted to diagnostic objects understood by Code Prober.
 		if(o instanceof ConsCell && o != ConsCell.nil && ((ConsCell)o).head().getClass().getSuperclass().getName().equals("silver.langutil.NMessage")) {
 			return CodeProberDiagnostic.fromMessageList((ConsCell)o);
+		}
+		// Data nonterminal trees are explorable like decorated trees
+		if(o instanceof DataNode) {
+			return decorateDataNode((DataNode)o);
 		}
 		// By default, just stringify it.
 		return Util.genericShow(o).toString();
@@ -1187,6 +1223,35 @@ public class DecoratedNode implements Decorable, Typed {
 		for(int i = 0; i < parent.self.getNumberOfSynAttrs(); i++) {
 			if(this == parent.synthesizedValues[i]) {
 				return parent.self.getNameOfSynAttr(i);
+			}
+		}
+		// Data nonterminal trees may appear in any position where they were initially demanded
+		if (self instanceof DataNode) {
+			for(int i = 0; i < parent.self.getNumberOfChildren(); i++) {
+				if(self == parent.self.getChild(i)) {
+					return parent.self.getNameOfChild(i);
+				}
+			}
+			for(int i = 0; i < parent.self.getNumberOfLocalAttrs(); i++) {
+				if(self == parent.localValues[i]) {
+					return parent.self.getNameOfLocalAttr(i);
+				}
+			}
+			for(int i = 0; i < parent.self.getNumberOfInhAttrs(); i++) {
+				if(self == parent.inheritedValues[i]) {
+					return parent.self.getNameOfInhAttr(i);
+				}
+			}
+			for(int i = 0; i < parent.self.getNumberOfSynAttrs(); i++) {
+				if(self == parent.synthesizedValues[i]) {
+					return parent.self.getNameOfSynAttr(i);
+				}
+			}
+			String[] annoNames = self.getAnnoNames();
+			for(int i = 0; i < annoNames.length; i++) {
+				if (self == parent.self.getAnno(annoNames[i])) {
+					return annoNames[i];
+				}
 			}
 		}
 		// Our parent doesn't know about us, so we must have been anonymously decorated somewhere.

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -72,7 +72,7 @@ public class DecoratedNode implements Decorable, Typed {
 	 * 
 	 * @see #child(int)
 	 */
-	protected final Object[] childrenValues;
+	protected final DecoratedNode[] childrenValues;
 	/**
 	 * The cache of the forward node.
 	 * 
@@ -155,7 +155,7 @@ public class DecoratedNode implements Decorable, Typed {
 		}
 		
 		// create caches
-		this.childrenValues =    (cc > 0) ? new Object[cc] : null;
+		this.childrenValues =    (cc > 0) ? new DecoratedNode[cc] : null;
 		this.inheritedValues =   (ic > 0) ? new Object[ic] : null;
 		this.synthesizedValues = (sc > 0) ? new Object[sc] : null;
 		this.localValues =       (lc > 0) ? new Object[lc] : null;
@@ -182,7 +182,7 @@ public class DecoratedNode implements Decorable, Typed {
 		this.forwardParent = null;
 		this.isProdForward = false;
 		
-		this.childrenValues = new Object[cc];
+		this.childrenValues = new DecoratedNode[cc];
 		this.inheritedValues = null;
 		this.synthesizedValues = null;
 		this.localValues = (lc > 0) ? new Object[lc] : null;
@@ -338,7 +338,7 @@ public class DecoratedNode implements Decorable, Typed {
 	 * @return The decorated value of the child.
 	 */
 	public DecoratedNode childDecorated(final int child) {
-		Object o = this.childrenValues[child]; 
+		DecoratedNode o = this.childrenValues[child]; 
 		if(o == null) {
 			o = createDecoratedChild(child);
 			
@@ -347,7 +347,7 @@ public class DecoratedNode implements Decorable, Typed {
 			// CACHE : probably should not comment out child caching?
 			this.childrenValues[child] = o;
 		}
-		return (DecoratedNode)o;
+		return o;
 	}
 
 	/**

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -996,16 +996,43 @@ public class DecoratedNode implements Decorable, Typed {
 		if(forwardParent != null) {
 			properties.add("l:forwardParent");
 		}
+		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
+			properties.add("l:" + self.getNameOfLocalAttr(i));
+		}
 		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
 			properties.add("l:" + self.getNameOfSynAttr(i));
 		}
 		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
 			properties.add("l:" + self.getNameOfInhAttr(i));
 		}
-		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
-			properties.add("l:" + self.getNameOfLocalAttr(i));
+		String[] annoNames = self.getAnnoNames();
+		for(int i = 0; i < annoNames.length; i++) {
+			properties.add("l:" + annoNames[i]);
 		}
 		return properties;
+	}
+  
+	public String cpr_lGetAspectName(String propName) {
+		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
+			if (propName.equals(self.getNameOfLocalAttr(i))) {
+				return getSourceFileName(self.getLocal(i));
+			}
+		}
+		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
+			if (propName.equals(self.getNameOfInhAttr(i))) {
+				return getSourceFileName(inheritedAttributes[i]);
+			}
+		}
+		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
+			if (propName.equals(self.getNameOfSynAttr(i))) {
+				return getSourceFileName(self.getSynthesized(i));
+			}
+		}
+		return null;
+	}
+	private static String getSourceFileName(Lazy l) {
+		if(l == null) return null;
+		return l.getSourceLocation().synthesized(silver.core.Init.silver_core_filename__ON__silver_core_Location).toString();
 	}
 
 	public Object cpr_lInvoke(String propName) {
@@ -1017,32 +1044,52 @@ public class DecoratedNode implements Decorable, Typed {
 			return Util.genericShow(self);
 		}
 		if (propName.equals("forward")) {
-			return Util.makeCprInvokeResult(forward());
+			return makeCprInvokeResult(forward());
 		}
 		if (propName.equals("forwardParent")) {
-			return Util.makeCprInvokeResult(forwardParent);
+			return makeCprInvokeResult(forwardParent);
+		}
+		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
+			if (propName.equals(self.getNameOfLocalAttr(i))) {
+				return makeCprInvokeResult(local(i));
+			}
 		}
 		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
 			if (propName.equals(self.getNameOfInhAttr(i))) {
-				return Util.makeCprInvokeResult(inherited(i));
+				return makeCprInvokeResult(inherited(i));
 			}
 		}
 		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
 			if (propName.equals(self.getNameOfSynAttr(i))) {
-				return Util.makeCprInvokeResult(synthesized(i));
+				return makeCprInvokeResult(synthesized(i));
 			}
 		}
-		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
-			if (propName.equals(self.getNameOfLocalAttr(i))) {
-				return Util.makeCprInvokeResult(local(i));
+		String[] annoNames = self.getAnnoNames();
+		for(int i = 0; i < annoNames.length; i++) {
+			if (propName.equals(annoNames[i])) {
+				return makeCprInvokeResult(self.getAnno(annoNames[i]));
 			}
 		}
 		throw new SilverInternalError("Unknown property '" + propName + "' for " + getDebugID());
 	}
+	/**
+	* Turn the value of an attribute into a value that we can return to Code Prober.
+	* Currently, this just stringifies anything that is not another DecoratedNode.
+	*/
+	private static Object makeCprInvokeResult(Object o) {
+		if(o instanceof DecoratedNode && ((DecoratedNode)o).determineParentPropertyName() != null) {
+			return o;
+		}
+		// Render Document values as strings.
+		// This (annoyingly) must be done with reflection to avoid depending on silver:langutil.
+		if(o.getClass().getSuperclass().getName().equals("silver.langutil.pp.NDocument") ) {
+			return Util.showDoc(o).toString();
+		}
+		return Util.genericShow(o).toString();
+	}
 
 	public Object[] cpr_describeParentConnection() {
 		String parentPropertyName = determineParentPropertyName();
-		System.err.println("DEBUG: " + getDebugID() + " parent property name: " + parentPropertyName);
 		if (parentPropertyName == null) {
 			return null;
 		} else {
@@ -1064,7 +1111,7 @@ public class DecoratedNode implements Decorable, Typed {
 				return parent.self.getNameOfSynAttr(i);
 			}
 		}
-		// TODO: Anonymous decoration sites?
+		// Our parent doesn't know about us, so we must have been anonymously decorated somewhere.
 		return null;
 	}
 }

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -910,6 +910,8 @@ public class DecoratedNode implements Decorable, Typed {
 		return parent;
 	}
   
+	// This is set by the generated main class CodeProber_parse method,
+	// to determine if any extracted location is in the main file.
 	static private String cprMainFilePath = null;
 	public static void setCprMainFilePath(String path) {
 		cprMainFilePath = path;
@@ -1119,10 +1121,10 @@ public class DecoratedNode implements Decorable, Typed {
 		throw new SilverInternalError("Unknown property '" + propName + "' for " + getDebugID());
 	}
 	/**
-	* Turn the value of an attribute into a value that we can return to Code Prober.
-	* Currently, this just stringifies anything that is not another DecoratedNode.
+	* Turn the value of an attribute into a value understood by Code Prober.
 	*/
 	private static Object makeCprInvokeResult(Object o) {
+		// Decorated trees that have a fixed relationship to their parent can be recursively explored.
 		if(o instanceof DecoratedNode && ((DecoratedNode)o).determineParentPropertyName() != null) {
 			return o;
 		}
@@ -1131,9 +1133,11 @@ public class DecoratedNode implements Decorable, Typed {
 		if(o.getClass().getSuperclass().getName().equals("silver.langutil.pp.NDocument") ) {
 			return Util.showDoc(o, 80).toString();
 		}
+		// Lists of silver:langutil:Message are converted to diagnostic objects understood by Code Prober.
 		if(o instanceof ConsCell && o != ConsCell.nil && ((ConsCell)o).head().getClass().getSuperclass().getName().equals("silver.langutil.NMessage")) {
 			return CodeProberDiagnostic.fromMessageList((ConsCell)o);
 		}
+		// By default, just stringify it.
 		return Util.genericShow(o).toString();
 	}
 

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -939,32 +939,32 @@ public class DecoratedNode implements Decorable, Typed {
 				startColumn = loc.synthesized(silver.core.Init.silver_core_column__ON__silver_core_Location);
 				endLine = loc.synthesized(silver.core.Init.silver_core_endLine__ON__silver_core_Location);
 				endColumn = loc.synthesized(silver.core.Init.silver_core_endColumn__ON__silver_core_Location);
-	
-				// Code Prober expects the start/end ranges of a parent node to include the ranges of its children.
-				// Sometimes, the locations reported by origin tracking do not respect this,
-				// so we have to manually adjust the start and end lines/columns.
-				if(getNumChild() > 0) {
-					DecoratedNode firstChild = getChild(0);
-					firstChild.determineLocs();
-					if(startLine > firstChild.startLine) {
-						startLine = firstChild.startLine;
-						startColumn = firstChild.startColumn;
-					} else if(startLine == firstChild.startLine &&
-							startColumn > firstChild.startColumn) {
-						startColumn = firstChild.startColumn;
-					}
-					DecoratedNode lastChild = getChild(getNumChild() - 1);
-					lastChild.determineLocs();
-					if(endLine < lastChild.endLine) {
-						endLine = lastChild.endLine;
-						endColumn = lastChild.endColumn;
-					} else if(endLine == lastChild.endLine &&
-							endColumn < lastChild.endColumn) {
-						endColumn = lastChild.endColumn;
-					}
-				}
 			} else {
 				isExternal = true;
+			}
+
+			// Code Prober expects the start/end ranges of a parent node to include the ranges of its children.
+			// Sometimes, the locations reported by origin tracking do not respect this,
+			// so we have to manually adjust the start and end lines/columns.
+			if(getNumChild() > 0) {
+				DecoratedNode firstChild = getChild(0);
+				firstChild.determineLocs();
+				if(isExternal || startLine > firstChild.startLine) {
+					startLine = firstChild.startLine;
+					startColumn = firstChild.startColumn;
+				} else if(startLine == firstChild.startLine &&
+						startColumn > firstChild.startColumn) {
+					startColumn = firstChild.startColumn;
+				}
+				DecoratedNode lastChild = getChild(getNumChild() - 1);
+				lastChild.determineLocs();
+				if(isExternal || endLine < lastChild.endLine) {
+					endLine = lastChild.endLine;
+					endColumn = lastChild.endColumn;
+				} else if(endLine == lastChild.endLine &&
+						endColumn < lastChild.endColumn) {
+					endColumn = lastChild.endColumn;
+				}
 			}
 		}
 	}

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -20,11 +20,6 @@ import silver.core.NMaybe;
  * @see Node
  */
 public class DecoratedNode implements Decorable, Typed {
-	// TODO list:
-	// - Delete parent / forwardParent. Or coalesce them (only NEED for debugging purposes, if inh become thunks!)
-	// - Delete forwardValue (make it a local/production attribute)
-	// - merge inheritedAttributes into inheritedValues
-	
 	// Please note: the methods in this file have been refined to be quite small
 	// because the JVM makes inlining decisions on a per-method basis (of course!)
 	// So we try to keep the "slow paths" in a separate method, so the hot paths
@@ -47,6 +42,7 @@ public class DecoratedNode implements Decorable, Typed {
 	/**
 	 * The node that forwards to this one. (May be null)
 	 * Not final, because we may set this when forwarding to a decorated tree via sharing.
+	 * Usually the same as 'parent', but may differ due to sharing.
 	 */
 	protected DecoratedNode forwardParent;
 	/**
@@ -658,25 +654,10 @@ public class DecoratedNode implements Decorable, Typed {
 	private final DecoratedNode evalForward() {
 		try {
 			return self.evalForward(this).decorate(
-				parent, getForwardInheritedAttributes(), this, true);
+				this, self.getForwardInheritedAttributes(), this, true);
 		} catch(Throwable t) {
 			throw handleFwdError(t);
 		}
-	}
-
-	private final Lazy[] getForwardInheritedAttributes() {
-		Lazy[] forwardInhs = self.getForwardInheritedAttributes();
-		if(forwardInhs == null) return null;
-		Lazy[] result = new Lazy[self.getNumberOfInhAttrs()];
-		for(int i = 0; i < result.length; i++) {
-			Lazy l = forwardInhs[i];
-			if (l != null) {
-				// The Lazys in self.getForwardInheritedAttributes expect this (forwarding) DecoratedNode as context,
-				// but will be passed the parent of this node instead.
-				result[i] = l.withContext(this);
-			}
-		}
-		return result;
 	}
 	
 	private final RuntimeException handleFwdError(Throwable t) {

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -913,17 +913,7 @@ public class DecoratedNode implements Decorable, Typed {
 	}
 
 	private boolean isChildTree(int idx) {
-		if(self.isChildDecorable(idx)) return true;
-		Object o = self.getChild(idx);
-		if(o instanceof DataNode) {
-			// For nodes with locations, only include data nonterminal children if they have locations,
-			// to avoid polluting node selection with lost of locationless nodes.
-			if(self instanceof silver.core.Alocation || self instanceof Tracked) {
-				return o instanceof silver.core.Alocation || o instanceof Tracked;
-			}
-			return true;
-		}
-		return false;
+		return self.isChildDecorable(idx) || self.getChild(idx) instanceof DataNode;
 	}
 
 	// Data nonterminal trees have TopNode as their parent in the AST,
@@ -1014,7 +1004,12 @@ public class DecoratedNode implements Decorable, Typed {
 	public boolean cpr_nodeListVisible() {
 		// Hide nodes from external files when creating a probe
 		determineLocs();
-		return !isExternal;
+		if (isExternal) return false;
+		if (self instanceof DataNode && !(self instanceof silver.core.Alocation || self instanceof Tracked)) {
+			// Hide data nonterminal nodes without locations
+			return false;
+		}
+		return true;
 	}
 
 	public String cpr_nodeLabel() {

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -931,16 +931,26 @@ public class DecoratedNode implements Decorable, Typed {
 		}
 		return parent;
 	}
-  
+
 	// This is set by the generated main class CodeProber_parse method,
 	// to determine if any extracted location is in the main file.
 	static private String cprMainFilePath = null;
-	public static void setCprMainFilePath(String path) {
+	static public void setCprMainFilePath(String path) {
 		cprMainFilePath = path;
 	}
 
+	public void setIsInMainFile(boolean isInMainFile) {
+		this.isInMainFile = isInMainFile;
+		this.isInMainFileSet = true;
+		int nc = getNumChild();
+		for(int i = 0; i < nc; i++) {
+			getChild(i).setIsInMainFile(isInMainFile);
+		}
+	}
+
 	private boolean hasLocs = false;
-	private boolean isExternal = false;
+	private boolean isInMainFile = false;
+	private boolean isInMainFileSet = false;
 	private int startLine = 0, startColumn = 0, endLine = 0, endColumn = 0;
 	private final void determineLocs() {
 		if (hasLocs) return; // Only determine once.
@@ -961,13 +971,14 @@ public class DecoratedNode implements Decorable, Typed {
 		}
 		if(loc != null) {
 			String fileName = loc.synthesized(silver.core.Init.silver_core_filename__ON__silver_core_Location).toString();
-			if(fileName.equals(cprMainFilePath)) {
+			if(!isInMainFileSet) {
+				isInMainFile = cprMainFilePath.equals(fileName);
+			}
+			if(isInMainFile) {
 				startLine = loc.synthesized(silver.core.Init.silver_core_line__ON__silver_core_Location);
 				startColumn = loc.synthesized(silver.core.Init.silver_core_column__ON__silver_core_Location);
 				endLine = loc.synthesized(silver.core.Init.silver_core_endLine__ON__silver_core_Location);
 				endColumn = loc.synthesized(silver.core.Init.silver_core_endColumn__ON__silver_core_Location);
-			} else {
-				isExternal = true;
 			}
 
 			// Code Prober expects the start/end ranges of a parent node to include the ranges of its children.
@@ -976,7 +987,7 @@ public class DecoratedNode implements Decorable, Typed {
 			if(getNumChild() > 0) {
 				DecoratedNode firstChild = getChild(0);
 				firstChild.determineLocs();
-				if(isExternal || startLine > firstChild.startLine) {
+				if(!isInMainFile || startLine > firstChild.startLine) {
 					startLine = firstChild.startLine;
 					startColumn = firstChild.startColumn;
 				} else if(startLine == firstChild.startLine &&
@@ -985,7 +996,7 @@ public class DecoratedNode implements Decorable, Typed {
 				}
 				DecoratedNode lastChild = getChild(getNumChild() - 1);
 				lastChild.determineLocs();
-				if(isExternal || endLine < lastChild.endLine) {
+				if(!isInMainFile || endLine < lastChild.endLine) {
 					endLine = lastChild.endLine;
 					endColumn = lastChild.endColumn;
 				} else if(endLine == lastChild.endLine &&
@@ -995,17 +1006,21 @@ public class DecoratedNode implements Decorable, Typed {
 			}
 		}
 	}
-	public boolean cpr_isInsideExternalFile() { determineLocs(); return isExternal; }
+	public boolean cpr_isInsideExternalFile() { determineLocs(); return !isInMainFile; }
 	public int cpr_getStartLine() { determineLocs(); return startLine; }
 	public int cpr_getStartColumn() { determineLocs(); return startColumn; }
 	public int cpr_getEndLine() { determineLocs(); return endLine; }
 	public int cpr_getEndColumn() { determineLocs(); return endColumn; }
 
+	private boolean hasLocInfo() {
+		return self instanceof silver.core.Alocation || self instanceof Tracked;
+	}
+
 	public boolean cpr_nodeListVisible() {
 		// Hide nodes from external files when creating a probe
 		determineLocs();
-		if (isExternal) return false;
-		if (self instanceof DataNode && !(self instanceof silver.core.Alocation || self instanceof Tracked)) {
+		if (!isInMainFile) return false;
+		if (!hasLocInfo()) {
 			// Hide data nonterminal nodes without locations
 			return false;
 		}

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -1,6 +1,8 @@
 package common;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
 
 import common.exceptions.MissingDefinitionException;
 import common.exceptions.SilverException;
@@ -878,5 +880,116 @@ public class DecoratedNode implements Decorable, Typed {
 	
 	public final String toString() {
 		return getDebugID();
+	}
+
+	// Code Prober interface methods.
+	// These have certain names and signatures that Code Prober expects to call reflectively;
+	// otherwise these methods should not be used directly.
+	public int getNumChild() {
+		int res = 0;
+		for (int i = 0; i < self.getNumberOfChildren(); i++) {
+			if (self.isChildDecorable(i)) res++;
+		}
+		return res;
+	}
+	public DecoratedNode getChild(int idx) {
+		int i = 0;
+		while (!self.isChildDecorable(i)) i++;
+		for (int j = 0; j < idx; j++) {
+			i++;
+			while (!self.isChildDecorable(i)) i++;
+		}
+		return childDecorated(i);
+	}
+	public DecoratedNode getParent() {
+		if (parent instanceof TopNode || parent.self instanceof FunctionNode) {
+			return null;
+		}
+		return parent;
+	}
+  
+	private boolean hasLocs = false;
+	private int startLine = -1, startColumn = -1, endLine = -1, endColumn = -1;
+	private final void determineLocs() {
+		if (hasLocs) return; // Only determine once.
+		hasLocs = true;
+		silver.core.NLocation loc = null;
+		if(self != null) {
+			if(self instanceof silver.core.Alocation) {
+				loc = ((silver.core.Alocation)self).getAnno_silver_core_location();
+			} else if(self instanceof Tracked) {
+				NMaybe maybeLoc = silver.core.PgetParsedOriginLocation.invoke(OriginContext.FFI_CONTEXT, self);
+				if(maybeLoc instanceof silver.core.Pjust) {
+					loc = (silver.core.NLocation)maybeLoc.getChild(0);
+				}
+			}
+		}
+		if(loc != null) {
+			startLine = loc.synthesized(silver.core.Init.silver_core_line__ON__silver_core_Location);
+			startColumn = loc.synthesized(silver.core.Init.silver_core_column__ON__silver_core_Location);
+			endLine = loc.synthesized(silver.core.Init.silver_core_endLine__ON__silver_core_Location);
+			endColumn = loc.synthesized(silver.core.Init.silver_core_endColumn__ON__silver_core_Location);
+
+			// Code Prober expects the start/end ranges of a parent node to include the ranges of its children.
+			// Sometimes, the locations reported by origin tracking do not respect this,
+			// so we have to manually adjust the start and end lines/columns.
+			if(getNumChild() > 0) {
+				DecoratedNode firstChild = getChild(0);
+				firstChild.determineLocs();
+				if(startLine > firstChild.startLine) {
+					startLine = firstChild.startLine;
+					startColumn = firstChild.startColumn;
+				} else if(startLine == firstChild.startLine &&
+						startColumn > firstChild.startColumn) {
+					startColumn = firstChild.startColumn;
+				}
+				DecoratedNode lastChild = getChild(getNumChild() - 1);
+				lastChild.determineLocs();
+				if(endLine < lastChild.endLine) {
+					endLine = lastChild.endLine;
+					endColumn = lastChild.endColumn;
+				} else if(endLine == lastChild.endLine &&
+						endColumn < lastChild.endColumn) {
+					endColumn = lastChild.endColumn;
+				}
+			}
+		}
+	}
+	public int cpr_getStartLine() { determineLocs(); return startLine; }
+	public int cpr_getStartColumn() { determineLocs(); return startColumn; }
+	public int cpr_getEndLine() { determineLocs(); return endLine; }
+	public int cpr_getEndColumn() { determineLocs(); return endColumn; }
+
+	public String cpr_nodeLabel() {
+		return self.getName();
+	}
+  
+	public List<String> cpr_propertyListShow() {
+		List<String> properties = new ArrayList<>();
+		properties.add("l:show");
+		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
+			properties.add("l:" + self.getNameOfInhAttr(i));
+		}
+		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
+			properties.add("l:" + self.getNameOfSynAttr(i));
+		}
+		return properties;
+	}
+
+	public Object cpr_lInvoke(String propName) {
+		if (propName.equals("show")) {
+			return Util.genericShow(this);
+		}
+		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
+			if (propName.equals(self.getNameOfInhAttr(i))) {
+				return Util.genericShow(inherited(i));
+			}
+		}
+		for(int i = 0; i < self.getNumberOfSynAttrs(); i++) {
+			if (propName.equals(self.getNameOfSynAttr(i))) {
+				return Util.genericShow(synthesized(i));
+			}
+		}
+		throw new SilverInternalError("Unknown property '" + propName + "' for " + getDebugID());
 	}
 }

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -215,7 +215,10 @@ public class DecoratedNode implements Decorable, Typed {
 	@Override
 	public DecoratedNode decorate(final DecoratedNode parent, final Lazy[] inhs, final Lazy decSite) {
 		// System.err.println("TRACE: " + parent.getDebugID() + " extra-decorating " + getDebugID());
-		if (forwardParent == null) {
+		// Decoration has no effect if a tree already has a forward parent.
+		// Also, we may be miscellaneously decorated with nothing by runtime utilities, outside the
+		// usual chain of decoration sites; this should not cause the decorationSite to be replaced.
+		if (forwardParent == null && !(parent instanceof TopNode)) {
 			if (inhs != null) {
 				if (inheritedAttributes == null) {
 					inheritedAttributes = new Lazy[self.getNumberOfInhAttrs()];
@@ -1029,7 +1032,7 @@ public class DecoratedNode implements Decorable, Typed {
 		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
 			// Ignore auxillary inhs for translation attributes
 			if(self.getNameOfInhAttr(i) != null) {
-			properties.add("l:" + self.getNameOfInhAttr(i));
+				properties.add("l:" + self.getNameOfInhAttr(i));
 			}
 		}
 		String[] annoNames = self.getAnnoNames();
@@ -1055,9 +1058,9 @@ public class DecoratedNode implements Decorable, Typed {
 			}
 		}
 		if(inheritedAttributes != null) {
-		for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
-			if (propName.equals(self.getNameOfInhAttr(i))) {
-				return getSourceFileName(inheritedAttributes[i]);
+			for(int i = 0; i < self.getNumberOfInhAttrs(); i++) {
+				if (propName.equals(self.getNameOfInhAttr(i))) {
+					return getSourceFileName(inheritedAttributes[i]);
 				}
 			}
 		}

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -1123,6 +1123,9 @@ public class DecoratedNode implements Decorable, Typed {
 		if(o.getClass().getSuperclass().getName().equals("silver.langutil.pp.NDocument") ) {
 			return Util.showDoc(o, 80).toString();
 		}
+		if(o instanceof ConsCell && o != ConsCell.nil && ((ConsCell)o).head().getClass().getSuperclass().getName().equals("silver.langutil.NMessage")) {
+			return CodeProberDiagnostic.fromMessageList((ConsCell)o);
+		}
 		return Util.genericShow(o).toString();
 	}
 

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -977,6 +977,9 @@ public class DecoratedNode implements Decorable, Typed {
 		if(forwardParent != null) {
 			properties.add("l:forwardParent");
 		}
+		for(int i = 0; i < self.getNumberOfChildren(); i++) {
+			properties.add("l:" + self.getChildName(i));
+		}
 		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
 			properties.add("l:" + self.getNameOfLocalAttr(i));
 		}
@@ -1030,6 +1033,11 @@ public class DecoratedNode implements Decorable, Typed {
 		if (propName.equals("forwardParent")) {
 			return makeCprInvokeResult(forwardParent);
 		}
+		for(int i = 0; i < self.getNumberOfChildren(); i++) {
+			if (propName.equals(self.getChildName(i))) {
+				return makeCprInvokeResult(child(i));
+			}
+		}
 		for(int i = 0; i < self.getNumberOfLocalAttrs(); i++) {
 			if (propName.equals(self.getNameOfLocalAttr(i))) {
 				return makeCprInvokeResult(local(i));
@@ -1058,6 +1066,7 @@ public class DecoratedNode implements Decorable, Typed {
 	* Currently, this just stringifies anything that is not another DecoratedNode.
 	*/
 	private static Object makeCprInvokeResult(Object o) {
+		System.err.println("DEBUG: makeCprInvokeResult " + o);
 		if(o instanceof DecoratedNode && ((DecoratedNode)o).determineParentPropertyName() != null) {
 			return o;
 		}
@@ -1078,21 +1087,32 @@ public class DecoratedNode implements Decorable, Typed {
 		}
 	}
 	private String determineParentPropertyName() {
-		if(isProdForward) {
+		System.err.println("DEBUG: determineParentPropertyName " + this + ", parent " + parent);
+		if(this == parent.forwardValue) {
+			System.err.println("found forward");
 			return "forward";
 		}
+		for(int i = 0; i < parent.self.getNumberOfChildren(); i++) {
+			if(this == parent.childrenValues[i]) {
+				System.err.println("found child " + parent.self.getChildName(i));
+				return self.getChildName(i);
+			}
+		}
 		for(int i = 0; i < parent.self.getNumberOfLocalAttrs(); i++) {
-			if (this == parent.localValues[i]) {
+			if(this == parent.localValues[i]) {
+				System.err.println("found local " + parent.self.getNameOfLocalAttr(i));
 				return parent.self.getNameOfLocalAttr(i);
 			}
 		}
 		// Translation attributes
 		for(int i = 0; i < parent.self.getNumberOfSynAttrs(); i++) {
-			if (this == parent.synthesizedValues[i]) {
+			if(this == parent.synthesizedValues[i]) {
+				System.err.println("found syn " + parent.self.getNameOfSynAttr(i));
 				return parent.self.getNameOfSynAttr(i);
 			}
 		}
 		// Our parent doesn't know about us, so we must have been anonymously decorated somewhere.
+		System.err.println("found nothing");
 		return null;
 	}
 }

--- a/runtime/java/src/common/DecoratedNode.java
+++ b/runtime/java/src/common/DecoratedNode.java
@@ -612,17 +612,19 @@ public class DecoratedNode implements Decorable, Typed {
 		Lazy[] inhs = null;
 		if (inheritedAttributes != null && inheritedAttributes[inhsAttribute] != null) {
 			if (inheritedAttributes[inhsAttribute] instanceof TransInhs) {
-				inhs = ((TransInhs)inheritedAttributes[inhsAttribute]).inhs;
+				inhs = ((TransInhs)inheritedAttributes[inhsAttribute]).withContext(parent).inhs;
 			} else {
 				throw new SilverInternalError("Supplied trans inhs attribute not TransInhs!");
 			}
 		}
-		Lazy decSite = inheritedAttributes == null? null : inheritedAttributes[decSiteAttribute];
-		if(decSite == null && forwardParent != null && isProdForward && forwardParent.synthesizedValues[attribute] == null) {
+		Lazy decSite = null;
+		if(inheritedAttributes != null && inheritedAttributes[decSiteAttribute] != null) {
+			decSite = inheritedAttributes[decSiteAttribute].withContext(parent);
+		} else if(forwardParent != null && isProdForward && forwardParent.synthesizedValues[attribute] == null) {
 			decSite = (context) -> forwardParent.translation(attribute, inhsAttribute, decSiteAttribute);
 		}
 		// Decorate the tree that we computed earlier.
-		return d.decorate(parent, inhs, decSite);
+		return d.decorate(this, inhs, decSite);
 	}
 
 	/**
@@ -1066,7 +1068,6 @@ public class DecoratedNode implements Decorable, Typed {
 	* Currently, this just stringifies anything that is not another DecoratedNode.
 	*/
 	private static Object makeCprInvokeResult(Object o) {
-		System.err.println("DEBUG: makeCprInvokeResult " + o);
 		if(o instanceof DecoratedNode && ((DecoratedNode)o).determineParentPropertyName() != null) {
 			return o;
 		}
@@ -1087,32 +1088,26 @@ public class DecoratedNode implements Decorable, Typed {
 		}
 	}
 	private String determineParentPropertyName() {
-		System.err.println("DEBUG: determineParentPropertyName " + this + ", parent " + parent);
 		if(this == parent.forwardValue) {
-			System.err.println("found forward");
 			return "forward";
 		}
 		for(int i = 0; i < parent.self.getNumberOfChildren(); i++) {
 			if(this == parent.childrenValues[i]) {
-				System.err.println("found child " + parent.self.getChildName(i));
 				return self.getChildName(i);
 			}
 		}
 		for(int i = 0; i < parent.self.getNumberOfLocalAttrs(); i++) {
 			if(this == parent.localValues[i]) {
-				System.err.println("found local " + parent.self.getNameOfLocalAttr(i));
 				return parent.self.getNameOfLocalAttr(i);
 			}
 		}
 		// Translation attributes
 		for(int i = 0; i < parent.self.getNumberOfSynAttrs(); i++) {
 			if(this == parent.synthesizedValues[i]) {
-				System.err.println("found syn " + parent.self.getNameOfSynAttr(i));
 				return parent.self.getNameOfSynAttr(i);
 			}
 		}
 		// Our parent doesn't know about us, so we must have been anonymously decorated somewhere.
-		System.err.println("found nothing");
 		return null;
 	}
 }

--- a/runtime/java/src/common/FunctionNode.java
+++ b/runtime/java/src/common/FunctionNode.java
@@ -66,6 +66,11 @@ public abstract class FunctionNode extends Node {
 	}
 
 	@Override
+	public final TransOccursInfo getTransOccurs(final int index) {
+		throw new SilverInternalError("Functions do not possess synthesized attributes! (Requested index " + index + ")");
+	}
+
+	@Override
 	public final Lazy getDefaultSynthesized(int index) {
 		throw new SilverInternalError("Functions do not possess synthesized attributes! (Requested default for index " + index + ")");
 	}

--- a/runtime/java/src/common/IOToken.java
+++ b/runtime/java/src/common/IOToken.java
@@ -455,4 +455,15 @@ public final class IOToken implements Typed {
 	public TypeRep getType() {
 		return new BaseTypeRep("silver:core:IO");
 	}
+
+	public IOToken setTreeIsInMainFile(final Object x, final boolean b) {
+		if(x instanceof DecoratedNode) {
+			((DecoratedNode)x).setIsInMainFile(b);
+			return this;
+		} else if(x instanceof DataNode) {
+			((DataNode)x).decorate().setIsInMainFile(b);
+			return this;
+		}
+		return this;
+	}
 }

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -179,7 +179,7 @@ public abstract class Node implements Decorable, Typed {
 	 * 
 	 * @return The name of the child at the given index.
 	 */
-	public abstract String getChildName(final int child);
+	public abstract String getNameOfChild(final int child);
 
 	/**
 	 * Determine if the child should be automatically decorated.

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -164,6 +164,13 @@ public abstract class Node implements Decorable, Typed {
 	 * @return The number of children this Node has.
 	 */
 	public abstract int getNumberOfChildren();
+	
+	/**
+	 * Get the name of a child. Used for debugging.
+	 * 
+	 * @return The name of the child at the given index.
+	 */
+	public abstract String getChildName(final int child);
 
 	/**
 	 * Determine if the child should be automatically decorated.

--- a/runtime/java/src/common/Node.java
+++ b/runtime/java/src/common/Node.java
@@ -107,6 +107,15 @@ public abstract class Node implements Decorable, Typed {
 	 * @return The name of the synthesized attribute at this index
 	 */
 	public abstract String getNameOfSynAttr(final int index);
+
+	/**
+	 * Used for debugging, determine if a synthesized attribute is a translation attributes.
+	 * 
+	 * @param index The index of the synthesized attribute
+	 * @return The TransOccursInfo containing the auxillary inherited attribute occurence indices,
+	 *   or null if it is not a translation attribute.
+	 */
+	public abstract TransOccursInfo getTransOccurs(final int index);
 	
 	/**
 	 * When a production does not forward and lacks an equation for a synthesized attribute, this is consulted instead.

--- a/runtime/java/src/common/TransOccursInfo.java
+++ b/runtime/java/src/common/TransOccursInfo.java
@@ -1,7 +1,7 @@
 package common;
 
 /**
- * Stores information about the auxilliary attributes used by a translation attribute, for debugging purposes.
+ * Stores information about the auxiliary attributes used by a translation attribute, for debugging purposes.
  */
 public class TransOccursInfo {
     public final int inhsAttribute;

--- a/runtime/java/src/common/TransOccursInfo.java
+++ b/runtime/java/src/common/TransOccursInfo.java
@@ -1,0 +1,14 @@
+package common;
+
+/**
+ * Stores information about the auxilliary attributes used by a translation attribute, for debugging purposes.
+ */
+public class TransOccursInfo {
+    public final int inhsAttribute;
+    public final int decSiteAttribute;
+
+    public TransOccursInfo(final int inhsAttribute, final int decSiteAttribute) {
+        this.inhsAttribute = inhsAttribute;
+        this.decSiteAttribute = decSiteAttribute;
+    }
+}

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -437,22 +437,6 @@ public final class Util {
 	}
 
 	/**
-	 * Turn the value of an attribute into a value that we can return to Code Prober.
-	 * Currently, this just stringifies anything that is not another DecoratedNode.
-	 */
-	public static Object makeCprInvokeResult(Object o) {
-		if(o instanceof DecoratedNode) {
-			return o;
-		}
-		// Render Document values as strings.
-		// This (annoyingly) must be done with reflection to avoid depending on silver:langutil.
-		if(o.getClass().getSuperclass().getName().equals("silver.langutil.pp.NDocument") ) {
-			return showDoc(o).toString();
-		}
-		return genericShow(o).toString();
-	}
-
-	/**
 	 * Calls a Copper parser, and returns a ParseResult<ROOT> object.
 	 *
 	 * @param parser The Copper parser to call

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -397,6 +397,23 @@ public final class Util {
 	}
 
 	/**
+	 * Attempt to reflectively call the showDoc function from silver:langutil:pp.
+	 * 
+	 * @param d  The Document to show
+	 * @return A string representation.
+	 */
+	public static StringCatter showDoc(Object d) {
+		try {
+			Method showDoc = Class.forName("silver.langutil.pp.PshowDoc")
+				.getMethod("invoke", OriginContext.class, Object.class, Object.class);
+			return (StringCatter)showDoc.invoke(null, OriginContext.FFI_CONTEXT, 80, d);
+		} catch(ClassNotFoundException | NoSuchMethodException | SecurityException |
+		        IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			throw new SilverInternalError("Failed to call silver:langutil:pp:showDoc on " + d + ": " + e.getMessage(), e);
+		}
+	}
+
+	/**
 	 * Attempt to use the improved genericPP from silver:langutil:reflect if that library is available;
 	 * else fall back to hackUnparse.
 	 * Note that we can't actually let the runtime/silver:core depend on that library,
@@ -417,6 +434,22 @@ public final class Util {
 		        IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
 			return hackyhackyUnparse(o);
 		}
+	}
+
+	/**
+	 * Turn the value of an attribute into a value that we can return to Code Prober.
+	 * Currently, this just stringifies anything that is not another DecoratedNode.
+	 */
+	public static Object makeCprInvokeResult(Object o) {
+		if(o instanceof DecoratedNode) {
+			return o;
+		}
+		// Render Document values as strings.
+		// This (annoyingly) must be done with reflection to avoid depending on silver:langutil.
+		if(o.getClass().getSuperclass().getName().equals("silver.langutil.pp.NDocument") ) {
+			return showDoc(o).toString();
+		}
+		return genericShow(o).toString();
 	}
 
 	/**

--- a/runtime/java/src/common/Util.java
+++ b/runtime/java/src/common/Util.java
@@ -400,13 +400,14 @@ public final class Util {
 	 * Attempt to reflectively call the showDoc function from silver:langutil:pp.
 	 * 
 	 * @param d  The Document to show
+	 * @param width The desired max column width
 	 * @return A string representation.
 	 */
-	public static StringCatter showDoc(Object d) {
+	public static StringCatter showDoc(Object d, int width) {
 		try {
 			Method showDoc = Class.forName("silver.langutil.pp.PshowDoc")
 				.getMethod("invoke", OriginContext.class, Object.class, Object.class);
-			return (StringCatter)showDoc.invoke(null, OriginContext.FFI_CONTEXT, 80, d);
+			return (StringCatter)showDoc.invoke(null, OriginContext.FFI_CONTEXT, width, d);
 		} catch(ClassNotFoundException | NoSuchMethodException | SecurityException |
 		        IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
 			throw new SilverInternalError("Failed to call silver:langutil:pp:showDoc on " + d + ": " + e.getMessage(), e);

--- a/tutorials/dc/Main.sv
+++ b/tutorials/dc/Main.sv
@@ -57,5 +57,11 @@ IO<Integer> ::= largs::[String]
   };
 }
 
-
-
+fun codeProberParse IO<Decorated Root> ::= args::[String] = do {
+  when_(null(args), fail("Invalid arguments to codeProberParse"));
+  let fileName = last(args);
+  content <- readFile(fileName);
+  let result = parse(content, fileName);
+  when_(!result.parseSuccess, fail(result.parseErrors));
+  return decorate result.parseTree.ast_Root with {};
+};


### PR DESCRIPTION
# Changes
* Add methods expected by the CodeProber API to `DecoratedNode`
* Refactor main class generation, allow specifying a `codeProberParse` method as the CodeProber entrypoint alongside `main`
* Translation changes to record additional information needed by CodeProber - child names, additional info about translation attributes
* Change parent relationships for forward and translation trees.  Apparently, the parent of a forwarding tree was the "logical parent" of its forward tree.  For consistency in tracking parent/child relationships, "parent" must just mean "the tree that decorated this tree".

# Documentation
Added source comments, also https://github.com/melt-umn/melt-website/pull/66

# Testing
Tested extensively with ableC and extensions.
