### PR TITLE
Fix branch encoding in upload-override-jars script

### DIFF
--- a/upload-override-jars
+++ b/upload-override-jars
@@ -10,7 +10,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 # fi
 
 branch_name="$(git rev-parse --abbrev-ref HEAD)"
-encoded_branch_name="$(curl -Gso /dev/null -w %{url_effective} --data-urlencode $branch_name "" | cut -c 3-)"
+encoded_branch_name="$(python3 -c 'import urllib.parse, sys; print(urllib.parse.quote_plus(sys.argv[1]))' "$branch_name")"
 commit_hash="$(git rev-parse HEAD)"
 
 # If your username on the your development machine doesn't match your username


### PR DESCRIPTION
# Changes
The `upload-override-jars` script seems to have broken at some point, as the encoded branch name in the printed URL is an empty string - perhaps this was relying on some non-standard behavior of the `curl` command that was broken by an update.  I have replaced this with a Python command that should be more portable.  

# Documentation
N/A

# Testing
Manually tested running the script on my machine and foundry.