### PR TITLE
Translation of `inhSetType` to allow parameterizing nonterminals by `InhSet`s

### DIFF
--- a/grammars/silver/compiler/translation/java/type/Type.sv
+++ b/grammars/silver/compiler/translation/java/type/Type.sv
@@ -165,7 +165,7 @@ aspect production inhSetType
 top::Type ::= inhs::[String]
 {
   top.transClassType = error("Demanded translation of InhSet type");
-  top.transTypeRep = error("Demanded TypeRep translation of InhSet type");
+  top.transTypeRep = s"new common.BaseTypeRep(\"{${implode(", ", inhs)}}\")";
   top.transTypeName = substitute(":", "_", implode("_", inhs));
 }
 

--- a/test/silver_features/Types.sv
+++ b/test/silver_features/Types.sv
@@ -273,6 +273,11 @@ global u1 :: DExpr = new(d1);
 global u2 :: DExpr = ^d2;
 global u3 :: DExpr = ^decorate mkDExpr() with {};
 
+-- tests demand of attribute silver:compiler:translation:java:type:transTypeRep
+-- on silver:compiler:definition:type:inhSetType
+nonterminal InhSetNT<(i::InhSet)>;
+production inhSetNT top::InhSetNT<{env1}> ::= {}
+
 function getEnv1ChainedAmb
 {env1} subset i1, i1 subset i2 => [String] ::= x::Decorated DExpr with i2
 {


### PR DESCRIPTION
# Changes
Redefines synthesized attribute `silver:compiler:translation:java:type:transTypeRep` for `silver:compiler:definition:type:inhSetType`. Its definition is currently an error, which is demanded when a production is defined for a nonterminal parameterized by `i::InhSet`.

# Documentation
No new documentation.

# Testing
One test added to `silver_features/Types.sv` with nonterminal and production definitions as described above.
