### PR TITLE
Fix/collection base aspect default

### DIFF
--- a/runtime/java/src/common/CollectionAttribute.java
+++ b/runtime/java/src/common/CollectionAttribute.java
@@ -68,7 +68,7 @@ public abstract class CollectionAttribute implements Lazy {
 				} catch(Throwable t) {
 					throw new TraceException("Error evaluating base of collection attribute " + un.getNameOfSynAttr(index) + " via forward of " + un.getName(),t);
 				}
-			}	else {
+			} else {
 				Lazy l = un.getDefaultSynthesized(index);
 				if(l != null) {
 					try {

--- a/runtime/java/src/common/CollectionAttribute.java
+++ b/runtime/java/src/common/CollectionAttribute.java
@@ -69,15 +69,15 @@ public abstract class CollectionAttribute implements Lazy {
 					throw new TraceException("Error evaluating base of collection attribute " + un.getNameOfSynAttr(index) + " via forward of " + un.getName(),t);
 				}
 			}	else {
-        Lazy l = un.getDefaultSynthesized(index);
-        if(l != null) {
-          try {
-            return l.eval(context);
-          } catch(Throwable t) {
-            throw new TraceException("While evaling default for collection attribute '" + un.getNameOfSynAttr(index) + "' in " + context.getDebugID(), t);
-          }
-        }
-		  }
+				Lazy l = un.getDefaultSynthesized(index);
+				if(l != null) {
+					try {
+						return l.eval(context);
+					} catch(Throwable t) {
+						throw new TraceException("While evaling default for collection attribute '" + un.getNameOfSynAttr(index) + "' in " + context.getDebugID(), t);
+					}
+				}
+			}
 
 			throw new MissingDefinitionException("No base defined for collection attribute " + un.getNameOfSynAttr(index) + " in " + un.getName());
 		}

--- a/runtime/java/src/common/CollectionAttribute.java
+++ b/runtime/java/src/common/CollectionAttribute.java
@@ -68,7 +68,16 @@ public abstract class CollectionAttribute implements Lazy {
 				} catch(Throwable t) {
 					throw new TraceException("Error evaluating base of collection attribute " + un.getNameOfSynAttr(index) + " via forward of " + un.getName(),t);
 				}
-			}	
+			}	else {
+        Lazy l = un.getDefaultSynthesized(index);
+        if(l != null) {
+          try {
+            return l.eval(context);
+          } catch(Throwable t) {
+            throw new TraceException("While evaling default for collection attribute '" + un.getNameOfSynAttr(index) + "' in " + context.getDebugID(), t);
+          }
+        }
+		  }
 
 			throw new MissingDefinitionException("No base defined for collection attribute " + un.getNameOfSynAttr(index) + " in " + un.getName());
 		}

--- a/test/silver_features/Collections.sv
+++ b/test/silver_features/Collections.sv
@@ -142,13 +142,13 @@ top::ColNT ::=
 {
   top.colList := ["one"];
   top.colList <- ["two"];
-  top.colOr := false;
+  --top.colOr := false; -- default below
   top.colOr <- true;
-  top.colAnd := true;
+  --top.colAnd := true; -- default below
   top.colAnd <- false;
-  top.colFun := nothing();
+  --top.colFun := nothing(); -- default below
   top.colFun <- just(1);
-  top.colProd := colLeaf();
+  --top.colProd := colLeaf(); -- default below
   top.colProd <- colLeaf();
   top.colTCFun := [1, 2, 3];
   top.colTCFun <- [2, 3, 4];
@@ -169,13 +169,13 @@ top::ColNT ::=
   top.colList <- [];
   top.colOr := true;
   top.colOr <- false;
-  top.colAnd := true;
+  --top.colAnd := true; -- default below
   top.colAnd <- true;
-  top.colFun := nothing();
+  --top.colFun := nothing(); -- default below
   top.colFun <- nothing();
   top.colProd := colProdLeaf();
   top.colProd <- colLeaf();
-  top.colTCFun := [];
+  --top.colTCFun := []; -- default below
 }
 
 equalityTest( colTest2().colList, ["one", "two"], [String], silver_tests );
@@ -187,16 +187,26 @@ equalityTest( colTest2().colProd.colSyn, " j  k ( d  e ) b ", String, silver_tes
 abstract production colTest3
 top::ColNT ::=
 {
-  top.colList := [];
+  --top.colList := []; -- default below
   top.colList <- ["one", "two"];
-  top.colOr := false;
+  --top.colOr := false; -- default below
   top.colOr <- false;
   top.colAnd := false;
   top.colAnd <- true;
   top.colFun := just(1);
   top.colFun <- just(2);
-  top.colProd := colLeaf();
+  --top.colProd := colLeaf(); -- default below
   top.colProd <- colProdLeaf();
+  --top.colTCFun := []; -- default below
+}
+
+aspect default production top::ColNT ::=
+{
+  top.colList := [];
+  top.colOr := false;
+  top.colAnd := true;
+  top.colFun := nothing();
+  top.colProd := colLeaf();
   top.colTCFun := [];
 }
 


### PR DESCRIPTION
# Changes
Modified runtime code for collection attributes so that base definitions can be taken from default productions. Essentially the same code as is used to look for synthesized attribute definitions in default productions, seen here:

https://github.com/melt-umn/silver/blob/1184b903f15a865044cabad58cbb17688aebe7d2/runtime/java/src/common/DecoratedNode.java#L521-L532

# Documentation
No new documentation added - small change to runtime.

# Testing
Modified existing collection attribute tests to include cases where base definitions are taken from default productions.
