### PR TITLE
Avoid running ant if jar file is up to date

### DIFF
--- a/check-compile
+++ b/check-compile
@@ -15,5 +15,9 @@ export GRAMMAR_PATH="../grammars"
 mkdir -p build
 cd build
 
+set +e
 time java "${JVM_ARGS[@]}" $BUILDGRAMMAR
 
+# Intercept exit code 127 meaning success, but ant should not be run
+CODE=$?
+[ $CODE -eq 127 ] || exit $CODE

--- a/grammars/silver/compiler/driver/Command.sv
+++ b/grammars/silver/compiler/driver/Command.sv
@@ -1,6 +1,6 @@
 grammar silver:compiler:driver;
 
-attribute genLocation, doClean, displayVersion, warnError, forceOrigins, noOrigins, noRedex, tracingOrigins, noStdlib, searchPath, outName, buildGrammars, silverHomeOption, noBindingChecking occurs on CmdArgs;
+attribute genLocation, doClean, displayVersion, warnError, forceOrigins, noOrigins, noRedex, tracingOrigins, noStdlib, searchPath, outName, buildGrammars, silverHomeOption, noSemanticAnalysis occurs on CmdArgs;
 
 synthesized attribute searchPath :: [String];
 synthesized attribute outName :: [String];
@@ -18,7 +18,7 @@ synthesized attribute noStdlib :: Boolean;
 
 synthesized attribute buildGrammars :: [String];
 
-synthesized attribute noBindingChecking :: Boolean;
+synthesized attribute noSemanticAnalysis :: Boolean;
 
 aspect production endCmdArgs
 top::CmdArgs ::= l::[String]
@@ -31,7 +31,7 @@ top::CmdArgs ::= l::[String]
   top.genLocation = [];
   top.silverHomeOption = [];
   top.buildGrammars = l;
-  top.noBindingChecking = false;
+  top.noSemanticAnalysis = false;
   top.forceOrigins = false;
   top.noOrigins = false;
   top.noRedex = false;
@@ -110,10 +110,10 @@ top::CmdArgs ::= rest::CmdArgs
   top.noStdlib = true;
   forwards to @rest;
 }
-abstract production nobindingFlag
+abstract production dontAnalyzeFlag
 top::CmdArgs ::= rest::CmdArgs
 {
-  top.noBindingChecking = true;
+  top.noSemanticAnalysis = true;
   forwards to @rest;
 }
 
@@ -149,7 +149,7 @@ Either<String  Decorated CmdArgs> ::= args::[String]
         flagParser=flag(cleanFlag))
     , flagSpec(name="--dont-analyze", paramString=nothing(),
         help="", -- TODO
-        flagParser=flag(nobindingFlag))
+        flagParser=flag(dontAnalyzeFlag))
     , flagSpec(name="--warn-error", paramString=nothing(),
         help="treat warnings as errors",
         flagParser=flag(warnErrorFlag))

--- a/grammars/silver/compiler/driver/DriverAction.sv
+++ b/grammars/silver/compiler/driver/DriverAction.sv
@@ -5,18 +5,19 @@ grammar silver:compiler:driver;
  - Negative = configuration/installation error
  - 1-19 = command line/start up error
  - 20+ = Normal use error (errors in spec)
- - 127 = "abnormal" success (e.g. printed version string, quit now)
+ - 127 = "abnormal" success, ant shouldn't run (e.g. printed version string, quit now)
  - 0 = success of course
  -}
 
 {- Orders:
  - 0: parsing errors (also flow graph emitting)
- - 1: binding errors
- - 3: interfaces and classes
- - 4: doc
- - 5: copper_mda
+ - 1: semantic errors
+ - 2: docs, refactor
+ - 3: copper_mda, report undoc
+ - 4: exit if no translation needed
+ - 5: java, interfaces
  - 6: buildxml
- - 7: impide
+ - 7: copper
  -}
 
 aspect production compilation
@@ -32,7 +33,7 @@ abstract production touchIfaces
 top::DriverAction ::= r::[Decorated RootSpec] genPath::String
 {
   top.run = do { touchFiles(map(sviPath(_, genPath), r)); return 0; };
-  top.order = 3;
+  top.order = 5;
 }
 fun sviPath String ::= r::Decorated RootSpec genPath::String =
   genPath ++ "src/" ++ grammarToPath(r.declaredName) ++ "Silver.svi";

--- a/grammars/silver/compiler/driver/DriverAction.sv
+++ b/grammars/silver/compiler/driver/DriverAction.sv
@@ -13,19 +13,20 @@ grammar silver:compiler:driver;
  - 0: parsing errors (also flow graph emitting)
  - 1: semantic errors
  - 2: docs, refactor
- - 3: copper_mda, report undoc
- - 4: exit if no translation needed
+ - 3: report undoc
+ - 4: copper_mda
  - 5: java, interfaces
  - 6: buildxml
  - 7: copper
+ - 8: check if ant should run
  -}
 
 aspect production compilation
 top::Compilation ::= g::Grammars  r::Grammars  buildGrammars::[String]  a::Decorated CmdArgs  benv::BuildEnv
 {
   top.postOps <- [printAllParsingErrors(top.allGrammars)];
-  top.postOps <- if a.noBindingChecking then [] else
-    [printAllBindingErrors(top.allGrammars)]; 
+  top.postOps <- if a.noSemanticAnalysis then [] else
+    [printAllSemanticErrors(top.allGrammars)]; 
   top.postOps <- [touchIfaces(r.grammarList, benv.silverGen)];
 }
 
@@ -38,7 +39,7 @@ top::DriverAction ::= r::[Decorated RootSpec] genPath::String
 fun sviPath String ::= r::Decorated RootSpec genPath::String =
   genPath ++ "src/" ++ grammarToPath(r.declaredName) ++ "Silver.svi";
 
-abstract production printAllBindingErrors
+abstract production printAllSemanticErrors
 top::DriverAction ::= specs::[Decorated RootSpec]
 {
   -- Force printing of status before doing error checks
@@ -47,10 +48,10 @@ top::DriverAction ::= specs::[Decorated RootSpec]
     forward.run;
   };
 
-  forwards to printAllBindingErrorsHelp(specs);
+  forwards to printAllSemanticErrorsHelp(specs);
 }
 
-abstract production printAllBindingErrorsHelp
+abstract production printAllSemanticErrorsHelp
 top::DriverAction ::= specs::[Decorated RootSpec]
 {
   top.run =
@@ -60,7 +61,7 @@ top::DriverAction ::= specs::[Decorated RootSpec]
         unless(null(spec.grammarErrors),
           eprintln("Errors for " ++ spec.declaredName ++ "\n" ++ flatMap(renderMessages(spec.grammarSource, _), spec.grammarErrors)));
         let containsErrors :: Boolean = grammarContainsErrors(spec.grammarErrors, spec.config.warnError);
-        recurse :: Integer <- printAllBindingErrorsHelp(rest).run;
+        recurse :: Integer <- printAllSemanticErrorsHelp(rest).run;
         return if containsErrors || recurse != 0 then 20 else 0;
       }
     end;

--- a/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/extension/doc/driver/BuildProcess.sv
@@ -105,7 +105,7 @@ top::DriverAction ::= a::Decorated CmdArgs  specs::[Decorated RootSpec]
       end), specs));
 
   top.run = do { println(report); return 0; };
-  top.order = 5;
+  top.order = 3;
 }
 
 
@@ -117,7 +117,7 @@ top::DriverAction ::= a::Decorated CmdArgs  specs::[Decorated RootSpec]  outputL
     traverse_(writeSpec(_, outputLoc), specs);
     return 0;
   };
-  top.order = 4;
+  top.order = 2;
 }
 
 function writeSpec

--- a/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
@@ -63,5 +63,5 @@ top::DriverAction ::= spec::MdaSpec  compiledGrammars::EnvTree<Decorated RootSpe
       } else buildGrammar;
     };
 
-  top.order = 3;
+  top.order = 4;
 }

--- a/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
+++ b/grammars/silver/compiler/modification/copper_mda/BuildProcess.sv
@@ -63,5 +63,5 @@ top::DriverAction ::= spec::MdaSpec  compiledGrammars::EnvTree<Decorated RootSpe
       } else buildGrammar;
     };
 
-  top.order = 5;
+  top.order = 3;
 }

--- a/grammars/silver/compiler/refactor/BuildProcess.sv
+++ b/grammars/silver/compiler/refactor/BuildProcess.sv
@@ -61,9 +61,9 @@ top::DriverAction ::= a::Decorated CmdArgs  specs::[Decorated RootSpec]
   top.run = do {
     eprintln("Applying Refactoring.");
     traverse_(refactorSpec, specs);
-    return 0;
+    return 127;  -- Terminate after refactoring is complete
   };
-  top.order = 4;
+  top.order = 2;
 }
 
 fun refactorSpec IO<()> ::= r::Decorated RootSpec =

--- a/grammars/silver/compiler/refactor/BuildProcess.sv
+++ b/grammars/silver/compiler/refactor/BuildProcess.sv
@@ -16,7 +16,7 @@ top::CmdArgs ::= rest::CmdArgs
 {
   top.doRefactor = true;
   top.doClean = true;
-  top.noBindingChecking = true;
+  top.noSemanticAnalysis = true;
   top.noJavaGeneration = true;
   forwards to @rest;
 }

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -108,11 +108,12 @@ top::Compilation ::= g::Grammars  _  buildGrammars::[String]  a::Decorated CmdAr
   -- Seed flow deps with {config}
   keepFiles <- if false then error(genericShow(a)) else [];
 
-  top.postOps <- [
-    exitIfNoTranslation(a.noJavaGeneration, outputFile, g.grammarList, grammarsToTranslate),
-    genJava(benv.silverGen, keepFiles, grammarsToTranslate),
-    genBuild(buildXmlLocation, buildXml)
-  ];
+  top.postOps <- 
+    checkJarUpToDate(a.noJavaGeneration, outputFile, g.grammarList, grammarsToTranslate) ::
+    if a.noJavaGeneration then [] else [
+      genJava(benv.silverGen, keepFiles, grammarsToTranslate),
+      genBuild(buildXmlLocation, buildXml)
+    ];
 
   -- From here on, it's all build.xml stuff:
 
@@ -229,7 +230,7 @@ implode("\n\n", extraTopLevelDecls) ++ "\n\n" ++
 "</project>\n";
 }
 
-abstract production exitIfNoTranslation
+abstract production checkJarUpToDate
 top::DriverAction ::= noJavaGeneration::Boolean  jarFile::String  specs::[Decorated RootSpec]  toTranslate::[Decorated RootSpec]
 {
   top.run = if noJavaGeneration then pure(127) else do {
@@ -241,7 +242,7 @@ top::DriverAction ::= noJavaGeneration::Boolean  jarFile::String  specs::[Decora
       }
       else pure(0);
   };
-  top.order = 4;
+  top.order = 8;
 }
 
 abstract production genJava

--- a/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
+++ b/grammars/silver/compiler/translation/java/driver/BuildProcess.sv
@@ -108,18 +108,19 @@ top::Compilation ::= g::Grammars  _  buildGrammars::[String]  a::Decorated CmdAr
   -- Seed flow deps with {config}
   keepFiles <- if false then error(genericShow(a)) else [];
 
-  top.postOps <-
-    [genBuild(buildXmlLocation, buildXml)] ++
-    (if a.noJavaGeneration then []
-     else [genJava(a, benv.silverGen, keepFiles, grammarsToTranslate)]);
+  top.postOps <- [
+    exitIfNoTranslation(a.noJavaGeneration, outputFile, g.grammarList, grammarsToTranslate),
+    genJava(benv.silverGen, keepFiles, grammarsToTranslate),
+    genBuild(buildXmlLocation, buildXml)
+  ];
 
   -- From here on, it's all build.xml stuff:
 
-  -- Presently, copper, copper_mda, and impide all contribute new targets into build.xml:
+  -- Presently, unused?
   production attribute extraTopLevelDecls :: [String] with ++;
   extraTopLevelDecls := [];
 
-  -- Presently, impide and copper_mda introduce a new top-level goal:
+  -- Presently, unused?
   production attribute extraDistDeps :: [String] with ++;
   extraDistDeps := if a.noJavaGeneration then [] else ["jars"];
   
@@ -228,15 +229,30 @@ implode("\n\n", extraTopLevelDecls) ++ "\n\n" ++
 "</project>\n";
 }
 
+abstract production exitIfNoTranslation
+top::DriverAction ::= noJavaGeneration::Boolean  jarFile::String  specs::[Decorated RootSpec]  toTranslate::[Decorated RootSpec]
+{
+  top.run = if noJavaGeneration then pure(127) else do {
+    jarFileTime <- fileTime(jarFile);
+    if null(toTranslate) && jarFileTime > foldr(max, 0, map((.grammarTime), specs))
+      then do {
+        eprintln("Jar file " ++ jarFile ++ " is up to date.");
+        return 127;
+      }
+      else pure(0);
+  };
+  top.order = 4;
+}
+
 abstract production genJava
-top::DriverAction ::= a::Decorated CmdArgs  silverGen::String  keepFiles::[String]  specs::[Decorated RootSpec]
+top::DriverAction ::= silverGen::String  keepFiles::[String]  specs::[Decorated RootSpec]
 {
   top.run = do {
     eprintln("Generating Translation.");
     traverse_(writeSpec(silverGen, keepFiles, _), specs);
     return 0;
   };
-  top.order = 4;
+  top.order = 5;
 }
 
 abstract production genBuild

--- a/support/bin/silver
+++ b/support/bin/silver
@@ -45,5 +45,10 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
+set +e
 # shellcheck disable=SC2086
 java $SVJVM_FLAGS -jar "$SILVER" "${SV_ARGS[@]}" && ant
+
+# Intercept exit code 127 meaning success, but ant should not be run
+CODE=$?
+[ $CODE -eq 127 ] || exit $CODE

--- a/support/bin/silver-custom
+++ b/support/bin/silver-custom
@@ -46,5 +46,10 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
+set +e
 # shellcheck disable=SC2086
 java $SVJVM_FLAGS -jar "$SILVER" "${SV_ARGS[@]}" && ant
+
+# Intercept exit code 127 meaning success, but ant should not be run
+CODE=$?
+[ $CODE -eq 127 ] || exit $CODE


### PR DESCRIPTION
This substantially speeds up scripts that sequentially build a bunch of artifacts, when some artifacts have no changes. This helps us avoid writing Makefiles sometimes in lieu of a proper build system, for now.
Also, audit the order numbers of DriverActions.

# Documentation
This is an optimization, not a user-facing change.  Updated comments about the orders of DriverActions.

# Testing
Tested by building projects with mutliple Silver artifacts.