### PR TITLE
Align Hello.sv with the documentation.

### DIFF
--- a/support/bin/install-silver-bin
+++ b/support/bin/install-silver-bin
@@ -28,51 +28,29 @@ fi
 
 echo "Found ~/bin"
 
-case `uname` in
-*Darwin*)
-  READLINK=greadlink
-  if [ ! -f `which greadlink` ]; then
-    echo "Missing greadlink. Please install coreutils:"
-    echo -e "\tbrew install coreutils"
-    exit 4
-  fi
-  ;;
-*)
-  READLINK=readlink
-  ;;
-esac
+# get REPO location from git
+REPO=$(git rev-parse --show-toplevel)
+echo "Found $REPO"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 for SCRIPT_NAME in silver silver-custom
 do
+    SRC_SCRIPT="${SCRIPT_DIR}/${SCRIPT_NAME}"
+    DST_SCRIPT="${HOME}/bin/${SCRIPT_NAME}"
 
-    if [ -f $SCRIPT_NAME ]; then
-        REPO=$("$READLINK" -f ../..)
-        SCRIPT=$SCRIPT_NAME
-    elif [ -f support/bin/$SCRIPT_NAME ]; then
-        REPO=$("$READLINK" -f .)
-        SCRIPT=support/bin/$SCRIPT_NAME
+    if [ -f "${SRC_SCRIPT}" ]; then
+       rm -f "${DST_SCRIPT}"
+       ln -s "${SRC_SCRIPT}" "${DST_SCRIPT}"
     else
-        echo "Couldn't find the Silver jars!"
-        echo "(if this is a fresh checkout, run fetch-jars before this script.)"
-        exit 2
-    fi
-    
-    echo "Found $REPO"
-
-    if [ -e ~/bin/$SCRIPT_NAME -o -h ~/bin/$SCRIPT_NAME ]; then
-        # -h needed in case the link exists but the targeted file does not
-        rm ~/bin/$SCRIPT_NAME
-        echo "Removed old(?) ~/bin/$SCRIPT_NAME file."
+       echo "Couldn't find ${SRC_SCRIPT}, there is a problem with the setup. Checkout from github again."
     fi
 
-    ln -s "$("$READLINK" -f "$SCRIPT")" ~/bin/
+    echo "Created ${DST_SCRIPT}"
 
-    echo "Created ~/bin/$SCRIPT_NAME"
-
-    # Just in case
-    chmod +x "$SCRIPT"
+    # Just in case...ahem...
+    chmod +x "${DST_SCRIPT}"
 
 done
 
 echo "Install finished."
-

--- a/support/bin/install-silver-bin
+++ b/support/bin/install-silver-bin
@@ -28,10 +28,6 @@ fi
 
 echo "Found ~/bin"
 
-# get REPO location from git
-REPO=$(git rev-parse --show-toplevel)
-echo "Found $REPO"
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 for SCRIPT_NAME in silver silver-custom

--- a/tutorials/hello/Hello.sv
+++ b/tutorials/hello/Hello.sv
@@ -2,6 +2,6 @@ grammar hello;
 
 fun main IO<Integer> ::= largs::[String] =
   do {
-    print("Hello, world!\n");
+    print("Hello, World!\n");
     return 0;
   };


### PR DESCRIPTION
Documentation at https://melt.cs.umn.edu/silver/install-guide/#testing-things-out-by-building-the-tutorials claims that the World is upper case (as is expected in most hello-world applications).

# Changes

1. Minor update on a string to align the output of the Hello.sv with the online documentation
2. Simplified the install script. Removed redundant calls to `readlink`, and the code that was required to maintain different executions per platform. Now the code only depends on a `bash`-ism.

# Documentation

- Align website documentation and source code, by updating the source code to align with existing documentation (and common casing in Hello World)

# Testing

Locally, this change affects my silver docker build where I validate that the image is correctly built and things are as expected by utilizing the Hello.sv and expecting the output. 
Same docker build process, also is using the install script.

# Assumptions

That the install script and the scripts to be installed live in the same directory (same as before). The install script is called directly (not symlinked - different than before).

# Quality

There are two `shellcheck` warnings that exist in code I didn't touch, newly added/modified code  is shellcheck warning free

```
$ shellcheck install-silver-bin 

In install-silver-bin line 6:
  echo "~/bin not found. Aborting."
        ^------------------------^ SC2088 (warning): Tilde does not expand in quotes. Use $HOME.


In install-silver-bin line 7:
  case `uname` in
       ^-----^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
  case $(uname) in

For more information:
  https://www.shellcheck.net/wiki/SC2088 -- Tilde does not expand in quotes. ...
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...
```


