### PR TITLE
Use a singleton object for any untracked production that has no contexts, children or annotations

### DIFF
--- a/grammars/silver/compiler/translation/java/core/Expr.sv
+++ b/grammars/silver/compiler/translation/java/core/Expr.sv
@@ -158,9 +158,14 @@ top::Expr ::= @q::QName
   top.invokeTranslation =
     case top.finalType.outputType of
     | dispatchType(fn) -> s"${top.translation}.invoke(${makeOriginContextRef(top)}, new Object[]{${argsTranslation(top.invokeArgs)}}, ${namedargsTranslation(top.invokeNamedArgs)})"
-    | _ ->
+    | ty ->
+      if !ty.isTracked
+      && null(typeScheme.contexts)
+      && null(q.lookupValue.dcl.namedSignature.inputElements)
+      && null(q.lookupValue.dcl.namedSignature.namedInputElements)
+      then s"${makeProdName(q.lookupValue.fullName)}.singleton"
       -- static constructor invocation
-      s"new ${makeProdName(q.lookupValue.fullName)}(${implode(", ",
+      else s"new ${makeProdName(q.lookupValue.fullName)}(${implode(", ",
         makeNewConstructionOrigin(top, !top.sameProdAsProductionDefinedOn) ++
         toString(top.invokeIsUnique) ::
         contexts.transContexts ++

--- a/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
+++ b/grammars/silver/compiler/translation/java/core/ProductionDcl.sv
@@ -21,6 +21,8 @@ top::AGDcl ::= 'abstract' 'production' id::Name d::ProductionImplements ns::Prod
   local fnnt :: String = makeNTName(ntName);
   local isData :: Boolean = namedSig.outputElement.typerep.isData;
   local wantsTracking :: Boolean = namedSig.outputElement.typerep.isTracked;
+  local hasSingleton :: Boolean =
+    !wantsTracking && null(namedSig.contexts) && null(namedSig.inputElements) && null(namedSig.namedInputElements);
 
   local ntDeclPackage :: String = implode(".", init(explode(".", fnnt)));
   local typeNameSnipped :: String = last(explode(":", namedSig.outputElement.typerep.typeName));
@@ -127,6 +129,8 @@ ${contexts.contextInitTrans}
     public ${className}(${namedSig.javaSignature}) {
         this(null${if length(namedSig.refInvokeTrans)!=0 then ", " ++ namedSig.refInvokeTrans else ""});
     }
+
+${if hasSingleton then s"    public static final ${className} singleton = new ${className}();" else ""}
 
 ${namedSig.childDecls}
 
@@ -371,12 +375,12 @@ ${contexts.contextInitTrans}
 	
 		@Override
         public final ${fnnt} invoke(final common.OriginContext originCtx, final Object[] children, final Object[] annotations) {
-            return new ${className}(
+            return ${if hasSingleton then s"${className}.singleton" else s"""new ${className}(
               ${implode(", ", (if wantsTracking then [newConstructionOriginUsingCtxRef] else []) ++
                 -- If this prod implements a dispatch signature, then it *can* have shared children when invoked.
                 (if d.implementsSig.isJust then "true" else "false") ::
                 map(\ c::Context -> decorate c with {boundVariables = namedSig.freeVariables;}.contextRefElem, namedSig.contexts) ++
-                unpackChildren(0, namedSig.inputElements) ++ unpackAnnotations(0, namedSig.namedInputElements))});
+                unpackChildren(0, namedSig.inputElements) ++ unpackAnnotations(0, namedSig.namedInputElements))})"""};
         }
 		
         @Override


### PR DESCRIPTION
# Changes
Small optimization to the Java translation - if a production has no children, contexts or annotations, then just use a singleton object.  This should slightly improve memory usage, and also allow for more caching of synthesized attributes on data nonterminals.  The build time on Jenkins was ~1 minute faster with this change, but that is in the margin of error.

Currently in the Silver compiler specification we sometimes define global singleton values instead of calling the production directly (e.g. `global lhsVertexType::VertexType = lhsVertexType_real();`.)  This change should make that unnecessary.  

# Documentation
N/A, minor implementation detail.

# Testing
Passes Jenkins.